### PR TITLE
docs: clarify the stick is for setup, not permanent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,14 +12,17 @@ them back **without any Bose cloud dependency**.
 
 ### Components
 
-- **Stick Agent** — a small Go binary on a USB flash drive that stays
-  plugged into the speaker. It emulates `streaming.bose.com` and the
-  Bose `bmx-cloud` services locally so the speaker pairs and accepts
-  presets. The agent persists itself to the speaker's NAND so it
-  survives reboots even if the stick is later removed.
+- **Stick Agent** — a small Go binary delivered via a USB stick used
+  for the initial install. The agent copies itself to the speaker's
+  NAND on first boot and from then on runs entirely from there — the
+  stick can be removed for normal operation. It emulates
+  `streaming.bose.com` and the Bose `bmx-cloud` services locally so
+  the speaker pairs and accepts presets.
 - **Desktop App (ST Reborn)** — Wails application for Windows, macOS,
-  Linux. Discovers sticks on the LAN via mDNS, ships a web UI for
-  browsing internet radio, managing presets, and controlling playback.
+  Linux. Discovers running agents on the LAN via mDNS, ships a web
+  UI for browsing internet radio, managing presets, and controlling
+  playback. Also performs the initial USB-stick provisioning and
+  later OTA agent updates.
 - **Website** — Astro site (English and German) at `st-reborn.de`
   with downloads, FAQ, privacy, imprint. Maintained in a separate
   repository.

--- a/README.md
+++ b/README.md
@@ -2,21 +2,21 @@
 
 **Cloud free firmware project for Bose SoundTouch speakers.**
 
-Bose discontinued their SoundTouch cloud service in February 2026. STR keeps the speakers usable: a small Go agent runs on a USB stick that stays plugged into the speaker. It emulates the missing cloud locally, talks to the speaker over the home network, and brings the hardware preset buttons back to life.
+Bose discontinued their SoundTouch cloud service in February 2026. STR keeps the speakers usable: a USB stick installs a small Go agent onto the speaker that emulates the missing cloud locally, talks to the speaker over the home network, and brings the hardware preset buttons back to life. **Once the agent is installed, the stick can be removed** — the agent persists on the speaker and survives reboots.
 
 ## What works
 
 - Internet Radio playback over the physical preset buttons 1 to 6
 - Desktop app for Windows and Mac with station search via radio-browser.info
-- Automatic discovery of all sticks on the LAN through mDNS
-- Multiple speakers in the same network, one stick each
-- Self contained on a USB stick, no separate server, no cloud account
+- Automatic discovery of every running agent on the LAN through mDNS
+- Multiple speakers in the same network; one USB stick is enough to install onto all of them in turn
+- No separate server, no cloud account
 
 Tested on SoundTouch 10. Other models on the roadmap.
 
 ## How it works in one paragraph
 
-The stick boots when the speaker is powered on and starts a small Go service. It hosts a stand in for the Bose cloud on the loopback interface and redirects the relevant DNS names so the speaker treats it as the real cloud. Internet Radio playback then happens over UPnP AVTransport on the speaker, which is supported natively. The hardware preset buttons are wired through the speaker's local WebSocket so a button press triggers playback of the saved station.
+After the first boot with the stick attached, the agent copies itself into the speaker's persistent storage and from then on starts automatically every time the speaker powers on — no stick required for normal use. It hosts a stand-in for the Bose cloud on the loopback interface and redirects the relevant DNS names so the speaker treats it as the real cloud. Internet Radio playback then happens over UPnP AVTransport on the speaker, which is supported natively. The hardware preset buttons are wired through the speaker's local WebSocket so a button press triggers playback of the saved station.
 
 ## Quick start for developers
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,7 @@ For severe issues a patched release and a public advisory will be published. Rep
 
 ## Threat Model
 
-STR (SoundTouch Reborn) runs on a USB stick plugged into a Bose SoundTouch speaker inside a user's home network. It also ships a desktop application and a website.
+STR (SoundTouch Reborn) installs a small agent onto a Bose SoundTouch speaker via a USB stick that is used for the initial install. After the install, the agent runs from the speaker's own persistent storage and the stick can be removed. It also ships a desktop application and a website.
 
 Critical trust boundaries:
 

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -14,8 +14,10 @@ companion.
 
 STR runs in a residential LAN and consists of:
 
-1. A small Go agent on a USB stick plugged into a Bose SoundTouch
-   speaker.
+1. A small Go agent installed onto a Bose SoundTouch speaker via a
+   USB stick. After the install the agent runs from the speaker's
+   own persistent storage; the stick is only needed for setup and
+   later for OTA agent updates.
 2. A cross-platform desktop application that discovers sticks via
    mDNS and offers a web UI.
 3. A static website that hosts downloads and documentation.


### PR DESCRIPTION
User feedback: \"der stick muss nicht dauerhaft in der box stecken\" — but several user-facing surfaces implied the opposite. The actual model:

1. plug stick in
2. agent copies itself to the speaker's NAND on first boot
3. stick can be removed; agent keeps running from NAND across reboots
4. stick is needed again only for OTA agent updates

## Surfaces fixed

- **README.md** — opening paragraph rewritten; **What works** list reframed (\"discovery of every running agent on the LAN\" rather than \"all sticks on the LAN\"); \"How it works in one paragraph\" expanded to explain the persist-to-NAND flow.
- **CLAUDE.md** — Components section: Stick Agent description corrected; Desktop App description expanded to mention OTA agent updates as well as initial provisioning.
- **SECURITY.md** — Threat Model scope updated.
- **docs/THREAT-MODEL.md** — Scope item 1 updated.

The website (\`st-reborn.de\`) lives in a separate repo; the user will mirror the corrected wording there.

## What I deliberately did not touch

- Code comments and identifiers that talk about \"the stick\" — those are technically accurate (the agent binary IS delivered via a stick) and the audience is contributors, not users.
- Translations / tagline copies in \`main.js\` — the existing taglines (\"Keep using your Bose SoundTouch speakers, without the Bose cloud.\") are neutral on the stick question; no fix needed.