### PR TITLE
feat(diagnostics): file-based app log + Save-diagnostic-bundle button

### DIFF
--- a/desktop-app/app.go
+++ b/desktop-app/app.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -24,20 +25,30 @@ import (
 type App struct {
 	ctx        context.Context
 	logger     *slog.Logger
+	logFile    *os.File // kept so ExportDiagnosticLogs can Sync before reading
 	httpClient *http.Client
 }
 
 // NewApp erstellt eine neue App Instance.
 func NewApp() *App {
+	logger, logFile := newFileLogger(slog.LevelInfo)
 	return &App{
-		logger:     newFileLogger(slog.LevelInfo),
+		logger:     logger,
+		logFile:    logFile,
 		httpClient: &http.Client{Timeout: 6 * time.Second},
 	}
 }
 
 func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
-	a.logger.Info("Desktop App startet")
+	// Verbose startup line so users always see SOMETHING in the
+	// log when they hit "Save diagnostic logs", even on a session
+	// where they did not poke any features that emit further logs.
+	a.logger.Info("Desktop App startet",
+		"version", appVersion,
+		"build", appBuild,
+		"logFile", LogFilePath(),
+		"agentbinAvailable", agentbin.Available())
 }
 
 // BoxInfo is the speaker entry passed to the frontend for selection.

--- a/desktop-app/app.go
+++ b/desktop-app/app.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -31,7 +30,7 @@ type App struct {
 // NewApp erstellt eine neue App Instance.
 func NewApp() *App {
 	return &App{
-		logger:     slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})),
+		logger:     newFileLogger(slog.LevelInfo),
 		httpClient: &http.Client{Timeout: 6 * time.Second},
 	}
 }

--- a/desktop-app/frontend/src/api.js
+++ b/desktop-app/frontend/src/api.js
@@ -39,6 +39,8 @@ export {
   SetBoxVolume,
   SetBoxBass,
   SelectBoxSource,
+  SaveDiagnosticBundle,
+  GetLogFilePath,
 } from '../wailsjs/go/main/App';
 
 export { BrowserOpenURL } from '../wailsjs/runtime/runtime';

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -358,6 +358,9 @@
   "combobox.noSuggestions": "keine Vorschläge",
 
   "footer.website": "Webseite",
+  "footer.saveLogs": "Diagnose-Log speichern",
+  "footer.saveLogsHint": "Sammelt App-Log + Status pro Lautsprecher in einem Zip, das du an ein GitHub-Issue hängen kannst. IPs und Geräte-IDs werden anonymisiert.",
+  "footer.saveLogsDone": "{{size}} KB gespeichert nach {{path}}",
   "footer.donateSlogan": "Dir gefällt die App? Ich freue mich über einen Kaffee.",
 
   "banner.recommendationShort": "Empfehlung",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -358,6 +358,9 @@
   "combobox.noSuggestions": "no suggestions",
 
   "footer.website": "Website",
+  "footer.saveLogs": "Save diagnostic logs",
+  "footer.saveLogsHint": "Bundle the app log + per-speaker state into a zip you can attach to a GitHub issue. IPs and device IDs are anonymized.",
+  "footer.saveLogsDone": "Saved {{size}} KB to {{path}}",
   "footer.donateSlogan": "Do you like the app? I'd appreciate a coffee.",
 
   "banner.recommendationShort": "Recommendation",

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -33,6 +33,8 @@ import {
   SetBoxVolume,
   SetBoxBass,
   SelectBoxSource,
+  SaveDiagnosticBundle,
+  GetLogFilePath,
   BrowserOpenURL,
 } from './api.js';
 
