### PR TITLE
feat(stick,wizard): per-model USB port guidance and mount-path discovery

### DIFF
--- a/desktop-app/install_str.go
+++ b/desktop-app/install_str.go
@@ -57,28 +57,48 @@ func (a *App) InstallSTROnBox(host string) (InstallResult, error) {
 
 	// Step 1: stick mounted, install.sh present. Retry up to ~60 s
 	// because sshd answers before the USB stack has finished
-	// mounting /media/sda1 on first boot.
+	// mounting the stick on first boot.
+	//
+	// Mount path: Bose's udev rule lands the first USB block device
+	// at /media/sda1 across every model we have observed (ST10
+	// micro-USB, ST20/30 USB-A — same /etc/udev/scripts/mount.sh).
+	// /media/sda1 stays the primary check; the probe also tries the
+	// next few /media/sd[b-d]1 slots so a firmware variant that
+	// numbers differently is not a hard fail. The first hit is
+	// echoed back as STICKPATH=... so step 2 reuses it.
 	res.Step = "check-stick"
+	const probeCmd = `for p in /media/sda1 /media/sdb1 /media/sdc1 /media/sdd1; do ` +
+		`if [ -x "$p/install.sh" ]; then echo "STICKPATH=$p"; exit 0; fi; ` +
+		`done; echo MISSING`
 	var probe string
 	var probeErr error
+	stickPath := "/media/sda1"
 	for attempt := 0; attempt < 20; attempt++ {
-		probe, probeErr = boxSSHOutput(host, "test -x /media/sda1/install.sh && echo READY || echo MISSING", 6*time.Second)
-		if probeErr == nil && strings.Contains(probe, "READY") {
+		probe, probeErr = boxSSHOutput(host, probeCmd, 6*time.Second)
+		if probeErr == nil && strings.Contains(probe, "STICKPATH=") {
+			for _, line := range strings.Split(probe, "\n") {
+				line = strings.TrimSpace(line)
+				if strings.HasPrefix(line, "STICKPATH=") {
+					stickPath = strings.TrimPrefix(line, "STICKPATH=")
+					break
+				}
+			}
 			break
 		}
 		if attempt == 19 {
 			if probeErr != nil {
 				return res, fmt.Errorf("ssh probe failed after retries: %w", probeErr)
 			}
-			res.Message = "install.sh did not appear on /media/sda1 within 60 s. Is the STR stick plugged into the speaker, and did the speaker mount it on this boot?"
+			res.Message = "install.sh did not appear on /media/sda[a-d]1 within 60 s. Is the STR stick plugged into the speaker, and did the speaker mount it on this boot?"
 			return res, nil
 		}
 		time.Sleep(3 * time.Second)
 	}
+	a.logger.Info("install_str: stick found", "host", host, "path", stickPath)
 
 	// Step 2: run install.sh install.
 	res.Step = "run-install"
-	out, err := boxSSHOutput(host, "sh /media/sda1/install.sh install 2>&1", 60*time.Second)
+	out, err := boxSSHOutput(host, "sh "+stickPath+"/install.sh install 2>&1", 60*time.Second)
 	res.Log = out
 	if err != nil {
 		return res, fmt.Errorf("install.sh failed: %w", err)

--- a/setup/Install-STR.ps1
+++ b/setup/Install-STR.ps1
@@ -209,7 +209,11 @@ function Action-Setup {
     Write-Host ""
     Write-Host "  Schritt 2:" -ForegroundColor Cyan -NoNewline
     Write-Host " Karte in den USB Port der Bose SoundTouch stecken"
-    Write-Host "             ST10/20/30: Micro USB Port auf der Rueckseite oder Unterseite."
+    Write-Host "             SoundTouch 10: Micro-USB Port unten an der Box."
+    Write-Host "                            Du brauchst dafuer einen OTG-faehigen Stick"
+    Write-Host "                            oder einen Micro-USB-OTG-Adapter."
+    Write-Host "             SoundTouch 20 / 30: USB-A Port auf der Rueckseite."
+    Write-Host "                                 Normaler USB-Stick passt direkt rein."
     Write-Host "             Karte komplett einstecken bis sie sitzt."
     Write-Host ""
     Write-Host "  Schritt 3:" -ForegroundColor Cyan -NoNewline

--- a/usb-stick/rc.local
+++ b/usb-stick/rc.local
@@ -15,22 +15,47 @@ mkdir -p "$LOGDIR" 2>/dev/null || true
 echo "$(date): rc.local triggered" >> "$LOGDIR/boot.log"
 
 # USB stick is mounted async by udev. Both the NAND override path
-# and the fallback path need /media/sda1 (binary, version.txt,
-# wlan.conf). Wait up to 30s for the stick before deciding —
-# otherwise run.sh fires, finds an empty NAND cache plus a
-# not-yet-mounted stick, and aborts with "weder NAND Cache noch
-# Stick Binary verfuegbar". The stick may legitimately never
+# and the fallback path need the stick directory (binary,
+# version.txt, wlan.conf). Wait up to 30s for the stick before
+# deciding — otherwise run.sh fires, finds an empty NAND cache
+# plus a not-yet-mounted stick, and aborts with "weder NAND Cache
+# noch Stick Binary verfuegbar". The stick may legitimately never
 # appear (post-install, user pulled it). In that case we still
 # fall back to NAND override below.
+#
+# Mount path discovery: Bose's udev rule almost always lands the
+# first USB block device at /media/sda1 across all SoundTouch
+# models (ST10 micro-USB, ST20/30 USB-A; same udev script). On a
+# firmware variant that numbers differently (e.g. /media/sdb1 if
+# something else claimed sda first), we still find the stick.
+# /media/sda1 stays the primary check so existing behaviour is
+# preserved on every box that already worked.
+STICK_PATH=""
 i=0
 while [ $i -lt 30 ]; do
-    if [ -e /media/sda1/run.sh ] || [ -e /media/sda1/streborn-armv7l ]; then
-        echo "$(date): stick detected after ${i}s" >> "$LOGDIR/boot.log"
+    for cand in /media/sda1 /media/sdb1 /media/sdc1 /media/sdd1; do
+        if [ -e "$cand/run.sh" ] || [ -e "$cand/streborn-armv7l" ]; then
+            STICK_PATH="$cand"
+            break
+        fi
+    done
+    if [ -n "$STICK_PATH" ]; then
+        echo "$(date): stick detected at $STICK_PATH after ${i}s" >> "$LOGDIR/boot.log"
         break
     fi
     sleep 1
     i=$((i+1))
 done
+# Backwards compatibility: downstream code still references
+# /media/sda1 hardcoded in many places. If the stick landed
+# elsewhere, expose it via a symlink so legacy paths keep working
+# without touching the agent binary or run.sh internals.
+if [ -n "$STICK_PATH" ] && [ "$STICK_PATH" != "/media/sda1" ]; then
+    if [ ! -e /media/sda1 ]; then
+        ln -s "$STICK_PATH" /media/sda1 2>/dev/null \
+            && echo "$(date): /media/sda1 -> $STICK_PATH symlink set for legacy paths" >> "$LOGDIR/boot.log"
+    fi
+fi
 
 # Self-update from stick if present and newer. This is what makes
 # the stick the single repair channel — once an updated stick is

--- a/usb-stick/run.sh
+++ b/usb-stick/run.sh
@@ -12,7 +12,21 @@
 
 set -u
 
+# STICK path discovery: Bose's udev rule mounts the USB stick at
+# /media/sda1 on every model we have observed (ST10 micro-USB,
+# ST20/30 USB-A — same /etc/udev/scripts/mount.sh). Keep sda1 as
+# the primary path so existing boxes do not change behaviour, and
+# probe /media/sd[a-d]1 as a fallback if a firmware variant ever
+# numbers differently (defensive, no live evidence of this yet).
 STICK="/media/sda1"
+if [ ! -e "$STICK/run.sh" ] && [ ! -e "$STICK/streborn-armv7l" ]; then
+    for cand in /media/sdb1 /media/sdc1 /media/sdd1; do
+        if [ -e "$cand/run.sh" ] || [ -e "$cand/streborn-armv7l" ]; then
+            STICK="$cand"
+            break
+        fi
+    done
+fi
 PERSIST="/mnt/nv/streborn"
 # Aktiver Log liegt in tmpfs (/tmp) damit der NAND Flash im Dauerbetrieb
 # nicht abgenutzt wird. Bei jedem Start retten wir den vorherigen Log
@@ -304,13 +318,13 @@ fi
 # rc.local on NAND skipped that step (e.g. older release without
 # the self-update block), this run.sh invocation can still fix it
 # so the NEXT boot uses the fresh files.
-if [ -f /media/sda1/rc.local ] && [ /media/sda1/rc.local -nt /mnt/nv/rc.local ]; then
-    cp /media/sda1/rc.local /mnt/nv/rc.local 2>/dev/null
+if [ -f "$STICK/rc.local" ] && [ "$STICK/rc.local" -nt /mnt/nv/rc.local ]; then
+    cp "$STICK/rc.local" /mnt/nv/rc.local 2>/dev/null
     chmod +x /mnt/nv/rc.local 2>/dev/null
     log "redeployed /mnt/nv/rc.local from stick (effective next boot)"
 fi
-if [ -f /media/sda1/run.sh ] && [ /media/sda1/run.sh -nt /mnt/nv/streborn/run-override.sh ]; then
-    cp /media/sda1/run.sh /mnt/nv/streborn/run-override.sh 2>/dev/null
+if [ -f "$STICK/run.sh" ] && [ "$STICK/run.sh" -nt /mnt/nv/streborn/run-override.sh ]; then
+    cp "$STICK/run.sh" /mnt/nv/streborn/run-override.sh 2>/dev/null
     chmod +x /mnt/nv/streborn/run-override.sh 2>/dev/null
     log "redeployed /mnt/nv/streborn/run-override.sh from stick (effective next boot)"
 fi


### PR DESCRIPTION
## Summary
- Wizard `setup/Install-STR.ps1` now tells users which USB port their model has: ST10 = micro-USB (needs OTG stick or adapter), ST20/30 = standard USB-A. The old "ST10/20/30: Micro USB Port" line was wrong for ST20/30.
- `usb-stick/rc.local`, `usb-stick/run.sh` and `desktop-app/install_str.go` keep `/media/sda1` as the primary mount path (every Bose firmware variant observed mounts the stick there via the same udev script) and add `/media/sd[b-d]1` as a defensive fallback. rc.local symlinks `/media/sda1` to the discovered path so legacy hardcoded references keep working.

Background research cross-referenced Bose's own support pages with community sources (Hackaday/flarn2006, soundcork, technologicalmisadventures.wordpress.com).

## Test plan
- [ ] Local Wails build runs and ST Reborn launches cleanly (verified locally before push).
- [ ] Wizard `setup/Install-STR.ps1` prints the new per-model port hint in Schritt 2.
- [ ] On the ST10 reference box: existing `/media/sda1` flow still wins, no regression — boot log shows `stick detected at /media/sda1 after Xs`.
- [ ] If a user reports a non-sda1 mount on ST20/30 (currently unverified), boot log should show the fallback path and the legacy symlink.
- [ ] `desktop-app/install_str.go` in-app install probe handles `/media/sda1` as before and falls back to `sdb1/sdc1/sdd1` only if `sda1` misses.

Refs the open question of ST20/30 end-to-end validation tracked in CLAUDE.md's v1.0 gates.