### PR TITLE
feat(discovery): detect stock Bose SoundTouch speakers in the LAN

### DIFF
--- a/desktop-app/app.go
+++ b/desktop-app/app.go
@@ -41,24 +41,30 @@ func (a *App) startup(ctx context.Context) {
 }
 
 // BoxInfo is the speaker entry passed to the frontend for selection.
+// Kind distinguishes STR-equipped speakers from stock Bose speakers
+// that still need a USB-stick install.
 type BoxInfo struct {
 	Name         string `json:"name"`
 	Host         string `json:"host"` // IPv4 for the REST API
-	Port         int    `json:"port"` // typically 8888
+	Port         int    `json:"port"` // typically 8888 for STR, 8090 for stock
 	DeviceID     string `json:"deviceID"`
 	FriendlyName string `json:"friendlyName"`
 	Model        string `json:"model"`
 	Version      string `json:"version"`
 	// Build is the agent's build stamp (YYYY-MM-DD-HHMM) as
 	// announced via mDNS TXT. Empty if the speaker runs an older
-	// agent that does not yet broadcast build. Used by the frontend
-	// update indicators to flag stamp drift even when version
-	// strings match.
+	// agent that does not yet broadcast build, or if Kind == "stock".
+	// Used by the frontend update indicators to flag stamp drift
+	// even when version strings match.
 	Build string `json:"build"`
+	// Kind is "str" for speakers running an STR agent, "stock" for
+	// vanilla Bose SoundTouch speakers that the desktop app can
+	// offer to flash. Frontend renders the two kinds differently.
+	Kind string `json:"kind"`
 }
 