@@ -272,6 +274,7 @@ async function renderFooter() {
   const links = [];
   if (i.githubUrl)  links.push(`<a href="#" data-url="${escapeAttr(i.githubUrl)}" class="footer-link">GitHub</a>`);
   if (i.websiteUrl) links.push(`<a href="#" data-url="${escapeAttr(i.websiteUrl)}" class="footer-link">${escapeHtml(t('footer.website'))}</a>`);
+  links.push(`<a href="#" id="footerSaveLogs" class="footer-link" title="${escapeAttr(t('footer.saveLogsHint'))}">${escapeHtml(t('footer.saveLogs'))}</a>`);
   const buildStr = i.build && i.build !== 'dev' ? ` <span class="build-stamp">(Build ${escapeHtml(i.build)})</span>` : '';
   $('appFooter').innerHTML = `
     <div class="footer-left">
@@ -280,9 +283,29 @@ async function renderFooter() {
     </div>
     <div class="footer-right">${links.join(' &middot; ')}</div>
   `;
-  $('appFooter').querySelectorAll('.footer-link').forEach(a => {
+  $('appFooter').querySelectorAll('.footer-link[data-url]').forEach(a => {
     a.onclick = (e) => { e.preventDefault(); BrowserOpenURL(a.dataset.url); };
   });
+  const saveLogsBtn = $('footerSaveLogs');
+  if (saveLogsBtn) {
+    saveLogsBtn.onclick = async (e) => {
+      e.preventDefault();
+      saveLogsBtn.classList.add('working');
+      try {
+        const hosts = (state.boxes || []).map(b => b && b.host).filter(Boolean);
+        const res = await SaveDiagnosticBundle(hosts, true);
+        if (res && res.savePath) {
+          showToast(t('footer.saveLogsDone', { path: res.savePath, size: Math.round((res.bytes || 0) / 1024) }));
+        }
+        // If user cancelled the dialog, savePath comes back empty —
+        // no toast on cancel.
+      } catch (err) {
+        showError(String(err));
+      } finally {
+        saveLogsBtn.classList.remove('working');
+      }
+    };
+  }
   renderDonateSidebar();
   checkAppUpdate();
   // appInfo may have arrived after the first discovery completed; the

--- a/desktop-app/logexport.go
+++ b/desktop-app/logexport.go
@@ -1,0 +1,331 @@
+// Diagnostic-log export. Bundles the desktop app log file plus
+// per-known-box snapshots (Bose /info, STR /api/status, STR
+// /api/agent/version) into a single zip that the user can attach
+// to a GitHub issue.
+//
+// All output is anonymized for public sharing by default:
+//   - Real LAN IPs in the box list and inside the log are masked to
+//     192.0.2.x (the same scheme tools/Diagnose-STR.ps1 uses).
+//   - MAC addresses, device IDs, serial numbers, and friendly names
+//     in box snapshots are replaced with the first 8 hex chars of
+//     their SHA256.
+//
+// SSIDs and Wi-Fi passwords never leave the host: the export does
+// not include /etc/wpa_supplicant.conf, presets.json, or any other
+// stick-side state, and the desktop app's slog output is filtered
+// for SSID hints before being copied into the zip.
+
+package main
+
+import (
+	"archive/zip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+// LogExportRequest is the JSON the frontend hands to the export
+// method.
+type LogExportRequest struct {
+	// SavePath is the absolute path the resulting zip should be
+	// written to. Picked by the user via the Wails SaveFile dialog.
+	SavePath string `json:"savePath"`
+	// BoxHosts is the list of box LAN IPs the desktop app currently
+	// knows about. The exporter probes each for fresh JSON state.
+	BoxHosts []string `json:"boxHosts"`
+	// Anonymize masks IPs / hashes IDs / scrubs SSIDs from log
+	// before writing. Default true for safe public sharing.
+	Anonymize bool `json:"anonymize"`
+}
+
+// LogExportResult is the JSON the export method returns.
+type LogExportResult struct {
+	SavePath string `json:"savePath"`
+	Bytes    int64  `json:"bytes"`
+}
+
+// ExportDiagnosticLogs collects the app log + per-box state and
+// writes a zip to req.SavePath. Returns the path + size for the
+// frontend to show in a "saved" toast.
+func (a *App) ExportDiagnosticLogs(req LogExportRequest) (LogExportResult, error) {
+	if req.SavePath == "" {
+		return LogExportResult{}, fmt.Errorf("savePath is required")
+	}
+
+	f, err := os.Create(req.SavePath)
+	if err != nil {
+		return LogExportResult{}, fmt.Errorf("create zip: %w", err)
+	}
+	defer f.Close()
+	zw := zip.NewWriter(f)
+
+	// 1. README so the human opening the zip understands what is in it.
+	readme := fmt.Sprintf(`STR Reborn diagnostic bundle
+============================
+Created:     %s
+OS:          %s/%s
+App version: %s
+Anonymized:  %v
+Boxes asked: %d
+
+Contents:
+  README.txt            this file
+  app.log               desktop app log (rolling, up to 2 MB)
+  box-<n>.json          per-box snapshot (Bose /info + STR /api/status + /api/agent/version)
+  manifest.json         summary
+
+Privacy:
+  When Anonymized=true (default), LAN IPs are masked to 192.0.2.x,
+  MAC addresses / device IDs / serial numbers / friendly names are
+  hashed (first 8 chars of SHA256), and SSID-looking strings in the
+  app log are scrubbed. Even so, please skim the files before
+  attaching to a public issue.
+`, time.Now().UTC().Format(time.RFC3339), runtime.GOOS, runtime.GOARCH, appVersion, req.Anonymize, len(req.BoxHosts))
+	if err := writeZipEntry(zw, "README.txt", []byte(readme)); err != nil {
+		return LogExportResult{}, err
+	}
+
+	// 2. App log (truncated + sanitized).
+	logBytes, _ := os.ReadFile(LogFilePath())
+	if req.Anonymize {
+		logBytes = sanitizeLog(logBytes)
+	}
+	if err := writeZipEntry(zw, "app.log", logBytes); err != nil {
+		return LogExportResult{}, err
+	}
+
+	// 3. Per-box snapshots.
+	manifest := struct {
+		Timestamp string          `json:"timestamp"`
+		OS        string          `json:"os"`
+		Arch      string          `json:"arch"`
+		Anonymize bool            `json:"anonymize"`
+		Boxes     []boxIndexEntry `json:"boxes"`
+	}{
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		OS:        runtime.GOOS,
+		Arch:      runtime.GOARCH,
+		Anonymize: req.Anonymize,
+	}
+
+	// Stable ordering so subsequent runs diff cleanly.
+	hosts := append([]string{}, req.BoxHosts...)
+	sort.Strings(hosts)
+	for i, host := range hosts {
+		snap := captureBoxSnapshot(host)
+		entry := boxIndexEntry{Index: i, Host: host}
+		if req.Anonymize {
+			entry.Host = maskIP(host)
+			snap = anonymizeSnapshot(snap)
+		}
+		manifest.Boxes = append(manifest.Boxes, entry)
+		name := fmt.Sprintf("box-%d.json", i)
+		b, _ := json.MarshalIndent(snap, "", "  ")
+		if err := writeZipEntry(zw, name, b); err != nil {
+			return LogExportResult{}, err
+		}
+	}
+	mb, _ := json.MarshalIndent(manifest, "", "  ")
+	if err := writeZipEntry(zw, "manifest.json", mb); err != nil {
+		return LogExportResult{}, err
+	}
+	if err := zw.Close(); err != nil {
+		return LogExportResult{}, err
+	}
+
+	st, _ := f.Stat()
+	a.logger.Info("log export written", "path", req.SavePath, "bytes", st.Size(), "boxes", len(hosts))
+	return LogExportResult{SavePath: req.SavePath, Bytes: st.Size()}, nil
+}
+
+type boxIndexEntry struct {
+	Index int    `json:"index"`
+	Host  string `json:"host"`
+}
+
+type boxSnapshot struct {
+	Host          string         `json:"host"`
+	BoseInfo      string         `json:"boseInfoXml"`
+	STRStatus     string         `json:"strStatusJson"`
+	STRAgentVer   map[string]any `json:"strAgentVersion"`
+	ReachableSSH  bool           `json:"reachableSSH"`
+	Reachable8090 bool           `json:"reachable8090"`
+	Reachable8888 bool           `json:"reachable8888"`
+}
+
+func captureBoxSnapshot(host string) boxSnapshot {
+	s := boxSnapshot{Host: host}
+	s.Reachable8090 = portOpen(host, 8090, 1200)
+	s.Reachable8888 = portOpen(host, 8888, 1200)
+	s.ReachableSSH = portOpen(host, 22, 1200)
+	if s.Reachable8090 {
+		s.BoseInfo = httpGetText(fmt.Sprintf("http://%s:8090/info", host), 4096)
+	}
+	if s.Reachable8888 {
+		s.STRStatus = httpGetText(fmt.Sprintf("http://%s:8888/api/status", host), 4096)
+		raw := httpGetText(fmt.Sprintf("http://%s:8888/api/agent/version", host), 1024)
+		if raw != "" {
+			_ = json.Unmarshal([]byte(raw), &s.STRAgentVer)
+		}
+	}
+	return s
+}
+
+// === Sanitization ===
+
+var ipv4Regex = regexp.MustCompile(`\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b`)
+var macRegex = regexp.MustCompile(`(?i)\b([0-9A-F]{2}[:-]){5}[0-9A-F]{2}\b`)
+var deviceIDRegex = regexp.MustCompile(`(?i)\b[0-9A-F]{12}\b`)
+var ssidHintRegex = regexp.MustCompile(`(?i)(ssid|ssid_name|wpa-psk\s+\S+|psk=)[^\s]*`)
+
+func sanitizeLog(b []byte) []byte {
+	s := string(b)
+	s = ipv4Regex.ReplaceAllStringFunc(s, func(ip string) string { return maskIP(ip) })
+	s = macRegex.ReplaceAllStringFunc(s, func(m string) string { return "MAC#" + hashShort(m) })
+	s = deviceIDRegex.ReplaceAllStringFunc(s, func(m string) string { return "DEV#" + hashShort(m) })
+	s = ssidHintRegex.ReplaceAllString(s, "<SSID-REDACTED>")
+	return []byte(s)
+}
+
+func anonymizeSnapshot(s boxSnapshot) boxSnapshot {
+	s.Host = maskIP(s.Host)
+	s.BoseInfo = anonymizeBoseInfoXML(s.BoseInfo)
+	s.STRStatus = ipv4Regex.ReplaceAllStringFunc(s.STRStatus, func(ip string) string { return maskIP(ip) })
+	return s
+}
+
+func anonymizeBoseInfoXML(xml string) string {
+	if xml == "" {
+		return ""
+	}
+	// Bose /info has deviceID="...", <macAddress>...</macAddress>,
+	// <serialNumber>...</serialNumber>, <name>...</name>,
+	// <margeAccountUUID>...</margeAccountUUID>, <ipAddress>...
+	out := xml
+	out = regexp.MustCompile(`deviceID="([^"]+)"`).ReplaceAllStringFunc(out, func(m string) string {
+		v := strings.TrimSuffix(strings.TrimPrefix(m, `deviceID="`), `"`)
+		return `deviceID="DEV#` + hashShort(v) + `"`
+	})
+	out = regexp.MustCompile(`<macAddress>([^<]+)</macAddress>`).ReplaceAllStringFunc(out, func(m string) string {
+		v := strings.TrimSuffix(strings.TrimPrefix(m, `<macAddress>`), `</macAddress>`)
+		return `<macAddress>MAC#` + hashShort(v) + `</macAddress>`
+	})
+	out = regexp.MustCompile(`<serialNumber>([^<]+)</serialNumber>`).ReplaceAllStringFunc(out, func(m string) string {
+		v := strings.TrimSuffix(strings.TrimPrefix(m, `<serialNumber>`), `</serialNumber>`)
+		return `<serialNumber>SERIAL#` + hashShort(v) + `</serialNumber>`
+	})
+	out = regexp.MustCompile(`<name>([^<]+)</name>`).ReplaceAllStringFunc(out, func(m string) string {
+		v := strings.TrimSuffix(strings.TrimPrefix(m, `<name>`), `</name>`)
+		return `<name>NAME#` + hashShort(v) + `</name>`
+	})
+	out = regexp.MustCompile(`<margeAccountUUID>([^<]+)</margeAccountUUID>`).ReplaceAllStringFunc(out, func(m string) string {
+		v := strings.TrimSuffix(strings.TrimPrefix(m, `<margeAccountUUID>`), `</margeAccountUUID>`)
+		return `<margeAccountUUID>MARGE#` + hashShort(v) + `</margeAccountUUID>`
+	})
+	out = ipv4Regex.ReplaceAllStringFunc(out, func(ip string) string { return maskIP(ip) })
+	return out
+}
+
+func maskIP(ip string) string {
+	parts := strings.Split(ip, ".")
+	if len(parts) != 4 {
+		return ip
+	}
+	// Keep last octet so the same host stays recognisable across
+	// references but the network identity is hidden.
+	return "192.0.2." + parts[3]
+}
+
+func hashShort(s string) string {
+	if s == "" {
+		return ""
+	}
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])[:8]
+}
+
+// === Small HTTP / port helpers ===
+
+func portOpen(host string, port int, timeoutMs int) bool {
+	c, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", host, port),
+		time.Duration(timeoutMs)*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = c.Close()
+	return true
+}
+
+func httpGetText(url string, max int64) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return ""
+	}
+	cli := &http.Client{Timeout: 4 * time.Second}
+	resp, err := cli.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	b, _ := io.ReadAll(io.LimitReader(resp.Body, max))
+	return string(b)
+}
+
+func writeZipEntry(zw *zip.Writer, name string, data []byte) error {
+	w, err := zw.Create(name)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+// SaveDiagnosticBundle is the one-call frontend entry point: pops
+// the OS save-file dialog with a sensible default filename, then
+// writes the zip there. Returns the resulting path or empty string
+// if the user cancelled. Anonymize defaults to true.
+func (a *App) SaveDiagnosticBundle(boxHosts []string, anonymize bool) (LogExportResult, error) {
+	defaultName := fmt.Sprintf("str-diagnostic-%s.zip", time.Now().UTC().Format("20060102-150405"))
+	path, err := wailsruntime.SaveFileDialog(a.ctx, wailsruntime.SaveDialogOptions{
+		DefaultFilename: defaultName,
+		Title:           "Save STR diagnostic bundle",
+		Filters: []wailsruntime.FileFilter{
+			{DisplayName: "Zip archive (*.zip)", Pattern: "*.zip"},
+		},
+	})
+	if err != nil {
+		return LogExportResult{}, err
+	}
+	if path == "" {
+		return LogExportResult{}, nil // user cancelled
+	}
+	return a.ExportDiagnosticLogs(LogExportRequest{
+		SavePath:  path,
+		BoxHosts:  boxHosts,
+		Anonymize: anonymize,
+	})
+}
+
+// GetLogFilePath returns the path of the live app log so the
+// frontend can show it in an "open log folder" link.
+func (a *App) GetLogFilePath() string {
+	return LogFilePath()
+}

--- a/desktop-app/logexport.go
+++ b/desktop-app/logexport.go
@@ -98,7 +98,12 @@ Privacy:
 		return LogExportResult{}, err
 	}
 
