### PR TITLE
ci: bump actions/download-artifact v5 → v7 (the actual Node 24 release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,8 +218,8 @@ jobs:
         run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0
 
       - name: Download ARM agent
-        # actions/download-artifact v5.0.0 pinned to SHA
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+        # actions/download-artifact v7.0.0 pinned to SHA
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           name: agent-armv7l
           path: agent-download
@@ -313,7 +313,7 @@ jobs:
         run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0
 
       - name: Download ARM agent
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           name: agent-armv7l
           path: agent-download
@@ -417,7 +417,7 @@ jobs:
         run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0
 
       - name: Download ARM agent
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           name: agent-armv7l
           path: agent-download
@@ -503,7 +503,7 @@ jobs:
           persist-credentials: false
 
       - name: Download all artifacts
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           path: dist
           merge-multiple: true


### PR DESCRIPTION
Follow-up to #37 — v5 only "supports" Node 24, default runtime stays Node 20. v7 is the actual cutover (`runs.using: node24`). Same pattern as upload-artifact v5→v7. Verified by the dry-run after #37 which still emitted the deprecation warning for `actions/download-artifact@634f93cb`.