### PR TITLE
fix(stick,desktop): keep agent install path alive on ethernet-only ST20

### DIFF
--- a/desktop-app/logexport.go
+++ b/desktop-app/logexport.go
@@ -199,7 +199,17 @@ type sshFallback struct {
 	UptimeSeconds  string   `json:"uptimeSeconds"`
 	RunningProcs   string   `json:"runningProcs"`
 	StickInstallSh string   `json:"stickInstallShPresent"`
-	Probed         []string `json:"probedMountPaths"`
+	// Network interface state pulled because "no wlan, only eth0"
+	// turned out to be the actual cause of #60's failing ST20 and
+	// only became visible after we asked the user to SSH manually.
+	// Including this in the bundle by default means future reports
+	// of the same shape arrive already diagnosed.
+	IPLinkShow string `json:"ipLinkShow"`
+	SysClassNet string `json:"sysClassNet"`
+	ProcNetDev  string `json:"procNetDev"`
+	DmesgWlan   string `json:"dmesgWlan"`
+	WlanMode    string `json:"wlanMode"`
+	Probed      []string `json:"probedMountPaths"`
 }
 
 func captureBoxSnapshot(host string) boxSnapshot {
@@ -272,6 +282,19 @@ func pullSSHFallback(host string) *sshFallback {
 		{"stickInstall", "for p in /media/sda1 /media/sdb1 /media/sdc1 /media/sdd1 /mnt/sda1 /mnt/usb /run/media/sda1; do " +
 			`if [ -e "$p/install.sh" ]; then echo "INSTALL_SH_AT=$p"; fi; done`,
 			5000, &out.StickInstallSh},
+		// Network state. ip link show is the canonical "what
+		// interfaces does the kernel know about" view; /sys/class/net
+		// catches the case where ip is missing on a stripped
+		// BusyBox. /proc/net/dev cross-checks that and shows packet
+		// counters so we can tell whether eth0 ever saw traffic.
+		// dmesg | grep wlan picks up driver load failures from the
+		// 2014-era SMSC chip on older ST20s that booted without a
+		// radio in #60.
+		{"ipLinkShow", "ip link show 2>&1 | head -40", 4000, &out.IPLinkShow},
+		{"sysClassNet", "ls /sys/class/net 2>&1", 3000, &out.SysClassNet},
+		{"procNetDev", "cat /proc/net/dev 2>/dev/null | head -20", 3000, &out.ProcNetDev},
+		{"dmesgWlan", "dmesg 2>/dev/null | grep -iE 'wlan|wifi|smsc|wireless|brcm|mt76|cfg80211|mac80211' | tail -30", 5000, &out.DmesgWlan},
+		{"wlanMode", "cat /mnt/nv/streborn/wlan-mode 2>/dev/null", 3000, &out.WlanMode},
 	}
 	for _, f := range fields {
 		txt, _ := boxSSHOutput(host, f.cmd, time.Duration(f.ms)*time.Millisecond)
@@ -314,6 +337,11 @@ func anonymizeSnapshot(s boxSnapshot) boxSnapshot {
 		s.SSHFallback.ProcMounts = anonymizeText(s.SSHFallback.ProcMounts)
 		s.SSHFallback.RunningProcs = anonymizeText(s.SSHFallback.RunningProcs)
 		s.SSHFallback.StickInstallSh = anonymizeText(s.SSHFallback.StickInstallSh)
+		s.SSHFallback.IPLinkShow = anonymizeText(s.SSHFallback.IPLinkShow)
+		s.SSHFallback.SysClassNet = anonymizeText(s.SSHFallback.SysClassNet)
+		s.SSHFallback.ProcNetDev = anonymizeText(s.SSHFallback.ProcNetDev)
+		s.SSHFallback.DmesgWlan = anonymizeText(s.SSHFallback.DmesgWlan)
+		s.SSHFallback.WlanMode = anonymizeText(s.SSHFallback.WlanMode)
 	}
 	return s
 }

--- a/usb-stick/run.sh
+++ b/usb-stick/run.sh
@@ -398,7 +398,27 @@ elif [ -r "$WLAN_CREDS_NAND" ]; then
     PASS=$(sed -n 's/^PASS=\(.*\)$/\1/p' "$WLAN_CREDS_NAND" | head -1)
     WLAN_SOURCE="NAND wlan-creds (replay)"
 fi
-if [ -n "$SSID" ] && [ -n "$PASS" ]; then
+# Ethernet-only short-circuit. If neither wlan0 nor wlan1 exists in
+# /sys/class/net, the box has no wireless radio (driver did not load,
+# or the chip is dead). Observed live on a scm-variant ST20 in #60
+# where /addWirelessProfile sat on slow 500 responses for ~4 minutes
+# per attempt, starving the agent start that lives after this block.
+# We instead skip the whole block: the speaker is already reachable
+# on its Ethernet cable per Bose's /networkInfo, and the desktop app
+# install path works fine against eth0.
+if [ ! -d /sys/class/net/wlan0 ] && [ ! -d /sys/class/net/wlan1 ]; then
+    setup_log "WLAN: no wlan0/wlan1 interface present, ethernet-only mode (skip provisioning)"
+    echo "ethernet-only" > "$PERSIST/wlan-mode" 2>/dev/null
+    SSID=""
+    PASS=""
+fi
+
+# Whole block runs in a backgrounded subshell so a slow Bose API
+# (4 minute /addWirelessProfile loops, observed on #60) cannot delay
+# start_agent below. Agent binds :8888 within seconds and the install
+# wizard's 180s poll window succeeds even when WLAN provisioning is
+# still trying its A/B/C/D fallbacks.
+( if [ -n "$SSID" ] && [ -n "$PASS" ]; then
     setup_log "=== WLAN provisioning start (boot at $(uptime | tr -s ' ')) source=$WLAN_SOURCE ==="
     setup_log "wlan.conf parsed: SSID='$SSID' password_length=${#PASS}"
     if [ -n "$SSID" ] && [ -n "$PASS" ]; then
@@ -668,6 +688,7 @@ WPAEOF
         setup_log "wlan creds invalid (SSID or PASS empty), aborting WLAN provisioning"
     fi
 fi
+) &
 
 # === Region Provisioning aus region.conf vom Stick ===
 # User hat im Setup Wizard ein Land gewaehlt. Persistieren nach NAND,
@@ -940,10 +961,23 @@ else
 # wir den Agent zu verwirren weil seine Goroutines (syncRunOverride,
 # initialBoxPresetSync) noch lesen.
 (
-    # 60 s grundsaetzliche Wartezeit: deckt syncRunOverrideFromStick
-    # (5 s) + initialBoxPresetSync (12 s) + autopair Timing + Sicherheits
-    # Puffer. Sollte fuer alle einmal-pro-Boot Stick Lesevorgaenge reichen.
-    sleep 60
+    # Pre-cleanup wait. Pre-1.0 we run it long, on purpose: the box
+    # is on the user's LAN and the SSH cost is real, but right now
+    # losing the debug channel costs us more than leaving it open
+    # does. 300 s covers (a) syncRunOverrideFromStick + initial preset
+    # sync + autopair timing (the old 60 s lower bound), (b) the
+    # backgrounded WLAN provisioning chain which on a failing scm-
+    # variant ST20 spans ~4 minutes of slow /addWirelessProfile 500s,
+    # (c) slow agent boot races on weak hardware, and (d) a healthy
+    # buffer before we commit to closing SSH. The :8888 gate below
+    # also still applies — if the agent never came up we never close
+    # SSH regardless of the timer.
+    #
+    # Trade-off accepted: stick stays mounted writable for 5 minutes,
+    # so a user who yanks it mid-bootstrap may see a dirty FAT on
+    # Windows. We accept that during dev. Tighten before broad
+    # release (see SECURITY.md hardening section).
+    sleep 300
 
     if ! mountpoint -q "$STICK" 2>/dev/null && ! mount | grep -q " $STICK "; then
         exit 0  # schon ausgehaengt, nichts zu tun
@@ -965,7 +999,30 @@ else
         WAIT_BUSY=$((WAIT_BUSY+5))
     done
 
+    # Agent reachability gate: never close the SSH escape hatch while
+    # the STR agent is missing. Observed live on #60: install timed
+    # out, agent never bound :8888, cleanup killed sshd anyway, and
+    # the diagnostic bundle came back empty because the on-box pull
+    # had no way in. Probe :8888 from inside the box before deciding.
+    AGENT_OK=0
+    if (echo > /dev/tcp/127.0.0.1/8888) >/dev/null 2>&1; then
+        AGENT_OK=1
+    elif command -v nc >/dev/null 2>&1 && nc -z 127.0.0.1 8888 >/dev/null 2>&1; then
+        AGENT_OK=1
+    fi
+
     sync
+    if [ "$AGENT_OK" = "0" ]; then
+        log "post-bootstrap: agent NOT bound on :8888 — leaving stick mounted + sshd alive for diagnostics"
+        setup_log "post-bootstrap: agent NOT bound on :8888 — leaving stick mounted + sshd alive"
+        # Read-only remount so a yanked stick does not corrupt FAT,
+        # but DO NOT umount and DO NOT stop sshd. Lets the desktop
+        # app's diagnostic bundle pull box-side logs after a failed
+        # install without the user typing anything.
+        mount -o remount,ro "$STICK" 2>/dev/null \
+            && log "USB Stick read-only remounted (sshd kept alive)"
+        exit 0
+    fi
     if umount "$STICK" 2>/dev/null; then
         log "USB Stick ausgehaengt — kann sicher gezogen werden"
         if [ -x /etc/init.d/sshd ]; then


### PR DESCRIPTION
## Summary

- `run.sh`: detect ethernet-only mode (no `wlan0`/`wlan1` in `/sys/class/net`), skip the WLAN provisioning block, write `/mnt/nv/streborn/wlan-mode=ethernet-only`.
- `run.sh`: WLAN provisioning runs in a backgrounded subshell so a slow Bose API cannot starve `start_agent`. The install wizard's 180 s `:8888` poll now succeeds in seconds instead of after a 4 min `/addWirelessProfile` loop.
- `run.sh`: extend the post-bootstrap sleep from 60 s to 300 s and gate the `sshd` kill on a `:8888` reachability probe. If the agent never bound, `sshd` stays alive and the stick stays mounted read-only so diagnostics can still be pulled.
- `logexport.go`: SSH fallback now also pulls `ip link show`, `/sys/class/net`, `/proc/net/dev`, a `dmesg` tail filtered for wireless drivers, and the new `wlan-mode` marker. Future reports of the same shape arrive already diagnosed.

## Why

#60: an ST20 reporter has the older `moduleType=scm` hardware revision with a 2014-era SMSC chip. No `wlan0`/`wlan1` ever appears at boot, Bose's `/addWirelessProfile` returns slow HTTP 500s, the agent that lives after the WLAN block misses the install wizard's 180 s window, and the cleanup killed `sshd` so the diagnostic bundle came back empty. With this change the box boots up over Ethernet, the agent binds `:8888` quickly, the wizard reports success, and if anything still fails the next bundle has the radio state and `dmesg` tail in it without anyone needing to SSH.

## Test plan

- [ ] Local Wails build runs (smoke test on Jens' ST10 over Wi-Fi: existing happy path unchanged).
- [ ] Run the existing happy path on the working ST20 (.134 in the reporter's bundle): WLAN provisioning still succeeds, agent comes up, sshd is killed as before because `:8888` is bound.
- [ ] Run on the failing ST20 (.177 in the reporter's bundle, reporter does this): agent installs and stays up over Ethernet, no 4 min wait, diagnostic bundle now contains `ipLinkShow` / `sysClassNet` / `dmesgWlan` / `wlanMode` fields.
- [ ] Bundle on a working speaker still anonymises the new fields (the unit test path covers `anonymizeText` already).

Refs #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)