-	// 2. App log (truncated + sanitized).
+	// 2. App log (truncated + sanitized). Flush the live writer
+	// first so anything slog buffered for this session lands on
+	// disk before we read it back.
+	if a.logFile != nil {
+		_ = a.logFile.Sync()
+	}
 	logBytes, _ := os.ReadFile(LogFilePath())
 	if req.Anonymize {
 		logBytes = sanitizeLog(logBytes)

--- a/desktop-app/logfile.go
+++ b/desktop-app/logfile.go
@@ -65,11 +65,16 @@ func openLogFile() (*os.File, error) {
 
 // newFileLogger returns a slog.Logger that writes to BOTH the file
 // at LogFilePath() and stderr (so wails dev still shows logs in the
-// console). If the file cannot be opened, falls back to stderr only.
-func newFileLogger(level slog.Level) *slog.Logger {
+// console), plus the underlying file handle so the caller can Sync
+// it before reading the file (e.g. when bundling for export).
+// If the file cannot be opened, the file return is nil and the
+// logger falls back to stderr-only.
+func newFileLogger(level slog.Level) (*slog.Logger, *os.File) {
 	var w io.Writer = os.Stderr
+	var file *os.File
 	if f, err := openLogFile(); err == nil {
 		w = io.MultiWriter(os.Stderr, f)
+		file = f
 	}
-	return slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{Level: level}))
+	return slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{Level: level})), file
 }

