### PR TITLE
refactor(frontend): split main.js leaf modules + OTA flow + radio mirror updates

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -224,6 +224,7 @@ func run() error {
 			FriendlyName: "Bose SoundTouch " + lastN(deviceID, 6),
 			Model:        "SoundTouch",
 			Version:      version,
+			Build:        buildStamp,
 		},
 	)
 	if mdnsErr != nil {

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -213,6 +213,23 @@ func run() error {
 		webui.WithRegionFile(*regionFile),
 		webui.WithStreamProxy(streamProxySrv))
 
+	// Box model — ask the local Bose firmware which actual model
+	// it is (SoundTouch 10 vs 20 vs 30 vs Portable). Falls back to
+	// the generic "SoundTouch" if /info is not yet answering on a
+	// cold boot. Used by the desktop app to disambiguate multiple
+	// boxes on the same LAN.
+	model := "SoundTouch"
+	{
+		infoCtx, infoCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if settings, err := boxapi.New(*boxHost).LoadSettings(infoCtx); err == nil && settings.Info.Type != "" {
+			model = settings.Info.Type
+			logger.Info("Box Modell erkannt", "type", model)
+		} else if err != nil {
+			logger.Debug("Box /info noch nicht erreichbar, nutze Fallback Model", "err", err)
+		}
+		infoCancel()
+	}
+
 	// mDNS Announce damit die Desktop App den Stick im LAN findet.
 	// Bei mehreren Boxen im Netz ist jeder Stick eine eigene Instance,
 	// die Desktop App listet alle.
@@ -222,7 +239,7 @@ func run() error {
 			Port:         8888,
 			DeviceID:     deviceID,
 			FriendlyName: "Bose SoundTouch " + lastN(deviceID, 6),
-			Model:        "SoundTouch",
+			Model:        model,
 			Version:      version,
 			Build:        buildStamp,
 		},

--- a/desktop-app/app.go
+++ b/desktop-app/app.go
@@ -49,6 +49,11 @@ type BoxInfo struct {
 	FriendlyName string `json:"friendlyName"`
 	Model        string `json:"model"`
 	Version      string `json:"version"`
+	// Build is the agent's build stamp (YYYY-MM-DD-HHMM) as
+	// announced via mDNS TXT. Empty if the box runs an older agent
+	// that did not yet broadcast build. Used by the frontend update
+	// indicators to flag stamp drift even when version strings match.
+	Build        string `json:"build"`
 }
 
 // DiscoverBoxes durchsucht das LAN nach Sticks via mDNS und blockiert max
@@ -79,6 +84,7 @@ func (a *App) DiscoverBoxes(timeoutSec int) ([]BoxInfo, error) {
 			FriendlyName: inst.FriendlyName,
 			Model:        inst.Model,
 			Version:      inst.Version,
+			Build:        inst.Build,
 		}
 	}
 

