### PR TITLE
chore: maintainer name + GitHub Sponsors badge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,3 +109,12 @@ Report incidents to the address listed in
 
 See [`.github/CODEOWNERS`](.github/CODEOWNERS) for the current
 owners of each part of the tree.
+
+## Support the project
+
+If you cannot contribute code but want to help anyway, a donation
+keeps the lights on.
+
+[![GitHub Sponsors](https://img.shields.io/github/sponsors/JRpersonal?label=Sponsor%20on%20GitHub&logo=GitHub&color=ea4aaa)](https://github.com/sponsors/JRpersonal)
+
+More payment options are listed on [st-reborn.de](https://st-reborn.de/#donate).

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Jens Rabe (JRpersonal)
+Copyright (c) 2026 Jens Roggenfelder (JRpersonal)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -72,7 +72,11 @@ Issues and pull requests welcome. By submitting a contribution you agree to lice
 
 ## Support the project
 
-If STR helped bring your speaker back to life, please consider a donation. Sponsor button at the top of the repo or links on [st-reborn.de](https://st-reborn.de/#donate).
+If STR helped bring your speaker back to life, please consider a donation.
+
+[![GitHub Sponsors](https://img.shields.io/github/sponsors/JRpersonal?label=Sponsor%20on%20GitHub&logo=GitHub&color=ea4aaa)](https://github.com/sponsors/JRpersonal)
+
+More payment options on [st-reborn.de](https://st-reborn.de/#donate).
 
 ## Disclaimer
 

--- a/desktop-app/app.go
+++ b/desktop-app/app.go
@@ -528,7 +528,7 @@ func (a *App) AppInfo() AppInfo {
 	return AppInfo{
 		Version:           appVersion,
 		Build:             appBuild,
-		Author:            "Jens R. (JRpersonal)",
+		Author:            "Jens Roggenfelder (JRpersonal)",
 		GitHubURL:         "https://github.com/JRpersonal/streborn",
 		WebsiteURL:        "", // gefuellt sobald Website live ist
 		DonateURL:         "", // gefuellt sobald PayPal Link auf der Website ist


### PR DESCRIPTION
Two small, related housekeeping items.

## Name

\"Jens Rabe\" → \"Jens Roggenfelder\" in:
- \`LICENSE\` (copyright line)
- \`desktop-app/app.go\` (\`AppInfo.Author\`, rendered in the desktop app footer)

The matching strings in the website repo (\`website/src/pages/{de/,}{impressum,datenschutz,imprint,privacy}.astro\`) live in the separate streborn-website repo and need mirroring there.

## GitHub Sponsors badge

README and CONTRIBUTING get a markdown sponsor badge under their support-the-project sections:

\`\`\`markdown
[![GitHub Sponsors](https://img.shields.io/github/sponsors/JRpersonal?label=Sponsor%20on%20GitHub&logo=GitHub&color=ea4aaa)](https://github.com/sponsors/JRpersonal)
\`\`\`

Markdown image link, not the raw \`<iframe>\` form — GitHub's markdown sanitiser strips iframes, so the iframe variant would render as nothing. The iframe form is reserved for the website-side embed.