### PR TITLE
docs: add ROADMAP.md for forward-looking ideas beyond v1.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,9 @@ measurable, not aspirational:
    their German equivalents have no placeholder text.
 
 Code signing, notarization, additional models, and Wails sandboxing
-are post-1.0.
+are post-1.0. Forward-looking ideas beyond v1.0 — currently an iOS
+PWA proposal and a factory-reset wizard for the desktop app — live
+in [`docs/ROADMAP.md`](docs/ROADMAP.md).
 
 ## Release pipeline dry-run
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,116 @@
+# STR Roadmap
+
+Forward-looking items beyond the v1.0 gate defined in `CLAUDE.md`.
+This is a wishlist with rough sequencing, not a commitment. Items
+move in and out as reality lands.
+
+For the security-specific roadmap see
+[`docs/THREAT-MODEL.md`](THREAT-MODEL.md#hardening-roadmap).
+
+## Post-1.0 (already named in CLAUDE.md)
+
+- Code signing and notarization for Windows and macOS installers.
+- Additional verified speaker models (ST20, ST30, Portable).
+- Wails sandboxing on macOS and Windows.
+
+## Under consideration
+
+### iOS web app (PWA) installable from the website
+
+Idea: the user opens `st-reborn.de` on an iPhone, taps "Add to Home
+Screen", and from then on has an app icon that controls the local
+SoundTouch speakers without going through the desktop app.
+
+Scope on day one would be the same surface the desktop app exposes:
+discover running agents on the LAN, browse internet radio, manage
+presets, control playback.
+
+**Feasibility — needs a study before this gets scheduled.** Several
+hard blockers exist and a clean answer to each is a prerequisite:
+
+1. **Mixed content / TLS.** A PWA served from `https://st-reborn.de`
+   cannot call `http://<speaker-lan-ip>:8888` from a SecureContext.
+   Safari blocks the request before it leaves the page.
+   Mitigation paths:
+   - Agent serves HTTPS with a cert signed by an STR root CA that
+     the user installs once via a configuration profile on iOS.
+     `internal/tlsgen` already produces per-agent certs; the gap is
+     the trust anchor on the client.
+   - Or: ship the PWA from the agent itself over plain HTTP. iOS
+     refuses to register service workers off `localhost` without
+     TLS, so "installable" likely degrades to "bookmarked website".
+2. **Discovery.** Browsers have no mDNS / DNS-SD API. The PWA cannot
+   see `_streborn._tcp.local` the way the desktop app does. Options:
+   - Manual IP entry on first launch.
+   - QR code printed by the desktop app or shown in the setup
+     wizard, encoding `https://<ip>:<port>` plus a pairing token.
+   - Optional: a tiny local-only helper on the user's router or NAS,
+     but that pushes the install bar back up.
+3. **Background and lock-screen control.** iOS PWAs do not get
+   MediaSession lock-screen controls the way native apps do, and
+   they suspend aggressively in the background. Playback control
+   from the lock screen is almost certainly out of scope for v1 of
+   the PWA.
+4. **Persistence and storage.** iOS evicts PWA storage after roughly
+   seven days of non-use. Presets and settings must be source-of-
+   truth on the agent, not in the PWA. This actually fits STR's
+   existing architecture, but is worth confirming.
+
+If the TLS-trust story can be made acceptable (one-tap profile
+install with a clear consent screen, or a route that does not need
+a custom CA at all), this is worth doing. If it requires walking
+users through manual certificate trust dialogs, it is not.
+
+### Factory reset wizard in the desktop app
+
+A guided flow in the desktop app that takes a paired speaker back to
+a known state without making the user open a shell. Useful when
+selling or giving away a speaker, when moving to a different Wi-Fi
+network, or when an install has ended up in a corrupt state and the
+user wants to try again from scratch.
+
+The wizard should offer at least three levels, in increasing
+severity, and explain in plain language what each does before it
+runs:
+
+1. **Reset STR data only.** Clears the preset store and any
+   per-device settings on the agent. Wi-Fi, the NAND override, and
+   the agent binary stay in place. Reversible — the user can
+   re-add presets.
+2. **Reset Wi-Fi.** Rewrites `/etc/wpa_supplicant.conf` to drop the
+   current network so the speaker comes back up in its own setup
+   mode on the next boot. The user reconnects via the desktop app
+   or the USB stick.
+3. **Uninstall STR.** Removes `/mnt/nv/streborn/` and the NAND
+   override so the speaker boots stock Bose firmware again. After
+   this the speaker has no working internet radio (Bose cloud is
+   dead), so the wizard must warn that the USB stick is needed to
+   reinstall.
+
+Hard requirements that must hold before this ships:
+
+- Every level must be **idempotent** and safe to interrupt. A wizard
+  step that half-writes the NAND override file and then dies leaves
+  the speaker in a worse state than before.
+- The "uninstall" path must not touch `/etc/wpa_supplicant.conf`
+  unless explicitly selected, so a user who only wants STR gone
+  keeps their Wi-Fi working.
+- The agent must expose a dedicated reset endpoint. The desktop app
+  should never SSH into the box for this; SSH-root with a known
+  password is the very thing
+  [[project-box-security-hardening]] is trying to close.
+- The USB stick remains the recovery medium of last resort. If the
+  wizard breaks something, plugging the stick back in must fix it
+  (per [[feedback-stick-is-recovery]]). The wizard reset paths and
+  the stick boot scripts must converge on the same expected state.
+
+Tracked as a GitHub issue under the `enhancement` label.
+
+### Other ideas (loose)
+
+- Android version of the same PWA, with the same feasibility caveats
+  except Android allows arbitrary CA install slightly more easily.
+- Multi-room grouping across speakers, if it can be implemented over
+  UPnP without resurrecting Bose's proprietary group protocol.
+- Optional Spotify Connect on the speaker, only if it can be done
+  without re-introducing a cloud dependency.


### PR DESCRIPTION
Reopens the work from #34 (auto-closed when its base branch \`ci/release-dryrun-enable\` was deleted after #33 merged). Rebased onto the new main.

## What

Introduces \`docs/ROADMAP.md\` as the single curated place for forward-looking ideas that are not on the v1.0 path. Adds a one-line pointer to CLAUDE.md so future sessions discover the file.

## Why

The v1.0 gate in CLAUDE.md is intentionally narrow and measurable. Forward-looking ideas were getting raised in conversation but had no durable home — either lost, or cluttering CLAUDE.md's already-busy "post-1.0" line. Two specific proposals motivated this:

- An iOS PWA installable from \`st-reborn.de\` to control local SoundTouch speakers.
- A factory reset wizard in the desktop app (also tracked as #31 for implementation).

## Structure

- Post-1.0 — items already named in CLAUDE.md (signing, more models, Wails sandboxing). Cross-referenced so CLAUDE.md does not need to grow.
- Under consideration — each entry includes a feasibility section so future scheduling has something to argue with, not a wishlist bullet.
- Loose ideas — Android PWA, multi-room grouping, optional Spotify Connect.

## Files

- \`docs/ROADMAP.md\` — new.
- \`CLAUDE.md\` — one-line pointer in the v1.0 section.