--- a/desktop-app/app.go
+++ b/desktop-app/app.go
@@ -536,7 +536,7 @@ func (a *App) AppInfo() AppInfo {
 		Build:             appBuild,
 		Author:            "Jens Roggenfelder (JRpersonal)",
 		GitHubURL:         "https://github.com/JRpersonal/streborn",
-		WebsiteURL:        "", // gefuellt sobald Website live ist
+		WebsiteURL:        "https://st-reborn.de",
 		DonateURL:         "", // gefuellt sobald PayPal Link auf der Website ist
 		DonateSlogan:      "Dir gefaellt die App? Ich freue mich ueber einen Kaffee.",
 		UpdateManifestURL: "", // gefuellt sobald die Manifest URL feststeht

--- a/desktop-app/frontend/index.html
+++ b/desktop-app/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>ST Reborn</title>
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml"/>
 </head>
 <body>
 <div class="layout">

--- a/desktop-app/frontend/public/favicon.svg
+++ b/desktop-app/frontend/public/favicon.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-label="STR SoundTouch Reborn">
+  <!--
+    STR Logo Mark.
+    Oben: sechs Punkte in zwei Reihen zu je drei (1-3 obere Reihe, 4-6 untere
+    Reihe). Identisch zur Anordnung der Preset Tasten auf der SoundTouch
+    Oberseite, deutet die Box von oben gesehen an.
+    Unten: EKG / Herzschlag Linie. Baseline in Schwarz, QRS Spike in Rot.
+    Bedeutung: Hardware lebt wieder, Signal pulsiert lokal ohne Cloud.
+    "Reborn".
+  -->
+  <g fill="#000000">
+    <circle cx="22" cy="14" r="3"/>
+    <circle cx="32" cy="14" r="3"/>
+    <circle cx="42" cy="14" r="3"/>
+    <circle cx="22" cy="26" r="3"/>
+    <circle cx="32" cy="26" r="3"/>
+    <circle cx="42" cy="26" r="3"/>
+  </g>
+  <path d="M 4 44 L 22 44" stroke="#000000" stroke-width="3" stroke-linecap="round"/>
+  <path d="M 22 44 L 26 48 L 30 32 L 34 54 L 38 40 L 42 44" stroke="#cc0000" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M 42 44 L 60 44" stroke="#000000" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/desktop-app/frontend/public/logo-wordmark.svg
+++ b/desktop-app/frontend/public/logo-wordmark.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 80" fill="none" role="img" aria-label="STR SoundTouch Reborn">
+  <g transform="translate(8 8)">
+    <g fill="#000000">
+      <circle cx="22" cy="14" r="3"/>
+      <circle cx="32" cy="14" r="3"/>
+      <circle cx="42" cy="14" r="3"/>
+      <circle cx="22" cy="26" r="3"/>
+      <circle cx="32" cy="26" r="3"/>
+      <circle cx="42" cy="26" r="3"/>
+    </g>
+    <path d="M 4 44 L 22 44" stroke="#000000" stroke-width="3" stroke-linecap="round"/>
+    <path d="M 22 44 L 26 48 L 30 32 L 34 54 L 38 40 L 42 44" stroke="#cc0000" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M 42 44 L 60 44" stroke="#000000" stroke-width="3" stroke-linecap="round"/>
+  </g>
+  <g font-family="Inter, 'Helvetica Neue', system-ui, sans-serif">
+    <text x="88" y="44" font-size="34" font-weight="800" letter-spacing="-1" fill="#000000">STR</text>
+    <text x="88" y="62" font-size="11" font-weight="500" letter-spacing="0.5" fill="#2a2a2a">SoundTouch Reborn</text>
+  </g>
+</svg>

--- a/desktop-app/frontend/public/logo.svg
+++ b/desktop-app/frontend/public/logo.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-label="STR SoundTouch Reborn">
+  <g fill="#000000">
+    <circle cx="22" cy="14" r="3"/>
+    <circle cx="32" cy="14" r="3"/>
+    <circle cx="42" cy="14" r="3"/>
+    <circle cx="22" cy="26" r="3"/>
+    <circle cx="32" cy="26" r="3"/>
+    <circle cx="42" cy="26" r="3"/>
+  </g>
+  <path d="M 4 44 L 22 44" stroke="#000000" stroke-width="3" stroke-linecap="round"/>
+  <path d="M 22 44 L 26 48 L 30 32 L 34 54 L 38 40 L 42 44" stroke="#cc0000" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M 42 44 L 60 44" stroke="#000000" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/desktop-app/frontend/src/api.js
+++ b/desktop-app/frontend/src/api.js
@@ -1,0 +1,52 @@
+// api.js — single entry point for talking to the backend.
+//
+// Re-exports the Wails-generated bindings (so view modules do not
+// need to know the wailsjs path) and adds a couple of HTTP helpers
+// for the agent endpoints that are not yet wrapped on the Go side
+// (status XML, radio search, etc.).
+
+export {
+  DiscoverBoxes,
+  GetPresets,
+  SetPreset,
+  DeletePreset,
+  PlaySlot,
+  PlayURL,
+  VoteStation,
+  RebootBox,
+  SyncBoxPresets,
+  Pause,
+  Stop,
+  Status,
+  ListDrives,
+  WriteStickFiles,
+  FormatStick,
+  StickVersion,
+  StickConfigs,
+  AppInfo,
+  EjectDrive,
+  BoxAgentVersion,
+  UpdateBoxAgent,
+  WriteWLANConfig,
+  WriteRegionConfig,
+  WriteNameConfig,
+  ListWiFiProfiles,
+  TryWiFiPassword,
+  CurrentWiFi,
+  CheckAppUpdate,
+  BoxSettings,
+  SetBoxName,
+  SetBoxVolume,
+  SetBoxBass,
+  SelectBoxSource,
+} from '../wailsjs/go/main/App';
+
+export { BrowserOpenURL } from '../wailsjs/runtime/runtime';
+
+// boxURL builds an absolute URL for an agent endpoint on a given box.
+// Centralised so the host/port pattern is in one place and switching
+// to HTTPS later only takes touching this helper.
+export function boxURL(box, path) {
+  if (!box) return '';
+  return `http://${box.host}:${box.port}${path}`;
+}

--- a/desktop-app/frontend/src/localization.js
+++ b/desktop-app/frontend/src/localization.js
@@ -1,0 +1,375 @@
+// localization.js — country code/name/flag handling plus genre and
+// tag translation tables.
+//
+// radio-browser.info emits country and tag strings in English (or a
+// techie short form). This module bundles all translation tables and
+// helpers so view modules only call simple t-like functions instead
+// of juggling dicts. Phase B (i18n) will swap the hardcoded German
+// fallbacks for locale-aware lookups; for now German is the only
+// non-English target and the canonical tag is the same as the
+// English tag the radio-browser API hands us.
+//
+// User-facing German strings inside the data tables (country names,
+// order labels, "alle Laender") are intentionally left as-is at this
+// stage — Phase B will move them into the i18n bundle.
+
+const COUNTRY_DE = {
+  'germany': 'Deutschland',
+  'austria': 'Oesterreich',
+  'switzerland': 'Schweiz',
+  'netherlands': 'Niederlande',
+  'belgium': 'Belgien',
+  'france': 'Frankreich',
+  'italy': 'Italien',
+  'spain': 'Spanien',
+  'portugal': 'Portugal',
+  'united kingdom': 'Vereinigtes Koenigreich',
+  'ireland': 'Irland',
+  'denmark': 'Daenemark',
+  'sweden': 'Schweden',
+  'norway': 'Norwegen',
+  'finland': 'Finnland',
+  'iceland': 'Island',
+  'poland': 'Polen',
+  'czech republic': 'Tschechien',
+  'czechia': 'Tschechien',
+  'slovakia': 'Slowakei',
+  'hungary': 'Ungarn',
+  'romania': 'Rumaenien',
+  'bulgaria': 'Bulgarien',
+  'greece': 'Griechenland',
+  'turkey': 'Tuerkei',
+  'russia': 'Russland',
+  'ukraine': 'Ukraine',
+  'united states of america': 'USA',
+  'united states': 'USA',
+  'canada': 'Kanada',
+  'mexico': 'Mexiko',
+  'brazil': 'Brasilien',
+  'argentina': 'Argentinien',
+  'australia': 'Australien',
+  'new zealand': 'Neuseeland',
+  'japan': 'Japan',
+  'china': 'China',
+  'india': 'Indien',
+  'south korea': 'Suedkorea',
+  'the united states of america': 'USA',
+};
+
+// SKIP_TAGS: tags that are meaningless / are languages / are countries
+// / regions / proper nouns. Filtered out before chip rendering or
+// per-station tag pills. Language and country already have dedicated
+// dropdowns, so duplicating them as tags is noise.
+const SKIP_TAGS = new Set([
+  // generic noise
+  'music', 'música', 'musica', 'musik', 'sound', 'sounds',
+  'radio', 'radios', 'radyo', 'station', 'estación', 'estacion',
+  'fm', 'am', 'ukw',
+  'live', 'online', 'internet', 'internet radio', 'streaming',
+  '24/7', '24 7', '24h', 'free', 'best', 'good', 'good music', 'best music',
+  'mp3', 'aac', 'flac',
+  // languages
+  'español', 'spanish', 'espanol',
+  'deutsch', 'german', 'germany',
+  'english', 'englisch',
+  'français', 'francais', 'french',
+  'italiano', 'italian',
+  'português', 'portuguese',
+  // countries / regions / continents
+  'mexico', 'méxico', 'brazil', 'brasil', 'argentina', 'chile', 'colombia',
+  'peru', 'venezuela', 'usa', 'canada', 'kanada',
+  'norteamérica', 'norteamerica', 'sudamérica', 'sudamerica',
+  'latinoamérica', 'latinoamerica', 'latin america',
+  'américa', 'america', 'europa', 'europe', 'asia', 'africa', 'oceania',
+  // known junk encountered in real samples
+  'moi merino',
+]);
+
+// GENRE_ALIAS: canonicalise common duplicates onto one value.
+const GENRE_ALIAS = {
+  'pop music': 'pop',
+  'pop musik': 'pop',
+  'rock music': 'rock',
+  'rock musik': 'rock',
+  'classic': 'classical',
+  'classic music': 'classical',
+  'classical music': 'classical',
+  'classic rock': 'classic rock', // keep separate, do NOT collapse into rock
+  'klassik': 'classical',
+  'klassische musik': 'classical',
+  'dance music': 'dance',
+  'electronic music': 'electronic',
+  'electro music': 'electro',
+  '80s80s': '80s',
+  '90s90s': '90s',
+  '2000s': '00s',
+  '2010s': '10s',
+  'top40': 'top 40',
+  'r&b': 'rnb',
+  'r and b': 'rnb',
+  'rhythm and blues': 'rnb',
+  'hip-hop': 'hip hop',
+  'hiphop': 'hip hop',
+  'heavy-metal': 'heavy metal',
+  'oeffentlich rechtlich': 'public radio',
+  'oeffentlich-rechtlich': 'public radio',
+  'news talk': 'news',
+  'news radio': 'news',
+  'nachrichten': 'news',
+  'sport': 'sports',
+  'electronica': 'electronic',
+};
+
+// German display labels for canonical genre tags. The English/canonical
+// tag is the key; Phase B will replace this map with a per-locale
+// lookup driven by the active locale.
+const GENRE_DE = {
+  'rock': 'Rock', 'pop': 'Pop', 'jazz': 'Jazz', 'classical': 'Klassik',
+  'classic': 'Klassik', 'klassik': 'Klassik',
+  'news': 'Nachrichten', 'talk': 'Talk', 'sport': 'Sport', 'sports': 'Sport',
+  'oldies': 'Oldies', 'hits': 'Hits',
+  '80s': '80er', '90s': '90er', '70s': '70er', '60s': '60er', '50s': '50er',
+  '80s80s': '80er', '90s90s': '90er',
+  'metal': 'Metal', 'heavy metal': 'Heavy Metal', 'death metal': 'Death Metal',
+  'punk': 'Punk', 'indie': 'Indie', 'alternative': 'Alternative',
+  'electronic': 'Elektronisch', 'electro': 'Elektro', 'techno': 'Techno',
+  'house': 'House', 'trance': 'Trance', 'edm': 'EDM',
+  'hip hop': 'Hip Hop', 'hip-hop': 'Hip Hop', 'rap': 'Rap',
+  'rnb': 'RnB', 'r&b': 'R&B', 'soul': 'Soul', 'funk': 'Funk', 'disco': 'Disco',
+  'reggae': 'Reggae', 'ska': 'Ska', 'blues': 'Blues', 'country': 'Country',
+  'folk': 'Folk', 'volksmusik': 'Volksmusik', 'schlager': 'Schlager',
+  'chillout': 'Chill', 'chill': 'Chill', 'lounge': 'Lounge',
+  'ambient': 'Ambient', 'dance': 'Dance',
+  'public radio': 'Oeffentlich Rechtlich', 'public': 'Oeffentlich Rechtlich',
+  'ard': 'ARD', 'wdr': 'WDR', 'ndr': 'NDR', 'mdr': 'MDR', 'rbb': 'RBB',
+  'swr': 'SWR', 'br': 'BR', 'hr': 'HR', 'orf': 'ORF', 'srf': 'SRF', 'bbc': 'BBC',
+  'top 40': 'Top 40', 'charts': 'Charts',
+  'christian': 'Christlich', 'religious': 'Religioes', 'gospel': 'Gospel',
+  'culture': 'Kultur', 'comedy': 'Comedy', 'kids': 'Kinder', 'children': 'Kinder',
+  'german': 'Deutsch', 'english': 'Englisch',
+  'world music': 'Weltmusik', 'world': 'Welt',
+  'instrumental': 'Instrumental', 'orchestra': 'Orchester',
+  'movie': 'Film', 'soundtrack': 'Soundtrack',
+  'news talk': 'Nachrichten Talk', 'news radio': 'Nachrichten',
+  'easy listening': 'Easy Listening',
+  'live': 'Live', 'local': 'Lokal',
+  'variety': 'Vielfalt', 'mix': 'Mix',
+  'eurodance': 'Eurodance', 'eurodisco': 'Eurodisco',
+  'entretenimiento': 'Unterhaltung', 'entertainment': 'Unterhaltung',
+  'sports': 'Sport', 'sport': 'Sport',
+  'family': 'Familie', 'kinder': 'Kinder',
+  'evergreen': 'Evergreens', 'evergreens': 'Evergreens',
+  'love songs': 'Liebeslieder', 'romantic': 'Romantik',
+  'party': 'Party', 'dj': 'DJ', 'mixtape': 'Mixtape',
+  'workout': 'Workout', 'fitness': 'Fitness',
+  'meditation': 'Meditation', 'relax': 'Entspannung', 'relaxation': 'Entspannung',
+  'piano': 'Klavier', 'guitar': 'Gitarre',
+  'opera': 'Oper', 'musical': 'Musical',
+  'singer-songwriter': 'Singer Songwriter', 'singer songwriter': 'Singer Songwriter',
+  'experimental': 'Experimentell', 'underground': 'Underground',
+  'drum and bass': 'Drum & Bass', 'dnb': 'Drum & Bass', 'd&b': 'Drum & Bass',
+  'minimal': 'Minimal', 'dubstep': 'Dubstep',
+  'pop rock': 'Pop Rock', 'hard rock': 'Hard Rock', 'soft rock': 'Soft Rock',
+  'classic rock': 'Classic Rock', 'indie rock': 'Indie Rock', 'alternative rock': 'Alternative Rock',
+  // Country-boost labels (kept in English where the genre name itself
+  // is a proper noun the audience would recognise everywhere).
+  'country': 'Country', 'deutschrap': 'Deutschrap', 'latin': 'Latin',
+  'reggaeton': 'Reggaeton', 'salsa': 'Salsa', 'samba': 'Samba',
+  'sertanejo': 'Sertanejo', 'bossa nova': 'Bossa Nova',
+  'j-pop': 'J-Pop', 'jpop': 'J-Pop', 'anime': 'Anime',
+  'bollywood': 'Bollywood', 'bhangra': 'Bhangra', 'hindi': 'Hindi',
+  'chanson': 'Chanson', 'variété': 'Variété', 'variete': 'Variété',
+  'italo': 'Italo', 'italian': 'Italienisch', 'italiano': 'Italienisch',
+  'levenslied': 'Levenslied', 'nederlandstalig': 'Niederländisch',
+  'turkish': 'Türkisch', 'tuerkisch': 'Türkisch', 'halk': 'Halk',
+  'disco polo': 'Disco Polo', 'polski': 'Polnisch',
+  'russian': 'Russisch', 'retro': 'Retro',
+};
+
+// GENRE_CORE: 14 globally relevant pills, always rendered regardless
+// of how many stations the current country actually has on each tag.
+// Ordered roughly by mass-appeal so the visible row reads top-down.
+// Curated from radio-browser's global tag stationcount distribution
+// plus Statista/Nielsen radio-format share data.
+export const GENRE_CORE = [
+  'pop', 'rock', 'hits', 'oldies',
+  'jazz', 'classical', 'chillout',
+  'dance', 'electronic', 'house',
+  'hip hop', 'latin',
+  '80s', '90s',
+  'news',
+];
+
+// GENRE_BY_COUNTRY: bubble these tags up as the "for your country"
+// row, in front of the core pills. Max 2 per country to keep the
+// visual budget tight. Country code matches state.searchCountry (ISO
+// 3166 alpha-2, uppercase).
+export const GENRE_BY_COUNTRY = {
+  'DE': ['schlager', 'deutschrap'],
+  'AT': ['schlager', 'volksmusik'],
+  'CH': ['schlager', 'volksmusik'],
+  'US': ['country', 'rnb'],
+  'CA': ['country', 'rnb'],
+  'AU': ['country', 'indie'],
+  'GB': ['indie', 'rnb'],
+  'IE': ['folk', 'indie'],
+  'FR': ['chanson', 'variété'],
+  'IT': ['italo', 'italian'],
+  'ES': ['reggaeton', 'salsa'],
+  'PT': ['fado', 'pimba'],
+  'MX': ['reggaeton', 'salsa'],
+  'AR': ['reggaeton', 'salsa'],
+  'CO': ['reggaeton', 'salsa'],
+  'CL': ['reggaeton', 'salsa'],
+  'PE': ['reggaeton', 'salsa'],
+  'VE': ['reggaeton', 'salsa'],
+  'BR': ['sertanejo', 'samba'],
+  'JP': ['j-pop', 'anime'],
+  'KR': ['k-pop', 'kpop'],
+  'IN': ['bollywood', 'bhangra'],
+  'NL': ['levenslied', 'nederlandstalig'],
+  'BE': ['chanson', 'levenslied'],
+  'TR': ['turkish', 'halk'],
+  'PL': ['disco polo', 'polski'],
+  'RU': ['russian', 'retro'],
+  'UA': ['ukrainian', 'retro'],
+  'GR': ['greek', 'laika'],
+  'SE': ['svensk', 'nordic'],
+  'NO': ['norsk', 'nordic'],
+  'DK': ['dansk', 'nordic'],
+  'FI': ['suomi', 'nordic'],
+};
+
+export function translateCountry(name) {
+  if (!name) return '';
+  const key = name.toLowerCase().trim();
+  return COUNTRY_DE[key] || name;
+}
+
+// canonGenre canonicalises a tag for filtering. Returns empty string
+// if the tag is in SKIP_TAGS (i.e. should not be displayed at all).
+export function canonGenre(t) {
+  const key = (t || '').toLowerCase().trim();
+  if (!key) return '';
+  if (SKIP_TAGS.has(key)) return '';
+  return GENRE_ALIAS[key] || key;
+}
+
+// translateGenre canonicalises a tag and translates it for display.
+export function translateGenre(t) {
+  const key = canonGenre(t);
+  if (!key) return '';
+  if (GENRE_DE[key]) return GENRE_DE[key];
+  if (/^[A-Z0-9]{2,5}$/.test(t)) return t;
+  return key.replace(/\b\w/g, c => c.toUpperCase());
+}
+
+export function translateTags(tagsCsv) {
+  if (!tagsCsv) return [];
+  const seen = new Set();
+  const out = [];
+  for (const raw of tagsCsv.split(',')) {
+    const t = translateGenre(raw);
+    if (t && !seen.has(t.toLowerCase())) {
+      seen.add(t.toLowerCase());
+      out.push(t);
+    }
+  }
+  return out;
+}
+
+// ---------- Country code → flag emoji ----------
+// ISO 3166-1 alpha-2 to regional indicator symbol (Unicode flag).
+export function flagFromCC(cc) {
+  if (!cc || cc.length !== 2) return '';
+  const A = 0x1F1E6;
+  const c0 = cc.toUpperCase().charCodeAt(0) - 65;
+  const c1 = cc.toUpperCase().charCodeAt(1) - 65;
+  if (c0 < 0 || c0 > 25 || c1 < 0 || c1 > 25) return '';
+  return String.fromCodePoint(A + c0) + String.fromCodePoint(A + c1);
+}
+
+// Country list for the filter dropdown. Only the most relevant
+// countries are listed by default — the user can always pick "all
+// countries" to see the global pool.
+// All supported countries, unsorted. Sorting happens below
+// (alphabetical by translated name, DACH pinned to the top for the
+// default user).
+const COUNTRIES_ALL = [
+  { cc: 'DE', name: 'Deutschland' },
+  { cc: 'AT', name: 'Oesterreich' },
+  { cc: 'CH', name: 'Schweiz' },
+  { cc: 'NL', name: 'Niederlande' },
+  { cc: 'BE', name: 'Belgien' },
+  { cc: 'LU', name: 'Luxemburg' },
+  { cc: 'FR', name: 'Frankreich' },
+  { cc: 'IT', name: 'Italien' },
+  { cc: 'ES', name: 'Spanien' },
+  { cc: 'PT', name: 'Portugal' },
+  { cc: 'GB', name: 'Vereinigtes Koenigreich' },
+  { cc: 'IE', name: 'Irland' },
+  { cc: 'DK', name: 'Daenemark' },
+  { cc: 'SE', name: 'Schweden' },
+  { cc: 'NO', name: 'Norwegen' },
+  { cc: 'FI', name: 'Finnland' },
+  { cc: 'IS', name: 'Island' },
+  { cc: 'PL', name: 'Polen' },
+  { cc: 'CZ', name: 'Tschechien' },
+  { cc: 'SK', name: 'Slowakei' },
+  { cc: 'HU', name: 'Ungarn' },
+  { cc: 'RO', name: 'Rumaenien' },
+  { cc: 'BG', name: 'Bulgarien' },
+  { cc: 'GR', name: 'Griechenland' },
+  { cc: 'HR', name: 'Kroatien' },
+  { cc: 'SI', name: 'Slowenien' },
+  { cc: 'TR', name: 'Tuerkei' },
+  { cc: 'RU', name: 'Russland' },
+  { cc: 'UA', name: 'Ukraine' },
+  { cc: 'US', name: 'USA' },
+  { cc: 'CA', name: 'Kanada' },
+  { cc: 'MX', name: 'Mexiko' },
+  { cc: 'BR', name: 'Brasilien' },
+  { cc: 'AR', name: 'Argentinien' },
+  { cc: 'CL', name: 'Chile' },
+  { cc: 'CO', name: 'Kolumbien' },
+  { cc: 'PE', name: 'Peru' },
+  { cc: 'JP', name: 'Japan' },
+  { cc: 'CN', name: 'China' },
+  { cc: 'TW', name: 'Taiwan' },
+  { cc: 'HK', name: 'Hongkong' },
+  { cc: 'KR', name: 'Suedkorea' },
+  { cc: 'IN', name: 'Indien' },
+  { cc: 'TH', name: 'Thailand' },
+  { cc: 'VN', name: 'Vietnam' },
+  { cc: 'ID', name: 'Indonesien' },
+  { cc: 'PH', name: 'Philippinen' },
+  { cc: 'MY', name: 'Malaysia' },
+  { cc: 'SG', name: 'Singapur' },
+  { cc: 'IL', name: 'Israel' },
+  { cc: 'AE', name: 'Vereinigte Arabische Emirate' },
+  { cc: 'SA', name: 'Saudi Arabien' },
+  { cc: 'EG', name: 'Aegypten' },
+  { cc: 'MA', name: 'Marokko' },
+  { cc: 'AU', name: 'Australien' },
+  { cc: 'NZ', name: 'Neuseeland' },
+  { cc: 'ZA', name: 'Suedafrika' },
+];
+
+const COUNTRIES_TOP = ['DE', 'AT', 'CH'];
+
+export const COUNTRIES = (() => {
+  const top = COUNTRIES_TOP
+    .map(cc => COUNTRIES_ALL.find(c => c.cc === cc))
+    .filter(Boolean);
+  const rest = COUNTRIES_ALL
+    .filter(c => !COUNTRIES_TOP.includes(c.cc))
+    .sort((a, b) => a.name.localeCompare(b.name, 'de'));
+  return [{ cc: '', name: 'alle Laender' }, ...top, ...rest];
+})();
+
+export const ORDERS = [
+  { v: 'votes',      label: 'Beliebtheit' },
+  { v: 'clickcount', label: 'Hoererzahlen' },
+  { v: 'clicktrend', label: 'Trend' },
+  { v: 'name',       label: 'Name' },
+];

--- a/desktop-app/frontend/src/logos.js
+++ b/desktop-app/frontend/src/logos.js
@@ -36,9 +36,26 @@ export function iconServicesFor(host) {
   ];
 }
 
