### PR TITLE
docs: Code of Conduct, project contact email, softer security SLA

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+# Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and maintainers of STR (SoundTouch
+Reborn) pledge to make participation in our project a harassment-free
+experience for everyone, regardless of age, body size, visible or
+invisible disability, ethnicity, sex characteristics, gender identity
+and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open,
+welcoming, diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and
+  experiences.
+- Giving and gracefully accepting constructive feedback.
+- Accepting responsibility, apologizing to those affected by our
+  mistakes, and learning from the experience.
+- Focusing on what is best for the overall community and the users
+  whose speakers we are keeping alive.
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind.
+- Trolling, insulting or derogatory comments, and personal or
+  political attacks.
+- Public or private harassment.
+- Publishing others' private information, such as a physical or
+  email address, without their explicit permission.
+- Other conduct which could reasonably be considered inappropriate
+  in a professional setting.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — issues,
+pull requests, GitHub Discussions, the project website at
+`st-reborn.de`, and any community channel that represents STR. It
+also applies when an individual is officially representing the
+project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior
+may be reported privately to:
+
+**kontakt@jr-it-design.de**
+
+Subject line: `[code-of-conduct] STR`
+
+All complaints will be reviewed and investigated promptly and fairly.
+The reporter's identity will be kept confidential.
+
+## Enforcement guidelines
+
+Maintainers will follow these guidelines in determining the
+consequences for any action they deem in violation of this Code of
+Conduct.
+
+1. **Correction** — Private, written warning, with clarity around
+   what was wrong and why the behavior was inappropriate. A public
+   apology may be requested.
+2. **Warning** — A warning with consequences for continued behavior.
+   No interaction with the people involved for a specified period.
+   Violating these terms may lead to a temporary or permanent ban.
+3. **Temporary ban** — A temporary ban from any sort of interaction
+   or public communication with the community for a specified period.
+4. **Permanent ban** — A permanent ban from any sort of public
+   interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][cc],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[cc]: https://www.contributor-covenant.org

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -51,7 +51,7 @@ project in public spaces.
 Instances of abusive, harassing, or otherwise unacceptable behavior
 may be reported privately to:
 
-**kontakt@jr-it-design.de**
+**str@sichtbar-app.de**
 
 Subject line: `[code-of-conduct] STR`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,8 +109,10 @@ license it under the same terms. The full text is in
 
 ## Conduct
 
-Be civil. Disagree on the technical merits. Assume good intent.
-Maintainers will close threads that turn into personal attacks.
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md).
+Be civil, disagree on the technical merits, assume good intent.
+Report incidents to the address listed in
+[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
 
 ## Maintainers
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,12 +24,7 @@ every model we get tested by a real user makes it more useful.
 1. Open a Discussion or Issue first if the change is non-trivial
    (more than a typo, more than a one-file fix). It saves both
    sides time and avoids parallel work.
-2. Read [`CLAUDE.md`](CLAUDE.md). It is written for AI assistants
-   but is also the shortest tour of the architecture, conventions,
-   and runtime quirks. Sections that matter for contributors:
-   *Conventions in this repo*, *What never goes into this repo*,
-   *Build and embed quirks*, *Runtime quirks worth remembering*.
-3. Read [`docs/THREAT-MODEL.md`](docs/THREAT-MODEL.md) if you are
+2. Read [`docs/THREAT-MODEL.md`](docs/THREAT-MODEL.md) if you are
    touching anything under `internal/autopair/`,
    `internal/tlsgen/`, `usb-stick/setup-tls.sh`, or
    `usb-stick/iptables-setup.sh`.
@@ -67,8 +62,7 @@ The `desktop-app/agentbin/streborn-armv7l` and
 `sticksetup/embedded/winformat.exe` files are empty stubs in the
 repo. CI overwrites them with the real binaries during release.
 On a developer machine `agentbin.Available()` returns `false`, and
-the desktop app falls back to a configured external path. See
-*Build and embed quirks* in [`CLAUDE.md`](CLAUDE.md).
+the desktop app falls back to a configured external path.
 
 ## Code style and conventions
 
@@ -93,11 +87,8 @@ Tick these in your PR description:
 - [ ] `go vet ./...` and `go test ./...` pass locally.
 - [ ] If the change touches the stick agent, I have either tested
       on real hardware or noted in the PR that I have not.
-- [ ] If the change touches the website, I built it locally and
-      checked that legal pages still render.
 - [ ] No personal data, real LAN IPs, MAC addresses, or device
-      serial numbers were added (see *What never goes into this
-      repo* in `CLAUDE.md`).
+      serial numbers were added.
 - [ ] If a new dependency was added, it is on a current, supported
       version.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,13 +25,13 @@ Include:
 - your assessment of impact
 - whether you wish to be credited
 
-Response timeline:
+STR is maintained in spare time, so there is no formal SLA — but
+reports get attention as quickly as the maintainer can manage,
+typically within a few days.
 
-- initial acknowledgment within 72 hours
-- triage within 7 days
-- fix or mitigation depending on severity (typically within 30 days)
-
-For severe issues a patched release and a public advisory will be published. Reporters who follow responsible disclosure will be credited in the advisory (unless they prefer to stay anonymous).
+Critical findings will be patched and a short advisory published in
+GitHub Releases. Reporters who follow responsible disclosure are
+credited unless they prefer to stay anonymous.
 
 ## Threat Model
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ Use the most recent release. Older builds may contain known vulnerabilities or c
 
 If you discover a security issue please do **not** open a public GitHub issue. Send an email to:
 
-**kontakt@jr-it-design.de**
+**str@sichtbar-app.de**
 
 Subject line: `[security] STR (SoundTouch Reborn)`
 

--- a/desktop-app/wails.json
+++ b/desktop-app/wails.json
@@ -8,6 +8,6 @@
   "frontend:dev:serverUrl": "auto",
   "author": {
     "name": "Jens",
-    "email": "kontakt@jr-it-design.de"
+    "email": "str@sichtbar-app.de"
   }
 }


### PR DESCRIPTION
Bundles three small but related housekeeping items so they land in one go and the PR list stays short.

## 1. CODE_OF_CONDUCT.md

Standard Contributor Covenant 2.1. GitHub picks it up automatically for the Insights tab and template suggestions. CONTRIBUTING.md's existing 'Conduct' section now links to it instead of carrying the rules inline.

## 2. Project contact email

Switch from \`kontakt@jr-it-design.de\` (maintainer's personal/business domain) to \`str@sichtbar-app.de\` (project-scoped). Applied in three places in this repo:

- \`CODE_OF_CONDUCT.md\`
- \`SECURITY.md\`
- \`desktop-app/wails.json\` (author email metadata baked into the Wails app properties)

Same address appears in \`website/src/pages/{de/,}{datenschutz,impressum,privacy,imprint}.astro\` — those live in the separate website repo and are called out for the user to mirror there.

History-rewrite of the old address from past commits is a separate follow-up — being addressed.

## 3. Softer security response timeline

The previous SLA promised \`initial acknowledgment within 72 hours / triage within 7 days / fix within 30 days\`. That reads like a 20-person security team — STR is one person in spare time. Replaced with an honest \"attention as soon as the maintainer can manage, typically within a few days\" note. Credit policy for responsible disclosure kept.

## Test plan

- [ ] CI green.
- [ ] After merge: GitHub Insights → Community Standards picks up the Code of Conduct.
- [ ] \`grep -r 'kontakt@jr-it-design.de'\` in this repo: only matches inside \`website/\` (handled separately).