### PR TITLE
build(make): wails-dev / wails-build targets with embedded helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,42 @@
 # STR Makefile
-# Ziele:
-#   make build         lokales Binary für die aktuelle Plattform
-#   make build-arm     armv7l (SoundTouch 10/20/30)
-#   make build-arm64   arm64 (Reserve)
-#   make build-all     alle Architekturen
-#   make test          go test
-#   make vet           go vet
-#   make tidy          go mod tidy
-#   make clean         bin/ aufräumen
+# Targets:
+#   make build              local binary for the current platform
+#   make build-arm          armv7l (SoundTouch 10/20/30, real target)
+#   make build-arm64        arm64 (reserve)
+#   make build-all          all architectures
+#   make winformat-embed    cross-compile the FAT32 helper and drop
+#                           it into sticksetup/embedded/ so go:embed
+#                           picks it up. Cross-compiles from any host.
+#   make agent-embed        same idea for the ARM stick agent that
+#                           the desktop app embeds via go:embed.
+#   make wails-dev          run the desktop app in dev mode with the
+#                           embedded helpers freshly built. The one
+#                           command you run for everyday work.
+#   make wails-build        production build of the desktop app
+#                           with embedded helpers and version stamp.
+#   make test               go test ./...
+#   make vet                go vet ./...
+#   make tidy               go mod tidy
+#   make clean              wipe build outputs (keeps stubs)
 
 BINARY      := streborn
 PKG         := ./cmd/agent
 BIN_DIR     := bin
 VERSION     ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
-LDFLAGS     := -s -w -X main.version=$(VERSION)
+BUILD_STAMP ?= $(shell date -u '+%Y-%m-%d-%H%M')
+LDFLAGS     := -s -w -X main.version=$(VERSION) -X main.buildStamp=$(BUILD_STAMP)
+APP_LDFLAGS := -s -w -X main.appVersion=$(VERSION) -X main.appBuild=$(BUILD_STAMP)
 GO          ?= go
 
-.PHONY: all build build-arm build-arm64 build-all test vet tidy clean
+# Embed targets — must exist before go:embed in desktop-app/agentbin
+# and sticksetup respectively. CI overwrites the empty stubs that
+# are checked in; these targets do the same locally.
+WINFORMAT_OUT := sticksetup/embedded/winformat.exe
+AGENT_EMBED_OUT := desktop-app/agentbin/streborn-armv7l
+
+.PHONY: all build build-arm build-arm64 build-all \
+        winformat-embed agent-embed wails-dev wails-build \
+        test vet tidy clean
 
 all: build
 
@@ -36,6 +56,43 @@ build-arm64:
 
 build-all: build build-arm build-arm64
 
+# Cross-compiled, no CGO — works from Windows, Linux or macOS host.
+# Drops the real binary into the embed slot so the next `go build`
+# of the package picks it up; without this the stub stays empty
+# and sticksetup.formatVolume errors with "winformat Helper fehlt".
+winformat-embed:
+	@mkdir -p $(dir $(WINFORMAT_OUT))
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 \
+		$(GO) build -trimpath -ldflags="-s -w" -o $(WINFORMAT_OUT) ./cmd/winformat
+	@echo "embedded $$(stat -c %s $(WINFORMAT_OUT) 2>/dev/null || stat -f %z $(WINFORMAT_OUT)) bytes into $(WINFORMAT_OUT)"
+
+# Cross-compile the stick agent for the real ARMv7l target and
+# drop it into desktop-app/agentbin so the desktop app's go:embed
+# picks it up. Required for OTA-from-app to actually push a binary.
+agent-embed:
+	@mkdir -p $(dir $(AGENT_EMBED_OUT))
+	GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 \
+		$(GO) build -trimpath -ldflags="$(LDFLAGS)" -o $(AGENT_EMBED_OUT) $(PKG)
+	@echo "embedded $$(stat -c %s $(AGENT_EMBED_OUT) 2>/dev/null || stat -f %z $(AGENT_EMBED_OUT)) bytes into $(AGENT_EMBED_OUT)"
+
+# Run the desktop app in dev mode with embedded helpers freshly
+# built so format and OTA features actually work locally. The
+# `-reloaddirs ..` flag makes wails dev rebuild the Go backend
+# when a file in the root module (discovery, internal, cmd)
+# changes — not just the desktop-app dir.
+wails-dev: winformat-embed agent-embed
+	cd desktop-app && wails dev \
+		-ldflags "$(APP_LDFLAGS)" \
+		-reloaddirs ".."
+
+# Production-style local build. Embed slots populated, version
+# stamps wired in. Outputs to desktop-app/build/bin/.
+wails-build: winformat-embed agent-embed
+	cd desktop-app && wails build \
+		-ldflags "$(APP_LDFLAGS)" \
+		-trimpath \
+		-clean
+
 test:
 	$(GO) test ./...
 
@@ -47,3 +104,4 @@ tidy:
 
 clean:
 	rm -rf $(BIN_DIR)
+	rm -rf desktop-app/build/bin


### PR DESCRIPTION
Automates the two-step \`build helper -> wails ...\` dance so the desktop app's format + OTA features work locally without having to remember the right cross-compile flags.

## Background

Two of the desktop app's features need binaries that are not on a developer's machine by default:

- **OTA agent push** embeds \`desktop-app/agentbin/streborn-armv7l\`, the ARM stick agent built for the speaker. Empty stub by default.
- **USB stick FAT32 format** embeds \`sticksetup/embedded/winformat.exe\`, a tiny Windows helper. Empty stub by default.

CI populates both during a release. Locally, \`wails dev\` previously inherited the empty stubs — OTA returned \"write tmp: no such file or directory\" on the box, and format errored with \"winformat Helper fehlt im Build\".

## New targets

| Target | What it does |
|---|---|
| \`make wails-dev\` | builds both embed slots, then runs \`wails dev -reloaddirs ..\` with version stamps so the running app reports something other than \`dev / dev\` |
| \`make wails-build\` | same prep, production \`wails build -trimpath -clean\` |
| \`make winformat-embed\` | standalone: cross-compile FAT32 helper for windows/amd64 |
| \`make agent-embed\` | standalone: cross-compile stick agent for linux/arm/7 |

All cross-compiles use \`CGO_ENABLED=0\` and pure-Go syscalls, so the targets work from a Windows, Linux, or macOS host.

\`make clean\` now also wipes \`desktop-app/build/bin\`. Updated header comment lists every target so \`make\` with no args followed by reading the file is enough to onboard.