+// stationLogoCandidates returns an ordered list of icon URLs to try
+// for a station. The browser's onerror cascade walks the list and
+// keeps the first one that loads.
+//
+// Ordering rule: derived DuckDuckGo icon-service URLs come BEFORE the
+// station's own `favicon` field. Empirically the favicon URLs that
+// radio-browser.info hands out are unreliable — REYFM's
+// www.reyfm.de/icon.png returns 402 (Cloudflare paywall), other
+// stations point at HTTP-only URLs the secure context blocks as
+// mixed content, others 404 outright. DDG's icon service returns a
+// clean 200 or clean 404 with no surprises and is much friendlier
+// in DevTools. We still keep the station's own favicon at the end
+// of the list so we never give up an image that only the station
+// itself can provide.
 export function stationLogoCandidates(s) {
   const out = [];
-  if (s.favicon) out.push(s.favicon);
+
+  // 1. DDG icon URLs derived from the station's known hostnames.
+  //    Multiple hosts (homepage / stream URL / resolved URL) plus
+  //    their root domains feed in — the first one DDG knows wins.
   const hosts = [];
   for (const u of [s.homepage, s.url, s.url_resolved]) {
     const h = extractHost(u);
@@ -51,6 +68,13 @@ export function stationLogoCandidates(s) {
       if (!out.includes(svc)) out.push(svc);
     }
   }
+
+  // 2. Last resort: the favicon field from radio-browser.info itself.
+  //    Likely original-quality where it works, but also the most
+  //    likely candidate to 402/403/mixed-content fail. Kept so we
+  //    do not lose stations that DDG genuinely does not know.
+  if (s.favicon && !out.includes(s.favicon)) out.push(s.favicon);
+
   return out;
 }
 

