### PR TITLE
fix(discover): dedup speakers by host + drop unreachable IP fallback

### DIFF
--- a/desktop-app/app.go
+++ b/desktop-app/app.go
@@ -94,16 +94,29 @@ func (a *App) DiscoverBoxes(timeoutSec int) ([]BoxInfo, error) {
 		if b.Host == "" {
 			return
 		}
-		key := b.DeviceID
-		if key == "" {
-			key = b.Name + "@" + b.Host
-		}
+		// Dedup primary key is host (the IPv4 address). Two records
+		// at the same IP are the same physical device, regardless
+		// of which port they expose (STR runs on 8888, stock Bose
+		// API on 8090). Using DeviceID was fragile because some
+		// Bose mDNS announcements (the stock _soundtouch._tcp
+		// service surfaced through our v0.4.1 scan) do not include
+		// MAC in their TXT, so STR and stock records for the same
+		// speaker landed under different keys and the user saw the
+		// box listed twice.
+		key := b.Host
 		prev, exists := seen[key]
 		if exists {
 			// STR announcement always wins over a stock entry for
-			// the same physical device.
+			// the same physical device. If both are STR (or both
+			// stock), the richer record wins (longer FriendlyName,
+			// non-empty Version).
 			if prev.Kind == "str" && b.Kind == "stock" {
 				return
+			}
+			if prev.Kind == b.Kind {
+				if len(prev.FriendlyName) >= len(b.FriendlyName) && prev.Version != "" {
+					return
+				}
 			}
 		}
 		seen[key] = b
@@ -620,6 +633,12 @@ func pickReachableIP(ips []string) string {
 			public = ipStr
 		}
 	}
+	// No "default: return ips[0]" fallback. If the only IP we got
+	// was loopback or TEST-NET-3, returning it would cause the
+	// desktop app to show an entry that cannot actually be reached
+	// (and dedup against the real entry would fail because the IPs
+	// differ). Better to drop the unreachable record and let the
+	// other discovery path or a refresh pick up the real IP.
 	switch {
 	case lan != "":
 		return lan
@@ -628,7 +647,7 @@ func pickReachableIP(ips []string) string {
 	case public != "":
 		return public
 	default:
-		return ips[0] // fallback
+		return ""
 	}
 }
 


### PR DESCRIPTION
## Summary

v0.4.1 ships a regression that surfaces on networks where the same physical SoundTouch is announced over BOTH `_streborn._tcp` (STR) AND Bose's own `_soundtouch._tcp` daemon — i.e. on every STR-installed box, because STR does not kill the original Bose mDNS stack.

Two symptoms hit during local testing:

1. **Same speaker listed twice**, once with the STR agent version and once tagged "needs STR install", both at the same IP. The dedup primarily keyed on `DeviceID` with a `name+host` fallback. Bose's stock `_soundtouch._tcp` TXT does not always include MAC, so the stock record landed under `name@host` while the STR record landed under `DeviceID`, and both surfaced.
2. **First load after a cold start showed `203.0.113.x`** (the USB-gadget TEST-NET-3 address baked into the STR agent's mDNS A record on older agents). `pickReachableIP` correctly filtered that range but fell through to a `return ips[0]` fallback when no other IP was present, which handed the unreachable address back to the caller.

## Changes

- `DiscoverBoxes` upsert: dedup key is now the host IP alone. Two records at the same IP are the same physical device regardless of port (STR runs on 8888, Bose API on 8090). STR always wins over stock; within the same kind the longer friendly name + non-empty version wins.
- `pickReachableIP`: drop the `ips[0]` fallback. If the only candidate was loopback or TEST-NET-3, return empty so the upsert skips the unreachable record. A refresh or another discovery path will surface the real IP next.

## Test plan

- [x] `go build ./...` cross-compile + desktop-app build green.
- [x] Local Wails build launched against my LAN, observed previously-duplicated SoundTouch is now a single entry.
- [ ] Confirm by reporter that the duplicate is gone after upgrading to v0.4.2.

Refs N/A (no public issue: hit by the maintainer locally; cannot reference an external report under the "no reporter names in repo" rule without an issue number to point to).

Will tag v0.4.2 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)