### PR TITLE
ci: auto-notify website + manual release trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ on:
     tags:
       - 'v*.*.*'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (must match vX.Y.Z, e.g. v0.3.0)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -110,9 +115,21 @@ jobs:
 
       - name: Derive version and build stamp
         id: version
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
+          # Three ways to enter this workflow:
+          #   1. push of a vX.Y.Z tag      → use the tag
+          #   2. workflow_dispatch + input → validate + use the input
+          #   3. workflow_dispatch w/o input (legacy) → dev build
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             VERSION="${GITHUB_REF#refs/tags/}"
+          elif [[ -n "${INPUT_VERSION}" ]]; then
+            VERSION="${INPUT_VERSION}"
+            if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+              echo "::error::version input '$VERSION' does not match vX.Y.Z[-suffix]"
+              exit 1
+            fi
           else
             VERSION="dev-$(git rev-parse --short HEAD)"
           fi
@@ -458,7 +475,12 @@ jobs:
       - build-desktop-windows
       - build-desktop-linux
       - build-desktop-macos
-    if: startsWith(github.ref, 'refs/tags/')
+    # Publish either on tag push or on a manual workflow_dispatch
+    # that supplies a version input. Plain workflow_dispatch with no
+    # input remains a build-only dry-run.
+    if: |
+      startsWith(github.ref, 'refs/tags/') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.version != '')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -621,9 +643,15 @@ jobs:
           cat release-notes.md
 
       - name: Publish GitHub Release
-        # softprops/action-gh-release v2.0.8 pinned to SHA
+        # softprops/action-gh-release v2.0.8 pinned to SHA.
+        # tag_name is explicit so the workflow_dispatch path works:
+        # the action creates the tag at github.sha when it does not
+        # already exist. The tag-push path uses the same value (the
+        # version derived from the pushed tag), so behaviour matches.
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191
         with:
+          tag_name: ${{ needs.build-agent.outputs.version }}
+          target_commitish: ${{ github.sha }}
           body_path: dist/release-notes.md
           files: |
             dist/STR-Windows.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -638,3 +638,25 @@ jobs:
           generate_release_notes: false
           draft: false
           prerelease: false
+
+      # Releases created via the default GITHUB_TOKEN deliberately do
+      # NOT fire `release: published` workflow triggers downstream — a
+      # GitHub-side safeguard against accidental loops. So a separate
+      # notify-website workflow listening for that event never runs
+      # after a tag-driven release. Dispatch directly from here using
+      # a fine-grained PAT instead; the website repo's deploy listens
+      # for repository_dispatch / app-release-published.
+      - name: Notify streborn-website
+        # peter-evans/repository-dispatch v3.0.0
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.WEBSITE_DISPATCH_PAT }}
+          repository: JRpersonal/streborn-website
+          event-type: app-release-published
+          client-payload: |
+            {
+              "tag": "${{ needs.build-agent.outputs.version }}",
+              "url": "${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.build-agent.outputs.version }}",
+              "build": "${{ needs.build-agent.outputs.build_stamp }}",
+              "commit": "${{ github.sha }}"
+            }


### PR DESCRIPTION
Two related release-pipeline fixes, both in release.yml.

## 1. Auto-notify website never fired

\`notify-website.yml\` listens for \`release: published\` but GitHub deliberately suppresses downstream workflow triggers when the event was caused by the default \`GITHUB_TOKEN\` (safeguard against loops). \`softprops/action-gh-release\` uses \`GITHUB_TOKEN\`, so v0.1.0 and v0.2.0 both shipped without firing the website rebuild — I had to manually \`workflow_dispatch\` both times.

**Fix:** dispatch \`app-release-published\` from inside release.yml's release job as a final step, using the \`WEBSITE_DISPATCH_PAT\` secret. Explicit chain, no GITHUB_TOKEN suppression in the way. \`notify-website.yml\` stays for manual workflow_dispatch testing.

## 2. Manual release trigger from the Actions UI

Tagging locally + \`git push\` is the current way to ship. Add a manual path so you can also trigger a release entirely from the GitHub UI without touching local:

- New \`workflow_dispatch.inputs.version\` (validated against \`vX.Y.Z[-suffix]\`).
- Release-job if-gate widened to also fire on dispatch when version input is non-empty.
- \`softprops/action-gh-release\` gets \`tag_name\` + \`target_commitish\` explicit, so it creates the tag at \`github.sha\` when missing. Tag-push path is unchanged (values match).
- Dispatch without a version input keeps the legacy dry-run behaviour: build everything, skip publish.

UX: open Actions → release → 'Run workflow' → branch=main, version=v0.3.0 → Run. Full pipeline runs, tag is created at main HEAD, release publishes, website rebuilds, all hands-off.

Re-using an existing version (e.g. v0.2.0) fails fast in the publish step because the tag already exists — intended.

## Verified

- Manual workflow_dispatch on notify-website.yml ran successfully against streborn-website earlier.
- Build of the workflow file passes YAML parsing (gh CLI server-side fetch worked).