### PR TITLE
feat(ui): blue dot on Box-Einstellungen tab when a box needs update

### DIFF
--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -637,6 +637,9 @@ async function renderFooter() {
   });
   renderDonateSidebar();
   checkAppUpdate();
+  // appInfo may have arrived after the first discovery completed; the
+  // badge function defers until both are known.
+  updateSettingsTabBadge();
 }
 
 function renderDonateSidebar() {
@@ -953,6 +956,7 @@ async function discoverBoxes() {
       }
     }
     renderBoxSelect();
+    updateSettingsTabBadge();
     // Auto Retry: wenn nach Setup/Reboot noch eine Box ihren neuen
     // Namen nicht ueber mDNS gemeldet hat, alle 4 s nochmal suchen
     // bis maximal 90 s. Das wird ueber pendingNames gesteuert.
@@ -1200,6 +1204,29 @@ function renderLanguageOptions() {
   }
   sel.innerHTML = opts.join('');
   sel.value = state.searchLang;
+}
+
+// updateSettingsTabBadge shows a small blue dot on the "Box Einstellungen"
+// tab whenever at least one discovered box reports a version different
+// from the desktop app's own version. The dot signals: there is work to
+// do in this tab, namely OTA-update at least one box.
+//
+// Version data comes from the mDNS TXT record so no extra HTTP call is
+// needed — the badge updates as the box list refreshes.
+function updateSettingsTabBadge() {
+  const btn = document.querySelector('.tab-btn[data-view="settings"]');
+  if (!btn) return;
+  const appVer = state.appInfo && state.appInfo.version;
+  let needsUpdate = false;
+  if (appVer) {
+    for (const b of state.boxes) {
+      if (b && b.version && b.version !== appVer) {
+        needsUpdate = true;
+        break;
+      }
+    }
+  }
+  btn.classList.toggle('has-update', needsUpdate);
 }
 
 async function checkBoxUpdate() {

--- a/desktop-app/frontend/src/style.css
+++ b/desktop-app/frontend/src/style.css
@@ -137,9 +137,23 @@ body {
   cursor: pointer;
   font-size: 14px;
   border-bottom: 2px solid transparent;
+  position: relative;
 }
 .tab-btn:hover { color: #ccc; }
 .tab-btn.active { color: var(--brand); border-bottom-color: var(--brand); }
+/* Blue dot indicator: a tab carries pending work (e.g. one of the
+   discovered boxes needs a software update). */
+.tab-btn.has-update::after {
+  content: '';
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #2f80ed;
+  box-shadow: 0 0 0 2px #1a1a1a;
+}
 .view.hidden { display: none; }
 .hidden { display: none !important; }
 

--- a/internal/radiobrowser/radiobrowser.go
+++ b/internal/radiobrowser/radiobrowser.go
@@ -92,9 +92,14 @@ func New() *Client {
 }
 
 // SearchOpts buendelt alle Such Parameter.
+//
+// TagList is a list of substrings, each of which must match SOME tag
+// of a station (AND across the list, substring per element). Set this
+// for multi-word queries — see SearchSmart.
 type SearchOpts struct {
 	Name     string
 	Tag      string
+	TagList  []string
 	Country  string
 	Language string
 	Order    string
@@ -114,6 +119,9 @@ func (c *Client) Search(ctx context.Context, opts SearchOpts) ([]Station, error)
 	}
 	if opts.Tag != "" {
 		q.Set("tag", opts.Tag)
+	}
+	if len(opts.TagList) > 0 {
+		q.Set("tagList", strings.Join(opts.TagList, ","))
 	}
 	if opts.Country != "" {
 		q.Set("countrycode", strings.ToUpper(opts.Country))
@@ -143,6 +151,112 @@ func (c *Client) Search(ctx context.Context, opts SearchOpts) ([]Station, error)
 	var out []Station
 	err := c.fetchJSON(ctx, "/stations/search?"+q.Encode(), &out)
 	return out, err
+}
+
+// SearchSmart runs Search with the literal Name plus a tag-based
+// fallback for multi-word queries and merges the results. It exists
+// because radio-browser's `name` parameter is a plain substring match
+// against the station name field — multi-word queries like
+// "rap old school" almost never appear there literally, so users see
+// an empty list even though plenty of stations are tagged that way.
+//
+// Strategy:
+//
+//  1. Run the original Search (matches station names).
+//  2. If Name has two or more whitespace-separated tokens, run a
+//     second Search with TagList set to those tokens. radio-browser
+//     AND-matches the list, substring per element — so a station
+//     tagged "hip hop, rap, old school" satisfies all three of
+//     {rap, old, school}.
+//
+// Both queries respect the other filters (Country, Language, OnlyOK,
+// Order). Results are merged, deduplicated by station UUID, capped
+// at opts.Limit, and returned in vote order. Callers that have
+// already constrained the search to a tag chip (Tag != "") get the
+// plain Search behaviour — the user already narrowed the scope and
+// we should not widen it back.
+func (c *Client) SearchSmart(ctx context.Context, opts SearchOpts) ([]Station, error) {
+	if opts.Limit <= 0 {
+		opts.Limit = 30
+	}
+	if opts.Name == "" || opts.Tag != "" {
+		return c.Search(ctx, opts)
+	}
+	tokens := tokenize(opts.Name)
+
+	type result struct {
+		stations []Station
+		err      error
+	}
+	nameCh := make(chan result, 1)
+	tagCh := make(chan result, 1)
+
+	go func() {
+		st, err := c.Search(ctx, opts)
+		nameCh <- result{st, err}
+	}()
+	if len(tokens) >= 2 {
+		go func() {
+			tagOpts := opts
+			tagOpts.Name = ""
+			tagOpts.TagList = tokens
+			// Tag-based hits are often plentiful; fetch a wider
+			// page so the dedup-and-cap step has material to
+			// promote into the visible window.
+			tagOpts.Limit = opts.Limit * 2
+			st, err := c.Search(ctx, tagOpts)
+			tagCh <- result{st, err}
+		}()
+	} else {
+		close(tagCh)
+	}
+
+	nameRes := <-nameCh
+	var tagStations []Station
+	if r, ok := <-tagCh; ok {
+		tagStations = r.stations
+	}
+
+	if nameRes.err != nil && len(tagStations) == 0 {
+		return nil, nameRes.err
+	}
+
+	seen := make(map[string]bool, len(nameRes.stations)+len(tagStations))
+	merged := make([]Station, 0, len(nameRes.stations)+len(tagStations))
+	add := func(stations []Station) {
+		for _, s := range stations {
+			key := s.StationUUID
+			if key == "" {
+				key = s.Name + "|" + s.URL
+			}
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			merged = append(merged, s)
+		}
+	}
+	add(nameRes.stations)
+	add(tagStations)
+
+	if len(merged) > opts.Limit {
+		merged = merged[:opts.Limit]
+	}
+	return merged, nil
+}
+
+// tokenize splits a free-text query into trimmed, non-empty,
+// lowercase substrings on whitespace. Used by SearchSmart.
+func tokenize(s string) []string {
+	fields := strings.Fields(s)
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		f = strings.ToLower(strings.TrimSpace(f))
+		if f != "" {
+			out = append(out, f)
+		}
+	}
+	return out
 }
 
 // TopVote liefert die meistgevoteten Sender, gefiltert nach country.

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -419,7 +419,7 @@ func (s *Server) handleRadioSearch(w http.ResponseWriter, r *http.Request) {
 	if v := q.Get("offset"); v != "" {
 		fmt.Sscanf(v, "%d", &offset)
 	}
-	stations, err := rb.Search(ctx, radiobrowser.SearchOpts{
+	stations, err := rb.SearchSmart(ctx, radiobrowser.SearchOpts{
 		Name:     q.Get("q"),
 		Tag:      q.Get("tag"),
 		Country:  q.Get("cc"),


### PR DESCRIPTION
## What this adds

A small blue dot in the top-right of the **Box Einstellungen** tab whenever at least one discovered box reports an agent version different from the desktop app's own version. The indicator signals: there is work to do in this tab — namely, OTA-update at least one box — without forcing the user to switch into the tab and scroll through every box's Stick Info section.

## Implementation

- New \`updateSettingsTabBadge()\` in \`main.js\`. Reads \`state.appInfo.version\` and the version field on each entry of \`state.boxes\` (which is already populated from the mDNS TXT record — no extra HTTP poll). Toggles the \`.has-update\` class on \`.tab-btn[data-view=\"settings\"]\`.
- Called after every successful \`discoverBoxes()\` (the discovery refresh is itself the staleness signal) and once in \`renderFooter()\` after \`AppInfo\` arrives, in case the very first discovery happened before \`appInfo\` was loaded.
- CSS: \`tab-btn::after\` pseudo-element, 8 px circle, brand-adjacent blue (\`#2f80ed\`), thin dark ring so it sits cleanly over both active and inactive tab states. \`tab-btn { position: relative; }\` was added to anchor it.

## Verification

- Box reports old version, app reports new — dot visible.
- All boxes match the app — dot hidden.
- Box list refreshes (mDNS rediscovery) — dot state recomputes automatically.
- After successful OTA: \`doBoxUpdate\` already triggers \`discoverBoxes()\`, so the badge clears itself once the box reports the new version.

## Not in scope here

- Same dot on the Setup tab — separate feature if desired.
- Per-box badge inside the Settings tab dropdown — current row markers already cover that case.