### PR TITLE
fix(ui): music-tab volume slider — visual fill + initial value + hw-button sync

### DIFF
--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -794,6 +794,12 @@ let musicVolTimer = null;
 let musicVolBox = null;
 const musicVolEl = $('musicVolume');
 const musicVolValEl = $('musicVolumeVal');
+// Drag-busy + grace period so the 2 s periodic refresh in
+// refreshStatus does not yank the thumb out from under the user
+// while they are wischen. musicVolUntil is the timestamp at which
+// auto-refresh is allowed to take over again after a release.
+state.musicVolBusy = false;
+state.musicVolUntil = 0;
 if (musicVolEl) {
   musicVolEl.oninput = () => {
     if (musicVolValEl) musicVolValEl.textContent = musicVolEl.value;
@@ -807,6 +813,45 @@ if (musicVolEl) {
         parseInt(musicVolEl.value, 10)).catch(showError);
     }, 200);
   };
+  // pointerdown/up flag is the most reliable cross-device drag
+  // signal. Keyboard arrows fire only `change`, which is already
+  // wired above, so the busy flag is unnecessary there. Add a
+  // ~1.2 s grace period after release so the network round-trip
+  // to the box (and its own state update) does not race with us.
+  const beginBusy = () => { state.musicVolBusy = true; };
+  const endBusy = () => {
+    state.musicVolBusy = false;
+    state.musicVolUntil = Date.now() + 1200;
+  };
+  musicVolEl.addEventListener('pointerdown', beginBusy);
+  musicVolEl.addEventListener('pointerup', endBusy);
+  musicVolEl.addEventListener('pointercancel', endBusy);
+  musicVolEl.addEventListener('pointerleave', () => {
+    if (state.musicVolBusy) endBusy();
+  });
+}
+
+// syncMusicTabVolumeFromBox refreshes the music-tab slider so
+// hardware-button volume changes on the box (or any other client
+// changing the volume out from under us) show up here within ~2 s.
+// Called from refreshStatus on every poll. Cheap to call: BoxSettings
+// caches well on the agent side.
+async function syncMusicTabVolumeFromBox() {
+  const box = state.currentBox;
+  if (!box || !musicVolEl) return;
+  if (state.view !== 'box') return;
+  if (state.musicVolBusy) return;
+  if (Date.now() < (state.musicVolUntil || 0)) return;
+  try {
+    const data = await BoxSettings(box.host, box.port);
+    const vol = (data && data.volume && data.volume.actual);
+    if (typeof vol !== 'number') return;
+    const current = parseInt(musicVolEl.value, 10);
+    if (current !== vol) {
+      musicVolEl.value = String(vol);
+      if (musicVolValEl) musicVolValEl.textContent = String(vol);
+    }
+  } catch {}
 }
 
 // checkSshBanner prueft via /api/stick/status ob auf der aktuellen
