### PR TITLE
feat(radio): tag-based fallback search for multi-word queries

### DIFF
--- a/internal/radiobrowser/radiobrowser.go
+++ b/internal/radiobrowser/radiobrowser.go
@@ -92,9 +92,14 @@ func New() *Client {
 }
 
 // SearchOpts buendelt alle Such Parameter.
+//
+// TagList is a list of substrings, each of which must match SOME tag
+// of a station (AND across the list, substring per element). Set this
+// for multi-word queries — see SearchSmart.
 type SearchOpts struct {
 	Name     string
 	Tag      string
+	TagList  []string
 	Country  string
 	Language string
 	Order    string
@@ -114,6 +119,9 @@ func (c *Client) Search(ctx context.Context, opts SearchOpts) ([]Station, error)
 	}
 	if opts.Tag != "" {
 		q.Set("tag", opts.Tag)
+	}
+	if len(opts.TagList) > 0 {
+		q.Set("tagList", strings.Join(opts.TagList, ","))
 	}
 	if opts.Country != "" {
 		q.Set("countrycode", strings.ToUpper(opts.Country))
@@ -143,6 +151,112 @@ func (c *Client) Search(ctx context.Context, opts SearchOpts) ([]Station, error)
 	var out []Station
 	err := c.fetchJSON(ctx, "/stations/search?"+q.Encode(), &out)
 	return out, err
+}
+
+// SearchSmart runs Search with the literal Name plus a tag-based
+// fallback for multi-word queries and merges the results. It exists
+// because radio-browser's `name` parameter is a plain substring match
+// against the station name field — multi-word queries like
+// "rap old school" almost never appear there literally, so users see
+// an empty list even though plenty of stations are tagged that way.
+//
+// Strategy:
+//
+//  1. Run the original Search (matches station names).
+//  2. If Name has two or more whitespace-separated tokens, run a
+//     second Search with TagList set to those tokens. radio-browser
+//     AND-matches the list, substring per element — so a station
+//     tagged "hip hop, rap, old school" satisfies all three of
+//     {rap, old, school}.
+//
+// Both queries respect the other filters (Country, Language, OnlyOK,
+// Order). Results are merged, deduplicated by station UUID, capped
+// at opts.Limit, and returned in vote order. Callers that have
+// already constrained the search to a tag chip (Tag != "") get the
+// plain Search behaviour — the user already narrowed the scope and
+// we should not widen it back.
+func (c *Client) SearchSmart(ctx context.Context, opts SearchOpts) ([]Station, error) {
+	if opts.Limit <= 0 {
+		opts.Limit = 30
+	}
+	if opts.Name == "" || opts.Tag != "" {
+		return c.Search(ctx, opts)
+	}
+	tokens := tokenize(opts.Name)
+
+	type result struct {
+		stations []Station
+		err      error
+	}
+	nameCh := make(chan result, 1)
+	tagCh := make(chan result, 1)
+
+	go func() {
+		st, err := c.Search(ctx, opts)
+		nameCh <- result{st, err}
+	}()
+	if len(tokens) >= 2 {
+		go func() {
+			tagOpts := opts
+			tagOpts.Name = ""
+			tagOpts.TagList = tokens
+			// Tag-based hits are often plentiful; fetch a wider
+			// page so the dedup-and-cap step has material to
+			// promote into the visible window.
+			tagOpts.Limit = opts.Limit * 2
+			st, err := c.Search(ctx, tagOpts)
+			tagCh <- result{st, err}
+		}()
+	} else {
+		close(tagCh)
+	}
+
+	nameRes := <-nameCh
+	var tagStations []Station
+	if r, ok := <-tagCh; ok {
+		tagStations = r.stations
+	}
+
+	if nameRes.err != nil && len(tagStations) == 0 {
+		return nil, nameRes.err
+	}
+
+	seen := make(map[string]bool, len(nameRes.stations)+len(tagStations))
+	merged := make([]Station, 0, len(nameRes.stations)+len(tagStations))
+	add := func(stations []Station) {
+		for _, s := range stations {
+			key := s.StationUUID
+			if key == "" {
+				key = s.Name + "|" + s.URL
+			}
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			merged = append(merged, s)
+		}
+	}
+	add(nameRes.stations)
+	add(tagStations)
+
+	if len(merged) > opts.Limit {
+		merged = merged[:opts.Limit]
+	}
+	return merged, nil
+}
+
+// tokenize splits a free-text query into trimmed, non-empty,
+// lowercase substrings on whitespace. Used by SearchSmart.
+func tokenize(s string) []string {
+	fields := strings.Fields(s)
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		f = strings.ToLower(strings.TrimSpace(f))
+		if f != "" {
+			out = append(out, f)
+		}
+	}
+	return out
 }
 
 // TopVote liefert die meistgevoteten Sender, gefiltert nach country.

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -419,7 +419,7 @@ func (s *Server) handleRadioSearch(w http.ResponseWriter, r *http.Request) {
 	if v := q.Get("offset"); v != "" {
 		fmt.Sscanf(v, "%d", &offset)
 	}
-	stations, err := rb.Search(ctx, radiobrowser.SearchOpts{
+	stations, err := rb.SearchSmart(ctx, radiobrowser.SearchOpts{
 		Name:     q.Get("q"),
 		Tag:      q.Get("tag"),
 		Country:  q.Get("cc"),


### PR DESCRIPTION
## What this changes

Searching the radio for a phrase like \"rap old school\" returns an empty list today. radio-browser's \`/stations/search?name=...\` is a plain substring match against the station name field, and almost no station is *named* \"rap old school\" even though plenty are *tagged* that way.

This PR adds a smarter search path that runs the literal name search and a parallel tag-list search in parallel, then merges the results. The user types nothing new — the existing \`q=\` parameter just produces richer matches.

## How it works

- New \`radiobrowser.SearchOpts.TagList []string\` forwards as the radio-browser \`tagList\` query parameter (AND across substrings, one substring per element).
- New \`radiobrowser.SearchSmart\` runs two parallel searches when the query has 2+ whitespace tokens: \`name=<query>\` and \`tagList=<tokens>\`. Single-token queries skip the second leg.
- \`internal/webui/handleRadioSearch\` calls \`SearchSmart\` instead of \`Search\`. \`TopVote\`, \`ByCountry\`, the chip drilldown, and any other call path stay on the plain \`Search\` so already-narrow queries are not widened back.
- Merge is dedup-by-UUID, name-first then tag-results, capped at \`Limit\`.

## Worked example

Query: \"rap old school\", country DE.

- Leg A (\`name=rap old school\`): typically empty.
- Leg B (\`tagList=rap,old,school\`): stations tagged with substrings matching all three tokens. Hits stations tagged \"hip hop, rap, old school\" etc.
- Merged result: leg B alone in this case, sorted by votes desc by radio-browser.

For single-station-name queries like \"Rock Antenne\", leg A finds the literal station, leg B usually misses (\"antenne\" rarely a tag), the merge falls through to leg A. Net: same behaviour as today.

## Test plan

- [ ] CI green (test, lint, vuln, codeql, three cross-compile legs).
- [ ] Once shipped on a stick: try \"rap old school\", \"deep dub techno\", \"jazz cool\" — non-empty results.
- [ ] \"Rock Antenne\" still finds Rock Antenne (regression check on the name path).
- [ ] Activating a tag chip in the UI is unchanged because Tag != \"\" skips SearchSmart.

## Out of scope

This lives in the stick agent's webui, so users only benefit after their stick agent is updated. A separate task can OTA-roll this out from the desktop app once a tagged release exists.