### PR TITLE
fix(desktop): regenerate Wails bindings -> green Frontend build CI

### DIFF
--- a/desktop-app/frontend/wailsjs/go/main/App.d.ts
+++ b/desktop-app/frontend/wailsjs/go/main/App.d.ts
@@ -50,6 +50,8 @@ export function PlayURL(arg1:string,arg2:number,arg3:string,arg4:string,arg5:str
 
 export function ProbeSetupAP():Promise<main.BoxInfo|boolean>;
 
+export function PushWLANToBox(arg1:string,arg2:string,arg3:string,arg4:string):Promise<main.SetupAPPushResult>;
+
 export function RebootBox(arg1:string,arg2:number):Promise<void>;
 
 export function SaveDiagnosticBundle(arg1:Array<string>,arg2:boolean):Promise<main.LogExportResult>;

--- a/desktop-app/frontend/wailsjs/go/main/App.js
+++ b/desktop-app/frontend/wailsjs/go/main/App.js
@@ -94,6 +94,10 @@ export function ProbeSetupAP() {
   return window['go']['main']['App']['ProbeSetupAP']();
 }
 
+export function PushWLANToBox(arg1, arg2, arg3, arg4) {
+  return window['go']['main']['App']['PushWLANToBox'](arg1, arg2, arg3, arg4);
+}
+
 export function RebootBox(arg1, arg2) {
   return window['go']['main']['App']['RebootBox'](arg1, arg2);
 }

--- a/desktop-app/frontend/wailsjs/go/models.ts
+++ b/desktop-app/frontend/wailsjs/go/models.ts
@@ -228,6 +228,24 @@ export namespace main {
 	        this.art = source["art"];
 	    }
 	}
+	export class SetupAPPushResult {
+	    step: string;
+	    message: string;
+	    ok: boolean;
+	    logTail: string[];
+	
+	    static createFrom(source: any = {}) {
+	        return new SetupAPPushResult(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.step = source["step"];
+	        this.message = source["message"];
+	        this.ok = source["ok"];
+	        this.logTail = source["logTail"];
+	    }
+	}
 	export class TrueFactoryResetResult {
 	    step: string;
 	    ok: boolean;


### PR DESCRIPTION
The recurring red **Frontend build** CI check was `vite build` failing with `"PushWLANToBox" is not exported by "wailsjs/go/main/App.js"`. `frontend/src/api.js` imports Go `App` methods (PushWLANToBox + setup-AP/library calls) whose generated wailsjs bindings were never regenerated and committed after the Go methods were added.

The **release** was never affected (`wails build` regenerates bindings during the build), but every PR inherited the red check. Ran `wails generate module`; `App.js` / `App.d.ts` / `models.ts` now export the missing bindings and `npm run build` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)