### PR TITLE
fix(usb-stick): auto-sync NAND from stick when version differs

### DIFF
--- a/usb-stick/run.sh
+++ b/usb-stick/run.sh
@@ -33,11 +33,38 @@ fi
 STICK_BIN="$STICK/streborn-armv7l"
 [ -e "$STICK_BIN" ] || STICK_BIN="$STICK/streborn"
 CACHED_BIN="$PERSIST/bin/streborn-armv7l"
+STICK_VER_FILE="$STICK/version.txt"
+NAND_VER_FILE="$PERSIST/version.txt"
 
 mkdir -p "$PERSIST/bin" "$PERSIST/logs" "$PERSIST/state" 2>/dev/null
 
 log() {
     echo "$(date): $*" >> "$LOG"
+}
+
+# Auto-sync trigger: a freshly prepared stick (Setup-Wizard) ships a
+# version.txt. If that string differs from the version we recorded
+# for the NAND cache the stick is authoritative — the user just
+# prepared it explicitly, so apply it. Without this, sync only
+# happens when something else touches $SYNC_FLAG, but the flag
+# path is on NAND and the Setup Wizard cannot write there.
+maybe_force_sync_on_version_mismatch() {
+    if [ ! -r "$STICK_VER_FILE" ]; then
+        return 0
+    fi
+    STICK_VER=$(cat "$STICK_VER_FILE" 2>/dev/null | tr -d '\r\n')
+    NAND_VER=""
+    if [ -r "$NAND_VER_FILE" ]; then
+        NAND_VER=$(cat "$NAND_VER_FILE" 2>/dev/null | tr -d '\r\n')
+    fi
+    if [ -z "$STICK_VER" ]; then
+        return 0
+    fi
+    if [ "$STICK_VER" = "$NAND_VER" ]; then
+        return 0
+    fi
+    log "version mismatch: stick='$STICK_VER' nand='$NAND_VER' — forcing sync"
+    touch "$SYNC_FLAG"
 }
 
 # NUR wenn Sync Flag gesetzt ist: Stick -> NAND kopieren.
@@ -55,6 +82,13 @@ sync_from_stick_if_requested() {
         chmod +x "$CACHED_BIN.new"
         mv "$CACHED_BIN.new" "$CACHED_BIN"
         log "Stick Binary in NAND Cache gesynct"
+        # Record the version that now lives in the NAND cache so
+        # the next boot's version check has something to compare
+        # against.
+        if [ -r "$STICK_VER_FILE" ]; then
+            cp "$STICK_VER_FILE" "$NAND_VER_FILE" 2>/dev/null
+            log "NAND version.txt aktualisiert: $(cat "$NAND_VER_FILE" 2>/dev/null)"
+        fi
         rm -f "$SYNC_FLAG"
         return 0
     fi
@@ -64,6 +98,7 @@ sync_from_stick_if_requested() {
     return 1
 }
 
+maybe_force_sync_on_version_mismatch
 sync_from_stick_if_requested
 
 # Binary Auswahl: NAND Cache zuerst, Stick als Fallback.


### PR DESCRIPTION
## What broke

A freshly prepared USB stick (Setup Wizard, current desktop app's agent + version.txt) is silently ignored if the box already has a cached agent in /mnt/nv/streborn/bin/. The user prepares the stick, plugs it in, reboots, and the box keeps running the previously cached agent. There is no autonomous recovery path — without SSH the box never picks up the new agent.

Reproduced on a real ST10 today: stick prepared with v0.2.0-1, plugged in, two power cycles, mDNS still reported the agent as 311d1da-dirty from a months-old OTA push.

## Root cause

\`run.sh\` had an explicit \"NAND is source of truth, stick is fallback\" policy:

\`\`\`sh
sync_from_stick_if_requested() {
    if [ ! -f \"\$SYNC_FLAG\" ]; then
        return 0
    fi
    ...
}
\`\`\`

Sync only fires when \`/mnt/nv/streborn/sync-from-stick\` exists. The Setup Wizard cannot create that file because it lives on NAND, not on the stick.

## Fix

Before the sync-flag check, compare the stick's \`version.txt\` (written by the Setup Wizard with the desktop app's version) against \`/mnt/nv/streborn/version.txt\`. If they differ, set the sync flag ourselves. The existing copy path then runs and, on success, persists the new version string to NAND.

Cases:
- Stick has no \`version.txt\` → noop, behave as before (defensive).
- NAND has no \`version.txt\` → sync (this is the first install with stick metadata).
- Versions equal → noop (steady state — stick stays in for OTA support, no extra writes).
- Versions differ → sync.

## Recovery path on the box now

Box already has an older agent in NAND, user prepares a new stick, plugs it in, reboots twice:

1. First reboot: old NAND-side \`run-override.sh\` runs. Agent (old) boots from cached binary. After 5 s the agent's existing \`syncRunOverrideFromStick\` copies the fresh stick run.sh into NAND.
2. Second reboot: rc.local picks the updated NAND-side run-override.sh which now contains the version-mismatch check. Mismatch detected, sync runs, NAND cache replaced, version.txt updated. Agent (new) starts.

No SSH, no manual flag-touch.

## Defensive shape kept

- No infinite loop: post-sync the versions match.
- No accidental downgrade: stick authority requires the user to have explicitly prepared the stick (Setup Wizard is the only thing that writes version.txt).
- No new attack surface: same files, same paths.