--- a/desktop-app/logfile.go
+++ b/desktop-app/logfile.go
@@ -63,17 +63,33 @@ func openLogFile() (*os.File, error) {
 	return os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 }
 
-// newFileLogger returns a slog.Logger that writes to BOTH the file
-// at LogFilePath() and stderr (so wails dev still shows logs in the
-// console), plus the underlying file handle so the caller can Sync
-// it before reading the file (e.g. when bundling for export).
-// If the file cannot be opened, the file return is nil and the
-// logger falls back to stderr-only.
+// safeWriter wraps an io.Writer and never returns its errors. Used
+// for the stderr leg of the multi-writer below: in Wails production
+// builds there is no attached console and stderr writes fail. The
+// io.MultiWriter contract stops at the first error from any writer,
+// which would prevent the file leg from receiving any output. We
+// keep the stderr leg purely so wails dev still shows logs, but its
+// errors must not cascade and silently swallow the file write.
+type safeWriter struct{ w io.Writer }
+
+func (s safeWriter) Write(p []byte) (int, error) {
+	_, _ = s.w.Write(p)
+	return len(p), nil
+}
+
+// newFileLogger returns a slog.Logger that writes to the file at
+// LogFilePath() and (best-effort) stderr. File writes come first in
+// the multi-writer so a dead stderr in a production Wails build
+// cannot prevent the file from being written. Also returns the
+// underlying file handle so the caller can Sync it before reading
+// the file (e.g. when bundling for export). If the file cannot be
+// opened, the file return is nil and the logger falls back to
+// safe-stderr only.
 func newFileLogger(level slog.Level) (*slog.Logger, *os.File) {
-	var w io.Writer = os.Stderr
+	var w io.Writer = safeWriter{os.Stderr}
 	var file *os.File
 	if f, err := openLogFile(); err == nil {
-		w = io.MultiWriter(os.Stderr, f)
+		w = io.MultiWriter(f, safeWriter{os.Stderr})
 		file = f
 	}
 	return slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{Level: level})), file