--- a/desktop-app/frontend/src/logos.js
+++ b/desktop-app/frontend/src/logos.js
@@ -1,0 +1,102 @@
+// logos.js — station logo / icon resolution.
+//
+// Many radio-browser entries ship without a favicon. When that is
+// the case we derive the domain from the homepage or stream URL and
+// fall back to the DuckDuckGo icon service. On 404 the img element
+// cascades through the remaining candidates via onerror.
+
+import { escapeAttr } from './utils.js';
+
+export function extractHost(u) {
+  if (!u) return '';
+  try { return new URL(u).hostname; } catch { return ''; }
+}
+
+// rootDomain strips the first subdomain. "stream.rockland-digital.de"
+// → "rockland-digital.de", "icecast.wdr.de" → "wdr.de". The favicon
+// services often hit even when the streaming host itself has no
+// branded logo.
+export function rootDomain(host) {
+  if (!host) return '';
+  const parts = host.split('.');
+  if (parts.length < 3) return host;
+  return parts.slice(1).join('.');
+}
+
+// iconServicesFor yields favicon-service URLs for a host. We only
+// query DuckDuckGo's privacy-friendly icon service. The Google
+// equivalent (www.google.com/s2/favicons) used to live in this list
+// too but was removed on user request — it is a data-mining service
+// and the few extra logos it might resolve are not worth handing
+// every browse session to Google.
+export function iconServicesFor(host) {
+  if (!host) return [];
+  return [
+    `https://icons.duckduckgo.com/ip3/${host}.ico`,
+  ];
+}
+
+export function stationLogoCandidates(s) {
+  const out = [];
+  if (s.favicon) out.push(s.favicon);
+  const hosts = [];
+  for (const u of [s.homepage, s.url, s.url_resolved]) {
+    const h = extractHost(u);
+    if (h && !hosts.includes(h)) hosts.push(h);
+    const r = rootDomain(h);
+    if (r && !hosts.includes(r)) hosts.push(r);
+  }
+  for (const h of hosts) {
+    for (const svc of iconServicesFor(h)) {
+      if (!out.includes(svc)) out.push(svc);
+    }
+  }
+  return out;
+}
+
+// logoImgTag renders an <img> wired up so onerror cycles through the
+// remaining fallback candidates encoded in data-fallbacks. Once the
+// list is empty, the helper at window.__nextLogoFallback hides the
+// element so CSS can render its placeholder.
+export function logoImgTag(s, cssClass) {
+  const candidates = stationLogoCandidates(s);
+  if (candidates.length === 0) return '<div class="fav-empty"></div>';
+  const first = candidates[0];
+  const rest = candidates.slice(1).join('|');
+  return `<img class="${cssClass}"
+            src="${escapeAttr(first)}"
+            data-fallbacks="${escapeAttr(rest)}"
+            onerror="window.__nextLogoFallback(this)"/>`;
+}
+
+// Global helper called by the inline onerror handler. Cycles through
+// data-fallbacks until one loads or the element is hidden. Lives on
+// window because the onerror handler runs in the inline-script global
+// scope and cannot import.
+window.__nextLogoFallback = function(img) {
+  const list = (img.dataset.fallbacks || '').split('|').filter(Boolean);
+  if (list.length === 0) {
+    img.onerror = null;
+    img.style.display = 'none';
+    return;
+  }
+  const next = list.shift();
+  img.dataset.fallbacks = list.join('|');
+  img.src = next;
+};
+
+// bestLogoForStation returns the best available logo URL for a
+// station. Used when saving to a preset slot so the preset button
+// and the box both have a logo to show.
+export function bestLogoForStation(s) {
+  return stationLogoCandidates(s)[0] || '';
+}
+
+// stationLogoChain returns all logo candidates as a pipe-separated
+// string. Persisted into preset.art so the frontend can keep
+// cascading through fallbacks even after an app restart. The stick
+// agent splits the pipe-separated art at PlayURL time and uses only
+// the first entry as the UPnP albumArtURI.
+export function stationLogoChain(s) {
+  return stationLogoCandidates(s).join('|');
+}

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -84,7 +84,20 @@ import {
 
 document.querySelector('#app').innerHTML = `
   <header class="app-header">
-    <div class="app-brand">ST <span class="app-brand-accent">Reborn</span></div>
+    <div class="app-header-row">
+      <span class="app-logo" aria-hidden="true">
+        <svg viewBox="0 0 64 64" fill="none">
+          <g fill="currentColor">
+            <circle cx="22" cy="14" r="3"/><circle cx="32" cy="14" r="3"/><circle cx="42" cy="14" r="3"/>
+            <circle cx="22" cy="26" r="3"/><circle cx="32" cy="26" r="3"/><circle cx="42" cy="26" r="3"/>
+          </g>
+          <path d="M 4 44 L 22 44" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+          <path d="M 22 44 L 26 48 L 30 32 L 34 54 L 38 40 L 42 44" stroke="#cc0000" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+          <path d="M 42 44 L 60 44" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+        </svg>
+      </span>
+      <div class="app-brand">ST <span class="app-brand-accent">Reborn</span></div>
+    </div>
     <div class="app-tagline" id="appTagline"></div>
     <div class="app-supported" id="appSupported"></div>
   </header>
@@ -233,22 +246,54 @@ async function renderFooter() {
   updateSettingsTabBadge();
 }
 
+// Donate sidebar — three branded buttons that open in the system
+// browser via Wails. Brand colours and assets follow each provider's
+// guidelines:
+//   * GitHub Sponsors: white background, #bf3989 (Mona Pink) border
+//     and Octicons heart-fill SVG (MIT licensed)
+//   * PayPal: #FFC439 yellow background, two-tone "PayPal" wordmark
+//     in #003087 + #009CDE per the official color system
+//   * Ko-fi: #FF5E5B coral background, coffee-cup mark + white text
+//
+// Links are baked in rather than fetched from appInfo because each
+// provider has its own canonical URL — keeping them inline removes a
+// round trip and means the sidebar renders even before AppInfo loads.
 function renderDonateSidebar() {
   const side = $('donateSide');
   if (!side) return;
   const i = state.appInfo || {};
   const slogan = i.donateSlogan || 'Dir gefaellt die App? Ich freue mich ueber einen Kaffee.';
-  const hasUrl = !!i.donateUrl;
+
+  // Octicons heart-fill-16, MIT licensed (https://github.com/primer/octicons).
+  const heartSvg = `<svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="m8 14.25.345.666a.75.75 0 0 1-.69 0l-.008-.004-.018-.01a7.152 7.152 0 0 1-.31-.17 22.055 22.055 0 0 1-3.434-2.414C2.045 10.731 0 8.35 0 5.5 0 2.836 2.086 1 4.25 1 5.797 1 7.153 1.802 8 3.02 8.847 1.802 10.203 1 11.75 1 13.914 1 16 2.836 16 5.5c0 2.85-2.045 5.231-3.885 6.818a22.066 22.066 0 0 1-3.744 2.584l-.018.01-.005.003h-.002Z"/></svg>`;
+  // Ko-fi has no single canonical inline mark; this is a compact
+  // coffee-cup glyph (taken from Simple Icons / Ko-fi brand kit
+  // composition) that recognisable at 14px.
+  const coffeeSvg = `<svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="M20.216 6.415C19.964 5.43 19.066 4.78 18.057 4.78H5.943c-1.009 0-1.907.65-2.159 1.635C2.987 9.085 3 12.34 4.97 14.605c1.236 1.42 3.116 2.13 5.59 2.13 1.85 0 3.62-.404 4.97-1.137A6.43 6.43 0 0 0 19.046 14H19.5a3.5 3.5 0 1 0 0-7h-.07a4.8 4.8 0 0 0-.214-.585zM19 9.5h.5a1.5 1.5 0 0 1 0 3H19a4.21 4.21 0 0 0 .003-.123V9.535c0-.012-.002-.023-.003-.035zM7.5 19h11a.5.5 0 0 1 0 1h-11a.5.5 0 0 1 0-1z"/></svg>`;
+
   side.innerHTML = `
     <div class="donate-icon">&#9749;</div>
     <div class="donate-slogan">${escapeHtml(slogan)}</div>
-    <button class="donate-btn" id="donateBtn"${hasUrl ? '' : ' disabled title="Spenden Link folgt sobald die Webseite live ist"'}>
-      Per PayPal spenden
+    <button class="donate-btn donate-gh" id="donateGhBtn" type="button" title="GitHub Sponsors">
+      <span class="donate-btn-icon">${heartSvg}</span>
+      <span class="donate-btn-label">Sponsor</span>
     </button>
-    <small>${hasUrl ? '' : '(Link folgt in Kuerze)'}</small>
+    <button class="donate-btn donate-paypal" id="donatePayPalBtn" type="button" title="PayPal">
+      <span class="donate-paypal-wordmark"><span class="pay">Pay</span><span class="pal">Pal</span></span>
+    </button>
+    <button class="donate-btn donate-kofi" id="donateKofiBtn" type="button" title="Ko-fi">
+      <span class="donate-btn-icon">${coffeeSvg}</span>
+      <span class="donate-btn-label">Ko-fi</span>
+    </button>
   `;
-  const btn = $('donateBtn');
-  if (btn && hasUrl) btn.onclick = () => BrowserOpenURL(i.donateUrl);
+
+  const wire = (id, url) => {
+    const b = $(id);
+    if (b) b.onclick = () => BrowserOpenURL(url);
+  };
+  wire('donateGhBtn',     'https://github.com/sponsors/JRpersonal');
+  wire('donatePayPalBtn', 'https://paypal.me/JR31337');
+  wire('donateKofiBtn',   'https://ko-fi.com/streborn');
 }
 
 async function checkAppUpdate() {
@@ -678,8 +723,15 @@ function renderBoxSelect() {
   sel.innerHTML = state.boxes.map(b => {
     const active = state.currentBox && state.currentBox.host === b.host ? ' active' : '';
     const label = b.friendlyName || b.name || b.host;
+    // Box model (e.g. "SoundTouch 10") right next to the name so
+    // users with several speakers can tell their ST10 from their
+    // ST20 at a glance. Fall back gracefully when an older agent
+    // only advertises the generic "SoundTouch".
+    const model = b.model && b.model !== 'SoundTouch'
+      ? `<span class="box-model" title="Box Modell">${escapeHtml(b.model)}</span>`
+      : '';
     const ver = b.version ? `<span class="box-ver" title="Stick Version">${escapeHtml(b.version)}</span>` : '';
-    return `<span class="box-btn${active}" data-host="${b.host}" data-port="${b.port}" role="button" tabindex="0">${escapeHtml(label)} <small>${b.host}</small>${ver}<span class="box-edit" data-host="${b.host}" data-port="${b.port}" title="Einstellungen dieser Box">&#9881;</span></span>`;
+    return `<span class="box-btn${active}" data-host="${b.host}" data-port="${b.port}" role="button" tabindex="0">${escapeHtml(label)}${model} <small>${b.host}</small>${ver}<span class="box-edit" data-host="${b.host}" data-port="${b.port}" title="Einstellungen dieser Box">&#9881;</span></span>`;
   }).join('');
   sel.querySelectorAll('.box-btn').forEach(btn => {
     btn.onclick = (e) => {
@@ -1898,7 +1950,12 @@ function renderSettingsBoxSelect() {
   if (target) state.settingsBox = target;
   sel.innerHTML = state.boxes.map(b => {
     const label = b.friendlyName || b.name || b.host;
-    return `<option value="${escapeAttr(b.deviceID)}">${escapeHtml(label)} (${escapeHtml(b.host)})</option>`;
+    // Append the box model so the dropdown can distinguish two
+    // boxes that happen to carry the same Bose-default friendly
+    // name. Older agents that only broadcast generic "SoundTouch"
+    // get no extra annotation — would just be noise.
+    const modelSuffix = b.model && b.model !== 'SoundTouch' ? ` · ${b.model}` : '';
+    return `<option value="${escapeAttr(b.deviceID)}">${escapeHtml(label + modelSuffix)} (${escapeHtml(b.host)})</option>`;
   }).join('');
   if (state.settingsBox) sel.value = state.settingsBox.deviceID;
 }

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -33,533 +33,52 @@ import {
   SetBoxVolume,
   SetBoxBass,
   SelectBoxSource,
-} from '../wailsjs/go/main/App';
-import {BrowserOpenURL} from '../wailsjs/runtime/runtime';
+  BrowserOpenURL,
+} from './api.js';
 
-// ---------- State ----------
+import {
+  state,
+  loadLastBox,
+  saveLastBox,
+  loadCachedBoxes,
+  saveCachedBoxes,
+} from './state.js';
 
-const state = {
-  view: 'box',
-  boxes: [],
-  currentBox: null,
-  settingsBox: null,   // Box deren Einstellungen wir gerade bearbeiten
-  presets: [],
-  searchResults: [],
-  drives: [],
-  selectedDrive: null,
-  // Set right after a successful prepare+eject. While set,
-  // refreshDrives() hides that path from the list until it either
-  // disappears (physical pull) or comes back with a valid FAT32
-  // mount. Prevents the wizard re-rendering the ejected stick as
-  // "unknown format". Cleared by the "Neu suchen" button.
-  justEjectedPath: null,
-  appInfo: null,
-  nowLocation: '',     // aktueller stream url aus now_playing
-  nowName: '',         // aktueller itemName aus now_playing
-  nowPlayState: '',    // aktueller PlayState
-  nowIcon: '',         // letztes bekanntes Sender Logo (favicon)
-  nowUUID: '',         // letzte radio-browser UUID
-  optimisticUntil: 0,  // Zeitpunkt ab dem refreshStatus wieder die Box als Quelle der Wahrheit nimmt
-  presetErrors: {},    // slot → letzte Fehlermeldung (rot anzeigen)
-  searchOrder: 'votes',
-  searchCountry: 'DE',
-  searchLang: '',
-  searchTag: '',       // aktive Genre Chip
-  searchOnlyOK: true,
-  searchOnlyBose: true,
-  searchOffset: 0,
-  searchLastMode: 'top', // "top" oder "search" — fuer "mehr laden"
-  searchLastQuery: '',
-  tags: [],            // Cache der Top Tags fuer Chips
-  languages: [],       // Cache der Sprachen
-  // Pending Names: Box ID -> { name, until } — nach lokaler Umbenennung
-  // ueberschreiben wir damit jeden mDNS Eintrag fuer max 90s. Genug bis
-  // der Stick seinen TXT Record neu announciert hat.
-  pendingNames: {},
-};
+import {
+  $,
+  escapeHtml,
+  escapeAttr,
+  decodeXmlEntities,
+  formatNumber,
+  debounce,
+  sleep,
+  confirmWarn,
+  closeWarn,
+  showError,
+  showToast,
+} from './utils.js';
 
-// Persistente Selection: deviceID aus localStorage, reload nach Refresh.
-function loadLastBox() {
-  try { return localStorage.getItem('lastBoxDeviceID') || null; } catch { return null; }
-}
-function saveLastBox(id) {
-  try { localStorage.setItem('lastBoxDeviceID', id || ''); } catch {}
-}
+import {
+  COUNTRIES,
+  ORDERS,
+  GENRE_CORE,
+  GENRE_BY_COUNTRY,
+  translateCountry,
+  canonGenre,
+  translateGenre,
+  translateTags,
+  flagFromCC,
+} from './localization.js';
 
-// Persistenter Cache der zuletzt gesehenen Boxen Liste. Damit kann die
-// App beim Start oder Tab Wechsel sofort die Box anzeigen ohne 4
-// Sekunden auf mDNS zu warten. Im Hintergrund refresht discoverBoxes
-// und ueberschreibt.
-function loadCachedBoxes() {
-  try {
-    const raw = localStorage.getItem('cachedBoxes');
-    if (!raw) return [];
-    const arr = JSON.parse(raw);
-    if (!Array.isArray(arr)) return [];
-    return arr;
-  } catch { return []; }
-}
-function saveCachedBoxes(list) {
-  try { localStorage.setItem('cachedBoxes', JSON.stringify(list || [])); } catch {}
-}
-
-// ---------- Lokalisierung Land + Genres ----------
-// radio-browser liefert country + tags auf Englisch / techsprech. Wir
-// uebersetzen die haeufigen Werte ins Deutsche und kapitalisieren den
-// Rest automatisch. Sender Namen bleiben unangetastet.
-
-const COUNTRY_DE = {
-  'germany': 'Deutschland',
-  'austria': 'Oesterreich',
-  'switzerland': 'Schweiz',
-  'netherlands': 'Niederlande',
-  'belgium': 'Belgien',
-  'france': 'Frankreich',
-  'italy': 'Italien',
-  'spain': 'Spanien',
-  'portugal': 'Portugal',
-  'united kingdom': 'Vereinigtes Koenigreich',
-  'ireland': 'Irland',
-  'denmark': 'Daenemark',
-  'sweden': 'Schweden',
-  'norway': 'Norwegen',
-  'finland': 'Finnland',
-  'iceland': 'Island',
-  'poland': 'Polen',
-  'czech republic': 'Tschechien',
-  'czechia': 'Tschechien',
-  'slovakia': 'Slowakei',
-  'hungary': 'Ungarn',
-  'romania': 'Rumaenien',
-  'bulgaria': 'Bulgarien',
-  'greece': 'Griechenland',
-  'turkey': 'Tuerkei',
-  'russia': 'Russland',
-  'ukraine': 'Ukraine',
-  'united states of america': 'USA',
-  'united states': 'USA',
-  'canada': 'Kanada',
-  'mexico': 'Mexiko',
-  'brazil': 'Brasilien',
-  'argentina': 'Argentinien',
-  'australia': 'Australien',
-  'new zealand': 'Neuseeland',
-  'japan': 'Japan',
-  'china': 'China',
-  'india': 'Indien',
-  'south korea': 'Suedkorea',
-  'the united states of america': 'USA',
-};
-
-// SKIP_TAGS: aussagelos / Sprachen / Laender / Regionen / Eigennamen.
-// Werden weder als Chip noch als Tag Pill am Sender angezeigt. Sprache
-// und Land sind in den dedizierten Dropdowns abgedeckt.
-const SKIP_TAGS = new Set([
-  // generisch
-  'music', 'música', 'musica', 'musik', 'sound', 'sounds',
-  'radio', 'radios', 'radyo', 'station', 'estación', 'estacion',
-  'fm', 'am', 'ukw',
-  'live', 'online', 'internet', 'internet radio', 'streaming',
-  '24/7', '24 7', '24h', 'free', 'best', 'good', 'good music', 'best music',
-  'mp3', 'aac', 'flac',
-  // Sprachen
-  'español', 'spanish', 'espanol',
-  'deutsch', 'german', 'germany',
-  'english', 'englisch',
-  'français', 'francais', 'french',
-  'italiano', 'italian',
-  'português', 'portuguese',
-  // Laender / Regionen / Kontinente
-  'mexico', 'méxico', 'brazil', 'brasil', 'argentina', 'chile', 'colombia',
-  'peru', 'venezuela', 'usa', 'canada', 'kanada',
-  'norteamérica', 'norteamerica', 'sudamérica', 'sudamerica',
-  'latinoamérica', 'latinoamerica', 'latin america',
-  'américa', 'america', 'europa', 'europe', 'asia', 'africa', 'oceania',
-  // bekannter Muell aus den Beispielen
-  'moi merino',
-]);
-
-// GENRE_ALIAS: kanonisiere haeufige Doubletten auf einen Wert.
-const GENRE_ALIAS = {
-  'pop music': 'pop',
-  'pop musik': 'pop',
-  'rock music': 'rock',
-  'rock musik': 'rock',
-  'classic': 'classical',
-  'classic music': 'classical',
-  'classical music': 'classical',
-  'classic rock': 'classic rock', // bleibt eigen, nicht zu rock kollabieren
-  'klassik': 'classical',
-  'klassische musik': 'classical',
-  'dance music': 'dance',
-  'electronic music': 'electronic',
-  'electro music': 'electro',
-  '80s80s': '80s',
-  '90s90s': '90s',
-  '2000s': '00s',
-  '2010s': '10s',
-  'top40': 'top 40',
-  'r&b': 'rnb',
-  'r and b': 'rnb',
-  'rhythm and blues': 'rnb',
-  'hip-hop': 'hip hop',
-  'hiphop': 'hip hop',
-  'heavy-metal': 'heavy metal',
-  'oeffentlich rechtlich': 'public radio',
-  'oeffentlich-rechtlich': 'public radio',
-  'news talk': 'news',
-  'news radio': 'news',
-  'nachrichten': 'news',
-  'sport': 'sports',
-  'electronica': 'electronic',
-};
-
-const GENRE_DE = {
-  'rock': 'Rock', 'pop': 'Pop', 'jazz': 'Jazz', 'classical': 'Klassik',
-  'classic': 'Klassik', 'klassik': 'Klassik',
-  'news': 'Nachrichten', 'talk': 'Talk', 'sport': 'Sport', 'sports': 'Sport',
-  'oldies': 'Oldies', 'hits': 'Hits',
-  '80s': '80er', '90s': '90er', '70s': '70er', '60s': '60er', '50s': '50er',
-  '80s80s': '80er', '90s90s': '90er',
-  'metal': 'Metal', 'heavy metal': 'Heavy Metal', 'death metal': 'Death Metal',
-  'punk': 'Punk', 'indie': 'Indie', 'alternative': 'Alternative',
-  'electronic': 'Elektronisch', 'electro': 'Elektro', 'techno': 'Techno',
-  'house': 'House', 'trance': 'Trance', 'edm': 'EDM',
-  'hip hop': 'Hip Hop', 'hip-hop': 'Hip Hop', 'rap': 'Rap',
-  'rnb': 'RnB', 'r&b': 'R&B', 'soul': 'Soul', 'funk': 'Funk', 'disco': 'Disco',
-  'reggae': 'Reggae', 'ska': 'Ska', 'blues': 'Blues', 'country': 'Country',
-  'folk': 'Folk', 'volksmusik': 'Volksmusik', 'schlager': 'Schlager',
-  'chillout': 'Chill', 'chill': 'Chill', 'lounge': 'Lounge',
-  'ambient': 'Ambient', 'dance': 'Dance',
-  'public radio': 'Oeffentlich Rechtlich', 'public': 'Oeffentlich Rechtlich',
-  'ard': 'ARD', 'wdr': 'WDR', 'ndr': 'NDR', 'mdr': 'MDR', 'rbb': 'RBB',
-  'swr': 'SWR', 'br': 'BR', 'hr': 'HR', 'orf': 'ORF', 'srf': 'SRF', 'bbc': 'BBC',
-  'top 40': 'Top 40', 'charts': 'Charts',
-  'christian': 'Christlich', 'religious': 'Religioes', 'gospel': 'Gospel',
-  'culture': 'Kultur', 'comedy': 'Comedy', 'kids': 'Kinder', 'children': 'Kinder',
-  'german': 'Deutsch', 'english': 'Englisch',
-  'world music': 'Weltmusik', 'world': 'Welt',
-  'instrumental': 'Instrumental', 'orchestra': 'Orchester',
-  'movie': 'Film', 'soundtrack': 'Soundtrack',
-  'news talk': 'Nachrichten Talk', 'news radio': 'Nachrichten',
-  'easy listening': 'Easy Listening',
-  'live': 'Live', 'local': 'Lokal',
-  'variety': 'Vielfalt', 'mix': 'Mix',
-  'eurodance': 'Eurodance', 'eurodisco': 'Eurodisco',
-  'entretenimiento': 'Unterhaltung', 'entertainment': 'Unterhaltung',
-  'sports': 'Sport', 'sport': 'Sport',
-  'family': 'Familie', 'kinder': 'Kinder',
-  'evergreen': 'Evergreens', 'evergreens': 'Evergreens',
-  'love songs': 'Liebeslieder', 'romantic': 'Romantik',
-  'party': 'Party', 'dj': 'DJ', 'mixtape': 'Mixtape',
-  'workout': 'Workout', 'fitness': 'Fitness',
-  'meditation': 'Meditation', 'relax': 'Entspannung', 'relaxation': 'Entspannung',
-  'piano': 'Klavier', 'guitar': 'Gitarre',
-  'opera': 'Oper', 'musical': 'Musical',
-  'singer-songwriter': 'Singer Songwriter', 'singer songwriter': 'Singer Songwriter',
-  'experimental': 'Experimentell', 'underground': 'Underground',
-  'drum and bass': 'Drum & Bass', 'dnb': 'Drum & Bass', 'd&b': 'Drum & Bass',
-  'minimal': 'Minimal', 'dubstep': 'Dubstep',
-  'pop rock': 'Pop Rock', 'hard rock': 'Hard Rock', 'soft rock': 'Soft Rock',
-  'classic rock': 'Classic Rock', 'indie rock': 'Indie Rock', 'alternative rock': 'Alternative Rock',
-  // Country-boost labels (kept in English where the genre name itself
-  // is a proper noun the audience would recognise everywhere).
-  'country': 'Country', 'deutschrap': 'Deutschrap', 'latin': 'Latin',
-  'reggaeton': 'Reggaeton', 'salsa': 'Salsa', 'samba': 'Samba',
-  'sertanejo': 'Sertanejo', 'bossa nova': 'Bossa Nova',
-  'j-pop': 'J-Pop', 'jpop': 'J-Pop', 'anime': 'Anime',
-  'bollywood': 'Bollywood', 'bhangra': 'Bhangra', 'hindi': 'Hindi',
-  'chanson': 'Chanson', 'variété': 'Variété', 'variete': 'Variété',
-  'italo': 'Italo', 'italian': 'Italienisch', 'italiano': 'Italienisch',
-  'levenslied': 'Levenslied', 'nederlandstalig': 'Niederländisch',
-  'turkish': 'Türkisch', 'tuerkisch': 'Türkisch', 'halk': 'Halk',
-  'disco polo': 'Disco Polo', 'polski': 'Polnisch',
-  'russian': 'Russisch', 'retro': 'Retro',
-};
-
-// GENRE_CORE: 14 globally relevant pills, always rendered regardless
-// of how many stations the current country actually has on each tag.
-// Ordered roughly by mass-appeal so the visible row reads top-down.
-// Curated from radio-browser's global tag stationcount distribution
-// plus Statista/Nielsen radio-format share data.
-const GENRE_CORE = [
-  'pop', 'rock', 'hits', 'oldies',
-  'jazz', 'classical', 'chillout',
-  'dance', 'electronic', 'house',
-  'hip hop', 'latin',
-  '80s', '90s',
-  'news',
-];
-
-// GENRE_BY_COUNTRY: bubble these tags up as the "for your country"
-// row, in front of the core pills. Max 2 per country to keep the
-// visual budget tight. Country code matches state.searchCountry (ISO
-// 3166 alpha-2, uppercase).
-const GENRE_BY_COUNTRY = {
-  'DE': ['schlager', 'deutschrap'],
-  'AT': ['schlager', 'volksmusik'],
-  'CH': ['schlager', 'volksmusik'],
-  'US': ['country', 'rnb'],
-  'CA': ['country', 'rnb'],
-  'AU': ['country', 'indie'],
-  'GB': ['indie', 'rnb'],
-  'IE': ['folk', 'indie'],
-  'FR': ['chanson', 'variété'],
-  'IT': ['italo', 'italian'],
-  'ES': ['reggaeton', 'salsa'],
-  'PT': ['fado', 'pimba'],
-  'MX': ['reggaeton', 'salsa'],
-  'AR': ['reggaeton', 'salsa'],
-  'CO': ['reggaeton', 'salsa'],
-  'CL': ['reggaeton', 'salsa'],
-  'PE': ['reggaeton', 'salsa'],
-  'VE': ['reggaeton', 'salsa'],
-  'BR': ['sertanejo', 'samba'],
-  'JP': ['j-pop', 'anime'],
-  'KR': ['k-pop', 'kpop'],
-  'IN': ['bollywood', 'bhangra'],
-  'NL': ['levenslied', 'nederlandstalig'],
-  'BE': ['chanson', 'levenslied'],
-  'TR': ['turkish', 'halk'],
-  'PL': ['disco polo', 'polski'],
-  'RU': ['russian', 'retro'],
-  'UA': ['ukrainian', 'retro'],
-  'GR': ['greek', 'laika'],
-  'SE': ['svensk', 'nordic'],
-  'NO': ['norsk', 'nordic'],
-  'DK': ['dansk', 'nordic'],
-  'FI': ['suomi', 'nordic'],
-};
-
-function translateCountry(name) {
-  if (!name) return '';
-  const key = name.toLowerCase().trim();
-  return COUNTRY_DE[key] || name;
-}
-
-// canonGenre kanonisiert einen Tag fuer Filter Zwecke. Liefert leeren
-// String falls der Tag in SKIP_TAGS ist (soll ausgeblendet werden).
-function canonGenre(t) {
-  const key = (t || '').toLowerCase().trim();
-  if (!key) return '';
-  if (SKIP_TAGS.has(key)) return '';
-  return GENRE_ALIAS[key] || key;
-}
-
-// translateGenre kanonisiert und uebersetzt einen Tag fuer die Anzeige.
-function translateGenre(t) {
-  const key = canonGenre(t);
-  if (!key) return '';
-  if (GENRE_DE[key]) return GENRE_DE[key];
-  if (/^[A-Z0-9]{2,5}$/.test(t)) return t;
-  return key.replace(/\b\w/g, c => c.toUpperCase());
-}
-
-function translateTags(tagsCsv) {
-  if (!tagsCsv) return [];
-  const seen = new Set();
-  const out = [];
-  for (const raw of tagsCsv.split(',')) {
-    const t = translateGenre(raw);
-    if (t && !seen.has(t.toLowerCase())) {
-      seen.add(t.toLowerCase());
-      out.push(t);
-    }
-  }
-  return out;
-}
-
-function formatNumber(n) {
-  if (!n || isNaN(n)) return '0';
-  return Number(n).toLocaleString('de-DE');
-}
-
-// ---------- Logo / Icon Resolution ----------
-// Viele radio-browser Eintraege haben kein favicon gesetzt. Wenn das
-// passiert, leiten wir aus homepage / stream URL die Domain ab und
-// nutzen den DuckDuckGo Icon Service als Fallback. Bei Fehler erneut
-// kaskadieren via onerror.
-
-function extractHost(u) {
-  if (!u) return '';
-  try { return new URL(u).hostname; } catch { return ''; }
-}
-
-// rootDomain entfernt die erste Subdomain. "stream.rockland-digital.de"
-// → "rockland-digital.de", "icecast.wdr.de" → "wdr.de". So treffen die
-// Favicon Services oft auch wenn der Streaming Host kein Logo hat.
-function rootDomain(host) {
-  if (!host) return '';
-  const parts = host.split('.');
-  if (parts.length < 3) return host;
-  return parts.slice(1).join('.');
-}
-
-// iconServicesFor liefert mehrere Favicon Service URLs fuer einen Host.
-// DDG ist Hauptquelle, Google als Backup (decken meist verschiedene
-// Domains ab).
-function iconServicesFor(host) {
-  if (!host) return [];
-  return [
-    `https://icons.duckduckgo.com/ip3/${host}.ico`,
-    `https://www.google.com/s2/favicons?domain=${encodeURIComponent(host)}&sz=64`,
-  ];
-}
-
-function stationLogoCandidates(s) {
-  const out = [];
-  if (s.favicon) out.push(s.favicon);
-  const hosts = [];
-  for (const u of [s.homepage, s.url, s.url_resolved]) {
-    const h = extractHost(u);
-    if (h && !hosts.includes(h)) hosts.push(h);
-    const r = rootDomain(h);
-    if (r && !hosts.includes(r)) hosts.push(r);
-  }
-  for (const h of hosts) {
-    for (const svc of iconServicesFor(h)) {
-      if (!out.includes(svc)) out.push(svc);
-    }
-  }
-  return out;
-}
-
-// onerrorChain feuert den naechsten Kandidaten im data-attribute. Wenn
-// keine mehr, blendet das img aus (CSS zeigt dann den Placeholder).
-function logoImgTag(s, cssClass) {
-  const candidates = stationLogoCandidates(s);
-  if (candidates.length === 0) return '<div class="fav-empty"></div>';
-  const first = candidates[0];
-  const rest = candidates.slice(1).join('|');
-  return `<img class="${cssClass}"
-            src="${escapeAttr(first)}"
-            data-fallbacks="${escapeAttr(rest)}"
-            onerror="window.__nextLogoFallback(this)"/>`;
-}
-
-// Global helper das vom onerror Handler gerufen wird. Cycled durch
-// data-fallbacks bis eines laedt oder das Element ausgeblendet ist.
-window.__nextLogoFallback = function(img) {
-  const list = (img.dataset.fallbacks || '').split('|').filter(Boolean);
-  if (list.length === 0) {
-    img.onerror = null;
-    img.style.display = 'none';
-    return;
-  }
-  const next = list.shift();
-  img.dataset.fallbacks = list.join('|');
-  img.src = next;
-};
-
-// bestLogoForStation liefert die beste verfuegbare Logo URL fuer eine
-// Station. Wird beim Speichern als Preset Art verwendet damit auch im
-// Preset Button + auf der Box ein Logo da ist.
-function bestLogoForStation(s) {
-  return stationLogoCandidates(s)[0] || '';
-}
-
-// stationLogoChain liefert alle Logo Kandidaten als pipe-separierte
-// Kette. Persistieren wir das in preset.art, kann das Frontend bei
-// onerror durch alle Fallbacks kaskadieren — auch nach App Neustart.
-// Der Stick splittet pipe-separated art beim PlayURL und nutzt nur den
-// ersten Eintrag fuer den UPnP albumArtURI.
-function stationLogoChain(s) {
-  return stationLogoCandidates(s).join('|');
-}
-
-// ---------- Country Code → Flag Emoji ----------
-// ISO 3166-1 alpha-2 zu Regional Indicator Symbol (Unicode Flag).
-function flagFromCC(cc) {
-  if (!cc || cc.length !== 2) return '';
-  const A = 0x1F1E6;
-  const c0 = cc.toUpperCase().charCodeAt(0) - 65;
-  const c1 = cc.toUpperCase().charCodeAt(1) - 65;
-  if (c0 < 0 || c0 > 25 || c1 < 0 || c1 > 25) return '';
-  return String.fromCodePoint(A + c0) + String.fromCodePoint(A + c1);
-}
-
-// Laenderliste fuer Filter Dropdown. Wir zeigen nur die haeufigsten — der
-// User kann jederzeit ohne Filter suchen um alles zu sehen.
-// Alle unterstuetzten Laender, ungeordnet — Sortierung passiert unten
-// (alphabetisch nach deutschem Namen, DACH oben fuer den Default User).
-const COUNTRIES_ALL = [
-  { cc: 'DE', name: 'Deutschland' },
-  { cc: 'AT', name: 'Oesterreich' },
-  { cc: 'CH', name: 'Schweiz' },
-  { cc: 'NL', name: 'Niederlande' },
-  { cc: 'BE', name: 'Belgien' },
-  { cc: 'LU', name: 'Luxemburg' },
-  { cc: 'FR', name: 'Frankreich' },
-  { cc: 'IT', name: 'Italien' },
-  { cc: 'ES', name: 'Spanien' },
-  { cc: 'PT', name: 'Portugal' },
-  { cc: 'GB', name: 'Vereinigtes Koenigreich' },
-  { cc: 'IE', name: 'Irland' },
-  { cc: 'DK', name: 'Daenemark' },
-  { cc: 'SE', name: 'Schweden' },
-  { cc: 'NO', name: 'Norwegen' },
-  { cc: 'FI', name: 'Finnland' },
-  { cc: 'IS', name: 'Island' },
-  { cc: 'PL', name: 'Polen' },
-  { cc: 'CZ', name: 'Tschechien' },
-  { cc: 'SK', name: 'Slowakei' },
-  { cc: 'HU', name: 'Ungarn' },
-  { cc: 'RO', name: 'Rumaenien' },
-  { cc: 'BG', name: 'Bulgarien' },
-  { cc: 'GR', name: 'Griechenland' },
-  { cc: 'HR', name: 'Kroatien' },
-  { cc: 'SI', name: 'Slowenien' },
-  { cc: 'TR', name: 'Tuerkei' },
-  { cc: 'RU', name: 'Russland' },
-  { cc: 'UA', name: 'Ukraine' },
-  { cc: 'US', name: 'USA' },
-  { cc: 'CA', name: 'Kanada' },
-  { cc: 'MX', name: 'Mexiko' },
-  { cc: 'BR', name: 'Brasilien' },
-  { cc: 'AR', name: 'Argentinien' },
-  { cc: 'CL', name: 'Chile' },
-  { cc: 'CO', name: 'Kolumbien' },
-  { cc: 'PE', name: 'Peru' },
-  { cc: 'JP', name: 'Japan' },
-  { cc: 'CN', name: 'China' },
-  { cc: 'TW', name: 'Taiwan' },
-  { cc: 'HK', name: 'Hongkong' },
-  { cc: 'KR', name: 'Suedkorea' },
-  { cc: 'IN', name: 'Indien' },
-  { cc: 'TH', name: 'Thailand' },
-  { cc: 'VN', name: 'Vietnam' },
-  { cc: 'ID', name: 'Indonesien' },
-  { cc: 'PH', name: 'Philippinen' },
-  { cc: 'MY', name: 'Malaysia' },
-  { cc: 'SG', name: 'Singapur' },
-  { cc: 'IL', name: 'Israel' },
-  { cc: 'AE', name: 'Vereinigte Arabische Emirate' },
-  { cc: 'SA', name: 'Saudi Arabien' },
-  { cc: 'EG', name: 'Aegypten' },
-  { cc: 'MA', name: 'Marokko' },
-  { cc: 'AU', name: 'Australien' },
-  { cc: 'NZ', name: 'Neuseeland' },
-  { cc: 'ZA', name: 'Suedafrika' },
-];
-
-const COUNTRIES_TOP = ['DE', 'AT', 'CH'];
-
-const COUNTRIES = (() => {
-  const top = COUNTRIES_TOP
-    .map(cc => COUNTRIES_ALL.find(c => c.cc === cc))
-    .filter(Boolean);
-  const rest = COUNTRIES_ALL
-    .filter(c => !COUNTRIES_TOP.includes(c.cc))
-    .sort((a, b) => a.name.localeCompare(b.name, 'de'));
-  return [{ cc: '', name: 'alle Laender' }, ...top, ...rest];
-})();
-
-const ORDERS = [
-  { v: 'votes',      label: 'Beliebtheit' },
-  { v: 'clickcount', label: 'Hoererzahlen' },
-  { v: 'clicktrend', label: 'Trend' },
-  { v: 'name',       label: 'Name' },
-];
+import {
+  extractHost,
+  rootDomain,
+  iconServicesFor,
+  stationLogoCandidates,
+  logoImgTag,
+  bestLogoForStation,
+  stationLogoChain,
+} from './logos.js';
 
 // ---------- DOM Skeleton ----------
 
@@ -621,7 +140,6 @@ document.querySelector('#app').innerHTML = `
   <footer class="app-footer" id="appFooter"></footer>
 `;
 
-const $ = (id) => document.getElementById(id);
 
 // Tabs
 document.querySelectorAll('.tab-btn').forEach(btn => {
@@ -1400,20 +918,34 @@ function renderLanguageOptions() {
 }
 
 // updateSettingsTabBadge shows a small blue dot on the "Box Einstellungen"
-// tab whenever at least one discovered box reports a version different
-// from the desktop app's own version. The dot signals: there is work to
-// do in this tab, namely OTA-update at least one box.
+// tab whenever at least one discovered box reports a version or build
+// stamp different from the desktop app's own. The dot signals: there is
+// work to do in this tab, namely OTA-update at least one box.
 //
-// Version data comes from the mDNS TXT record so no extra HTTP call is
-// needed — the badge updates as the box list refreshes.
+// Compared against BOTH version and build because two local dev builds
+// often share the same `git describe` version but carry distinct build
+// stamps — without the build check the badge silently agrees while
+// the Box-Einstellungen status line is screaming "Update verfügbar".
+//
+// Version + build data comes from the mDNS TXT record so no extra HTTP
+// call is needed — the badge updates as the box list refreshes.
 function updateSettingsTabBadge() {
   const btn = document.querySelector('.tab-btn[data-view="settings"]');
   if (!btn) return;
-  const appVer = state.appInfo && state.appInfo.version;
+  const appVer   = state.appInfo && state.appInfo.version;
+  const appBuild = state.appInfo && state.appInfo.build;
   let needsUpdate = false;
   if (appVer) {
     for (const b of state.boxes) {
-      if (b && b.version && b.version !== appVer) {
+      if (!b || !b.version) continue;
+      const verDiffers   = b.version !== appVer;
+      // Three build-related cases to flag as drift:
+      //   - both sides populated and different
+      //   - we have a build, box has none (older agent that does not
+      //     yet broadcast `build=` in mDNS — guaranteed pre-update)
+      const buildDiffers = appBuild && b.build && b.build !== appBuild;
+      const buildMissing = appBuild && !b.build;
+      if (verDiffers || buildDiffers || buildMissing) {
         needsUpdate = true;
         break;
       }
@@ -1432,15 +964,20 @@ async function checkBoxUpdate() {
     const boxBuild = v.build || '';
     const appVer = state.appInfo.version;
     const appBuild = state.appInfo.build || '';
-    // Banner zeigen wir nur bei echtem Version Unterschied. Build
-    // Stamp Differenzen (jeder Rebuild bekommt neuen Stamp) sind
-    // nicht alarmierend genug fuer ein prominentes Update Banner.
-    if (boxVer === appVer) return;
+    // Show the banner on any version OR build difference. Stamp-only
+    // drift used to be ignored as "not alarming enough", but in
+    // practice it is exactly the case the Box-Einstellungen status
+    // line already flags as "Update verfügbar" — keeping the
+    // music-tab banner silent in that situation produced confusing
+    // inconsistency across the two tabs.
+    const sameVer   = boxVer === appVer;
+    const sameBuild = boxBuild === appBuild;
+    if (sameVer && sameBuild) return;
     const boxLabel = boxBuild ? `${boxVer} (Build ${boxBuild})` : boxVer;
     const appLabel = appBuild ? `${appVer} (Build ${appBuild})` : appVer;
     banner.innerHTML = `
       <div class="update-msg">
-        <b>Box Software Update verfuegbar</b>
+        <b>Box Software Update verfuegbar</b><br>
         <small>Box: ${escapeHtml(boxLabel)} &middot; App: ${escapeHtml(appLabel)}</small>
       </div>
       <button class="btn btn-primary btn-mini" id="boxUpdateBtn">Aktualisieren</button>
@@ -1451,7 +988,7 @@ async function checkBoxUpdate() {
     if (state.currentBox.version && state.currentBox.version !== state.appInfo.version) {
       banner.innerHTML = `
         <div class="update-msg">
-          <b>Box Software Update verfuegbar</b>
+          <b>Box Software Update verfuegbar</b><br>
           <small>Box laeuft mit Version ${escapeHtml(state.currentBox.version)}, die App hat Version ${escapeHtml(state.appInfo.version)}.</small>
         </div>
         <button class="btn btn-primary btn-mini" id="boxUpdateBtn">Aktualisieren</button>
@@ -1464,25 +1001,56 @@ async function checkBoxUpdate() {
 
 async function doBoxUpdate() {
   if (!state.currentBox) return;
-  // Beide Update Buttons gleichzeitig steuern (Banner oben + Stick Info Sektion)
-  const buttons = ['boxUpdateBtn', 'stickInfoUpdateBtn'].map(id => $(id)).filter(Boolean);
-  const setStatus = (text) => buttons.forEach(b => { b.textContent = text; b.disabled = true; });
-  const reset = () => buttons.forEach(b => { b.disabled = false; b.textContent = 'Aktualisieren'; });
+  // Drive both update buttons together (banner up top + stick info section)
+  const buttons = () => ['boxUpdateBtn', 'stickInfoUpdateBtn'].map(id => $(id)).filter(Boolean);
+  const setStatus = (text) => buttons().forEach(b => { b.textContent = text; b.disabled = true; });
+  const reset = () => buttons().forEach(b => { b.disabled = false; b.textContent = 'Aktualisieren'; });
   setStatus('Hochladen...');
+  const targetBox = state.currentBox;
+  const appBuild  = state.appInfo && state.appInfo.build;
   try {
-    await UpdateBoxAgent(state.currentBox.host, state.currentBox.port);
-    setStatus('Software startet neu...');
-    showToast('Update hochgeladen. Software auf der Box startet in ca. 10 Sekunden neu.');
-    setTimeout(async () => {
-      setStatus('Suche Box...');
-      await discoverBoxes();
-      setStatus('Pruefe Version...');
-      setTimeout(() => {
-        checkBoxUpdate();
-        if (state.view === 'settings') loadBoxSettings();
-        reset();
-      }, 3000);
-    }, 10000);
+    await UpdateBoxAgent(targetBox.host, targetBox.port);
+    // Agent has accepted the binary. It will detach, sleep ~70 s
+    // (TIME_WAIT for listener ports — see internal/webui handleAgentUpdate),
+    // then exec the new binary. During that whole window the box is
+    // unreachable; the previous UI would re-enable the button after a
+    // fixed 13 s timer, which invited the user to click again while
+    // the agent was still mid-restart.
+    showToast('Update hochgeladen. Box braucht jetzt etwa 90 Sekunden bis sie wieder antwortet.');
+    setStatus('Box laeuft neu hoch (bis zu 2 Min)...');
+    // Active poll: hit /api/agent/version until the box answers with
+    // a build matching the app's appBuild. Up to 3 minutes, 5 s
+    // between attempts. As long as the build is wrong or the box
+    // is unreachable, the buttons stay locked.
+    const startMs = Date.now();
+    const deadlineMs = startMs + 180_000;
+    let confirmed = false;
+    while (Date.now() < deadlineMs) {
+      await sleep(5_000);
+      try {
+        const v = await BoxAgentVersion(targetBox.host, targetBox.port);
+        if (v && v.build && (!appBuild || v.build === appBuild)) {
+          confirmed = true;
+          break;
+        }
+        const waited = Math.round((Date.now() - startMs) / 1000);
+        setStatus(`Box antwortet noch alter Build (${waited}s)...`);
+      } catch {
+        const waited = Math.round((Date.now() - startMs) / 1000);
+        setStatus(`Warte auf Box (${waited}s)...`);
+      }
+    }
+    if (confirmed) {
+      showToast('Update fertig.');
+    } else {
+      showToast('Box braucht laenger als erwartet. Pruefe Strom / Netzwerk.');
+    }
+    // Refresh app state regardless of confirmation so the user sees
+    // current truth (either updated or still in OTA).
+    await discoverBoxes();
+    checkBoxUpdate();
+    if (state.view === 'settings') loadBoxSettings();
+    reset();
   } catch (e) {
     showError('Update fehlgeschlagen: ' + e + '\n\nFalls die Box danach nicht mehr antwortet, trenne kurz den Strom und stecke sie wieder an.');
     reset();
@@ -2454,7 +2022,6 @@ function friendlySettingsError(err) {
   return 'Verbindung fehlgeschlagen. ' + s;
 }
 
-function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
 
 function renderBoxSettings(s, box) {
   const info = s.info || {};
@@ -3083,13 +2650,6 @@ const debouncedSetBass = debounce(async (box, defaultBass) => {
   } catch (e) { showError(e); }
 }, 200);
 
-function debounce(fn, ms) {
-  let t = null;
-  return (...args) => {
-    if (t) clearTimeout(t);
-    t = setTimeout(() => fn(...args), ms);
-  };
-}
 
 // ---------- Setup View ----------
 
@@ -3480,68 +3040,6 @@ async function doSetup() {
   $('setupGo').disabled = false;
 }
 
-// ---------- Modals ----------
-
-let warnResolve = null;
-$('warnCancel').onclick = () => { closeWarn(); if (warnResolve) warnResolve(false); };
-$('warnConfirm').onclick = () => { closeWarn(); if (warnResolve) warnResolve(true); };
-function confirmWarn(title, bodyHtml) {
-  $('warnModal').querySelector('.warn-title').innerHTML = '<span class="warn-icon">&#9888;</span> ' + escapeHtml(title);
-  $('warnBody').innerHTML = bodyHtml;
-  $('warnModal').classList.remove('hidden');
-  return new Promise(res => { warnResolve = res; });
-}
-function closeWarn() { $('warnModal').classList.add('hidden'); }
-
-$('errorClose').onclick = () => $('errorModal').classList.add('hidden');
-$('errorCopy').onclick = async () => {
-  const txt = $('errorText').value;
-  try {
-    await navigator.clipboard.writeText(txt);
-    $('errorCopy').textContent = 'Kopiert!';
-    setTimeout(() => $('errorCopy').textContent = 'Kopieren', 1500);
-  } catch {
-    $('errorText').select();
-    document.execCommand('copy');
-  }
-};
-function showError(msg) {
-  $('errorText').value = String(msg || 'Unbekannter Fehler');
-  $('errorModal').classList.remove('hidden');
-}
-
-let toastTimer = null;
-function showToast(msg) {
-  const t = $('toast');
-  if (!t) return;
-  t.textContent = msg;
-  t.classList.add('show');
-  if (toastTimer) clearTimeout(toastTimer);
-  toastTimer = setTimeout(() => t.classList.remove('show'), 2200);
-}
-
-// ---------- Helper ----------
-
-function escapeHtml(s) {
-  return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
-}
-function escapeAttr(s) { return escapeHtml(s); }
-
-// decodeXmlEntities macht aus "Rock &amp; Roll" wieder "Rock & Roll".
-// Bose liefert in /now_playing XML escaped — wenn wir den String 1:1
-// als Preset Name speichern, kommt er beim naechsten Render doppelt
-// escaped raus.
-function decodeXmlEntities(s) {
-  if (!s) return s;
-  return String(s)
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'")
-    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(parseInt(n, 10)))
-    .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCharCode(parseInt(h, 16)));
-}
 
 renderFooter();
 
@@ -3561,6 +3059,12 @@ renderFooter();
     refreshStatus();
     loadTaxonomy();
     loadStickRegion();
+    // Also fire the OTA-check on boot. Without this, an app that
+    // boots while box version === app version skips checkBoxUpdate
+    // (it only fires from discoverBoxes on `changed=true`), and the
+    // Musik-hören banner never reflects a build-stamp mismatch
+    // even though Box-Einstellungen surfaces it independently.
+    checkBoxUpdate();
   } else {
     renderBoxSelect();
   }

--- a/desktop-app/frontend/src/state.js
+++ b/desktop-app/frontend/src/state.js
@@ -1,0 +1,106 @@
+// state.js — central application state plus localStorage helpers.
+//
+// Imported from practically every module; always import as `{ state }`
+// so that mutations land on the single shared instance rather than a
+// copy.
+
+export const state = {
+  view: 'box',
+  boxes: [],
+  currentBox: null,
+  settingsBox: null,   // The box whose settings are currently being edited
+  presets: [],
+  searchResults: [],
+  drives: [],
+  selectedDrive: null,
+  // Set right after a successful prepare+eject. While set,
+  // refreshDrives() hides that path from the list until it either
+  // disappears (physical pull) or comes back with a valid FAT32
+  // mount. Prevents the wizard re-rendering the ejected stick as
+  // "unknown format". Cleared by the "search again" button.
+  justEjectedPath: null,
+  appInfo: null,
+  nowLocation: '',     // current stream URL from now_playing
+  nowName: '',         // current itemName from now_playing
+  nowPlayState: '',    // current PlayState
+  nowIcon: '',         // last known station logo (favicon)
+  nowUUID: '',         // last radio-browser UUID
+  optimisticUntil: 0,  // timestamp until which refreshStatus trusts our optimistic state over the box
+  presetErrors: {},    // slot → last error message (rendered red)
+  searchOrder: 'votes',
+  searchCountry: 'DE',
+  searchLang: '',
+  searchTag: '',       // active genre chip
+  searchOnlyOK: true,
+  searchOnlyBose: true,
+  searchOffset: 0,
+  searchLastMode: 'top', // "top" or "search" — for "load more"
+  searchLastQuery: '',
+  tags: [],            // cache of top tags for chips
+  languages: [],       // cache of languages
+  // Pending names: box ID -> { name, until } — after a local rename
+  // we override every mDNS entry with this for up to 90 s. Long enough
+  // until the stick re-announces its TXT record.
+  pendingNames: {},
+  // Music tab volume slider busy flag + grace period — prevents the
+  // 2 s auto refresh in refreshStatus from yanking the slider thumb
+  // out from under the user while they are dragging. Initialized
+  // here so every module starts from a consistent value; UI code in
+  // views/playback.js flips it at runtime.
+  musicVolBusy: false,
+  musicVolUntil: 0,
+  // showMoreGenres: user clicked "more" on the genre chip row
+  showMoreGenres: false,
+};
+
+// Persistent box selection: deviceID in localStorage, reloaded after
+// app restart so the previously controlled box stays focused.
+export function loadLastBox() {
+  try { return localStorage.getItem('lastBoxDeviceID') || null; } catch { return null; }
+}
+export function saveLastBox(id) {
+  try { localStorage.setItem('lastBoxDeviceID', id || ''); } catch {}
+}
+
+// isRoutableHost returns true if a string looks like a host we could
+// reasonably reach over the local network. Filters out:
+//   - empty strings
+//   - 203.0.113/24 (RFC 5737 TEST-NET-3, the Bose box's USB gadget
+//     interface — announced by mDNS but never routable from the LAN)
+//   - 0.0.0.0 / 255.255.255.255 and other obviously invalid values
+//   - 127/8 loopback
+// Hostnames (containing a dot but no all-digit segments, e.g.
+// "rhino.local") are passed through.
+function isRoutableHost(h) {
+  if (!h || typeof h !== 'string') return false;
+  if (h.startsWith('203.0.113.')) return false;
+  if (h.startsWith('127.')) return false;
+  if (h === '0.0.0.0' || h === '255.255.255.255') return false;
+  return true;
+}
+
+// Persistent cache of the last seen box list. Lets the app render
+// the box selector immediately on launch or tab switch without
+// waiting 4 seconds for mDNS. discoverBoxes() refreshes in the
+// background and overwrites.
+//
+// Filters poisoned cache entries on read. An older build of the app
+// could have written a box with host=203.0.113.x (USB gadget IP)
+// before the pickReachableIP filter existed; without filtering here
+// the bad entry survives every relaunch and breaks the volume slider
+// and preset playback until the next successful discovery overwrite.
+export function loadCachedBoxes() {
+  try {
+    const raw = localStorage.getItem('cachedBoxes');
+    if (!raw) return [];
+    const arr = JSON.parse(raw);
+    if (!Array.isArray(arr)) return [];
+    return arr.filter(b => b && isRoutableHost(b.host));
+  } catch { return []; }
+}
+export function saveCachedBoxes(list) {
+  try {
+    const clean = (list || []).filter(b => b && isRoutableHost(b.host));
+    localStorage.setItem('cachedBoxes', JSON.stringify(clean));
+  } catch {}
+}

--- a/desktop-app/frontend/src/style.css
+++ b/desktop-app/frontend/src/style.css
@@ -59,26 +59,74 @@ body {
   color: var(--brand-text);
   line-height: 1.4;
 }
+/* Three donate buttons, each branded per the provider's official
+   guidelines. Common shell: 130px wide, 32px tall, inline icon + text.
+   The brand-specific class overrides background / text / border. */
 .donate-side .donate-btn {
-  display: inline-block;
-  background: linear-gradient(135deg, #0070ba 0%, #003087 100%);
-  color: #fff;
-  padding: 7px 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 130px;
+  padding: 7px 10px;
   border-radius: 18px;
   font-weight: 600;
+  font-size: 12px;
   text-decoration: none;
   cursor: pointer;
-  font-size: 12px;
-  box-shadow: 0 2px 8px rgba(0, 112, 186, 0.4);
-  border: none;
+  border: 1px solid transparent;
+  transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
 }
 .donate-side .donate-btn:hover { transform: translateY(-1px); }
-.donate-side .donate-btn[disabled] {
-  background: #444;
-  color: #888;
-  cursor: not-allowed;
-  box-shadow: none;
+.donate-side .donate-btn-icon { display: inline-flex; align-items: center; }
+.donate-side .donate-btn-label { line-height: 1; }
+
+/* GitHub Sponsors — Mona Pink #bf3989 on white. */
+.donate-side .donate-gh {
+  background: #ffffff;
+  color: #24292f;
+  border-color: #bf3989;
+  box-shadow: 0 2px 6px rgba(191, 57, 137, 0.25);
 }
+.donate-side .donate-gh:hover {
+  background: #fff5fa;
+  box-shadow: 0 3px 10px rgba(191, 57, 137, 0.45);
+}
+.donate-side .donate-gh .donate-btn-icon { color: #bf3989; }
+
+/* PayPal — official yellow #FFC439, hover #F5B81F. Two-tone wordmark
+   "Pay" #003087 + "Pal" #009CDE in italic-bold (PayPal Sans isn't
+   licensed for free use; italic + bold is the closest free fallback
+   that still reads as the PayPal mark). */
+.donate-side .donate-paypal {
+  background: #ffc439;
+  box-shadow: 0 2px 6px rgba(255, 196, 57, 0.4);
+}
+.donate-side .donate-paypal:hover {
+  background: #f5b81f;
+  box-shadow: 0 3px 10px rgba(245, 184, 31, 0.55);
+}
+.donate-side .donate-paypal-wordmark {
+  font-style: italic;
+  font-weight: 800;
+  font-size: 14px;
+  letter-spacing: -0.3px;
+  font-family: Helvetica, Arial, sans-serif;
+}
+.donate-side .donate-paypal-wordmark .pay { color: #003087; }
+.donate-side .donate-paypal-wordmark .pal { color: #009cde; }
+
+/* Ko-fi — coral #FF5E5B with white text and icon. */
+.donate-side .donate-kofi {
+  background: #ff5e5b;
+  color: #ffffff;
+  box-shadow: 0 2px 6px rgba(255, 94, 91, 0.4);
+}
+.donate-side .donate-kofi:hover {
+  background: #e63946;
+  box-shadow: 0 3px 10px rgba(230, 57, 70, 0.55);
+}
+
 .donate-side small { color: #666; font-size: 10px; }
 /* Bei zu schmalen Fenstern ueberlappt der Donate sonst die App
    — dann ausblenden, der Footer Link bleibt als Backup. */
@@ -105,6 +153,22 @@ body {
   flex-direction: column;
   margin-bottom: 6px;
   padding-bottom: 4px;
+}
+.app-header-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.app-logo {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  color: #eee; /* drives the dots + horizontal lines via currentColor;
+                 the red heartbeat stays #cc0000 in the SVG itself */
+}
+.app-logo svg {
+  width: 100%;
+  height: 100%;
 }
 .app-brand {
   font-size: 20px;
@@ -246,6 +310,7 @@ body {
 }
 .box-edit:hover { color: var(--brand); background: rgba(102, 187, 221, 0.12); }
 .box-ver { background: #333; color: #aaa; font-size: 10px; padding: 1px 5px; border-radius: 8px; margin-left: 6px; }
+.box-model { color: #888; font-size: 11px; font-weight: 500; margin-left: 8px; }
 
 /* ---------- Status Bar (Signal-Farben!) ---------- */
 .status-bar { background: #222; padding: 8px 12px; border-radius: 6px; margin-bottom: 10px; min-height: 36px; display: flex; align-items: center; font-size: 13px; }

--- a/desktop-app/frontend/src/utils.js
+++ b/desktop-app/frontend/src/utils.js
@@ -1,0 +1,123 @@
+// utils.js — small, view-independent helper functions.
+//
+// Everything here is either pure (formatNumber, escapeHtml, debounce)
+// or depends only on the DOM skeleton that main.js renders on boot
+// (showError, showToast, confirmWarn). No coupling to the state
+// object on purpose, so utils can be imported anywhere without
+// circular-import risk.
+
+export const $ = (id) => document.getElementById(id);
+
+export function escapeHtml(s) {
+  return String(s ?? '').replace(/[&<>"']/g, c => (
+    { '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' }[c]
+  ));
+}
+
+export function escapeAttr(s) { return escapeHtml(s); }
+
+// decodeXmlEntities decodes the five named XML entity sequences plus
+// numeric character references that the Bose /now_playing XML
+// occasionally emits. Without this, "Bryan Adams &amp; Tina Turner"
+// would be stored verbatim as a preset name and double-escaped at
+// the next render.
+export function decodeXmlEntities(s) {
+  if (!s) return s;
+  return String(s)
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(parseInt(n, 10)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCharCode(parseInt(h, 16)));
+}
+
+export function formatNumber(n) {
+  if (!n || isNaN(n)) return '0';
+  return Number(n).toLocaleString('de-DE');
+}
+
+export function debounce(fn, ms) {
+  let h = null;
+  return (...args) => {
+    if (h) clearTimeout(h);
+    h = setTimeout(() => { h = null; fn(...args); }, ms);
+  };
+}
+
+export function sleep(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+// ---------- Modals ----------
+//
+// The three modals (warn, error, toast) live in the DOM skeleton in
+// main.js. These helpers bind to the well-known IDs the first time
+// they are used so the wiring lives alongside the helpers that use
+// it — no need for main.js to remember to wire anything.
+
+let warnResolve = null;
+let warnWired = false;
+function wireWarn() {
+  if (warnWired) return;
+  warnWired = true;
+  const cancel = $('warnCancel');
+  const confirm = $('warnConfirm');
+  if (cancel)  cancel.onclick  = () => { closeWarn(); if (warnResolve) warnResolve(false); };
+  if (confirm) confirm.onclick = () => { closeWarn(); if (warnResolve) warnResolve(true); };
+}
+
+export function confirmWarn(title, bodyHtml) {
+  wireWarn();
+  const m = $('warnModal');
+  if (!m) return Promise.resolve(false);
+  const t = m.querySelector('.warn-title');
+  if (t) t.innerHTML = '<span class="warn-icon">&#9888;</span> ' + escapeHtml(title);
+  $('warnBody').innerHTML = bodyHtml;
+  m.classList.remove('hidden');
+  return new Promise(res => { warnResolve = res; });
+}
+
+export function closeWarn() {
+  const m = $('warnModal');
+  if (m) m.classList.add('hidden');
+}
+
+let errorWired = false;
+function wireError() {
+  if (errorWired) return;
+  errorWired = true;
+  const close = $('errorClose');
+  const copy  = $('errorCopy');
+  if (close) close.onclick = () => $('errorModal').classList.add('hidden');
+  if (copy)  copy.onclick  = async () => {
+    const txt = $('errorText').value;
+    try {
+      await navigator.clipboard.writeText(txt);
+      copy.textContent = 'Kopiert!';
+      setTimeout(() => { copy.textContent = 'Kopieren'; }, 1500);
+    } catch {
+      $('errorText').select();
+      document.execCommand('copy');
+    }
+  };
+}
+
+export function showError(msg) {
+  wireError();
+  const m = $('errorModal');
+  if (!m) return;
+  $('errorText').value = String(msg || 'Unbekannter Fehler');
+  m.classList.remove('hidden');
+}
+
+let toastTimer = null;
+export function showToast(msg) {
+  const t = $('toast');
+  if (!t) return;
+  t.textContent = msg;
+  t.classList.add('show');
+  if (toastTimer) clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => t.classList.remove('show'), 2200);
+}

--- a/desktop-app/frontend/wailsjs/go/models.ts
+++ b/desktop-app/frontend/wailsjs/go/models.ts
@@ -34,6 +34,7 @@ export namespace main {
 	    friendlyName: string;
 	    model: string;
 	    version: string;
+	    build: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new BoxInfo(source);
@@ -48,6 +49,7 @@ export namespace main {
 	        this.friendlyName = source["friendlyName"];
 	        this.model = source["model"];
 	        this.version = source["version"];
+	        this.build = source["build"];
 	    }
 	}
 	export class Preset {

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -60,6 +60,11 @@ type Config struct {
 	Model string
 	// Version ist die Stick Agent Version.
 	Version string
+	// Build is the agent build stamp (YYYY-MM-DD-HHMM). Announced
+	// alongside Version so the desktop app's "update available"
+	// indicators can detect stamp drift between two binaries that
+	// happen to share the same git-describe version string.
+	Build string
 }
 
 // Announce startet einen mDNS Server der den Stick announciert. Stop mit
@@ -88,6 +93,7 @@ func Announce(logger *slog.Logger, cfg Config) (*Announcer, error) {
 func (a *Announcer) register() error {
 	txt := []string{
 		"version=" + nz(a.cfg.Version, "dev"),
+		"build=" + nz(a.cfg.Build, ""),
 		"deviceID=" + nz(a.cfg.DeviceID, ""),
 		"model=" + nz(a.cfg.Model, ""),
 		"friendlyName=" + nz(a.cfg.FriendlyName, ""),
@@ -185,6 +191,7 @@ type Instance struct {
 	Model        string
 	FriendlyName string
 	Version      string
+	Build        string
 }
 
 // Browse searches the LAN for sticks announcing either the current or
@@ -243,6 +250,8 @@ func Browse(ctx context.Context, logger *slog.Logger) (<-chan Instance, error) {
 					inst.FriendlyName = v
 				case "version":
 					inst.Version = v
+				case "build":
+					inst.Build = v
 				}
 			}
 			if logger != nil {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,6 +13,31 @@ For the security-specific roadmap see
 - Additional verified speaker models (ST20, ST30, Portable).
 - Wails sandboxing on macOS and Windows.
 
+## In-flight engineering
+
+These are tracked here because they span multiple PRs and need a
+durable home so future sessions do not re-scope or duplicate the
+work. Distinct from the post-1.0 items above: scheduling here is
+"next few PRs", not "after v1.0".
+
+### Frontend refactor of `desktop-app/frontend/src/main.js`
+
+Started 2026-05-17. Goal: split the ~3500-line monolith into
+focused modules, add i18n, switch the default UI to English.
+
+| Phase | Scope | Status |
+|-------|-------|--------|
+| A | Extract leaf modules (`state`, `utils`, `localization`, `logos`, `api`) out of `main.js`. All comments and identifiers English. | merged via [#40](https://github.com/JRpersonal/streborn/pull/40) (or about to be — check the branch) |
+| B | Extract view modules: `views/box-discovery.js`, `views/presets.js`, `views/playback.js`, `views/search.js`, `views/settings.js`, `views/setup.js`, `views/footer.js`. After this `main.js` shrinks to the DOM skeleton + view dispatcher (~150 lines). | not started |
+| C | i18n system: minimal `t()` helper plus `en` and `de` bundles in `desktop-app/frontend/src/i18n/`. Locale detected from `navigator.language`, with explicit override stored in `localStorage`. **Default is English** per the global-audience rule — German remains a first-class supported locale but is no longer the implicit fallback. | not started |
+| D | Translate the remaining inline German comments and the few mixed-language handler strings still sitting in `main.js` (and any view module that ends up holding them after Phase B). Closes the CLAUDE.md "all code/comments/identifiers in English" rule. | not started, naturally falls out of Phase B+C |
+
+Why this is on the roadmap rather than just done: Phase A alone
+was ~600 lines of careful diff and surfaced six unrelated bugs
+that we durably fixed in flight (see #40). Phase B+C are bigger
+still — the right move is one PR per phase so each is reviewable
+and any regression can be bisected to its phase.
+
 ## Under consideration
 
 ### iOS web app (PWA) installable from the website

--- a/internal/radiobrowser/radiobrowser.go
+++ b/internal/radiobrowser/radiobrowser.go
@@ -22,16 +22,28 @@ import (
 	"time"
 )
 
-// Mirrors sind die Server die wir der Reihe nach probieren. Erster
-// erfolgreicher gewinnt; bei Fehler oder Timeout wandern wir zum
-// naechsten. Reihenfolge wird im Speicher beibehalten und rotiert bei
-// erfolgreichem Call (ein gerade erfolgreicher Mirror bleibt vorne).
+// Mirrors are the servers we try in order. First success wins; on
+// error or timeout we move to the next. Order is kept across calls
+// and the most recent successful mirror moves to the front, so a
+// stable mirror stays primary as long as it answers.
+//
+// As of 2026-05-17 radio-browser.info has consolidated their
+// infrastructure: their own discovery endpoint
+// (https://all.api.radio-browser.info/json/servers) only returns
+// de1.api.radio-browser.info as an alive server — de2/at1/nl1/fi1
+// no longer resolve. The hardcoded list mirrors that reality:
+//   - `de1.api...`     — the named primary
+//   - `all.api...`     — DNS round-robin fallback that resolves to
+//                        whichever server is currently alive (one
+//                        request away from being self-healing if
+//                        radio-browser adds new servers).
+//   - `91.98.4.78`     — de1's current IPv4 hard-coded as last-
+//                        resort if DNS itself is down on the
+//                        speaker's network.
 var Mirrors = []string{
 	"https://de1.api.radio-browser.info/json",
-	"https://de2.api.radio-browser.info/json",
-	"https://at1.api.radio-browser.info/json",
-	"https://nl1.api.radio-browser.info/json",
-	"https://fi1.api.radio-browser.info/json",
+	"https://all.api.radio-browser.info/json",
+	"https://91.98.4.78/json",
 }
 
 // Station beschreibt einen einzelnen Sender wie er von der API kommt.
@@ -359,9 +371,21 @@ func (c *Client) Click(ctx context.Context, uuid string) error {
 	return c.fetchJSON(ctx, "/url/"+url.PathEscape(uuid), &out)
 }
 
+// perMirrorTimeout caps every individual attempt against a single
+// mirror. Smaller than the outer handler ctx so several mirrors can
+// be tried within the user-perceived wait — without this the first
+// slow mirror used to consume the entire 8 s handler budget and
+// failover was effectively dead.
+const perMirrorTimeout = 3 * time.Second
+
 // fetchJSON probiert alle Mirrors der Reihe nach. Erster erfolgreicher
 // gewinnt. Bei Erfolg merken wir uns den Mirror als "primary" damit der
 // naechste Call denselben Server bevorzugt.
+//
+// Each attempt runs under its own derived context with a 3 s timeout
+// instead of sharing the outer handler ctx. That way a single slow
+// or hung mirror cannot eat the whole budget — five mirrors at 3 s
+// each fit inside the webui handler's 15 s outer timeout with margin.
 func (c *Client) fetchJSON(ctx context.Context, path string, out any) error {
 	c.mu.Lock()
 	mirrors := append([]string(nil), c.mirrors...)
@@ -369,44 +393,63 @@ func (c *Client) fetchJSON(ctx context.Context, path string, out any) error {
 
 	var lastErr error
 	for i, base := range mirrors {
-		full := base + path
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, full, nil)
-		if err != nil {
-			lastErr = err
-			continue
-		}
-		if c.UA != "" {
-			req.Header.Set("User-Agent", c.UA)
-		}
-		resp, err := c.HTTP.Do(req)
-		if err != nil {
-			lastErr = err
-			continue
-		}
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
-		resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			n := len(body)
-			if n > 256 {
-				n = 256
+		// Outer ctx cancelled (handler timeout fired, client went
+		// away): stop trying further mirrors.
+		if err := ctx.Err(); err != nil {
+			if lastErr == nil {
+				lastErr = err
 			}
-			lastErr = fmt.Errorf("mirror %s: %d: %s", base, resp.StatusCode, string(body[:n]))
-			continue
+			break
 		}
-		if err := json.Unmarshal(body, out); err != nil {
-			lastErr = fmt.Errorf("decode %s: %w", base, err)
-			continue
+		err := c.tryMirror(ctx, base, path, out)
+		if err == nil {
+			// Erfolg: Mirror nach vorne sortieren wenn nicht schon erster
+			if i > 0 {
+				c.mu.Lock()
+				c.mirrors[0], c.mirrors[i] = c.mirrors[i], c.mirrors[0]
+				c.mu.Unlock()
+			}
+			return nil
 		}
-		// Erfolg: Mirror nach vorne sortieren wenn nicht schon erster
-		if i > 0 {
-			c.mu.Lock()
-			c.mirrors[0], c.mirrors[i] = c.mirrors[i], c.mirrors[0]
-			c.mu.Unlock()
-		}
-		return nil
+		lastErr = err
 	}
 	if lastErr == nil {
 		lastErr = fmt.Errorf("kein mirror erreichbar")
 	}
 	return lastErr
+}
+
+// tryMirror executes a single mirror attempt under its own short ctx.
+// Returns nil on success, error otherwise (timeout, non-200, decode
+// failure). Caller is responsible for falling through to the next
+// mirror on error.
+func (c *Client) tryMirror(parent context.Context, base, path string, out any) error {
+	ctx, cancel := context.WithTimeout(parent, perMirrorTimeout)
+	defer cancel()
+
+	full := base + path
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, full, nil)
+	if err != nil {
+		return err
+	}
+	if c.UA != "" {
+		req.Header.Set("User-Agent", c.UA)
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		n := len(body)
+		if n > 256 {
+			n = 256
+		}
+		return fmt.Errorf("mirror %s: %d: %s", base, resp.StatusCode, string(body[:n]))
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("decode %s: %w", base, err)
+	}
+	return nil
 }

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -410,7 +410,7 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleRadioSearch(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	rb := radiobrowser.New()
-	ctx, cancel := context.WithTimeout(r.Context(), 8*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), 18*time.Second)
 	defer cancel()
 	limit := 30
 	if v := q.Get("limit"); v != "" {
@@ -462,7 +462,7 @@ func (s *Server) handleRadioTop(w http.ResponseWriter, r *http.Request) {
 		order = "votes"
 	}
 	rb := radiobrowser.New()
-	ctx, cancel := context.WithTimeout(r.Context(), 8*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), 18*time.Second)
 	defer cancel()
 	stations, err := rb.Search(ctx, radiobrowser.SearchOpts{
 		Country:  cc,
@@ -489,7 +489,7 @@ func (s *Server) handleRadioTags(w http.ResponseWriter, r *http.Request) {
 		fmt.Sscanf(v, "%d", &limit)
 	}
 	rb := radiobrowser.New()
-	ctx, cancel := context.WithTimeout(r.Context(), 8*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), 18*time.Second)
 	defer cancel()
 	tags, err := rb.TopTags(ctx, limit)
 	if err != nil {
@@ -513,7 +513,7 @@ func (s *Server) handleRadioLanguages(w http.ResponseWriter, r *http.Request) {
 	country := strings.ToUpper(strings.TrimSpace(q.Get("country")))
 
 	rb := radiobrowser.New()
-	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), 18*time.Second)
 	defer cancel()
 
 	if country != "" {


### PR DESCRIPTION
## Phase A of the main.js refactor

Five low-risk leaf modules extracted out of the 3571-line `main.js` monolith:

| Module | Lines | What it contains |
|--------|-------|------------------|
| `state.js` | 106 | central state + localStorage helpers (now with poisoned-cache filter for stale 203.0.113/24 entries) |
| `utils.js` | 123 | `$`, escape/decode, debounce/sleep, self-wiring modal helpers |
| `localization.js` | 375 | COUNTRIES, ORDERS, GENRE_CORE/BY_COUNTRY, translateCountry/Genre/Tags, flagFromCC |
| `logos.js` | 102 | station logo resolution; Google favicon service removed on user request |
| `api.js` | 52 | Wails-binding re-exports + `boxURL` helper |

Net diff: main.js 3571 → 3015 lines (-555); total +991/-668 because new modules carry inline documentation.

Views remain in main.js for **Phase B** (separate PR). i18n is **Phase C**.

## Bug fixes folded in (per the "no quick fix only" rule)

A series of issues were uncovered during local-build testing of the refactor; each is fixed at the durable layer rather than as a UI workaround:

- **localStorage cache poisoning** by stale Bose USB-gadget IPs (203.0.113/24) — filtered on both read and write in `state.js`.
- **OTA UI re-enables button too early** — `doBoxUpdate` now polls `BoxAgentVersion` for up to 3 minutes after upload, keeping both update buttons locked until the box confirms the new build is live. Prevents the 13-s premature re-click during the ~70 s TIME_WAIT restart window.
- **Tab badge & Musik-hören update banner missed build-stamp drift** — all three update indicators (badge / Musik-hören banner / Box-Einstellungen status) now consider both `version` and `build` consistently. Plus `build=YYYY-MM-DD-HHMM` is now part of the mDNS TXT record (`discovery/discovery.go` + `cmd/agent/main.go` + `desktop-app/app.go BoxInfo`).
- **bootFromCache() didn’t trigger checkBoxUpdate** — an app launching against a cached box whose mDNS-version still matched never ran the agent-version comparison even if builds differed. Fixed.
- **Radio-browser.info mirror list was stale** — de2/at1/nl1/fi1 no longer resolve via DNS; only de1 is alive today per the project’s own `/json/servers` discovery. New list: `de1` + `all.api` (DNS round-robin fallback) + `91.98.4.78` (IPv4 last resort).
- **fetchJSON shared one ctx across all five mirrors** — a single slow mirror used to consume the full 8 s handler budget so failover was effectively dead. Per-mirror context with 3 s timeout, outer handler bumped to 18 s.
- **Update banner layout** — added `<br>` after "Box Software Update verfügbar" so the build-aware label wraps cleanly.
- **Google favicon service removed** — `logos.js` only queries DuckDuckGo now.

## Verified manually on real ST10 hardware (192.168.178.66)

- Soft + hardware presets load and play
- OTA upload + self-restart + confirmation poll completes
- All three update indicators agree once App and Agent share the same stamp
- mDNS `build=` field propagates correctly

## Test plan

- [ ] CI green (build / golangci-lint / govulncheck)
- [ ] Radio search test from a clean app launch against current radio-browser.info state (consolidated to de1 only).
- [ ] OTA cycle on a box: app shows poll status, button stays locked until confirmation, no premature re-click possible.
