### PR TITLE
fix(usb-stick): recover from USB-mount race, make stick auto-update

### DIFF
--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -47,6 +47,12 @@ const state = {
   searchResults: [],
   drives: [],
   selectedDrive: null,
+  // Set right after a successful prepare+eject. While set,
+  // refreshDrives() hides that path from the list until it either
+  // disappears (physical pull) or comes back with a valid FAT32
+  // mount. Prevents the wizard re-rendering the ejected stick as
+  // "unknown format". Cleared by the "Neu suchen" button.
+  justEjectedPath: null,
   appInfo: null,
   nowLocation: '',     // aktueller stream url aus now_playing
   nowName: '',         // aktueller itemName aus now_playing
@@ -3227,8 +3233,30 @@ async function prefillWizardFromStick(path) {
 
 async function refreshDrives(clearResult) {
   state.selectedDrive = null;
+  // Manual "Neu suchen" click clears the just-ejected guard so the
+  // wizard returns to its normal listing behaviour.
+  if (clearResult) {
+    state.justEjectedPath = null;
+  }
   try {
     state.drives = await ListDrives() || [];
+    // Filter out a stick we just ejected: Windows reports the
+    // dismounted volume for a few seconds with totalBytes=0 and an
+    // empty filesystem, which the wizard otherwise reads as "unknown
+    // format, must be reformatted" — confusing right after a
+    // successful prepare. If the same path comes back with a valid
+    // FAT32 mount (user pulled and re-inserted), allow it again.
+    if (state.justEjectedPath) {
+      state.drives = state.drives.filter(d => {
+        if (d.path !== state.justEjectedPath) return true;
+        const looksMounted = d.totalBytes > 0 && (d.filesystem || '').toUpperCase() === 'FAT32';
+        if (looksMounted) {
+          state.justEjectedPath = null;
+          return true;
+        }
+        return false;
+      });
+    }
     // Erfolgsmeldung nur loeschen wenn der User AKTIV neu gesucht hat
     // (Button Klick). Beim automatischen Refresh nach Setup soll die
     // Erfolgsmeldung sichtbar bleiben.
@@ -3424,6 +3452,14 @@ async function doSetup() {
       await EjectDrive(drive.path);
       html += '<p>Stick wurde ausgeworfen. Jetzt entnehmen und in den USB Port der Bose Box stecken. Beim ersten Boot dauert es etwa eine Minute, dann kannst du im Tab <b>Musik hoeren</b> die Box bedienen.</p>';
       html += '<p class="setup-warn"><b>Wichtig:</b> Der Stick ist jetzt fuer genau diese Box konfiguriert. Beim ersten Boot wendet die Box die Einstellungen an und loescht alle Geheimnisse (z.B. WLAN Passwort) vom Stick. Wenn du spaeter eine andere Box einrichten oder geaenderte Werte aufspielen willst, musst du den Stick zuerst wieder hier vorbereiten.</p>';
+      // Remember the path we just ejected. Windows keeps reporting the
+      // dismounted volume for a few seconds with totalBytes=0 and an
+      // empty filesystem string. refreshDrives would then auto-select
+      // it and updateDrivePanels would render the misleading "Stick ist
+      // unbekannt formatiert" warning right under the success message.
+      // Hide it until the user either pulls + re-inserts (path becomes
+      // valid again) or clicks "Neu suchen" explicitly.
+      state.justEjectedPath = drive.path;
     } catch (ejErr) {
       html += '<p class="setup-warn">Die Daten sind drauf, aber das automatische Auswerfen ging nicht: <small>' + escapeHtml(String(ejErr)) + '</small> Bitte ueber den Explorer "Auswerfen".</p>';
     }

--- a/usb-stick/provision-wlan.sh
+++ b/usb-stick/provision-wlan.sh
@@ -1,14 +1,22 @@
 #!/bin/sh
-# provision-wlan.sh: liest /media/sda1/wlan.conf und uebermittelt das WLAN
-# Profil an die BoseApp HTTP API damit sich die Box automatisch verbindet.
+# provision-wlan.sh: DEPRECATED.
 #
-# wlan.conf Format (key=value):
+# WLAN provisioning is now handled inline by run.sh: it parses the
+# JSON wlan.conf written by the Desktop App setup wizard
+# ({"ssid":"...","password":"..."}) and writes
+# /etc/wpa_supplicant.conf directly, then restarts wpa_supplicant.
+# That path is reliable and does not depend on the BoseApp HTTP API
+# being up early enough.
+#
+# This script remains on the stick as a manual fallback only. It
+# expects a key=value wlan.conf and posts an addWirelessProfile to
+# the BoseApp HTTP API. The Desktop App does NOT produce that
+# format. If you need to run this manually, write wlan.conf as:
 #   ssid=MyHomeWifi
 #   security=wpa2     (oder wpa, wpa_or_wpa2, wep, open)
 #   passphrase=secret-password
-#
-# Aufruf:  sh /media/sda1/provision-wlan.sh
-# Logs:    /mnt/nv/streborn/wlan-provision.log
+# Then: sh /media/sda1/provision-wlan.sh
+# Logs: /mnt/nv/streborn/wlan-provision.log
 
 set -u
 

--- a/usb-stick/rc.local
+++ b/usb-stick/rc.local
@@ -14,6 +14,44 @@ mkdir -p "$LOGDIR" 2>/dev/null || true
 # Erster Reboot Marker, hilft beim Debuggen falls Stick fehlt
 echo "$(date): rc.local triggered" >> "$LOGDIR/boot.log"
 
+# USB stick is mounted async by udev. Both the NAND override path
+# and the fallback path need /media/sda1 (binary, version.txt,
+# wlan.conf). Wait up to 30s for the stick before deciding —
+# otherwise run.sh fires, finds an empty NAND cache plus a
+# not-yet-mounted stick, and aborts with "weder NAND Cache noch
+# Stick Binary verfuegbar". The stick may legitimately never
+# appear (post-install, user pulled it). In that case we still
+# fall back to NAND override below.
+i=0
+while [ $i -lt 30 ]; do
+    if [ -e /media/sda1/run.sh ] || [ -e /media/sda1/streborn-armv7l ]; then
+        echo "$(date): stick detected after ${i}s" >> "$LOGDIR/boot.log"
+        break
+    fi
+    sleep 1
+    i=$((i+1))
+done
+
+# Self-update from stick if present and newer. This is what makes
+# the stick the single repair channel — once an updated stick is
+# inserted, the next boot picks up new rc.local + run-override.sh
+# without anyone running install.sh again.
+#   * rc.local update takes effect on the NEXT boot (this run is
+#     already past the wait loop, but cannot safely re-exec itself
+#     without risking a loop).
+#   * run-override.sh update takes effect on THIS boot because we
+#     invoke it immediately below.
+if [ -f /media/sda1/rc.local ] && [ /media/sda1/rc.local -nt /mnt/nv/rc.local ]; then
+    cp /media/sda1/rc.local /mnt/nv/rc.local 2>/dev/null
+    chmod +x /mnt/nv/rc.local 2>/dev/null
+    echo "$(date): /mnt/nv/rc.local updated from stick (effective next boot)" >> "$LOGDIR/boot.log"
+fi
+if [ -f /media/sda1/run.sh ] && [ /media/sda1/run.sh -nt /mnt/nv/streborn/run-override.sh ]; then
+    cp /media/sda1/run.sh /mnt/nv/streborn/run-override.sh 2>/dev/null
+    chmod +x /mnt/nv/streborn/run-override.sh 2>/dev/null
+    echo "$(date): /mnt/nv/streborn/run-override.sh updated from stick (effective this boot)" >> "$LOGDIR/boot.log"
+fi
+
 # NAND Override hat Prioritaet. Damit koennen Updates ueberleben auch
 # wenn die SD Karte read only ist oder eine alte run.sh hat.
 NAND_OVERRIDE="/mnt/nv/streborn/run-override.sh"
@@ -23,18 +61,12 @@ if [ -x "$NAND_OVERRIDE" ]; then
     exit 0
 fi
 
-# Auf USB Stick warten (bis zu 30 Sekunden)
-i=0
-while [ $i -lt 30 ]; do
-    if [ -x /media/sda1/run.sh ]; then
-        echo "$(date): run.sh gefunden nach $i s" >> "$LOGDIR/boot.log"
-        # Detached starten, damit shelby_local sofort weiter kommt
-        nohup /media/sda1/run.sh > "$LOGDIR/run.out" 2>&1 &
-        exit 0
-    fi
-    sleep 1
-    i=$((i+1))
-done
+# Fallback ohne NAND override: stick run.sh direkt starten falls da.
+if [ -x /media/sda1/run.sh ]; then
+    echo "$(date): kein NAND override, nutze /media/sda1/run.sh" >> "$LOGDIR/boot.log"
+    nohup /media/sda1/run.sh > "$LOGDIR/run.out" 2>&1 &
+    exit 0
+fi
 
-echo "$(date): run.sh nach 30 s nicht gefunden, USB Stick fehlt" >> "$LOGDIR/boot.log"
+echo "$(date): weder NAND override noch /media/sda1/run.sh — USB Stick fehlt" >> "$LOGDIR/boot.log"
 exit 1

--- a/usb-stick/run.sh
+++ b/usb-stick/run.sh
@@ -98,6 +98,39 @@ sync_from_stick_if_requested() {
     return 1
 }
 
+# Defense in depth: if the NAND cache is empty and the stick mount
+# is still racing in (rc.local should have waited, but a direct
+# invocation of run.sh may skip that), give the stick up to 20s to
+# appear. Otherwise the version-mismatch sync below has nothing to
+# work with and we abort immediately.
+if [ ! -x "$CACHED_BIN" ]; then
+    j=0
+    while [ $j -lt 20 ]; do
+        if [ -e "$STICK_BIN" ] || [ -e "$STICK_VER_FILE" ]; then
+            log "stick became visible after ${j}s wait"
+            break
+        fi
+        sleep 1
+        j=$((j+1))
+    done
+fi
+
+# Defense in depth: redeploy rc.local + run-override.sh from stick
+# if newer. rc.local itself does the same — but if a buggy
+# rc.local on NAND skipped that step (e.g. older release without
+# the self-update block), this run.sh invocation can still fix it
+# so the NEXT boot uses the fresh files.
+if [ -f /media/sda1/rc.local ] && [ /media/sda1/rc.local -nt /mnt/nv/rc.local ]; then
+    cp /media/sda1/rc.local /mnt/nv/rc.local 2>/dev/null
+    chmod +x /mnt/nv/rc.local 2>/dev/null
+    log "redeployed /mnt/nv/rc.local from stick (effective next boot)"
+fi
+if [ -f /media/sda1/run.sh ] && [ /media/sda1/run.sh -nt /mnt/nv/streborn/run-override.sh ]; then
+    cp /media/sda1/run.sh /mnt/nv/streborn/run-override.sh 2>/dev/null
+    chmod +x /mnt/nv/streborn/run-override.sh 2>/dev/null
+    log "redeployed /mnt/nv/streborn/run-override.sh from stick (effective next boot)"
+fi
+
 maybe_force_sync_on_version_mismatch
 sync_from_stick_if_requested
 

--- a/usb-stick/run.sh
+++ b/usb-stick/run.sh
@@ -33,11 +33,38 @@ fi
 STICK_BIN="$STICK/streborn-armv7l"
 [ -e "$STICK_BIN" ] || STICK_BIN="$STICK/streborn"
 CACHED_BIN="$PERSIST/bin/streborn-armv7l"
+STICK_VER_FILE="$STICK/version.txt"
+NAND_VER_FILE="$PERSIST/version.txt"
 
 mkdir -p "$PERSIST/bin" "$PERSIST/logs" "$PERSIST/state" 2>/dev/null
 
 log() {
     echo "$(date): $*" >> "$LOG"
+}
+
+# Auto-sync trigger: a freshly prepared stick (Setup-Wizard) ships a
+# version.txt. If that string differs from the version we recorded
+# for the NAND cache the stick is authoritative — the user just
+# prepared it explicitly, so apply it. Without this, sync only
+# happens when something else touches $SYNC_FLAG, but the flag
+# path is on NAND and the Setup Wizard cannot write there.
+maybe_force_sync_on_version_mismatch() {
+    if [ ! -r "$STICK_VER_FILE" ]; then
+        return 0
+    fi
+    STICK_VER=$(cat "$STICK_VER_FILE" 2>/dev/null | tr -d '\r\n')
+    NAND_VER=""
+    if [ -r "$NAND_VER_FILE" ]; then
+        NAND_VER=$(cat "$NAND_VER_FILE" 2>/dev/null | tr -d '\r\n')
+    fi
+    if [ -z "$STICK_VER" ]; then
+        return 0
+    fi
+    if [ "$STICK_VER" = "$NAND_VER" ]; then
+        return 0
+    fi
+    log "version mismatch: stick='$STICK_VER' nand='$NAND_VER' — forcing sync"
+    touch "$SYNC_FLAG"
 }
 
 # NUR wenn Sync Flag gesetzt ist: Stick -> NAND kopieren.
@@ -55,6 +82,13 @@ sync_from_stick_if_requested() {
         chmod +x "$CACHED_BIN.new"
         mv "$CACHED_BIN.new" "$CACHED_BIN"
         log "Stick Binary in NAND Cache gesynct"
+        # Record the version that now lives in the NAND cache so
+        # the next boot's version check has something to compare
+        # against.
+        if [ -r "$STICK_VER_FILE" ]; then
+            cp "$STICK_VER_FILE" "$NAND_VER_FILE" 2>/dev/null
+            log "NAND version.txt aktualisiert: $(cat "$NAND_VER_FILE" 2>/dev/null)"
+        fi
         rm -f "$SYNC_FLAG"
         return 0
     fi
@@ -64,6 +98,7 @@ sync_from_stick_if_requested() {
     return 1
 }
 
+maybe_force_sync_on_version_mismatch
 sync_from_stick_if_requested
 
 # Binary Auswahl: NAND Cache zuerst, Stick als Fallback.


### PR DESCRIPTION
## Summary

- **rc.local**: wait up to 30s for `/media/sda1` before invoking NAND override (USB mount races against shelby_local at boot).
- **rc.local + run.sh**: re-deploy `/mnt/nv/rc.local` and `/mnt/nv/streborn/run-override.sh` from the stick when newer — future fixes propagate by inserting an updated stick, no SSH-triggered install.sh needed after the first onboarding.
- **run.sh**: defense-in-depth wait (20s) so a direct invocation still tolerates a slow mount.
- **provision-wlan.sh**: re-labeled deprecated; run.sh parses wlan.conf and writes wpa_supplicant.conf inline.
- **wizard UX**: hide the just-ejected drive from the list (Windows reports it for a few seconds with totalBytes=0 / empty FS, which the wizard otherwise reads as "unknown format, must be reformatted" right under the success message).

## Why

Reproduced end-to-end on real hardware (SoundTouch 10, firmware 27.0.6). Before the fix:

- Factory-reset box would boot with stick inserted
- Old rc.local fired immediately, invoked NAND override
- run.sh saw neither stick binary (mount not done yet) nor NAND cache (empty on fresh install) → aborted
- Agent never came up, box stuck

After the fix:

\`\`\`
20:42:01  /mnt/nv/rc.local updated from stick (effective next boot)
20:42:01  /mnt/nv/streborn/run-override.sh updated from stick (effective this boot)
20:42:01  version mismatch — forcing sync
20:42:03  Stick Binary in NAND Cache gesynct
20:42:04  WLAN provisioniert, Region DE, Box Name persistiert
20:42:06  Agent gestartet mit PID 1948
\`\`\`

## Test plan

- [x] Local Wails build with embedded helpers
- [x] Wrote stick via wizard (FAT32 format + 13 entries + region + name + WLAN)
- [x] Factory-reset SoundTouch 10, inserted stick, booted: race fixed, self-update copied new rc.local + run-override.sh to NAND, binary synced, agent up
- [x] Wizard UX: prepare + eject no longer triggers "unknown format" warning on the just-ejected drive

🤖 Generated with [Claude Code](https://claude.com/claude-code)