-// DiscoverBoxes scans the LAN for sticks via mDNS and blocks at most
-// timeoutSec seconds.
+// DiscoverBoxes durchsucht das LAN nach Sticks via mDNS und blockiert max
+// timeoutSec Sekunden.
 func (a *App) DiscoverBoxes(timeoutSec int) ([]BoxInfo, error) {
 	if timeoutSec <= 0 {
 		timeoutSec = 4
@@ -77,6 +83,17 @@ func (a *App) DiscoverBoxes(timeoutSec int) ([]BoxInfo, error) {
 		if host == "" {
 			continue
 		}
+		kind := string(inst.Kind)
+		if kind == "" {
+			kind = "str"
+		}
+		// STR-announced speaker wins over a stock entry for the same
+		// device. The discovery layer already prefers STR; we also
+		// guard here against the deduplication key collisions across
+		// different mDNS announces.
+		if prev, ok := seen[inst.Name]; ok && prev.Kind == "str" && kind == "stock" {
+			continue
+		}
 		seen[inst.Name] = BoxInfo{
 			Name:         inst.Name,
 			Host:         host,
@@ -86,6 +103,7 @@ func (a *App) DiscoverBoxes(timeoutSec int) ([]BoxInfo, error) {
 			Model:        inst.Model,
 			Version:      inst.Version,
 			Build:        inst.Build,
+			Kind:         kind,
 		}
 	}
 

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -49,6 +49,10 @@
   "speaker.rebootConfirmTitle": "Lautsprecher jetzt neu starten?",
   "speaker.rebootConfirmBody": "Hast du den USB-Stick bereits gezogen? Sonst bleibt SSH nach dem Reboot weiter offen. Aktuelle Wiedergabe wird unterbrochen.",
   "speaker.rebootingToast": "Lautsprecher startet neu. Er ist gleich wieder verfügbar.",
+  "speaker.needsInstallBadge": "STR-Installation nötig",
+  "speaker.stockTooltip": "Original-Bose-Firmware. STR ist auf diesem Lautsprecher noch nicht installiert.",
+  "speaker.stockConfirmTitle": "STR auf diesem Lautsprecher installieren?",
+  "speaker.stockConfirmBody": "<b>{{label}}</b> läuft noch mit der Original-Bose-Firmware. Um ihn von dieser App zu steuern, musst du den STR-Agent zuerst per USB-Stick installieren.<br><br>Jetzt die USB-Stick-Einrichtung öffnen?",
 
   "controls.pause": "Pause",
   "controls.stop": "Stop",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -49,6 +49,10 @@
   "speaker.rebootConfirmTitle": "Restart speaker now?",
   "speaker.rebootConfirmBody": "Have you removed the USB stick? Otherwise SSH stays open after the reboot. Current playback will be interrupted.",
   "speaker.rebootingToast": "Speaker is restarting. It will be available again shortly.",
+  "speaker.needsInstallBadge": "needs STR install",
+  "speaker.stockTooltip": "Stock Bose firmware. STR is not installed on this speaker yet.",
+  "speaker.stockConfirmTitle": "Install STR on this speaker?",
+  "speaker.stockConfirmBody": "<b>{{label}}</b> still runs the stock Bose firmware. To control it from this app, install the STR agent via a USB stick first.<br><br>Open the USB stick setup now?",
 
   "controls.pause": "Pause",
   "controls.stop": "Stop",

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -765,7 +765,9 @@ function renderBoxSelect() {
     return;
   }
   sel.innerHTML = state.boxes.map(b => {
-    const active = state.currentBox && state.currentBox.host === b.host ? ' active' : '';
+    const isStock = b.kind === 'stock';
+    const active = state.currentBox && state.currentBox.host === b.host && !isStock ? ' active' : '';
+    const stockCls = isStock ? ' stock' : '';
     const label = b.friendlyName || b.name || b.host;
     // Model (e.g. "SoundTouch 10") right next to the name so users
     // with several speakers can tell ST10 from ST20 at a glance.
@@ -774,17 +776,32 @@ function renderBoxSelect() {
     const model = b.model && b.model !== 'SoundTouch'
       ? `<span class="box-model" title="${escapeAttr(t('speaker.modelTitle'))}">${escapeHtml(b.model)}</span>`
       : '';
+    if (isStock) {
+      return `<span class="box-btn${stockCls}" data-host="${b.host}" data-port="${b.port}" data-stock="1" role="button" tabindex="0" title="${escapeAttr(t('speaker.stockTooltip'))}">${escapeHtml(label)}${model} <small>${b.host}</small><span class="box-stock-badge">${escapeHtml(t('speaker.needsInstallBadge'))}</span></span>`;
+    }
     const ver = b.version ? `<span class="box-ver" title="${escapeAttr(t('speaker.stickVersionTitle'))}">${escapeHtml(b.version)}</span>` : '';
     return `<span class="box-btn${active}" data-host="${b.host}" data-port="${b.port}" role="button" tabindex="0">${escapeHtml(label)}${model} <small>${b.host}</small>${ver}<span class="box-edit" data-host="${b.host}" data-port="${b.port}" title="${escapeAttr(t('speaker.editTitle'))}">&#9881;</span></span>`;
   }).join('');
   sel.querySelectorAll('.box-btn').forEach(btn => {
-    btn.onclick = (e) => {
+    btn.onclick = async (e) => {
       // A click on the gear icon opens the settings view rather than
       // selecting the speaker.
       if (e.target.closest('.box-edit')) return;
       const host = btn.dataset.host;
       const port = parseInt(btn.dataset.port, 10);
       const box = state.boxes.find(b => b.host === host && b.port === port);
+      if (!box) return;
+      if (box.kind === 'stock') {
+        // Stock speaker: the desktop app cannot control it directly.
+        // Offer to jump to the USB stick setup flow.
+        const label = box.friendlyName || box.name || box.host;
+        const ok = await confirmWarn(
+          t('speaker.stockConfirmTitle'),
+          t('speaker.stockConfirmBody', { label: escapeHtml(label) }),
+        );
+        if (ok) switchView('setup');
+        return;
+      }
       selectBox(box);
     };
   });
@@ -801,9 +818,13 @@ function renderBoxSelect() {
     };
   });
   if (!state.currentBox) {
+    // Auto-select only STR speakers. Stock speakers cannot be
+    // controlled and would put the music tab into a permanent
+    // "loading" state.
+    const strBoxes = state.boxes.filter(b => b.kind !== 'stock');
     const lastID = loadLastBox();
-    let target = lastID ? state.boxes.find(b => b.deviceID === lastID) : null;
-    if (!target && state.boxes.length === 1) target = state.boxes[0];
+    let target = lastID ? strBoxes.find(b => b.deviceID === lastID) : null;
+    if (!target && strBoxes.length === 1) target = strBoxes[0];
     if (target) selectBox(target);
   }
   updateBoxUiVisibility();
@@ -1141,9 +1162,13 @@ async function doBoxUpdate() {
 
 function updateBoxUiVisibility() {
   const hasBox = !!state.currentBox;
-  const hasAny = state.boxes.length > 0;
+  const hasSTR = state.boxes.some(b => b.kind !== 'stock');
+  // Show controls only when a selected STR speaker exists. Show the
+  // "pick a speaker" hint when STR speakers exist but none is
+  // selected; stock-only LAN scenarios fall through to the empty
+  // state rendered by renderBoxSelect (the badge speaks for itself).
   $('boxControls').classList.toggle('hidden', !hasBox);
-  $('boxHint').classList.toggle('hidden', !hasAny || hasBox);
+  $('boxHint').classList.toggle('hidden', !hasSTR || hasBox);
 }
 
 async function loadPresets(retry = 0) {

--- a/desktop-app/frontend/src/style.css
+++ b/desktop-app/frontend/src/style.css
@@ -380,6 +380,30 @@ body {
 .box-edit:hover { color: var(--brand); background: rgba(102, 187, 221, 0.12); }
 .box-ver { background: #333; color: #aaa; font-size: 10px; padding: 1px 5px; border-radius: 8px; margin-left: 6px; }
 .box-model { color: #888; font-size: 11px; font-weight: 500; margin-left: 8px; }
+.box-btn.stock {
+  background: #1f1f1f;
+  border-style: dashed;
+  border-color: #555;
+  color: #bbb;
+  padding-right: 10px;
+}
+.box-btn.stock:hover {
+  background: #292929;
+  border-color: var(--brand);
+  color: #eee;
+}
+.box-stock-badge {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: rgba(204, 0, 0, 0.18);
+  color: #f08080;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
 
 /* ---------- Status Bar (Signal-Farben!) ---------- */
 .status-bar { background: #222; padding: 8px 12px; border-radius: 6px; margin-bottom: 10px; min-height: 36px; display: flex; align-items: center; font-size: 13px; }

--- a/desktop-app/frontend/wailsjs/go/models.ts
+++ b/desktop-app/frontend/wailsjs/go/models.ts
@@ -35,6 +35,7 @@ export namespace main {
 	    model: string;
 	    version: string;
 	    build: string;
+	    kind: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new BoxInfo(source);
@@ -50,6 +51,7 @@ export namespace main {
 	        this.model = source["model"];
 	        this.version = source["version"];
 	        this.build = source["build"];
+	        this.kind = source["kind"];
 	    }
 	}
 	export class Preset {

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -1,10 +1,20 @@
-// Package discovery announciert den Stick via mDNS / DNS-SD im lokalen Netz
-// damit die Desktop App und andere Clients ihn automatisch finden ohne
-// dass der User eine IP eintippen muss.
+// Package discovery announces the stick agent via mDNS / DNS-SD on
+// the local network so the desktop app and other clients find it
+// without the user having to enter an IP. It also browses for stock
+// Bose SoundTouch speakers that do not yet run STR, so the desktop
+// app can offer to flash them.
 //
-// Service Typ: _streborn._tcp.local
-// Damit kann ein User mehrere SoundTouch Boxen im Netz haben (jede mit
-// eigenem Stick); die Desktop App listet alle Sticks via DNS-SD Browse.
+// Service types:
+//   _streborn._tcp.local         current STR service
+//   _soundtouchstick._tcp.local  legacy STR pre-rename, still in use
+//                                on speakers that have not been
+//                                OTA-updated yet
+//   _bose-soundtouch._tcp.local  stock Bose speakers (informational
+//                                only, not announced by STR)
+//
+// Multiple speakers on the same network are supported. The desktop
+// app lists every announced stick via DNS-SD browse plus every
+// detected stock speaker.
 package discovery
 
 import (
@@ -30,7 +40,23 @@ const (
 	// network still discovers every box.
 	LegacyServiceType = "_soundtouchstick._tcp"
 
+	// StockServiceType is the mDNS service that stock Bose SoundTouch
+	// firmware advertises out of the box. STR does not announce under
+	// this name; Browse() scans for it so the desktop app can show
+	// "needs STR install" speakers next to already-flashed ones.
+	StockServiceType = "_bose-soundtouch._tcp"
+
 	Domain = "local."
+)
+
+// Kind enumerates how a discovered speaker reports itself.
+//   - KindSTR:   announces an STR agent (current or legacy service)
+//   - KindStock: stock Bose firmware, no STR yet
+type Kind string
+
+const (
+	KindSTR   Kind = "str"
+	KindStock Kind = "stock"
 )
 
 // Announcer holds the active mDNS servers. We announce on both the
@@ -181,7 +207,9 @@ func (a *Announcer) Run(ctx context.Context) {
 	a.Close()
 }
 
-// Instance ist das Ergebnis eines Browse() Aufrufs.
+// Instance is the result of a Browse() call. Kind distinguishes
+// STR-equipped speakers from stock Bose speakers; for stock entries
+// Version and Build are empty.
 type Instance struct {
 	Name         string
 	Host         string
@@ -192,12 +220,16 @@ type Instance struct {
 	FriendlyName string
 	Version      string
 	Build        string
+	Kind         Kind
 }
 
-// Browse searches the LAN for sticks announcing either the current or
-// the legacy service type and returns a single merged channel.
-// Duplicate boxes (announced under both names by a single new agent)
-// are deduplicated by instance name.
+// Browse searches the LAN for sticks announcing either the current
+// or the legacy STR service type and for stock Bose SoundTouch
+// speakers, then returns a single merged channel. Duplicate
+// speakers (announced under both STR names by a single new agent,
+// or surfacing on both STR and Bose service types) are deduplicated
+// by instance name. STR announcements win over stock for the same
+// speaker so a flashed speaker never shows up as "needs install".
 func Browse(ctx context.Context, logger *slog.Logger) (<-chan Instance, error) {
 	out := make(chan Instance, 16)
 
@@ -211,9 +243,14 @@ func Browse(ctx context.Context, logger *slog.Logger) (<-chan Instance, error) {
 	if err != nil {
 		return nil, fmt.Errorf("resolver (legacy): %w", err)
 	}
+	stockResolver, err := zeroconf.NewResolver(nil)
+	if err != nil {
+		return nil, fmt.Errorf("resolver (stock): %w", err)
+	}
 
 	curEntries := make(chan *zeroconf.ServiceEntry, 8)
 	legacyEntries := make(chan *zeroconf.ServiceEntry, 8)
+	stockEntries := make(chan *zeroconf.ServiceEntry, 8)
 
 	if err := curResolver.Browse(ctx, ServiceType, Domain, curEntries); err != nil {
 		return nil, fmt.Errorf("browse current: %w", err)
@@ -221,20 +258,35 @@ func Browse(ctx context.Context, logger *slog.Logger) (<-chan Instance, error) {
 	if err := legacyResolver.Browse(ctx, LegacyServiceType, Domain, legacyEntries); err != nil {
 		return nil, fmt.Errorf("browse legacy: %w", err)
 	}
+	if err := stockResolver.Browse(ctx, StockServiceType, Domain, stockEntries); err != nil {
+		// Stock browse is best-effort. If it fails, keep going with
+		// STR discovery only so a flaky network stack does not
+		// disable the desktop app's main path.
+		if logger != nil {
+			logger.Warn("stock mDNS browse failed, continuing without it",
+				slog.String("service", StockServiceType), slog.Any("err", err))
+		}
+		stockEntries = nil
+	}
 
 	go func() {
 		defer close(out)
-		seen := map[string]bool{}
-		emit := func(e *zeroconf.ServiceEntry, legacy bool) {
+		// seen[instanceName] holds the Kind that won. STR wins over
+		// stock so an already-flashed speaker is not re-announced
+		// as a stock entry from a stale Bose-service record.
+		seen := map[string]Kind{}
+		emit := func(e *zeroconf.ServiceEntry, kind Kind, legacy bool) {
 			key := e.Instance + "|" + e.HostName
-			if seen[key] {
-				return
+			prev, exists := seen[key]
+			if exists && prev == KindSTR {
+				return // STR wins
 			}
-			seen[key] = true
+			seen[key] = kind
 			inst := Instance{
 				Name: e.Instance,
 				Host: e.HostName,
 				Port: e.Port,
+				Kind: kind,
 			}
 			for _, ip := range e.AddrIPv4 {
 				inst.IPv4 = append(inst.IPv4, ip.String())
@@ -252,35 +304,81 @@ func Browse(ctx context.Context, logger *slog.Logger) (<-chan Instance, error) {
 					inst.Version = v
 				case "build":
 					inst.Build = v
+				// Stock Bose firmware uses different TXT keys.
+				// MAC: hex MAC address of the speaker
+				// MODEL: short product code (e.g. "soundtouch_10")
+				// SOFTWAREVERSION: stock firmware version
+				case "MAC":
+					if inst.DeviceID == "" {
+						inst.DeviceID = strings.ToUpper(v)
+					}
+				case "MODEL":
+					if inst.Model == "" {
+						inst.Model = stockModelLabel(v)
+					}
+				case "NAME":
+					if inst.FriendlyName == "" {
+						inst.FriendlyName = v
+					}
+				case "SOFTWAREVERSION":
+					if inst.Version == "" {
+						inst.Version = v
+					}
 				}
 			}
 			if logger != nil {
 				logger.Debug("mDNS discovered",
 					slog.String("instance", inst.Name),
+					slog.String("kind", string(kind)),
 					slog.Bool("legacyServiceType", legacy),
 					slog.Any("ipv4", inst.IPv4))
 			}
 			out <- inst
 		}
-		for curEntries != nil || legacyEntries != nil {
+		for curEntries != nil || legacyEntries != nil || stockEntries != nil {
 			select {
 			case e, ok := <-curEntries:
 				if !ok {
 					curEntries = nil
 					continue
 				}
-				emit(e, false)
+				emit(e, KindSTR, false)
 			case e, ok := <-legacyEntries:
 				if !ok {
 					legacyEntries = nil
 					continue
 				}
-				emit(e, true)
+				emit(e, KindSTR, true)
+			case e, ok := <-stockEntries:
+				if !ok {
+					stockEntries = nil
+					continue
+				}
+				emit(e, KindStock, false)
 			}
 		}
 	}()
 
 	return out, nil
+}
+
+// stockModelLabel turns Bose's short product code from the stock
+// mDNS TXT record into a human-readable label that matches what STR
+// already shows for flashed speakers ("SoundTouch 10", etc.).
+// Falls back to the raw code if no mapping is known.
+func stockModelLabel(code string) string {
+	switch strings.ToLower(code) {
+	case "soundtouch_10", "st10":
+		return "SoundTouch 10"
+	case "soundtouch_20", "st20":
+		return "SoundTouch 20"
+	case "soundtouch_30", "st30":
+		return "SoundTouch 30"
+	case "soundtouch_portable", "stp":
+		return "SoundTouch Portable"
+	default:
+		return code
+	}
 }
 
 // pickAnnounceIfaces filtert net.Interfaces auf die Interfaces auf denen


### PR DESCRIPTION
## Summary

- Adds discovery of vanilla SoundTouch speakers that do not yet run an STR agent. The desktop app lists them next to flashed speakers, badged with a red **\"needs STR install\"** chip. Clicking a stock entry opens a confirm dialog that jumps to the USB-stick setup flow.
- \`discovery/discovery.go\`: also browses \`_bose-soundtouch._tcp.local\` in parallel with the existing STR service types. New \`Kind\` enum (\`KindSTR\`, \`KindStock\`) on \`Instance\`. STR announcements always win over stock entries for the same instance name. \`stockModelLabel()\` maps Bose's product codes (\`soundtouch_10\`) to readable labels.
- \`desktop-app/app.go\`: \`BoxInfo\` gains a \`Kind\` field exposed to the frontend; \`DiscoverBoxes\` carries it through and guards the dedup against a stale stock record shadowing a flashed speaker.
- \`main.js\`: stock entries render with a dashed border + red badge, are not auto-selected on first load (they would otherwise leave the music tab stuck), and clicking one opens a confirm dialog that switches to the Setup tab on OK. Visibility logic updated so a stock-only LAN does not show the dangling \"pick a speaker\" hint.
- Four new bundle keys (\`speaker.needsInstallBadge\`, \`speaker.stockTooltip\`, \`speaker.stockConfirmTitle\`, \`speaker.stockConfirmBody\`) in en/de.
- \`style.css\`: \`.box-btn.stock\` + \`.box-stock-badge\` for the visual.

Replaces #47 (auto-closed when the base branch was deleted on merge of #46). Now rebased onto main and ready to merge.

Closes the visibility gap noted in #44.

## Test plan

- [ ] Local Wails build green (verified locally)
- [ ] A stock SoundTouch on the LAN appears with the dashed border + red badge
- [ ] Clicking a stock entry opens the dialog and jumps to the Setup tab on OK
- [ ] An already-flashed speaker is NOT badged stock
- [ ] The auto-select on first run picks the lone STR speaker, never a stock one

🤖 Generated with [Claude Code](https://claude.com/claude-code)