### PR TITLE
ci: bump remaining Node-20 actions off the deprecation warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      # actions/checkout v4.2.2 pinned to SHA
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      # actions/checkout v5.0.0 pinned to SHA
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
 
@@ -44,7 +44,7 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
@@ -65,7 +65,7 @@ jobs:
     # remove this once setup-go reliably installs the latest 1.25.x.
     continue-on-error: true
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
@@ -95,7 +95,7 @@ jobs:
             goarch: amd64
             suffix: amd64
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,8 +30,8 @@ jobs:
         language: [go]
 
     steps:
-      # actions/checkout v4.2.2 pinned to SHA
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      # actions/checkout v5.0.0 pinned to SHA
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
 

--- a/.github/workflows/notify-website.yml
+++ b/.github/workflows/notify-website.yml
@@ -19,9 +19,8 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Repository dispatch to streborn-website
-        # peter-evans/repository-dispatch v3.0.0. Tag reference,
-        # Dependabot will pin to a SHA on first update.
-        uses: peter-evans/repository-dispatch@v3
+        # peter-evans/repository-dispatch v4.0.1 pinned to SHA
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697
         with:
           token: ${{ secrets.WEBSITE_DISPATCH_PAT }}
           repository: JRpersonal/streborn-website

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        # actions/checkout v4.2.2 pinned to SHA
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        # actions/checkout v5.0.0 pinned to SHA
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
 
@@ -196,7 +196,7 @@ jobs:
       attestations: write
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
 
@@ -218,8 +218,8 @@ jobs:
         run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0
 
       - name: Download ARM agent
-        # actions/download-artifact v4 pinned to SHA
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        # actions/download-artifact v5.0.0 pinned to SHA
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         with:
           name: agent-armv7l
           path: agent-download
@@ -284,7 +284,7 @@ jobs:
       attestations: write
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
 
@@ -313,7 +313,7 @@ jobs:
         run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0
 
       - name: Download ARM agent
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         with:
           name: agent-armv7l
           path: agent-download
@@ -396,7 +396,7 @@ jobs:
       attestations: write
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
 
@@ -417,7 +417,7 @@ jobs:
         run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0
 
       - name: Download ARM agent
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         with:
           name: agent-armv7l
           path: agent-download
@@ -497,13 +497,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Download all artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         with:
           path: dist
           merge-multiple: true
@@ -683,8 +683,8 @@ jobs:
       # a fine-grained PAT instead; the website repo's deploy listens
       # for repository_dispatch / app-release-published.
       - name: Notify streborn-website
-        # peter-evans/repository-dispatch v3.0.0
-        uses: peter-evans/repository-dispatch@v3
+        # peter-evans/repository-dispatch v4.0.1 pinned to SHA
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697
         with:
           token: ${{ secrets.WEBSITE_DISPATCH_PAT }}
           repository: JRpersonal/streborn-website

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -22,8 +22,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Code auschecken
-        # actions/checkout v4.2.2 auf SHA gepinnt. Dependabot pflegt das automatisch.
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        # actions/checkout v5.0.0 auf SHA gepinnt. Dependabot pflegt das automatisch.
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
 


### PR DESCRIPTION
v0.3.1 release run flagged three actions still on Node 20. GitHub forces Node 24 on 2026-06-02 and removes Node 20 entirely on 2026-09-16. Bump now while it is cheap rather than under deadline.

## Bumps

| Action | From | To | New SHA |
|--------|------|------|------|
| \`actions/checkout\` | v4.2.2 (Node 20) | v5.0.0 (Node 24) | \`93cb6efe18208431cddfb8368fd83d5badbf9bfd\` |
| \`actions/download-artifact\` | v4 (Node 20) | v5.0.0 (Node 24) | \`634f93cb2916e3fdff6788551b99b062d0335ce0\` |
| \`peter-evans/repository-dispatch\` | v3.0.0 (Node 20, tag ref) | v4.0.1 (Node 24, SHA pin) | \`28959ce8df70de7be546dd1250a005dd32156697\` |

All single-major bumps; release notes confirm the only breaking change in each is the runtime swap to Node 24, input/output contracts unchanged.

## Coverage

The previous Dependabot batch (#1, #3, #13, #14, #15) brought every other workflow action to Node 24. After this merge a release run should produce zero deprecation annotations.

## Test plan

- [ ] CI green on this PR (Test, golangci-lint, govulncheck — the build.yml uses the bumped checkout, so a successful run on this PR is the smoke test).
- [ ] After merge, trigger a release dry-run via the new \`workflow_dispatch\` mode (PR #33) to confirm the bumped download-artifact and repository-dispatch behave on the release path.