### PR TITLE
chore: gitignore .claude/ (keep captures, Bose binaries, agent notes out of the repo)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,8 @@ Thumbs.db
 *.tmp
 *.bak
 .cache/
+
+# Claude Code working directory. Holds sensitive, non-project material
+# (network captures, Bose firmware binaries, API docs, local settings,
+# agent memory/notes). MUST NEVER be committed.
+.claude/


### PR DESCRIPTION
The repo-local `.claude/` working directory accumulates non-project, sensitive material: network captures (.pcap), Bose firmware binaries, the SoundTouch API PDF, local settings, and agent memory/notes. It was never tracked (history is clean, nothing on GitHub), but nothing stopped a stray `git add` from committing it. This ignores it outright.

Note: the agent's persistent memory lives in the user-level `~/.claude/projects/.../memory/`, outside this repo, so it is not and was never in version control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)