### PR TITLE
ci: add frontend build check + weekly release dry-run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,33 @@ jobs:
       - name: Scan
         run: govulncheck ./...
 
+  # Vite build for the Wails frontend. Catches broken template
+  # literals, JSON parse errors in i18n bundles and missing imports
+  # at PR time rather than at the next release. The build only
+  # exercises the Vite pipeline; the Wails-Go glue is covered by
+  # release.yml's full desktop builds on tag push.
+  frontend:
+    name: Frontend build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: desktop-app/frontend/package-lock.json
+
+      - name: Install frontend deps
+        working-directory: desktop-app/frontend
+        run: npm ci --no-audit --no-fund
+
+      - name: Build frontend
+        working-directory: desktop-app/frontend
+        run: npm run build
+
   build:
     name: Cross Compile
     needs: test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,13 @@ on:
         description: 'Release version (vX.Y.Z, e.g. v0.3.0). Leave empty for a build-only dry-run.'
         required: false
         type: string
+  schedule:
+    # Weekly automatic dry-run, Sundays 04:30 UTC. Catches breakage
+    # introduced by Dependabot bumps of release-only actions
+    # (attest-build-provenance, action-gh-release, upload-artifact)
+    # before the next real tag. The publish step is gated on a
+    # non-empty version input, so a scheduled run is build-only.
+    - cron: "30 4 * * 0"
 
 permissions:
   contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,43 +146,25 @@ in [`docs/ROADMAP.md`](docs/ROADMAP.md).
 
 ## Release pipeline dry-run
 
-After Dependabot bumps a release-only action — `attest-build-provenance`,
-`action-gh-release`, or the release.yml usage of `upload-artifact` —
-the change is not exercised by PR CI (those actions only live in
-`release.yml`, which runs on tag push or `workflow_dispatch`).
+`release.yml` runs a weekly automatic dry-run (Sundays 04:30 UTC) so
+Dependabot bumps of release-only actions like
+`attest-build-provenance`, `action-gh-release`, or
+`upload-artifact`'s release-only usage pattern are exercised before
+the next real tag. PR CI does not exercise these actions.
 
-To smoke-test before the next real tag, dispatch the release workflow
-without a version input:
-
-```bash
-gh workflow run release.yml
-```
-
-The pipeline runs verify-source, builds the agent and all three
-desktop OS packages, and attests every artifact via Sigstore. The
-final `Publish GitHub Release` step is skipped automatically when
-the version input is empty. If this green-checks, the next real
-`vX.Y.Z` tag will work.
-
-## Release pipeline dry-run
-
-After Dependabot bumps a release-only action — `attest-build-provenance`,
-`action-gh-release`, or the release.yml usage of `upload-artifact` —
-the change is not exercised by PR CI (those actions only live in
-`release.yml`, which runs on tag push or `workflow_dispatch`).
-
-To smoke-test before the next real tag, dispatch the release workflow
-without a version input:
+To trigger a dry-run manually (e.g. after a Dependabot bump you do
+not want to wait a week for), dispatch the release workflow without
+a version input:
 
 ```bash
 gh workflow run release.yml
 ```
 
-The pipeline runs verify-source, builds the agent and all three
+Either path runs verify-source, builds the agent and all three
 desktop OS packages, and attests every artifact via Sigstore. The
 final `Publish GitHub Release` step is skipped automatically when
-the version input is empty. If this green-checks, the next real
-`vX.Y.Z` tag will work.
+no `version` input is supplied. If a dry-run green-checks, the next
+real `vX.Y.Z` tag will work.
 
 ## Build version stamping
 


### PR DESCRIPTION
## Summary

Two CI gaps closed.

1. **Frontend build is now exercised on every PR.** A new \`Frontend build\` job in \`build.yml\` runs \`npm ci && npm run build\` in \`desktop-app/frontend/\`. Catches:
   - broken template literals in \`main.js\`
   - JSON parse errors in i18n bundles
   - missing imports

   at PR time instead of at the next release. The Wails-Go glue is still only covered by \`release.yml\`'s full desktop builds on tag push, which is fine: those bugs show up in the release dry-run.

2. **Weekly release dry-run.** \`release.yml\` gains a \`schedule\` trigger (Sundays 04:30 UTC). With no version input the \`Publish GitHub Release\` step is gated off, so a scheduled run is build-only: verify-source, build-agent, build-desktop-* and Sigstore attestation all run. This catches Dependabot bumps of release-only actions (\`attest-build-provenance\`, \`action-gh-release\`, \`upload-artifact\`'s release-only usage pattern) **before** the next real tag, instead of finding out at tag push time.

Also dedup the \"Release pipeline dry-run\" section in \`CLAUDE.md\` (it was accidentally duplicated) and update its prose to mention the new automatic cron.

## Test plan

- [ ] CI on this PR shows the new \`Frontend build\` job green
- [ ] Sunday's scheduled run of release.yml completes with the \`release\` job skipped
- [ ] CLAUDE.md \"Release pipeline dry-run\" section appears once, with cron mention

🤖 Generated with [Claude Code](https://claude.com/claude-code)