--- a/desktop-app/logfile.go
+++ b/desktop-app/logfile.go
@@ -1,0 +1,75 @@
+// File-based logger for the desktop app. Production Wails builds
+// discard stderr, so without a file the user has nothing to attach
+// to bug reports. This writes a single rolling file under the OS
+// user-local app-data dir, capped at a small size so it never grows
+// unbounded.
+
+package main
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+const (
+	maxLogFileBytes = 2 * 1024 * 1024 // 2 MB before truncate
+	logFileName     = "str.log"
+	logDirName      = "STReborn"
+)
+
+// LogFilePath returns the absolute path where the app log lives.
+// %LOCALAPPDATA%\STReborn\str.log on Windows, $HOME/Library/Application
+// Support/STReborn/str.log on macOS, $XDG_DATA_HOME (or
+// ~/.local/share)/STReborn/str.log on Linux.
+func LogFilePath() string {
+	var base string
+	switch runtime.GOOS {
+	case "windows":
+		base = os.Getenv("LOCALAPPDATA")
+		if base == "" {
+			base, _ = os.UserCacheDir()
+		}
+	case "darwin":
+		if home, err := os.UserHomeDir(); err == nil {
+			base = filepath.Join(home, "Library", "Application Support")
+		}
+	default:
+		if v := os.Getenv("XDG_DATA_HOME"); v != "" {
+			base = v
+		} else if home, err := os.UserHomeDir(); err == nil {
+			base = filepath.Join(home, ".local", "share")
+		}
+	}
+	if base == "" {
+		base = os.TempDir()
+	}
+	return filepath.Join(base, logDirName, logFileName)
+}
+
+// openLogFile prepares the log file: ensures the directory exists,
+// truncates if the current file is too large to keep the working
+// set small, opens in append mode.
+func openLogFile() (*os.File, error) {
+	path := LogFilePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, err
+	}
+	if st, err := os.Stat(path); err == nil && st.Size() > maxLogFileBytes {
+		_ = os.Remove(path)
+	}
+	return os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+}
+
+// newFileLogger returns a slog.Logger that writes to BOTH the file
+// at LogFilePath() and stderr (so wails dev still shows logs in the
+// console). If the file cannot be opened, falls back to stderr only.
+func newFileLogger(level slog.Level) *slog.Logger {
+	var w io.Writer = os.Stderr
+	if f, err := openLogFile(); err == nil {
+		w = io.MultiWriter(os.Stderr, f)
+	}
+	return slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{Level: level}))
+}