@@ -1071,6 +1116,12 @@ function selectBox(box) {
   refreshStatus();
   checkBoxUpdate();
   loadTaxonomy();
+  // Pull the current volume so the music-tab slider does not start
+  // at 0 — otherwise the first touch yanks it to whatever value the
+  // slider was last left at. The tab-switch path in switchView()
+  // also calls this, but a tab switch is not always involved (the
+  // box-select buttons can fire without leaving the music view).
+  loadMusicTabVolume();
   // Region vom Stick holen und als Default fuer Radio Suche nutzen.
   // Wenn der User schon manuell ein Land im Dropdown gewaehlt hat, nicht
   // ueberschreiben.
@@ -1669,6 +1720,10 @@ async function action(kind) {
 
 async function refreshStatus() {
   if (!state.currentBox || state.view !== 'box') return;
+  // Reflect hardware-button volume changes back into the slider.
+  // Fired in parallel with the Status fetch so a slow Status call
+  // does not delay the volume update. Cheap, drag-aware.
+  syncMusicTabVolumeFromBox();
   try {
     const xml = await Status(state.currentBox.host, state.currentBox.port);
     const name = decodeXmlEntities((xml.match(/<itemName>([^<]+)<\/itemName>/) || [])[1] || '');

--- a/desktop-app/frontend/src/style.css
+++ b/desktop-app/frontend/src/style.css
@@ -254,11 +254,16 @@ body {
 .btn-source-icon svg { display: block; }
 .volume-control { display: flex; align-items: center; gap: 8px; margin-left: auto; flex: 1; min-width: 180px; max-width: 300px; }
 .volume-control .vol-icon { font-size: 16px; opacity: 0.7; }
-.volume-control input[type=range] { flex: 1; -webkit-appearance: none; appearance: none; background: transparent; height: 22px; }
-.volume-control input[type=range]::-webkit-slider-runnable-track { background: #333; height: 4px; border-radius: 2px; }
-.volume-control input[type=range]::-webkit-slider-thumb { -webkit-appearance: none; appearance: none; background: var(--brand); width: 14px; height: 14px; border-radius: 50%; margin-top: -5px; cursor: pointer; }
-.volume-control input[type=range]::-moz-range-track { background: #333; height: 4px; border-radius: 2px; }
-.volume-control input[type=range]::-moz-range-thumb { background: var(--brand); width: 14px; height: 14px; border-radius: 50%; border: none; cursor: pointer; }
+/* Music tab volume slider: native control with accent-color so the
+   filled portion on the left renders in brand blue — matches the
+   slider in Box Einstellungen exactly. The previous custom -webkit
+   pseudo-elements drew their own gray track and blocked accent-color
+   from doing its job, leaving only the thumb visible in brand
+   colour. */
+.volume-control input[type=range] {
+  flex: 1;
+  accent-color: var(--brand);
+}
 .volume-control .vol-val { font-size: 12px; color: #aaa; min-width: 28px; text-align: right; }
 .btn { background: #2a2a2a; color: #eee; border: 1px solid #444; border-radius: 6px; padding: 8px 12px; cursor: pointer; font-size: 13px; }
 .btn:hover { background: #3a3a3a; }


### PR DESCRIPTION
Bundles three user-reported issues with the **Musik hoeren** volume slider into one fix:

## 1. No left-side brand fill

The slider didn't render the filled portion left of the thumb in brand blue — only the thumb itself was coloured. The **Box Einstellungen** slider has the correct fill.

**Root cause:** custom \`-webkit-slider-runnable-track\` / \`-moz-range-track\` rules drew a flat gray track and blocked the native \`accent-color\` from doing its job.

**Fix:** drop the custom pseudo-elements, set \`accent-color: var(--brand)\` — exactly what the settings slider does.

## 2. First touch yanks the volume

On the very first selection of a box, the slider sat at its default position, not the box's actual current volume. The user's first touch dragged the volume to whatever the slider happened to be on — often way louder than they wanted.

**Root cause:** \`loadMusicTabVolume()\` was only called from the tab-switch path. The box-select buttons (and the auto-select on first start) can change \`state.currentBox\` without leaving the music view, so the load never fired.

**Fix:** call \`loadMusicTabVolume()\` from \`selectBox()\` too.

## 3. Hardware buttons / IR remote don't reflect in the slider

Changing the volume via the speaker's hardware buttons (or any other client) didn't move the slider. The app drifted out of sync until the next deliberate slider drag.

**Fix:** new \`syncMusicTabVolumeFromBox()\` helper, called from the existing \`refreshStatus\` poll (2 s cadence already running on the music view). Drag-aware via \`pointerdown\`/\`pointerup\` busy flag with a 1.2 s grace window after release, so the periodic sync can never yank the thumb out from under the user mid-drag.

## Verification

- \`node --check main.js\` passes.
- Vite hot-reload absorbs both files cleanly.
- Cold-open → box shows the right slider position.
- Turning the volume knob on the box → slider in app moves within ~2 s.
- Dragging the slider → no jitter, no fight with periodic refresh.