### PR TITLE
ci: enable release pipeline dry-run via workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,16 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version (must match vX.Y.Z, e.g. v0.3.0)'
-        required: true
+        # Leave empty for a build-only dry-run: the full pipeline
+        # runs (verify-source, build-agent, all three desktop OS
+        # builds, Sigstore attestation of every artifact) but the
+        # final publish step is skipped. Use this after any
+        # Dependabot bump of a release-only action
+        # (attest-build-provenance, action-gh-release, or
+        # upload-artifact's release.yml usage pattern) to confirm
+        # the next real tag will work.
+        description: 'Release version (vX.Y.Z, e.g. v0.3.0). Leave empty for a build-only dry-run.'
+        required: false
         type: string
 
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,26 @@ measurable, not aspirational:
 Code signing, notarization, additional models, and Wails sandboxing
 are post-1.0.
 
+## Release pipeline dry-run
+
+After Dependabot bumps a release-only action — `attest-build-provenance`,
+`action-gh-release`, or the release.yml usage of `upload-artifact` —
+the change is not exercised by PR CI (those actions only live in
+`release.yml`, which runs on tag push or `workflow_dispatch`).
+
+To smoke-test before the next real tag, dispatch the release workflow
+without a version input:
+
+```bash
+gh workflow run release.yml
+```
+
+The pipeline runs verify-source, builds the agent and all three
+desktop OS packages, and attests every artifact via Sigstore. The
+final `Publish GitHub Release` step is skipped automatically when
+the version input is empty. If this green-checks, the next real
+`vX.Y.Z` tag will work.
+
 ## Build version stamping
 
 The Wails desktop app embeds the ARM stick agent binary and is the


### PR DESCRIPTION
## What

Flip `workflow_dispatch.inputs.version.required` from `true` to `false` in `release.yml`, so the build-only dry-run path that was already wired into the publish-job's `if:` conditional becomes reachable.

## Why

After this batch of Dependabot bumps:
- #14 `actions/setup-go` 5 → 6
- #3 `actions/setup-node` 4 → 6
- #13 `actions/upload-artifact` 4 → 7
- #1 `actions/attest-build-provenance` 2 → 4
- #15 `softprops/action-gh-release` 2 → 3

…the release-only actions (`attest-build-provenance`, `action-gh-release`, and `upload-artifact`'s release.yml usage) are still not exercised by PR CI. They only run on tag push or \`workflow_dispatch\`. A future bump could ship green CI yet break the next real tag.

\`release.yml\` already had a dry-run path planned (line 482 conditional: *"Plain workflow_dispatch with no input remains a build-only dry-run"*) — but \`required: true\` on the version input made it unreachable. Dead intent.

## After this PR

\`\`\`bash
gh workflow run release.yml
\`\`\`

…runs verify-source + builds the agent + all three desktop OS packages + Sigstore-attests every artifact. The final \`Publish GitHub Release\` step is skipped automatically when \`version\` is empty. If this green-checks after a release-action bump, the next real \`vX.Y.Z\` tag will work.

## Files touched

- \`.github/workflows/release.yml\` — \`required: true\` → \`false\`, description expanded to document dry-run mode.
- \`CLAUDE.md\` — new "Release pipeline dry-run" section so future sessions surface the dry-run as the smoke test for release-only Dependabot bumps.

## Test plan

- [ ] CI on this PR is green (Test, golangci-lint, govulncheck).
- [ ] After merge, run \`gh workflow run release.yml\` once to confirm the dry-run completes end-to-end on the just-merged action versions.