### PR TITLE
fix: OTA mkdir, setup wizard copy, SSH banner timing

### DIFF
--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -940,8 +940,13 @@ async function checkSshBanner() {
     const r = await fetch(`http://${box.host}:${box.port}/api/stick/status`);
     if (!r.ok) return;
     const data = await r.json();
-    if (data && data.sshOpen) gb.classList.remove('hidden');
-    else gb.classList.add('hidden');
+    // Only warn once the stick is no longer mounted on the box. While
+    // mounted, the agent is mid-setup or mid-update — SSH is expected
+    // to be open, the user cannot act on the warning yet, and the
+    // banner is just noise. After the stick is removed (or the next
+    // setup phase has unmounted it), the SSH state is meaningful.
+    const show = !!(data && data.sshOpen && !data.mounted);
+    gb.classList.toggle('hidden', !show);
   } catch {}
 }
 
@@ -2645,14 +2650,14 @@ function renderBoxSettings(s, box) {
       }
     } catch {}
 
-    // Globalen Top Banner toggeln — sshOpen ist die Quelle der Wahrheit
-    // (wir pruefen aktiv ob Port 22 listened). Mounted Stick allein
-    // reicht nicht, weil ein Stick ohne remote_services Datei den
-    // SSH Dienst nicht aktiviert.
+    // Show the warning banner only once the stick is no longer
+    // mounted — while a stick is in the box, the agent is either
+    // doing initial install or applying an update, SSH is expected
+    // to be open in that window, and the banner is just noise.
     const gb = $('globalSecurityBanner');
     if (gb) {
-      if (sshOpen) gb.classList.remove('hidden');
-      else gb.classList.add('hidden');
+      const show = sshOpen && !stickMounted;
+      gb.classList.toggle('hidden', !show);
     }
 
     const securityWarn = sshOpen ? `
@@ -3079,7 +3084,7 @@ function debounce(fn, ms) {
 
 $('view-setup').innerHTML = `
   <h2>USB-Stick vorbereiten</h2>
-  <p class="setup-intro">Stecke einen USB-Stick (mindestens 4 GB) in den Rechner. Die App findet ihn automatisch. Waehle ihn aus und klicke auf den Knopf unten. Danach wird der Stick automatisch ausgeworfen, und du steckst ihn in die Bose Box.</p>
+  <p class="setup-intro">Stecke einen USB-Stick (mindestens 4 GB) in den Rechner. Die App findet ihn automatisch. Waehle ihn aus und klicke auf den Knopf unten. Danach wird der Stick ausgeworfen — steck ihn <b>einmalig</b> in die Bose Box, damit sich der Agent von dort in den internen Speicher der Box installiert. Sobald die Box ueber den Stick neu gebootet hat (WLAN-LED leuchtet) kannst du den Stick wieder abziehen; die Box laeuft dann selbststaendig weiter. Den Stick brauchst du erst wieder fuer ein spaeteres Box-Update.</p>
   <div class="setup-section">
     <div class="setup-section-head">
       <h3>1. USB-Stick auswaehlen</h3>

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -629,6 +630,13 @@ func (s *Server) handleAgentUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	const dst = "/mnt/nv/streborn/bin/streborn-armv7l"
+	// On a fresh speaker the parent /mnt/nv/streborn/bin directory may
+	// not exist yet — first OTA after install hits this. Create it so
+	// the write does not 500 on "no such file or directory".
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		http.Error(w, "mkdir parent: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
 	tmp := dst + ".new"
 	if err := os.WriteFile(tmp, body, 0o755); err != nil {
 		http.Error(w, "write tmp: "+err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Three issues surfaced from real-use feedback right after v0.1.0 shipped:

## 1. OTA update fails on a fresh speaker

\`Update fehlgeschlagen: status 500: write tmp: open /mnt/nv/streborn/bin/streborn-armv7l.new: no such file or directory\`

\`handleAgentUpdate\` writes the new binary atomically via \`<dst>.new\` + rename, but on a freshly installed agent (first ever OTA) the parent \`/mnt/nv/streborn/bin/\` does not exist yet, so \`os.WriteFile\` returns ENOENT and the 500 bubbles up to the desktop app as an opaque failure.

Fix: \`os.MkdirAll(filepath.Dir(dst), 0o755)\` before the write. Three-line change.

## 2. Setup wizard copy still implies the stick stays in

The wizard intro said \"...du steckst ihn in die Bose Box\" with no follow-up, leaving users to assume the stick lives in the box permanently. Rewritten to spell out the actual flow:

> Stecke einen USB-Stick (mindestens 4 GB) in den Rechner. ... Danach wird der Stick ausgeworfen — steck ihn **einmalig** in die Bose Box, damit sich der Agent von dort in den internen Speicher der Box installiert. Sobald die Box ueber den Stick neu gebootet hat (WLAN-LED leuchtet) kannst du den Stick wieder abziehen; die Box laeuft dann selbststaendig weiter. Den Stick brauchst du erst wieder fuer ein spaeteres Box-Update.

Matches the wording line from the recent docs/stick-not-permanent pass.

## 3. Security banner shows during setup

The \"Empfehlung: USB-Stick aus der Box ziehen und Box neu starten\" banner fired whenever SSH was open on the box — including the entire setup phase where SSH is *expected* to be open and the user cannot act on the warning yet (the stick is mid-install).

Gate the banner on \`!mounted\` in both code paths that render it:

- \`checkSshBanner()\` — the periodic poll triggered by refreshStatus
- The inline render inside the Box-Einstellungen tab

The banner now appears only after the stick has been physically removed and SSH is still listening. That's the moment when the user can actually do something about it (reboot the box).