### PR TITLE
feat(setup): cold-bootstrap wizard for factory-state speakers

### DIFF
--- a/desktop-app/coldbootstrap.go
+++ b/desktop-app/coldbootstrap.go
@@ -44,7 +44,9 @@ type SetupAP struct {
 // "SoundTouch*"). Best-effort, returns empty slice on errors so the
 // caller can simply fall through to "no setup AP found".
 func (a *App) ScanForSetupAPs() ([]SetupAP, error) {
-	out, err := exec.Command("netsh", "wlan", "show", "networks", "mode=Bssid").CombinedOutput()
+	c := exec.Command("netsh", "wlan", "show", "networks", "mode=Bssid")
+	hideCmdWindow(c)
+	out, err := c.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("netsh wlan show networks: %w", err)
 	}
@@ -239,6 +241,7 @@ func xmlEscape(s string) string {
 
 func netshRun(args ...string) error {
 	cmd := exec.Command("netsh", args...)
+	hideCmdWindow(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("netsh %s: %w (%s)", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
@@ -247,7 +250,9 @@ func netshRun(args ...string) error {
 }
 
 func currentWifiSSID() string {
-	out, err := exec.Command("netsh", "wlan", "show", "interfaces").CombinedOutput()
+	c := exec.Command("netsh", "wlan", "show", "interfaces")
+	hideCmdWindow(c)
+	out, err := c.CombinedOutput()
 	if err != nil {
 		return ""
 	}

--- a/desktop-app/coldbootstrap.go
+++ b/desktop-app/coldbootstrap.go
@@ -1,0 +1,378 @@
+// Cold-bootstrap helpers: configure Wi-Fi on a brand-new (or factory-
+// reset) Bose SoundTouch speaker that has no Wi-Fi yet by joining its
+// open setup-AP from the host, POSTing addWirelessProfile to the
+// Bose API on the AP gateway, then reconnecting the host to the home
+// Wi-Fi so the box can find us again on the LAN.
+//
+// Bose has no native stick-only setup path; their own NetManager
+// reads /media/sda1 only for dprint.conf (debug). So this is the
+// only Wi-Fi bootstrap option that does not require extra hardware
+// (USB cable, second WLAN adapter, smartphone hotspot, ...).
+//
+// Windows-only for now. macOS/Linux will need their own netsh
+// equivalents; the high-level App methods are platform-neutral so
+// the frontend will not need changes when we add those.
+
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// SetupAP is a candidate Bose factory-mode access point found in the
+// host's Wi-Fi scan. The frontend uses this to decide whether to
+// surface a "brand-new speaker detected, want to configure it?" UI.
+type SetupAP struct {
+	SSID      string `json:"ssid"`
+	Interface string `json:"interface"`
+	Signal    string `json:"signal"`
+}
+
+// ScanForSetupAPs returns visible Wi-Fi networks whose SSID matches a
+// Bose factory-mode pattern ("Bose ST*", "Bose SoundTouch*",
+// "SoundTouch*"). Best-effort, returns empty slice on errors so the
+// caller can simply fall through to "no setup AP found".
+func (a *App) ScanForSetupAPs() ([]SetupAP, error) {
+	out, err := exec.Command("netsh", "wlan", "show", "networks", "mode=Bssid").CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("netsh wlan show networks: %w", err)
+	}
+	return parseSetupAPs(string(out)), nil
+}
+
+func parseSetupAPs(netshOutput string) []SetupAP {
+	var out []SetupAP
+	var curSSID, curIface, curSignal string
+	for _, line := range strings.Split(netshOutput, "\n") {
+		l := strings.TrimSpace(line)
+		// netsh prints localized strings; the "SSID N : NAME" form is
+		// stable across locales (only the prefix word changes). We
+		// match on " : " plus a numbered SSID prefix.
+		if i := strings.Index(l, " : "); i > 0 && (strings.HasPrefix(l, "SSID ") || strings.HasPrefix(l, "Schnittstellenname")) {
+			if strings.HasPrefix(l, "SSID ") {
+				if curSSID != "" && isBoseSetupSSID(curSSID) {
+					out = append(out, SetupAP{SSID: curSSID, Interface: curIface, Signal: curSignal})
+				}
+				curSSID = strings.TrimSpace(l[i+3:])
+				curSignal = ""
+			} else {
+				curIface = strings.TrimSpace(l[i+3:])
+			}
+		}
+		if strings.HasPrefix(l, "Signal") || strings.HasPrefix(l, "Signalqualität") {
+			if i := strings.Index(l, " : "); i > 0 {
+				curSignal = strings.TrimSpace(l[i+3:])
+			}
+		}
+	}
+	if curSSID != "" && isBoseSetupSSID(curSSID) {
+		out = append(out, SetupAP{SSID: curSSID, Interface: curIface, Signal: curSignal})
+	}
+	// Dedup by SSID.
+	seen := map[string]struct{}{}
+	uniq := out[:0]
+	for _, ap := range out {
+		if _, dup := seen[ap.SSID]; dup {
+			continue
+		}
+		seen[ap.SSID] = struct{}{}
+		uniq = append(uniq, ap)
+	}
+	return uniq
+}
+
+func isBoseSetupSSID(ssid string) bool {
+	low := strings.ToLower(ssid)
+	return strings.HasPrefix(low, "bose st") ||
+		strings.HasPrefix(low, "bose soundtouch") ||
+		strings.HasPrefix(low, "soundtouch ")
+}
+
+// BootstrapResult is the JSON-serializable outcome handed back to the
+// frontend.
+type BootstrapResult struct {
+	Step    string `json:"step"`    // last step reached
+	OK      bool   `json:"ok"`      // overall success
+	Message string `json:"message"` // user-facing string in EN (frontend localizes the Step)
+	BoxIP   string `json:"boxIP"`   // home-LAN IP of the box if confirmed
+}
+
+// BootstrapBoxOnSetupAP performs the full cold-bootstrap dance:
+//   1. snapshot the current home Wi-Fi profile so we can reconnect
+//   2. add a transient open-Wi-Fi profile for setupSSID
+//   3. join setupSSID, wait for a 192.0.2.x IP on the adapter
+//   4. POST addWirelessProfile with home credentials to 192.0.2.1:8090
+//   5. disconnect from setup-AP, delete the transient profile
+//   6. reconnect to homeSSID, wait for IP
+//   7. poll the home LAN until the box answers /info
+//
+// Returns step-by-step so the frontend can show live progress. Errors
+// at any step are returned with the partial state for diagnostics.
+func (a *App) BootstrapBoxOnSetupAP(setupSSID, homeSSID, homePassphrase, securityType string) (BootstrapResult, error) {
+	res := BootstrapResult{Step: "start"}
+	if setupSSID == "" || homeSSID == "" {
+		return res, fmt.Errorf("setupSSID and homeSSID are both required")
+	}
+	if securityType == "" {
+		securityType = "wpa_or_wpa2"
+	}
+
+	// Step 1: note the host's current Wi-Fi state so we can come back.
+	// Best-effort: if it fails, the user just has to manually pick the
+	// home network in the tray after we are done.
+	prevSSID := currentWifiSSID()
+	if prevSSID == "" {
+		prevSSID = homeSSID
+	}
+	a.logger.Info("coldbootstrap: start", "setupSSID", setupSSID, "homeSSID", homeSSID, "prevSSID", prevSSID)
+
+	// Step 2: add transient profile.
+	res.Step = "add-profile"
+	profilePath, cleanup, err := writeOpenWifiProfile(setupSSID)
+	if err != nil {
+		return res, fmt.Errorf("write profile xml: %w", err)
+	}
+	defer cleanup()
+	if err := netshRun("wlan", "add", "profile", "filename="+profilePath, "user=current"); err != nil {
+		return res, fmt.Errorf("netsh add profile: %w", err)
+	}
+	defer func() {
+		_ = netshRun("wlan", "delete", "profile", "name="+setupSSID)
+	}()
+
+	// Step 3: connect to the setup-AP and wait for IP.
+	res.Step = "join-setup-ap"
+	if err := netshRun("wlan", "connect", "name="+setupSSID); err != nil {
+		return res, fmt.Errorf("netsh connect setup-AP: %w", err)
+	}
+	if err := waitForIPOn(192_000, 12*time.Second); err != nil {
+		return res, fmt.Errorf("waiting for 192.0.2.x IP after joining setup-AP: %w", err)
+	}
+
+	// Step 4: POST addWirelessProfile.
+	res.Step = "send-config"
+	if err := postAddWirelessProfile("192.0.2.1", homeSSID, homePassphrase, securityType); err != nil {
+		// Try to recover Wi-Fi before returning so the user is not
+		// stranded on an inert setup-AP.
+		_ = netshRun("wlan", "disconnect")
+		_ = netshRun("wlan", "connect", "name="+prevSSID)
+		return res, fmt.Errorf("POST addWirelessProfile: %w", err)
+	}
+
+	// Step 5: disconnect from setup-AP. We do not wait for the box's
+	// AP to actually go down (it may stay up briefly while the box
+	// reassociates). Cleanup of the transient profile is the deferred
+	// netsh delete profile above.
+	res.Step = "leave-setup-ap"
+	_ = netshRun("wlan", "disconnect")
+
+	// Step 6: reconnect to home Wi-Fi. Windows usually does this on
+	// its own once the setup-AP is gone, but we nudge it explicitly.
+	res.Step = "rejoin-home"
+	if err := netshRun("wlan", "connect", "name="+prevSSID); err != nil {
+		// Not fatal: the OS may already have started reconnecting on
+		// its own. Continue to the box-poll step.
+		a.logger.Warn("coldbootstrap: netsh connect home failed, continuing", "err", err)
+	}
+	if err := waitForRoutable(20 * time.Second); err != nil {
+		return res, fmt.Errorf("waiting for home Wi-Fi to come back: %w", err)
+	}
+
+	// Step 7: confirm the box reached the LAN.
+	res.Step = "wait-for-box"
+	ctx, cancel := context.WithTimeout(a.ctx, 75*time.Second)
+	defer cancel()
+	ip := pollBoxOnHomeLAN(ctx, a.logger)
+	if ip == "" {
+		res.OK = false
+		res.Message = "Box did not show up on the home LAN within 75s after sending the config. Check Wi-Fi password and try again."
+		return res, nil
+	}
+	res.Step = "done"
+	res.OK = true
+	res.BoxIP = ip
+	res.Message = "Box is on the home Wi-Fi at " + ip
+	return res, nil
+}
+
+// writeOpenWifiProfile drops a Windows WLAN profile XML for an open
+// network into TEMP and returns its path plus a cleanup func.
+func writeOpenWifiProfile(ssid string) (string, func(), error) {
+	xml := `<?xml version="1.0"?>
+<WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
+  <name>` + xmlEscape(ssid) + `</name>
+  <SSIDConfig><SSID><name>` + xmlEscape(ssid) + `</name></SSID></SSIDConfig>
+  <connectionType>ESS</connectionType>
+  <connectionMode>manual</connectionMode>
+  <MSM><security>
+    <authEncryption>
+      <authentication>open</authentication>
+      <encryption>none</encryption>
+      <useOneX>false</useOneX>
+    </authEncryption>
+  </security></MSM>
+</WLANProfile>
+`
+	stamp := time.Now().UnixNano()
+	path := filepath.Join(os.TempDir(), fmt.Sprintf("str-coldboot-%d.xml", stamp))
+	if err := os.WriteFile(path, []byte(xml), 0o600); err != nil {
+		return "", func() {}, err
+	}
+	return path, func() { _ = os.Remove(path) }, nil
+}
+
+func xmlEscape(s string) string {
+	r := strings.NewReplacer(`&`, `&amp;`, `<`, `&lt;`, `>`, `&gt;`, `"`, `&quot;`, `'`, `&apos;`)
+	return r.Replace(s)
+}
+
+func netshRun(args ...string) error {
+	cmd := exec.Command("netsh", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("netsh %s: %w (%s)", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func currentWifiSSID() string {
+	out, err := exec.Command("netsh", "wlan", "show", "interfaces").CombinedOutput()
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		l := strings.TrimSpace(line)
+		if strings.HasPrefix(l, "SSID") && !strings.HasPrefix(l, "SSID-BSSID") && !strings.HasPrefix(l, "BSSID") {
+			if i := strings.Index(l, " : "); i > 0 {
+				return strings.TrimSpace(l[i+3:])
+			}
+		}
+	}
+	return ""
+}
+
+// waitForIPOn polls local interface IPs for one in the 192.0.2.0/24
+// (TEST-NET-1) range used by Bose's setup-AP. The first octet
+// argument is kept for symmetry; we hard-code on 192.0.2 because
+// that is what Bose hands out.
+func waitForIPOn(_ int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		addrs, err := net.InterfaceAddrs()
+		if err == nil {
+			for _, a := range addrs {
+				if ipnet, ok := a.(*net.IPNet); ok {
+					ip4 := ipnet.IP.To4()
+					if ip4 != nil && ip4[0] == 192 && ip4[1] == 0 && ip4[2] == 2 {
+						return nil
+					}
+				}
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return fmt.Errorf("no 192.0.2.x address appeared within %s", timeout)
+}
+
+func waitForRoutable(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		addrs, err := net.InterfaceAddrs()
+		if err == nil {
+			for _, a := range addrs {
+				if ipnet, ok := a.(*net.IPNet); ok {
+					ip4 := ipnet.IP.To4()
+					if ip4 != nil && ip4.IsPrivate() &&
+						!(ip4[0] == 192 && ip4[1] == 0 && ip4[2] == 2) {
+						return nil
+					}
+				}
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return fmt.Errorf("no routable private IP within %s", timeout)
+}
+
+func pollBoxOnHomeLAN(ctx context.Context, logger *slog.Logger) string {
+	for {
+		select {
+		case <-ctx.Done():
+			return ""
+		default:
+		}
+		for _, subnet := range localIPv4Subnets() {
+			for i := 1; i <= 254; i++ {
+				select {
+				case <-ctx.Done():
+					return ""
+				default:
+				}
+				ip := fmt.Sprintf("%s%d", subnet, i)
+				if box, ok := probeStock(ctx, ip); ok && box.Host != "" {
+					if logger != nil {
+						logger.Info("coldbootstrap: box found on home LAN", "ip", box.Host)
+					}
+					return box.Host
+				}
+			}
+		}
+		// Give the box a moment between full /24 sweeps. The whole
+		// sweep at ~1.2s/host with 32 parallel probes via probeStock
+		// is fast; sleeping a bit avoids 100% CPU if it takes
+		// several sweeps.
+		select {
+		case <-ctx.Done():
+			return ""
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+// postAddWirelessProfile pushes the home Wi-Fi credentials to the
+// Bose box over the setup-AP. The XML schema below was confirmed
+// live against a SoundTouch 10 (variant rhino, firmware 27.0.6) and
+// matches the community-documented Bose SoundTouch Web API. The box
+// drops its setup-AP and starts re-associating as soon as it
+// accepts the request, so a mid-response disconnect (EOF / reset)
+// is treated as success rather than a hard error.
+func postAddWirelessProfile(boxIP, ssid, passphrase, securityType string) error {
+	body := `<AddWirelessProfile timeout="30">` +
+		`<profile ssid="` + xmlEscape(ssid) + `" ` +
+		`password="` + xmlEscape(passphrase) + `" ` +
+		`securityType="` + xmlEscape(securityType) + `" />` +
+		`</AddWirelessProfile>`
+	url := fmt.Sprintf("http://%s:8090/addWirelessProfile", boxIP)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/xml")
+	client := &http.Client{Timeout: 8 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		if strings.Contains(err.Error(), "EOF") || strings.Contains(err.Error(), "reset") {
+			return nil
+		}
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
+	}
+	return nil
+}

--- a/desktop-app/coldbootstrap_other.go
+++ b/desktop-app/coldbootstrap_other.go
@@ -1,0 +1,35 @@
+// Non-Windows stub for the cold-bootstrap helpers. macOS and Linux
+// each need their own implementation (airport/networksetup on
+// macOS, nmcli/wpa_cli on Linux) before this feature works on those
+// platforms. Until then the App methods are exposed but always
+// return "not implemented on this platform" so the Wails-generated
+// frontend bindings still compile and the UI can render a sensible
+// error.
+
+//go:build !windows
+
+package main
+
+import "fmt"
+
+type SetupAP struct {
+	SSID      string `json:"ssid"`
+	Interface string `json:"interface"`
+	Signal    string `json:"signal"`
+}
+
+type BootstrapResult struct {
+	Step    string `json:"step"`
+	OK      bool   `json:"ok"`
+	Message string `json:"message"`
+	BoxIP   string `json:"boxIP"`
+}
+
+func (a *App) ScanForSetupAPs() ([]SetupAP, error) {
+	return nil, fmt.Errorf("cold-bootstrap is currently only implemented on Windows")
+}
+
+func (a *App) BootstrapBoxOnSetupAP(setupSSID, homeSSID, homePassphrase, securityType string) (BootstrapResult, error) {
+	return BootstrapResult{Step: "unsupported", OK: false, Message: "cold-bootstrap is currently only implemented on Windows"},
+		fmt.Errorf("cold-bootstrap is currently only implemented on Windows")
+}

--- a/desktop-app/frontend/src/api.js
+++ b/desktop-app/frontend/src/api.js
@@ -39,6 +39,8 @@ export {
   SetBoxVolume,
   SetBoxBass,
   SelectBoxSource,
+  ScanForSetupAPs,
+  BootstrapBoxOnSetupAP,
 } from '../wailsjs/go/main/App';
 
 export { BrowserOpenURL } from '../wailsjs/runtime/runtime';

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -500,6 +500,13 @@
   "setup.ejectedBody": "Stick wurde ausgeworfen. Jetzt entnehmen und in den USB-Port des Bose-Lautsprechers stecken. Beim ersten Boot dauert es etwa eine Minute, dann kannst du im Tab <b>Musik hören</b> den Lautsprecher bedienen.",
   "setup.ejectedWarn": "<b>Wichtig:</b> Der Stick ist jetzt für genau diesen Lautsprecher konfiguriert. Beim ersten Boot wendet der Lautsprecher die Einstellungen an und löscht alle Geheimnisse (z.B. WLAN-Passwort) vom Stick. Wenn du später einen anderen Lautsprecher einrichten oder geänderte Werte aufspielen willst, musst du den Stick zuerst wieder hier vorbereiten.",
   "setup.ejectFailed": "Die Daten sind drauf, aber das automatische Auswerfen ging nicht: <small>{{err}}</small> Bitte über den Explorer „Auswerfen\".",
+  "setup.waitingForBox": "Suche den Lautsprecher im LAN ... ({{sec}} s)",
+  "setup.setupAPDetected": "Brandneuer Lautsprecher im Setup-Modus erkannt (SSID: {{ssid}}). Konfiguriere ihn für dein WLAN.",
+  "setup.bootstrapStarting": "Verbinde kurz mit dem Setup-Netz des Lautsprechers und übertrage die WLAN-Zugangsdaten ...",
+  "setup.bootstrapFailed": "Konfiguration über das Setup-Netz fehlgeschlagen: {{msg}}. Du kannst trotzdem manuell über den PowerShell-Wizard installieren.",
+  "setup.boxFoundOnLAN": "Lautsprecher ist im LAN auf {{ip}}.",
+  "setup.boxFoundHint": "Er taucht jetzt im Tab Musik hören auf. Den STR-Install bitte solange noch über den PowerShell-Wizard starten (App-Installer kommt im nächsten Release), damit die Preset-Tasten funktionieren.",
+  "setup.waitForBoxTimeout": "Lautsprecher in 5 Minuten nicht im LAN aufgetaucht. Strom, WLAN-Passwort prüfen und Stick erneut einlegen.",
 
   "lang.german": "Deutsch",
   "lang.english": "Englisch",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -500,6 +500,13 @@
   "setup.ejectedBody": "Stick was ejected. Pull it out and plug it into the USB port of the Bose speaker. The first boot takes about a minute, then you can control the speaker from the <b>Listen to music</b> tab.",
   "setup.ejectedWarn": "<b>Important:</b> The stick is now configured for exactly this speaker. On first boot the speaker applies the settings and deletes all secrets (for example the Wi-Fi password) from the stick. If you later want to set up a different speaker or change values, prepare the stick here first.",
   "setup.ejectFailed": "The data is on the stick, but the automatic eject failed: <small>{{err}}</small> Please eject via the system file manager.",
+  "setup.waitingForBox": "Searching for the speaker on the LAN... ({{sec}} s)",
+  "setup.setupAPDetected": "Brand-new speaker detected in setup mode (SSID: {{ssid}}). Configuring it for your Wi-Fi.",
+  "setup.bootstrapStarting": "Joining the speaker's setup network and pushing your Wi-Fi credentials...",
+  "setup.bootstrapFailed": "Could not configure the speaker from its setup network: {{msg}}. You can still install via the PowerShell wizard.",
+  "setup.boxFoundOnLAN": "Speaker is on the LAN at {{ip}}.",
+  "setup.boxFoundHint": "It will show up in the Listen to music tab. Run the STR install from the PowerShell wizard (until the in-app installer ships) to enable preset playback.",
+  "setup.waitForBoxTimeout": "Did not see the speaker on the LAN within 5 minutes. Check power, Wi-Fi credentials, and try inserting the stick again.",
 
   "lang.german": "German",
   "lang.english": "English",

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -33,6 +33,8 @@ import {
   SetBoxVolume,
   SetBoxBass,
   SelectBoxSource,
+  ScanForSetupAPs,
+  BootstrapBoxOnSetupAP,
   BrowserOpenURL,
 } from './api.js';
 
@@ -3155,10 +3157,100 @@ async function doSetup() {
     state.presets = [];
     refreshDrives();
     discoverBoxes();
+
+    // Start the post-eject wait loop in the background so the result
+    // panel updates live while the user inserts the stick and powers
+    // the box. The wait does two things in parallel: poll mDNS /
+    // active probe for the box appearing on the home LAN, and scan
+    // visible Wi-Fi for a Bose setup-AP. The setup-AP path only
+    // matters for brand-new or factory-reset boxes; for boxes that
+    // already had Wi-Fi the LAN discovery wins first and the
+    // setup-AP branch is silently ignored.
+    waitForBoxAfterSetup({ ssid, pass, html });
   } catch (e) {
     $('setupResult').innerHTML = `<div class="setup-err">${escapeHtml(t('common.error'))}: ${escapeHtml(String(e))}</div>`;
   }
   $('setupGo').disabled = false;
+}
+
+// waitForBoxAfterSetup runs after the stick has been ejected. It
+// shows a live "waiting for box" panel and offers a cold-bootstrap
+// path if a Bose setup-AP shows up before the box reaches the LAN.
+//
+// Called with the WLAN credentials the user just entered for the
+// stick. They are kept only in this closure and never persisted.
+async function waitForBoxAfterSetup({ ssid, pass, html }) {
+  const baseHtml = html;
+  const startTs = Date.now();
+  const setupResult = $('setupResult');
+  if (!setupResult) return;
+
+  function render(extra) {
+    setupResult.innerHTML = baseHtml + extra;
+  }
+
+  let bootstrapTriggered = false;
+  let bootstrapDone = false;
+  let foundBoxIP = null;
+
+  function progressLine(elapsedSec, ap) {
+    const apHint = ap
+      ? `<div class="setup-ok">${escapeHtml(t('setup.setupAPDetected', { ssid: ap.ssid }))}</div>`
+      : '';
+    const status = `<div class="muted small">${escapeHtml(t('setup.waitingForBox', { sec: elapsedSec }))}</div>`;
+    return apHint + status;
+  }
+
+  // Background loop: poll for box on LAN + scan for setup-AP.
+  // 5-minute cap, then we stop polling and leave the last state.
+  const deadline = Date.now() + 5 * 60 * 1000;
+  while (Date.now() < deadline && !bootstrapDone && !foundBoxIP) {
+    try {
+      const list = await DiscoverBoxes(4);
+      const ours = (list || []).find(b => b.kind === 'str' || b.kind === 'stock');
+      if (ours) {
+        foundBoxIP = ours.host;
+        break;
+      }
+    } catch {}
+
+    if (!bootstrapTriggered && ssid) {
+      try {
+        const aps = await ScanForSetupAPs();
+        if (aps && aps.length > 0) {
+          const ap = aps[0];
+          bootstrapTriggered = true;
+          render(progressLine(Math.floor((Date.now() - startTs) / 1000), ap) +
+                 `<div class="muted small">${escapeHtml(t('setup.bootstrapStarting'))}</div>`);
+          try {
+            const res = await BootstrapBoxOnSetupAP(ap.ssid, ssid, pass, 'wpa_or_wpa2');
+            if (res && res.ok) {
+              foundBoxIP = res.boxIP || foundBoxIP;
+              bootstrapDone = true;
+              break;
+            } else {
+              render(progressLine(Math.floor((Date.now() - startTs) / 1000), ap) +
+                     `<div class="setup-warn">${escapeHtml(t('setup.bootstrapFailed', { msg: (res && res.message) || 'unknown' }))}</div>`);
+            }
+          } catch (bsErr) {
+            render(progressLine(Math.floor((Date.now() - startTs) / 1000), ap) +
+                   `<div class="setup-err">${escapeHtml(t('setup.bootstrapFailed', { msg: String(bsErr) }))}</div>`);
+          }
+        }
+      } catch {}
+    }
+
+    render(progressLine(Math.floor((Date.now() - startTs) / 1000), null));
+    await sleep(3000);
+  }
+
+  if (foundBoxIP) {
+    render(`<div class="setup-ok">${escapeHtml(t('setup.boxFoundOnLAN', { ip: foundBoxIP }))}</div>` +
+           `<div class="muted small">${escapeHtml(t('setup.boxFoundHint'))}</div>`);
+    discoverBoxes();
+  } else {
+    render(`<div class="setup-warn">${escapeHtml(t('setup.waitForBoxTimeout'))}</div>`);
+  }
 }
 
 

--- a/desktop-app/hidewindow_other.go
+++ b/desktop-app/hidewindow_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package main
+
+import "os/exec"
+
+// hideCmdWindow is a no-op on macOS and Linux: those platforms do
+// not attach a console window to spawned subprocesses by default,
+// so there is nothing to hide.
+func hideCmdWindow(cmd *exec.Cmd) {}

--- a/desktop-app/hidewindow_windows.go
+++ b/desktop-app/hidewindow_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// hideCmdWindow attaches a Windows-specific SysProcAttr to the
+// exec.Cmd so subprocesses (ssh, netsh, ...) do not pop a flashing
+// CMD console window during loops that spawn many short-lived
+// processes (cold-bootstrap netsh dance, post-eject auto-install
+// SSH retry loop). Without this every probe briefly raises an
+// empty terminal on top of the Wails app.
+func hideCmdWindow(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+}


### PR DESCRIPTION
## Summary

Configures Wi-Fi on a brand-new or factory-reset Bose SoundTouch speaker **without USB cable, SSH, or a second WLAN adapter** — using just the existing setup tab and a single WLAN chip on the host.

### How it works

After the user ejects the prepared stick, the desktop app runs a parallel two-track wait loop:

1. **LAN-discovery track**: polls mDNS + active probe for the speaker showing up on the home LAN. Wins for speakers that already had Wi-Fi.
2. **Setup-AP track**: scans visible Wi-Fi for `Bose ST*` / `SoundTouch*` SSIDs (Bose's factory setup-AP). If one is found, triggers `BootstrapBoxOnSetupAP`:
   - `netsh wlan add profile` for the open setup-AP (no UAC needed on Win11)
   - `netsh wlan connect` to the setup-AP, wait for `192.0.2.x` IP
   - POST `addWirelessProfile` to `http://192.0.2.1:8090/addWirelessProfile` with the Wi-Fi credentials the user already entered for the stick
   - `netsh wlan disconnect`, delete transient profile
   - `netsh wlan connect <home SSID>`, wait for routable IP
   - Resume LAN-poll until the speaker answers `/info`

If both paths progress at once (rare), LAN-discovery wins and the setup-AP branch is silently dropped.

### Why this matters

Bose has no native stick-only Wi-Fi setup path — their own `NetManager` reads `/media/sda1` only for `dprint.conf` (debug). On a factory-reset speaker without the dead Bose cloud or a second adapter, the box would otherwise be unreachable. `addWirelessProfile` is the exact endpoint Bose's own SoundTouch app used in the same scenario.

### Verified schema

Live test against a SoundTouch 10 (variant rhino, firmware 27.0.6):

```
POST /addWirelessProfile  Content-Type: application/xml

<AddWirelessProfile timeout="30">
  <profile ssid="..." password="..." securityType="wpa_or_wpa2"/>
</AddWirelessProfile>

-> 200  <AddWirelessProfileResponse/>
```

Sources:
- [Bose SoundTouch Web API (PDF)](https://assets.bosecreative.com/m/496577402d128874/original/SoundTouch-Web-API.pdf)
- [SoundTouch WebServices API Wiki](https://github.com/thlucas1/homeassistantcomponent_soundtouchplus/wiki/SoundTouch-WebServices-API)

### Scope

- **Windows-only initially.** macOS and Linux stubs return "not implemented on this platform" so the Wails frontend bindings resolve. macOS (`networksetup`) and Linux (`nmcli`) implementations are follow-ups.
- The current PR does **NOT** also auto-install the STR agent via SSH after Wi-Fi comes up — that is the next PR (`feat/desktop-app-install-str`) and addresses #44 directly. Cold-bootstrap is for a different user class (factory-reset speakers); the in-app installer is for speakers that have Wi-Fi but no STR.

## Test plan

- [x] `go build ./desktop-app/...` host (Win) green; `go build ./...` ARM cross-compile (agent) green
- [x] `wails build` produces `ST Reborn.exe`; manually launched
- [x] Live: factory-reset ST10 (rhino), broadcast `Bose ST 10 (02FFD8)` setup-AP, `addWirelessProfile` POST verified, box joins `JJ3` home WLAN, reappears at `192.168.178.66`
- [x] Confirmed `netsh wlan add/delete profile` works without UAC on Win11 (non-elevated PowerShell)
- [ ] Live: factory-reset ST20 / ST30 (different variants might use different `securityType` values)
- [ ] macOS / Linux stub returns sensible error in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Refs: #44, #60 (candidate fix in v0.5.0, awaiting reporter confirmation)