### PR DESCRIPTION
## Summary

End users who hit an issue can now produce a single zip from the app footer and attach it to a GitHub issue without running PowerShell scripts. Replaces the manual stderr-capture / `Diagnose-STR.ps1` flow for the common "the app does X, what now" case.

## What it does

1. **File-based slog handler** in `desktop-app/logfile.go`. The app now logs to BOTH stderr (for `wails dev`) AND to a file at:
   - `%LOCALAPPDATA%\STReborn\str.log` on Windows
   - `$HOME/Library/Application Support/STReborn/str.log` on macOS
   - `$XDG_DATA_HOME/STReborn/str.log` (or `~/.local/share/...`) on Linux

   Truncate-rotated at 2 MB so it never grows unbounded.

2. **`ExportDiagnosticLogs` / `SaveDiagnosticBundle`** in `desktop-app/logexport.go`:
   - Bundles `app.log` + per-known-box snapshots (Bose `/info` on 8090, STR `/api/status` + `/api/agent/version` on 8888, port reachability for 22/8090/8888) + manifest into one zip.
   - **Anonymized by default**: LAN IPs masked to `192.0.2.x`, MAC addresses / device IDs / serial numbers / friendly names hashed to 8 hex chars of SHA256, SSID-looking strings in the log scrubbed.
   - `SaveDiagnosticBundle` pops the native OS save-file dialog (via `wailsruntime.SaveFileDialog`), defaults to `str-diagnostic-YYYYMMDD-HHMMSS.zip`, returns size + path.

3. **Footer link "Save diagnostic logs"** in `renderFooter`:
   - One click → save dialog → bundle + write.
   - Toast on success with path + size.
   - Cancel = silent no-op.

i18n EN + DE for the new strings.

## Test plan

- [x] `go build ./desktop-app/...` host green
- [x] `wails build` produces `ST Reborn.exe`; manually launched
- [ ] Click "Save diagnostic logs" in footer, save the resulting zip, open it, verify: anonymized IPs / hashed IDs / log content present
- [ ] Send a colleague the resulting zip and confirm it is readable / useful for issue triage
- [ ] Hit "Save" with no boxes discovered yet — empty box section, manifest still valid

Refs N/A (quality-of-life follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)