### PR TITLE
fix: bind listeners first + keep SSH open + inline OTA CTA

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -214,71 +214,6 @@ func run() error {
 		webui.WithRegionFile(*regionFile),
 		webui.WithStreamProxy(streamProxySrv))
 
-	// Box model — ask the local Bose firmware which actual model
-	// it is (SoundTouch 10 vs 20 vs 30 vs Portable). Falls back to
-	// the generic "SoundTouch" if /info is not yet answering on a
-	// cold boot. Used by the desktop app to disambiguate multiple
-	// boxes on the same LAN.
-	model := "SoundTouch"
-	{
-		infoCtx, infoCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		if settings, err := boxapi.New(*boxHost).LoadSettings(infoCtx); err == nil && settings.Info.Type != "" {
-			model = settings.Info.Type
-			logger.Info("Box Modell erkannt", "type", model)
-			// Bose's countryCode is set at the factory or during the
-			// original Bose pairing flow and is rarely the user's
-			// actual location after STR install. STR uses region.txt
-			// (written by the setup wizard) for radio defaults. Log
-			// the mismatch once so it is documented in diagnostic
-			// bundles and not mistaken for a bug; nothing in STR
-			// reads Bose's countryCode at runtime.
-			boseCC := strings.ToUpper(strings.TrimSpace(settings.Info.CountryCode))
-			if region != "" && boseCC != "" && region != boseCC {
-				logger.Info("Region: STR uses region.txt for radio defaults; Bose firmware countryCode is informational only",
-					"strRegion", region, "boseCountryCode", boseCC)
-			}
-		} else if err != nil {
-			logger.Debug("box /info not yet reachable, using fallback model", "err", err)
-		}
-		infoCancel()
-	}
-
-	// mDNS Announce damit die Desktop App den Stick im LAN findet.
-	// Bei mehreren Boxen im Netz ist jeder Stick eine eigene Instance,
-	// die Desktop App listet alle.
-	mdnsAnnouncer, mdnsErr := discovery.Announce(
-		logger.With("comp", "discovery"),
-		discovery.Config{
-			Port:         8888,
-			DeviceID:     deviceID,
-			FriendlyName: "Bose SoundTouch " + lastN(deviceID, 6),
-			Model:        model,
-			Version:      version,
-			Build:        buildStamp,
-		},
-	)
-	if mdnsErr != nil {
-		logger.Warn("mDNS announce failed, continuing without", "err", mdnsErr)
-	}
-
-	// Box Name dynamisch in mDNS halten: regelmaessig info.name pollen
-	// und bei Aenderung den Announce TXT Record refreshen. Damit bekommt
-	// die Desktop App den neuen Namen sofort mit ohne Box Neustart.
-	if mdnsAnnouncer != nil {
-		go pollBoxName(context.Background(), *boxHost, mdnsAnnouncer, logger)
-	}
-
-	if *pendingNameFile != "" {
-		go applyPendingBoxName(context.Background(), *boxHost, *pendingNameFile, deviceID, logger)
-	}
-
-	// Wenn der USB Stick ein neueres run.sh hat als das NAND
-	// run-override.sh: kopieren. Das ist der Selbst-Update-Pfad fuer
-	// den Bootstrap. Ohne das laeuft die alte run-override.sh aus dem
-	// allerersten Setup auf ewig und neue Setup Wizard Configs werden
-	// ignoriert.
-	go syncRunOverrideFromStick(logger)
-
 	// Hardware Preset Tasten: Box sendet via WebSocket auf 8080 (gabbo Protocol)
 	// einen presetSelectionUpdated event wenn der User physisch eine Taste
 	// drueckt. Wir hooken den Event und triggern unseren UPnP Player.
