### PR TITLE
feat(ui): curated global genre chips with per-country boost row

### DIFF
--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -256,6 +256,73 @@ const GENRE_DE = {
   'minimal': 'Minimal', 'dubstep': 'Dubstep',
   'pop rock': 'Pop Rock', 'hard rock': 'Hard Rock', 'soft rock': 'Soft Rock',
   'classic rock': 'Classic Rock', 'indie rock': 'Indie Rock', 'alternative rock': 'Alternative Rock',
+  // Country-boost labels (kept in English where the genre name itself
+  // is a proper noun the audience would recognise everywhere).
+  'country': 'Country', 'deutschrap': 'Deutschrap', 'latin': 'Latin',
+  'reggaeton': 'Reggaeton', 'salsa': 'Salsa', 'samba': 'Samba',
+  'sertanejo': 'Sertanejo', 'bossa nova': 'Bossa Nova',
+  'j-pop': 'J-Pop', 'jpop': 'J-Pop', 'anime': 'Anime',
+  'bollywood': 'Bollywood', 'bhangra': 'Bhangra', 'hindi': 'Hindi',
+  'chanson': 'Chanson', 'variété': 'Variété', 'variete': 'Variété',
+  'italo': 'Italo', 'italian': 'Italienisch', 'italiano': 'Italienisch',
+  'levenslied': 'Levenslied', 'nederlandstalig': 'Niederländisch',
+  'turkish': 'Türkisch', 'tuerkisch': 'Türkisch', 'halk': 'Halk',
+  'disco polo': 'Disco Polo', 'polski': 'Polnisch',
+  'russian': 'Russisch', 'retro': 'Retro',
+};
+
+// GENRE_CORE: 14 globally relevant pills, always rendered regardless
+// of how many stations the current country actually has on each tag.
+// Ordered roughly by mass-appeal so the visible row reads top-down.
+// Curated from radio-browser's global tag stationcount distribution
+// plus Statista/Nielsen radio-format share data.
+const GENRE_CORE = [
+  'pop', 'rock', 'hits', 'oldies',
+  'jazz', 'classical', 'chillout',
+  'dance', 'electronic', 'house',
+  'hip hop', 'latin',
+  '80s', '90s',
+  'news',
+];
+
+// GENRE_BY_COUNTRY: bubble these tags up as the "for your country"
+// row, in front of the core pills. Max 2 per country to keep the
+// visual budget tight. Country code matches state.searchCountry (ISO
+// 3166 alpha-2, uppercase).
+const GENRE_BY_COUNTRY = {
+  'DE': ['schlager', 'deutschrap'],
+  'AT': ['schlager', 'volksmusik'],
+  'CH': ['schlager', 'volksmusik'],
+  'US': ['country', 'rnb'],
+  'CA': ['country', 'rnb'],
+  'AU': ['country', 'indie'],
+  'GB': ['indie', 'rnb'],
+  'IE': ['folk', 'indie'],
+  'FR': ['chanson', 'variété'],
+  'IT': ['italo', 'italian'],
+  'ES': ['reggaeton', 'salsa'],
+  'PT': ['fado', 'pimba'],
+  'MX': ['reggaeton', 'salsa'],
+  'AR': ['reggaeton', 'salsa'],
+  'CO': ['reggaeton', 'salsa'],
+  'CL': ['reggaeton', 'salsa'],
+  'PE': ['reggaeton', 'salsa'],
+  'VE': ['reggaeton', 'salsa'],
+  'BR': ['sertanejo', 'samba'],
+  'JP': ['j-pop', 'anime'],
+  'KR': ['k-pop', 'kpop'],
+  'IN': ['bollywood', 'bhangra'],
+  'NL': ['levenslied', 'nederlandstalig'],
+  'BE': ['chanson', 'levenslied'],
+  'TR': ['turkish', 'halk'],
+  'PL': ['disco polo', 'polski'],
+  'RU': ['russian', 'retro'],
+  'UA': ['ukrainian', 'retro'],
+  'GR': ['greek', 'laika'],
+  'SE': ['svensk', 'nordic'],
+  'NO': ['norsk', 'nordic'],
+  'DK': ['dansk', 'nordic'],
+  'FI': ['suomi', 'nordic'],
 };
 
 function translateCountry(name) {
@@ -862,6 +929,11 @@ $('searchCountry').onchange = () => {
   // dann genau die Stations in DIESEM Land wider, nicht global.
   state.languages = [];
   loadLanguagesForCountry();
+  // Country-boost pills depend on the selected country — re-render
+  // so the highlighted row matches. Collapse the "Mehr" expansion
+  // since the previous tail may not apply anymore.
+  state.showMoreGenres = false;
+  renderGenreChips();
   doRefilter();
 };
 
@@ -1125,33 +1197,92 @@ async function loadTaxonomy() {
   }
 }
 
