### PR TITLE
Status section at top of Speaker Settings + publish system requirements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -843,6 +843,15 @@ jobs:
 
           The website at st-reborn.de fetches \`manifest.json\` to render the current download links. The desktop app filenames carry the version; the stick agent binaries keep stable \`/releases/latest/download/<file>\` URLs for direct linking.
 
+          ### System requirements
+
+          | | |
+          |---|---|
+          | Windows | Windows 10 or 11, 64-bit. The app uses Microsoft Edge WebView2; Windows 7 and 8 are not supported. |
+          | macOS | macOS 12 Monterey or newer. |
+          | Linux | 64-bit (x86_64) with WebKitGTK (webkit2gtk 4.x) on a current glibc-based distribution. |
+          | Speaker | Bose SoundTouch 10, 20, 30 or Portable on the final Bose firmware (27.0.6). |
+
           ### Verify your download
 
           Every binary in this release is attested by GitHub's build provenance system.

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -3853,6 +3853,10 @@ function renderBoxSettings(s, box) {
   const uid = uidSuffixFor(box);
 
   $('settingsBody').innerHTML = `
+    <div class="settings-section" id="stickInfoSection">
+      <h3>${escapeHtml(t('settingsView.statusHeading'))}</h3>
+      <div id="stickInfoBody"><span class="muted small">${escapeHtml(t('common.loading'))}</span></div>
+    </div>
     <div class="settings-section">
       <h3>${escapeHtml(t('settingsView.nameHeading'))}</h3>
       <div class="setting-row">
@@ -4032,10 +4036,6 @@ function renderBoxSettings(s, box) {
         <button class="btn btn-mini" id="appRegionSave">${escapeHtml(t('common.save'))}</button>
       </div>
       <small class="muted small">${escapeHtml(t('settingsView.regionHelp'))}</small>
-    </div>
-    <div class="settings-section" id="stickInfoSection">
-      <h3>${escapeHtml(t('settingsView.statusHeading'))}</h3>
-      <div id="stickInfoBody"><span class="muted small">${escapeHtml(t('common.loading'))}</span></div>
     </div>
     <div class="settings-section">
       <h3>${escapeHtml(t('settingsView.actionsHeading'))}</h3>


### PR DESCRIPTION
Two small follow-ups:

- **feat(app):** the status/update section is now the first section in Speaker Settings (update prompt is the first thing the user sees there).
- **ci(release):** release notes now list minimum OS versions (Windows 10/11, macOS 12 Monterey, Linux x64 WebKitGTK) and supported speakers, so users do not try unsupported systems (Windows 7, macOS 11). macOS 11 support is not feasible because the golang.org/x/* stack requires Go 1.25 (macOS 12+).

Refs #121