@@ -302,31 +237,18 @@ func run() error {
 	var wg sync.WaitGroup
 	errs := make(chan error, 3)
 
+	// === Listener boot FIRST ===
+	// Bind marge / bmx / webui before any slow init (box /info,
+	// TLS bundle generation, mDNS announce). The boot-watchdog in
+	// usb-stick/run.sh checks ALIVE + BOUND every 5s starting at
+	// t=5s; on weak SoundTouch hardware the previous order spent
+	// 20-30s on pre-listen work (5s boxapi /info timeout, first-
+	// boot CA generation, etc.) and the watchdog killed the agent
+	// mid-init in a respawn loop. Listeners up first means :8888
+	// answers in 1-2s and the watchdog sees BOUND=1 from the
+	// first check.
 	startHTTP(ctx, &wg, errs, "marge", *margeAddr, margeSrv.Handler(), logger)
 	startHTTP(ctx, &wg, errs, "bmx", *bmxAddr, bmxSrv.Handler(), logger)
-
-	// TLS Termination fuer Marge auf 8443. iptables redirected die echte
-	// Box Anfrage von 443 dorthin. Wenn TLS deaktiviert wird, ueberspringen.
-	if *tlsEnabled {
-		tlsMgr := tlsgen.New(*tlsDir, nil, logger.With("comp", "tlsgen"))
-		bundle, err := tlsMgr.EnsureBundle()
-		if err != nil {
-			logger.Error("TLS bundle unavailable, continuing without TLS listener", "err", err)
-		} else {
-			cert, err := bundle.TLSCert()
-			if err != nil {
-				logger.Error("TLS cert not loadable, continuing without TLS listener", "err", err)
-			} else {
-				tlsConfig := &tls.Config{
-					Certificates: []tls.Certificate{cert},
-					MinVersion:   tls.VersionTLS12,
-				}
-				startHTTPS(ctx, &wg, errs, "marge-tls", *margeTLSAddr,
-					margeSrv.Handler(), tlsConfig, logger)
-			}
-		}
-	}
-
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -352,7 +274,118 @@ func run() error {
 		autoPair.RunBackground(ctx, 8*time.Second, 5*time.Minute)
 	}()
 
-	logger.Info("all subsystems started")
+	// === Deferred heavy init (background) ===
+	// Everything below this point runs while the agent's listeners
+	// are already serving. Slow steps are isolated in their own
+	// goroutines so a stall in one (e.g. TLS CA generation on a
+	// flash-bound NAND) does not delay another (e.g. mDNS announce).
+	// All goroutines respect ctx so shutdown still terminates them
+	// promptly.
+	//
+	// Order within each goroutine is preserved from the previous
+	// sync flow; only the cross-goroutine ordering changes.
+
+	// mDNS announce: detect model from box /info, then announce. The
+	// model lookup is a 5 s blocking call against the Bose firmware
+	// which on a cold boot may not yet be answering. Doing it here
+	// (after listeners are up) costs nothing user-visible — the
+	// desktop app's discovery retries until the announce lands.
+	var (
+		mdnsMu        sync.Mutex
+		mdnsAnnouncer *discovery.Announcer
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		model := "SoundTouch"
+		infoCtx, infoCancel := context.WithTimeout(ctx, 5*time.Second)
+		if settings, err := boxapi.New(*boxHost).LoadSettings(infoCtx); err == nil && settings.Info.Type != "" {
+			model = settings.Info.Type
+			logger.Info("Box Modell erkannt", "type", model)
+			// Bose's countryCode is set at the factory or during the
+			// original Bose pairing flow and is rarely the user's
+			// actual location after STR install. STR uses region.txt
+			// (written by the setup wizard) for radio defaults. Log
+			// the mismatch once so it is documented in diagnostic
+			// bundles and not mistaken for a bug; nothing in STR
+			// reads Bose's countryCode at runtime.
+			boseCC := strings.ToUpper(strings.TrimSpace(settings.Info.CountryCode))
+			if region != "" && boseCC != "" && region != boseCC {
+				logger.Info("Region: STR uses region.txt for radio defaults; Bose firmware countryCode is informational only",
+					"strRegion", region, "boseCountryCode", boseCC)
+			}
+		} else if err != nil {
+			logger.Debug("box /info not yet reachable, using fallback model", "err", err)
+		}
+		infoCancel()
+
+		// mDNS Announce damit die Desktop App den Stick im LAN findet.
+		// Bei mehreren Boxen im Netz ist jeder Stick eine eigene Instance,
+		// die Desktop App listet alle.
+		ann, err := discovery.Announce(
+			logger.With("comp", "discovery"),
+			discovery.Config{
+				Port:         8888,
+				DeviceID:     deviceID,
+				FriendlyName: "Bose SoundTouch " + lastN(deviceID, 6),
+				Model:        model,
+				Version:      version,
+				Build:        buildStamp,
+			},
+		)
+		if err != nil {
+			logger.Warn("mDNS announce failed, continuing without", "err", err)
+			return
+		}
+		mdnsMu.Lock()
+		mdnsAnnouncer = ann
+		mdnsMu.Unlock()
+
+		// Box Name dynamisch in mDNS halten: regelmaessig info.name pollen
+		// und bei Aenderung den Announce TXT Record refreshen. Damit bekommt
+		// die Desktop App den neuen Namen sofort mit ohne Box Neustart.
+		go pollBoxName(ctx, *boxHost, ann, logger)
+	}()
+
+	if *pendingNameFile != "" {
+		go applyPendingBoxName(context.Background(), *boxHost, *pendingNameFile, deviceID, logger)
+	}
+
+	// Wenn der USB Stick ein neueres run.sh hat als das NAND
+	// run-override.sh: kopieren. Das ist der Selbst-Update-Pfad fuer
+	// den Bootstrap. Ohne das laeuft die alte run-override.sh aus dem
+	// allerersten Setup auf ewig und neue Setup Wizard Configs werden
+	// ignoriert.
+	go syncRunOverrideFromStick(logger)
+
+	// TLS Termination fuer Marge auf 8443. iptables redirected die echte
+	// Box Anfrage von 443 dorthin. Wenn TLS deaktiviert wird, ueberspringen.
+	// EnsureBundle generates a per-box CA on the very first boot, which
+	// touches NAND and can take several seconds — keep this off the
+	// listener-boot path.
+	if *tlsEnabled {
+		go func() {
+			tlsMgr := tlsgen.New(*tlsDir, nil, logger.With("comp", "tlsgen"))
+			bundle, err := tlsMgr.EnsureBundle()
+			if err != nil {
+				logger.Error("TLS bundle unavailable, continuing without TLS listener", "err", err)
+				return
+			}
+			cert, err := bundle.TLSCert()
+			if err != nil {
+				logger.Error("TLS cert not loadable, continuing without TLS listener", "err", err)
+				return
+			}
+			tlsConfig := &tls.Config{
+				Certificates: []tls.Certificate{cert},
+				MinVersion:   tls.VersionTLS12,
+			}
+			startHTTPS(ctx, &wg, errs, "marge-tls", *margeTLSAddr,
+				margeSrv.Handler(), tlsConfig, logger)
+		}()
+	}
+
+	logger.Info("agent listeners bound, deferred init continues in background")
 
 	var firstErr error
 	select {
@@ -366,8 +399,11 @@ func run() error {
 
 	wg.Wait()
 
-	if mdnsAnnouncer != nil {
-		mdnsAnnouncer.Close()
+	mdnsMu.Lock()
+	mdnsAnn := mdnsAnnouncer
+	mdnsMu.Unlock()
+	if mdnsAnn != nil {
+		mdnsAnn.Close()
 	}
 
 	if hostsMgr != nil {

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -553,6 +553,8 @@
   "setup.bootstrapFailed": "Konfiguration über das Setup-Netz fehlgeschlagen: {{msg}}.",
   "setup.boxFoundOnLAN": "Lautsprecher ist im LAN auf {{ip}}. Installiere STR ...",
   "setup.alreadyInstalled": "Lautsprecher auf {{ip}} läuft schon mit STR. Nichts zu installieren.",
+  "setup.alreadyInstalledUpdateBtn": "Agent auf diesen Stand aktualisieren",
+  "setup.alreadyInstalledUpdateHint": "Schiebt den Agent, der mit dieser App-Version mitgeliefert wird, auf den Lautsprecher. Nutze das, wenn der Lautsprecher auf einem älteren Build läuft als die Desktop-App.",
   "setup.installRunning": "install.sh läuft per SSH auf dem Lautsprecher, dann Reboot. Dauert etwa 2 Minuten.",
   "setup.installFailed": "Installation fehlgeschlagen: {{msg}}",
   "setup.installLogToggle": "Install-Log anzeigen",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -553,6 +553,8 @@
   "setup.bootstrapFailed": "Could not configure the speaker from its setup network: {{msg}}.",
   "setup.boxFoundOnLAN": "Speaker is on the LAN at {{ip}}. Installing STR...",
   "setup.alreadyInstalled": "Speaker at {{ip}} already runs STR. Nothing to install.",
+  "setup.alreadyInstalledUpdateBtn": "Update box agent to this build",
+  "setup.alreadyInstalledUpdateHint": "Pushes the agent that ships with this version of the app to the speaker. Use this when the speaker is on an older build than the desktop app.",
   "setup.installRunning": "Running install.sh on the speaker via SSH, then rebooting. This takes about 2 minutes.",
   "setup.installFailed": "Install failed: {{msg}}",
   "setup.installLogToggle": "Show install log",

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -3661,7 +3661,27 @@ async function waitForBoxAfterSetup({ ssid, pass, html }) {
   }
 
   if (foundBox.kind === 'str') {
-    render(`<div class="setup-ok">${escapeHtml(t('setup.alreadyInstalled', { ip: foundBox.host }))}</div>`);
+    // Show "already runs STR" PLUS an inline "Update agent" CTA so
+    // users in this state are not stuck. Without the button the
+    // setup view is a dead end: it told the user STR is installed,
+    // but the only way to actually push a newer embedded agent to
+    // the box was a separate OTA banner elsewhere in the UI that
+    // multiple testers missed. Observed live in #60: tester wrote
+    // a fresh v0.5.9 stick to upgrade a v0.5.5 box, the setup
+    // screen said "Nothing to install" and they had no way to
+    // proceed. The button calls the existing doBoxUpdate() flow
+    // which uploads the embedded ARM binary over /api/agent/update
+    // and waits for the box to come back on the new build.
+    state.currentBox = foundBox;
+    render(`<div class="setup-ok">${escapeHtml(t('setup.alreadyInstalled', { ip: foundBox.host }))}</div>` +
+           `<div class="setup-ok-actions">` +
+             `<button id="setupUpdateAgentBtn" class="btn">${escapeHtml(t('setup.alreadyInstalledUpdateBtn'))}</button>` +
+             `<div class="muted small">${escapeHtml(t('setup.alreadyInstalledUpdateHint'))}</div>` +
+           `</div>`);
+    const btn = $('setupUpdateAgentBtn');
+    if (btn) {
+      btn.onclick = () => { doBoxUpdate(); };
+    }
     discoverBoxes();
     return;
   }

--- a/desktop-app/frontend/src/style.css
+++ b/desktop-app/frontend/src/style.css
@@ -1033,6 +1033,8 @@ code { background: #1a1a1a; padding: 1px 4px; border-radius: 3px; font-size: 12p
 .setup-ok { color: var(--signal-green); }
 .setup-err { color: var(--signal-red); }
 .setup-warn { color: #f88; }
+.setup-ok-actions { margin-top: 10px; display: flex; flex-direction: column; gap: 6px; align-items: flex-start; }
+.setup-ok-actions .muted { max-width: 38rem; }
 .fw-stale {
   display: inline-block;
   background: #3a2a1a;

--- a/usb-stick/run.sh
+++ b/usb-stick/run.sh
@@ -85,6 +85,46 @@ setup_log() {
     echo "$line" >> "$SETUP_LOG_NAND" 2>/dev/null
 }
 
+# ensure_sshd_running keeps the box reachable by SSH from boot until
+# next reboot, on every boot regardless of whether the stick is
+# inserted. Pre-1.0 we explicitly prefer debug visibility over
+# security: when an install or OTA leaves the agent stuck, SSH is
+# the only channel that still lets the desktop app's diagnostic
+# bundle pull /tmp/streborn-agent.log, /mnt/nv/streborn/setup.log
+# etc. Without it every "no luck yet" report ended in a stick-yank
+# cycle.
+#
+# Box default state: Bose's /etc/init.d/shelby_local starts sshd
+# only when /media/sda1/remote_services exists. On a steady-state
+# boot (no stick, NAND override only) that file is absent, so sshd
+# never comes up. This function plugs that gap by starting sshd
+# unconditionally from run.sh. If sshd is already running (e.g. the
+# stick is in and Bose already started it), the start call is a
+# cheap no-op.
+#
+# Security note: the speaker's root password is the well-known Bose
+# default. As soon as the v1.0 hardening lands ([[project-box-
+# security-hardening]]), this function becomes opt-in via a stick
+# marker file, not opt-out. Tracked separately.
+ensure_sshd_running() {
+    if pidof sshd >/dev/null 2>&1; then
+        setup_log "sshd already running, leaving it alone"
+        return 0
+    fi
+    if [ -x /etc/init.d/sshd ]; then
+        /etc/init.d/sshd start >/dev/null 2>&1 \
+            && setup_log "sshd started via /etc/init.d/sshd" \
+            && return 0
+    fi
+    if [ -x /usr/sbin/sshd ]; then
+        /usr/sbin/sshd >/dev/null 2>&1 \
+            && setup_log "sshd started via /usr/sbin/sshd direct" \
+            && return 0
+    fi
+    setup_log "sshd start: no init script and no /usr/sbin/sshd found"
+    return 1
+}
+
 # initial_snapshot writes a one-shot record of "what does the box
 # look like the moment run.sh starts" so we can compare variants and
 # see what was already initialised by Bose vs what we had to wait
@@ -239,6 +279,10 @@ background_phase_probe() {
 # Probe is best-effort: failures are silent, only successes log.
 initial_snapshot
 background_phase_probe
+
+# Keep SSH up across stick + stickless boots. Has to happen early so
+# the channel is available even if the agent never binds.
+ensure_sshd_running
 
 # Auto-sync trigger: a freshly prepared stick (Setup-Wizard) ships a
 # version.txt. If that string differs from the version we recorded
@@ -916,7 +960,24 @@ agent_port_bound() {
     # 24 checks * 5s = 120s aggressive phase. After that, the slow
     # Phase-B loop below takes over. No flash writes while agent
     # stays up.
+    #
+    # Boot grace window: for the first 30 s after start_agent the
+    # watchdog only checks ALIVE, not BOUND. The Go agent does a
+    # sequence of pre-listen init steps (presets.Load, hosts.Apply,
+    # tlsgen.EnsureBundle which generates a CA on first run, mDNS
+    # announce, a 5 s timeout against the Bose firmware /info
+    # endpoint) before startHTTP fires. On weak hardware those steps
+    # can take 20-25 s end to end. Previously the t=5 s check saw
+    # alive=1 bound=0, killed the process during init, and the box
+    # ended up in a respawn loop with no listener ever reaching its
+    # bind call. Observed live in deqw #60 v0.5.5 setup_log at t=57s.
+    #
+    # During grace we still respawn if the process is GONE (ALIVE=0)
+    # because that means it crashed — we want to recover. After the
+    # grace window the full BOUND check kicks in so a hung agent
+    # that never binds also gets restarted.
     BOOT_RESTARTS=0
+    GRACE_S=30
     i=0
     while [ $i -lt 24 ]; do
         sleep 5
@@ -933,7 +994,17 @@ agent_port_bound() {
         if agent_port_bound; then
             BOUND=1
         fi
+        NOW_S=$(uptime_s)
+        IN_GRACE=0
+        if [ "$NOW_S" != "?" ] && [ "$i" -lt $((GRACE_S / 5)) ]; then
+            IN_GRACE=1
+        fi
         if [ "$ALIVE" = "1" ] && [ "$BOUND" = "1" ]; then
+            continue
+        fi
+        if [ "$ALIVE" = "1" ] && [ "$IN_GRACE" = "1" ]; then
+            # Process is alive, bind has not happened yet, still in
+            # the 30 s pre-listen init window. Let it cook.
             continue
         fi
         # Hard cap: 6 restarts in 120s. If we still cannot keep the
@@ -944,7 +1015,7 @@ agent_port_bound() {
             break
         fi
         BOOT_RESTARTS=$((BOOT_RESTARTS+1))
-        setup_log "boot-watchdog: agent dead/unbound at t=$(uptime_s)s pid=$CUR_PID alive=$ALIVE bound=$BOUND, fast respawn #$BOOT_RESTARTS"
+        setup_log "boot-watchdog: agent dead/unbound at t=$(uptime_s)s pid=$CUR_PID alive=$ALIVE bound=$BOUND grace=$IN_GRACE, fast respawn #$BOOT_RESTARTS"
         # Drain listener ports before respawn. The agent uses
         # SO_REUSEADDR so TIME_WAIT alone would not block bind, but
         # the previous instance may still be alive briefly after
@@ -1018,24 +1089,28 @@ fi
 
 log "bootstrap complete"
 
-# === USB Stick komplett aushaengen + SSH schliessen ===
+# === USB Stick aushaengen ===
 # Bootstrap ist durch — alle Configs (wlan/region/name/presets/binary)
 # sind nach NAND uebernommen. Den Stick brauchen wir zur Laufzeit
-# nicht mehr. Wir haengen ihn aktiv aus damit:
-#   1. User den Stick im Betrieb ziehen kann ohne dirty FS (Windows
-#      muss dann keine FAT Reparatur mehr machen).
-#   2. SSH wird sauber gestoppt — Bose's sshd Init hat ihn nur
-#      gestartet weil remote_services auf dem Stick lag. Nach umount
-#      ist diese Datei nicht mehr lesbar; wir stoppen sshd zusaetzlich.
+# nicht mehr. Wir haengen ihn aktiv aus damit der User den Stick im
+# Betrieb ziehen kann ohne dirty FS (Windows muss dann keine FAT
+# Reparatur mehr machen).
+#
+# SSH wird absichtlich NICHT gestoppt — pre-1.0 lassen wir den Kanal
+# offen damit die Desktop App ihren Diagnostic Bundle Pull auch bei
+# kaputtem Agent durchziehen kann (siehe ensure_sshd_running am
+# Anfang von run.sh). Die fruehere Logik hat sshd hier explizit
+# beendet sobald der Agent auf :8888 erreichbar war, was bei jedem
+# spaeteren Crash den Pfad zu den Logs verschloss.
 #
 # Debug opt-out: if /media/sda1/keep-open exists, skip the entire
-# cleanup so SSH stays reachable and the stick stays mounted. Used
-# during interactive debugging when we want to read /mnt/nv state
-# live over SSH without rebooting the box. Removed by deleting the
-# file (e.g. del E:\keep-open from Jens' laptop) — next boot
-# returns to normal cleanup behavior.
+# cleanup so the stick stays mounted. Used during interactive
+# debugging when we want to read live /media/sda1 state without
+# rebooting the box. Removed by deleting the file (e.g. del
+# E:\keep-open from Jens' laptop) — next boot returns to normal
+# cleanup behavior.
 if [ -e "$STICK/keep-open" ]; then
-    setup_log "keep-open marker on stick — skipping umount + sshd kill for live debug"
+    setup_log "keep-open marker on stick — skipping umount for live debug"
 else
 #
 # Detached Hintergrund Block damit run.sh sofort returnen kann
@@ -1083,11 +1158,11 @@ else
         WAIT_BUSY=$((WAIT_BUSY+5))
     done
 
-    # Agent reachability gate: never close the SSH escape hatch while
-    # the STR agent is missing. Observed live on #60: install timed
-    # out, agent never bound :8888, cleanup killed sshd anyway, and
-    # the diagnostic bundle came back empty because the on-box pull
-    # had no way in. Probe :8888 from inside the box before deciding.
+    # Agent reachability gate: if the agent is still down we keep the
+    # stick MOUNTED (not just sshd alive) so manual recovery via the
+    # stick's run.sh / install.sh stays possible. Probe :8888 from
+    # inside the box. sshd itself stays alive in either branch — that
+    # decision moved to ensure_sshd_running at boot time.
     AGENT_OK=0
     if (echo > /dev/tcp/127.0.0.1/8888) >/dev/null 2>&1; then
         AGENT_OK=1
@@ -1097,23 +1172,18 @@ else
 
     sync
     if [ "$AGENT_OK" = "0" ]; then
-        log "post-bootstrap: agent NOT bound on :8888 — leaving stick mounted + sshd alive for diagnostics"
-        setup_log "post-bootstrap: agent NOT bound on :8888 — leaving stick mounted + sshd alive"
+        log "post-bootstrap: agent NOT bound on :8888 — leaving stick mounted for diagnostics"
+        setup_log "post-bootstrap: agent NOT bound on :8888 — leaving stick mounted"
         # Read-only remount so a yanked stick does not corrupt FAT,
-        # but DO NOT umount and DO NOT stop sshd. Lets the desktop
-        # app's diagnostic bundle pull box-side logs after a failed
-        # install without the user typing anything.
+        # but DO NOT umount. Lets the desktop app's diagnostic bundle
+        # pull box-side logs after a failed install without the user
+        # typing anything.
         mount -o remount,ro "$STICK" 2>/dev/null \
-            && log "USB Stick read-only remounted (sshd kept alive)"
+            && log "USB Stick read-only remounted"
         exit 0
     fi
     if umount "$STICK" 2>/dev/null; then
         log "USB Stick ausgehaengt — kann sicher gezogen werden"
-        if [ -x /etc/init.d/sshd ]; then
-            /etc/init.d/sshd stop 2>/dev/null && log "sshd gestoppt"
-        else
-            killall sshd 2>/dev/null && log "sshd via killall beendet"
-        fi
     else
         log "umount fehlgeschlagen (Prozess haelt Stick), versuche read only remount"
         if mount -o remount,ro "$STICK" 2>/dev/null; then


### PR DESCRIPTION
@
## Summary

Four changes that turn the two failure modes still tripping testers on `#60` (deqw, .134 + .177) and the new bleco install (`str_logs/`, .144) into recoverable states without another stick-yank cycle.

1. **`cmd/agent/main.go` — bind listeners before heavy init.** Previously the agent did up to ~25 s of pre-listen work (`presets.Load`, `hosts.Apply`, `tlsgen.EnsureBundle` CA generation, a 5 s blocking `boxapi.LoadSettings` call, mDNS announce) before `startHTTP` fired. The boot-watchdog in `run.sh` kills the agent at the first 5 s check that sees `BOUND=0`, which on weak hardware was DURING init. Listeners now bind right after the cheap constructors; box `/info` + mDNS + TLS bundle generation move to background goroutines that respect `ctx`. `:8888` reachable in 1-2 s instead of 25+ s. Matches deqw v0.5.5 `setup_log` exactly: `alive=1 bound=0 at t=57s`, six fast respawns, then exhaustion.
2. **`usb-stick/run.sh` — boot-watchdog 30 s grace period.** Belt-and-suspenders for (1). During the first 30 s the watchdog only respawns the process when it is genuinely dead (`ALIVE=0`). After grace the full `BOUND` check kicks in.
3. **`usb-stick/run.sh` — SSH stays open.** Removed the `sshd stop` from post-bootstrap cleanup, added `ensure_sshd_running()` early in run.sh so stickless steady-state boots also start sshd (Bose's shelby_local only does that when the stick's `remote_services` marker exists). Trade-off: the well-known Bose root password is the access vector; pre-1.0 the diagnostic channel matters more. Tracked under the existing box-security-hardening roadmap. Bleco's `box-1` showed `reachable8888=false`, `reachableSSH=false`, `debugState=null` — total black box. With this change, the desktop-app's diagnostic bundle always has the SSH fallback path available.
4. **`desktop-app/frontend` — inline "Update box agent" CTA on the "already installed" setup screen.** Previously a dead end: tester writes fresh stick from newer desktop app to upgrade older agent, screen says "Nothing to install", only the separate OTA banner offered a path forward, multiple testers missed it. Button reuses the existing `doBoxUpdate()` flow.

## Test plan

- [ ] CI green
- [ ] Cold boot ST10 with new stick: agent reachable on `:8888` within ~5 s (was 25+ s before)
- [ ] Cold boot deqw .134 (ST20 sm2): no fast-respawn loop, agent stays bound on first try, marge/bmx no longer hit `bind: address already in use`
- [ ] Cold boot bleco .144 (ST20 scm): even if agent fails, SSH stays reachable on :22 so the desktop-app diagnostic bundle pulls `agentLogTail` and `setupLog`
- [ ] Setup view with a speaker that already runs an older STR: "Nothing to install" screen renders the new "Update box agent" button, click triggers OTA, build comparison shows new version

Refs #60.
@