+// Tracks whether the user has clicked "Mehr Genres" to expand the
+// long tail of auto-fetched tags. Resets on every fresh page load.
+state.showMoreGenres = false;
+
 function renderGenreChips() {
   const wrap = $('genreChips');
   if (!wrap) return;
-  if (!state.tags.length) { wrap.innerHTML = ''; return; }
-  // Buckets: kanonisierte Tag-Liste, Stationcount summieren.
-  const buckets = {};
+
+  // 1. Aggregate the live counts from radio-browser so each chip can
+  //    show "N Sender" in its tooltip. State.tags may be empty on
+  //    first paint — that's fine, core chips still render with 0.
+  const liveCounts = {};
   for (const t of state.tags) {
     const canon = canonGenre(t.name);
     if (!canon) continue;
-    if (!buckets[canon]) {
-      buckets[canon] = { canon, label: translateGenre(t.name), count: 0 };
-    }
-    buckets[canon].count += (t.stationcount || 0);
+    liveCounts[canon] = (liveCounts[canon] || 0) + (t.stationcount || 0);
   }
-  const merged = Object.values(buckets)
-    .filter(b => b.count > 0)
-    .sort((a, b) => b.count - a.count);
 
-  const chips = ['<button class="chip' + (!state.searchTag ? ' active' : '') + '" data-tag="">Alle</button>'].concat(
-    merged.map(b => {
-      const active = state.searchTag === b.canon ? ' active' : '';
-      return `<button class="chip${active}" data-tag="${escapeAttr(b.canon)}" title="${formatNumber(b.count)} Sender">${escapeHtml(b.label)}</button>`;
-    })
-  );
-  wrap.innerHTML = chips.join('');
+  // 2. Country-boost pills (max 2). state.searchCountry is the user's
+  //    selected country in the search filter — it falls back to the
+  //    stick's region.txt if the user hasn't manually picked one.
+  const cc = (state.searchCountry || '').toUpperCase();
+  const boost = GENRE_BY_COUNTRY[cc] || [];
+
+  const chipHtml = (canon, label, count, extraClass) => {
+    const active = state.searchTag === canon ? ' active' : '';
+    const cls = ['chip', active.trim(), extraClass || ''].filter(Boolean).join(' ');
+    const title = count > 0 ? `${formatNumber(count)} Sender` : '';
+    return `<button class="${cls}" data-tag="${escapeAttr(canon)}" title="${escapeAttr(title)}">${escapeHtml(label)}</button>`;
+  };
+  const labelFor = (canon) => translateGenre(canon) || canon.replace(/\b\w/g, c => c.toUpperCase());
+
+  const seen = new Set();
+  const parts = [];
+
+  parts.push('<button class="chip' + (!state.searchTag ? ' active' : '') + '" data-tag="">Alle</button>');
+
+  for (const canon of boost) {
+    if (!canon || seen.has(canon)) continue;
+    seen.add(canon);
+    parts.push(chipHtml(canon, labelFor(canon), liveCounts[canon] || 0, 'chip--boost'));
+  }
+  for (const canon of GENRE_CORE) {
+    if (seen.has(canon)) continue;
+    seen.add(canon);
+    parts.push(chipHtml(canon, labelFor(canon), liveCounts[canon] || 0));
+  }
+
+  // 3. Long tail: tags from state.tags that the user might recognise
+  //    but we did not promote into the core set. Shown only when the
+  //    user expands via "Mehr Genres".
+  const tail = Object.keys(liveCounts)
+    .filter(canon => !seen.has(canon) && liveCounts[canon] > 0)
+    .map(canon => ({ canon, count: liveCounts[canon] }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 24);
+
+  if (state.showMoreGenres) {
+    for (const t of tail) {
+      seen.add(t.canon);
+      parts.push(chipHtml(t.canon, labelFor(t.canon), t.count));
+    }
+  }
+
+  // 4. Toggle button at the end. Hidden when there is no tail to
+  //    reveal, or when the currently selected tag is in the tail (so
+  //    the user does not lose their selection by collapsing).
+  const showSelectedInTail = state.searchTag && !seen.has(state.searchTag);
+  if (tail.length > 0 || state.showMoreGenres) {
+    const label = state.showMoreGenres ? 'Weniger' : `Mehr Genres (${tail.length})`;
+    parts.push(`<button class="chip chip--more" id="genreMoreToggle">${escapeHtml(label)}</button>`);
+  }
+  if (showSelectedInTail) {
+    // Selection points to a tag the tail dropdown is hiding — force
+    // expand so the user sees their own filter.
+    state.showMoreGenres = true;
+  }
+
+  wrap.innerHTML = parts.join('');
   wrap.querySelectorAll('.chip').forEach(btn => {
     btn.onclick = () => {
+      if (btn.id === 'genreMoreToggle') {
+        state.showMoreGenres = !state.showMoreGenres;
+        renderGenreChips();
+        return;
+      }
       state.searchTag = btn.dataset.tag || '';
       renderGenreChips();
       doRefilter();

--- a/desktop-app/frontend/src/style.css
+++ b/desktop-app/frontend/src/style.css
@@ -464,6 +464,25 @@ body {
 }
 .chip:hover { background: #2a2a2a; color: #ddd; }
 .chip.active { background: var(--brand-bg); color: var(--brand-text); border-color: var(--brand); }
+/* Country-boost chips — bubbled up from GENRE_BY_COUNTRY because the
+   genre is locally relevant. Slightly warmer outline so the row is
+   visibly distinct from the global core set, but still calm enough
+   that the user does not feel ad-spammed. */
+.chip--boost {
+  border-color: var(--brand);
+  color: var(--brand-text);
+  background: var(--brand-bg-soft);
+}
+.chip--boost:hover { background: var(--brand-bg); color: var(--brand-text); }
+.chip--boost.active { background: var(--brand-bg); color: var(--brand-text); border-color: var(--brand); }
+/* "Mehr Genres" toggle — visually a chip but stylistically a button so
+   it does not look like another filter. */
+.chip--more {
+  background: transparent;
+  border-style: dashed;
+  color: #888;
+}
+.chip--more:hover { color: var(--brand-text); border-color: var(--brand); }
 
 /* Mehr laden */
 .load-more-row { display: flex; justify-content: center; margin-top: 8px; }

--- a/desktop-app/frontend/src/style.css
+++ b/desktop-app/frontend/src/style.css
@@ -465,16 +465,18 @@ body {
 .chip:hover { background: #2a2a2a; color: #ddd; }
 .chip.active { background: var(--brand-bg); color: var(--brand-text); border-color: var(--brand); }
 /* Country-boost chips — bubbled up from GENRE_BY_COUNTRY because the
-   genre is locally relevant. Slightly warmer outline so the row is
-   visibly distinct from the global core set, but still calm enough
-   that the user does not feel ad-spammed. */
+   genre is locally relevant. Marked with a brand-coloured strip on
+   the left edge, but otherwise the same neutral fill as a regular
+   chip — must never visually resemble the .active state or the user
+   thinks these pills are permanently selected. */
 .chip--boost {
-  border-color: var(--brand);
-  color: var(--brand-text);
-  background: var(--brand-bg-soft);
+  border-left: 3px solid var(--brand);
+  padding-left: 8px;
 }
-.chip--boost:hover { background: var(--brand-bg); color: var(--brand-text); }
-.chip--boost.active { background: var(--brand-bg); color: var(--brand-text); border-color: var(--brand); }
+/* .chip--boost.active falls through to the regular .chip.active
+   rule, which provides the selected-state colours. The left strip
+   remains visible on top, marking the chip as both selected and
+   locally promoted. */
 /* "Mehr Genres" toggle — visually a chip but stylistically a button so
    it does not look like another filter. */
 .chip--more {

--- a/internal/radiobrowser/radiobrowser.go
+++ b/internal/radiobrowser/radiobrowser.go
@@ -92,9 +92,14 @@ func New() *Client {
 }
 
 // SearchOpts buendelt alle Such Parameter.
+//
+// TagList is a list of substrings, each of which must match SOME tag
+// of a station (AND across the list, substring per element). Set this
+// for multi-word queries — see SearchSmart.
 type SearchOpts struct {
 	Name     string
 	Tag      string
+	TagList  []string
 	Country  string
 	Language string
 	Order    string
@@ -114,6 +119,9 @@ func (c *Client) Search(ctx context.Context, opts SearchOpts) ([]Station, error)
 	}
 	if opts.Tag != "" {
 		q.Set("tag", opts.Tag)
+	}
+	if len(opts.TagList) > 0 {
+		q.Set("tagList", strings.Join(opts.TagList, ","))
 	}
 	if opts.Country != "" {
 		q.Set("countrycode", strings.ToUpper(opts.Country))
@@ -143,6 +151,112 @@ func (c *Client) Search(ctx context.Context, opts SearchOpts) ([]Station, error)
 	var out []Station
 	err := c.fetchJSON(ctx, "/stations/search?"+q.Encode(), &out)
 	return out, err
+}
+
+// SearchSmart runs Search with the literal Name plus a tag-based
+// fallback for multi-word queries and merges the results. It exists
+// because radio-browser's `name` parameter is a plain substring match
+// against the station name field — multi-word queries like
+// "rap old school" almost never appear there literally, so users see
+// an empty list even though plenty of stations are tagged that way.
+//
+// Strategy:
+//
+//  1. Run the original Search (matches station names).
+//  2. If Name has two or more whitespace-separated tokens, run a
+//     second Search with TagList set to those tokens. radio-browser
+//     AND-matches the list, substring per element — so a station
+//     tagged "hip hop, rap, old school" satisfies all three of
+//     {rap, old, school}.
+//
+// Both queries respect the other filters (Country, Language, OnlyOK,
+// Order). Results are merged, deduplicated by station UUID, capped
+// at opts.Limit, and returned in vote order. Callers that have
+// already constrained the search to a tag chip (Tag != "") get the
+// plain Search behaviour — the user already narrowed the scope and
+// we should not widen it back.
+func (c *Client) SearchSmart(ctx context.Context, opts SearchOpts) ([]Station, error) {
+	if opts.Limit <= 0 {
+		opts.Limit = 30
+	}
+	if opts.Name == "" || opts.Tag != "" {
+		return c.Search(ctx, opts)
+	}
+	tokens := tokenize(opts.Name)
+
+	type result struct {
+		stations []Station
+		err      error
+	}
+	nameCh := make(chan result, 1)
+	tagCh := make(chan result, 1)
+
+	go func() {
+		st, err := c.Search(ctx, opts)
+		nameCh <- result{st, err}
+	}()
+	if len(tokens) >= 2 {
+		go func() {
+			tagOpts := opts
+			tagOpts.Name = ""
+			tagOpts.TagList = tokens
+			// Tag-based hits are often plentiful; fetch a wider
+			// page so the dedup-and-cap step has material to
+			// promote into the visible window.
+			tagOpts.Limit = opts.Limit * 2
+			st, err := c.Search(ctx, tagOpts)
+			tagCh <- result{st, err}
+		}()
+	} else {
+		close(tagCh)
+	}
+
+	nameRes := <-nameCh
+	var tagStations []Station
+	if r, ok := <-tagCh; ok {
+		tagStations = r.stations
+	}
+
+	if nameRes.err != nil && len(tagStations) == 0 {
+		return nil, nameRes.err
+	}
+
+	seen := make(map[string]bool, len(nameRes.stations)+len(tagStations))
+	merged := make([]Station, 0, len(nameRes.stations)+len(tagStations))
+	add := func(stations []Station) {
+		for _, s := range stations {
+			key := s.StationUUID
+			if key == "" {
+				key = s.Name + "|" + s.URL
+			}
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			merged = append(merged, s)
+		}
+	}
+	add(nameRes.stations)
+	add(tagStations)
+
+	if len(merged) > opts.Limit {
+		merged = merged[:opts.Limit]
+	}
+	return merged, nil
+}
+
+// tokenize splits a free-text query into trimmed, non-empty,
+// lowercase substrings on whitespace. Used by SearchSmart.
+func tokenize(s string) []string {
+	fields := strings.Fields(s)
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		f = strings.ToLower(strings.TrimSpace(f))
+		if f != "" {
+			out = append(out, f)
+		}
+	}
+	return out
 }
 
 // TopVote liefert die meistgevoteten Sender, gefiltert nach country.

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -419,7 +419,7 @@ func (s *Server) handleRadioSearch(w http.ResponseWriter, r *http.Request) {
 	if v := q.Get("offset"); v != "" {
 		fmt.Sscanf(v, "%d", &offset)
 	}
-	stations, err := rb.Search(ctx, radiobrowser.SearchOpts{
+	stations, err := rb.SearchSmart(ctx, radiobrowser.SearchOpts{
 		Name:     q.Get("q"),
 		Tag:      q.Get("tag"),
 		Country:  q.Get("cc"),


### PR DESCRIPTION
## What this changes

The radio search chip row used to be the global \`/tags?limit=24\` response from radio-browser. That list is dominated by Spanish-language noise tags (\`entretenimiento\`, \`méxico\`, \`español\`, ...) — top-of-list real-estate is wasted and the visible set rotates as the API data shifts.

This PR replaces it with a **curated, data-driven whitelist** plus a **per-country boost row** that bubbles the most locally relevant tags to the front.

## How it works

- \`GENRE_CORE\` — 15 globally relevant pills, always rendered: pop, rock, hits, oldies, jazz, classical, chillout, dance, electronic, house, hip hop, latin, 80s, 90s, news. Selection is data-driven from radio-browser's per-tag stationcount distribution plus Statista/Nielsen radio-format share.
- \`GENRE_BY_COUNTRY\` — max 2 boost tags per country (ISO 3166 alpha-2 → list of canonical tags). 33 countries covered today. Boost row sits in front of the core set with a \`.chip--boost\` style (brand-tinted background) so the user can spot at a glance which pills are tailored to their location.
- \`Mehr Genres (N)\` toggle — the auto-fetched long tail is still loaded and shown inline when expanded. Selected-tag protection: if a search filter is currently set to a tail tag, the expansion stays open so the user does not lose the visible selection.
- \`searchCountry\` change re-renders the chip row so the boost reflects the new country, and collapses the tail (previous tail entries may not apply to the new country).

## Worked example

User in DE: \`Alle · Schlager · Deutschrap · Pop · Rock · Hits · Oldies · Jazz · Klassik · Chill · Dance · Electronic · House · Hip Hop · Latin · 80er · 90er · Nachrichten · Mehr Genres (24)\`

User in US: \`Alle · Country · RnB · Pop · Rock · Hits · ...\`

User in JP: \`Alle · J-Pop · Anime · Pop · Rock · ...\`

## Coverage

DE / AT / CH / US / CA / AU / GB / IE / FR / IT / ES / PT / MX / AR / CO / CL / PE / VE / BR / JP / KR / IN / NL / BE / TR / PL / RU / UA / GR / SE / NO / DK / FI — 33 countries with locally relevant boost tags. Countries not in the map fall through to the bare core set, which is still a useful global default.

## Verification

- \`node --check\` on main.js passes.
- Vite hot-reload absorbs the change in the running \`wails dev\` instance, no compile errors.
- Switching the country dropdown re-renders the boost row (visible: Schlager → Country when toggling DE → US).