### PR TITLE
v0.7.19: Spotify OOM crash fix + sshd/uninstall + shim-skip + OTA stick refresh

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -439,14 +439,19 @@ func run() error {
 	go func() {
 		defer wg.Done()
 		logResourceHealth(logger)
-		t := time.NewTicker(5 * time.Minute)
-		defer t.Stop()
+		health := time.NewTicker(5 * time.Minute)
+		defer health.Stop()
+		// The guard polls far more often than the heartbeat log: a runaway can
+		// fall from a safe level toward OOM well within a 5-minute window.
+		guard := time.NewTicker(60 * time.Second)
+		defer guard.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-t.C:
+			case <-health.C:
 				logResourceHealth(logger)
+			case <-guard.C:
 				memoryGuardCheck(logger, spotifyMgr, *boxHost)
 			}
 		}
@@ -1750,7 +1755,14 @@ const (
 	// backstop only: 6 MB sits below the normal ~9 MB idle floor (no reboot
 	// after a normal session) yet above the danger zone. When idle the leak
 	// does not grow, so a low reading is stable and the 5-min cycle is fine.
-	memGuardThresholdKB  = 6 * 1024
+	memGuardThresholdKB = 6 * 1024
+	// While Spotify is actively streaming the firmware leak is GROWING, so the
+	// old "never interrupt playback" hold-off let it run to an uncontrolled OOM
+	// (garbled audio then crash/reboot, live 2026-06-10). Below this critical
+	// floor we reboot even during playback: a clean reboot + auto-resume beats
+	// the firmware OOM. Set below the ~4.4 MB normal-session dip so it only fires
+	// on a genuine runaway, not a healthy self-limiting session.
+	memGuardCriticalKB   = 4 * 1024
 	memGuardMinUptimeSec = 900 // never reboot in the first 15 min (boot-loop guard)
 )
 
@@ -1768,15 +1780,17 @@ func memoryGuardCheck(logger *slog.Logger, sp *spotify.Manager, boxHost string) 
 		logger.Warn("memory guard: low memAvail but uptime too short, holding off", "memAvailKB", avail, "uptimeSec", up)
 		return
 	}
-	if sp != nil && sp.Streaming() {
-		logger.Warn("memory guard: low memAvail but Spotify is streaming, not rebooting", "memAvailKB", avail)
+	playing := (sp != nil && sp.Streaming()) || boxIsPlaying(boxHost)
+	if playing && avail > memGuardCriticalKB {
+		// Tolerate low memory during playback to avoid interrupting, but only down
+		// to the critical floor. The Spotify manager's single-connection invariant
+		// should keep steady playback stable; this is a last-resort net for any
+		// runaway, where a controlled reboot + auto-resume beats the uncontrolled
+		// firmware OOM (garbled audio then crash).
+		logger.Warn("memory guard: low memAvail but playing and above critical, holding off", "memAvailKB", avail, "criticalKB", memGuardCriticalKB)
 		return
 	}
-	if boxIsPlaying(boxHost) {
-		logger.Warn("memory guard: low memAvail but box is playing, not rebooting", "memAvailKB", avail)
-		return
-	}
-	logger.Warn("memory guard: memAvail critically low while idle, rebooting box to clear firmware leak", "memAvailKB", avail)
+	logger.Warn("memory guard: memAvail critically low, rebooting box to clear firmware leak", "memAvailKB", avail, "playing", playing)
 	_ = exec.Command("sync").Run()
 	if err := exec.Command("reboot").Run(); err != nil {
 		logger.Error("memory guard: reboot failed", "err", err)

--- a/desktop-app/app.go
+++ b/desktop-app/app.go
@@ -2637,9 +2637,54 @@ func (a *App) UpdateBoxAgent(host string, port int) error {
 			return fmt.Errorf("HTTP preflight rejected the listener at :%d and SSH fallback also failed: %w (preflight: %v)", port, sshErr, perr)
 		}
 		a.logger.Info("update agent: SSH-OTA succeeded", "host", host, "bytes", len(bin))
+		a.refreshStickAfterOTA(host)
 		return nil
 	}
-	return a.updateAgentViaHTTP(host, port, bin)
+	if err := a.updateAgentViaHTTP(host, port, bin); err != nil {
+		return err
+	}
+	a.refreshStickAfterOTA(host)
+	return nil
+}
+
+// refreshStickAfterOTA is a best-effort step run after a successful agent OTA:
+// if the STR USB stick is still inserted in the speaker, rewrite its program
+// files (agent binary, run.sh, rc.local, shim, version.txt, ...) so the next
+// boot's stick->NAND sync does not revert the freshly OTA'd binary back to the
+// stick's older one (project_deploy_stick_overwrites_nand). The write is
+// durable-flushed so it survives a reboot (project_durable_stick_write: a plain
+// write to /media/sda1 sits in the USB controller cache and is lost otherwise).
+// Never fatal: the OTA itself already succeeded, so any failure here is logged
+// and the user is simply told to re-prepare the stick if they keep it inserted.
+func (a *App) refreshStickAfterOTA(host string) {
+	out, err := boxSSHOutput(host, "test -f /media/sda1/install.sh && echo STR_STICK_PRESENT", 8*time.Second)
+	if err != nil || !strings.Contains(out, "STR_STICK_PRESENT") {
+		a.logger.Info("OTA stick refresh: no STR stick mounted on the box, nothing to refresh",
+			"host", host, "detail", strings.TrimSpace(out))
+		return
+	}
+	v := appVersion
+	if appBuild != "" && appBuild != "dev" {
+		v = appVersion + "+" + appBuild
+	}
+	files, err := sticksetup.StickFileSet(agentbin.Bytes(), v)
+	if err != nil {
+		a.logger.Warn("OTA stick refresh: could not assemble stick file set", "err", err)
+		return
+	}
+	for name, data := range files {
+		// File names in the stick set are flat and safe (alphanumeric, '.', '-').
+		if out, werr := boxSSHUploadStdin(host, "cat > /media/sda1/"+name, bytes.NewReader(data), 120*time.Second); werr != nil {
+			a.logger.Warn("OTA stick refresh: write failed, stick left as-is (OTA still applied to NAND)",
+				"file", name, "err", werr, "out", strings.TrimSpace(out))
+			return
+		}
+	}
+	// Durable flush: SYNCHRONIZE CACHE + STOP UNIT commits the writes to flash.
+	// This also detaches the stick from the running kernel; it re-mounts on the
+	// next boot (updated), which is exactly when the stick->NAND sync runs.
+	_ = boxSSHFireAndForget(host, "sync; echo 1 > /sys/block/sda/device/delete", 8*time.Second)
+	a.logger.Info("OTA stick refresh: stick rewritten and flushed to flash", "host", host, "files", len(files), "version", v)
 }
 
 // updateAgentPreflight checks that /api/agent/version on host:port really

--- a/desktop-app/app.go
+++ b/desktop-app/app.go
@@ -121,6 +121,10 @@ func (a *App) startup(ctx context.Context) {
 	// that returns zero results is indistinguishable from "no servers
 	// on the LAN" in the diagnostic bundle.
 	dlna.Logger = a.logger.With("comp", "dlna")
+	// Same for sticksetup, so USB-stick discovery timing (a slow search
+	// while Windows finishes mounting a freshly inserted stick) is visible
+	// in the diagnostic bundle instead of an unexplained UI hang.
+	sticksetup.Logger = a.logger.With("comp", "sticksetup")
 	// Verbose startup line so users always see SOMETHING in the
 	// log when they hit "Save diagnostic logs", even on a session
 	// where they did not poke any features that emit further logs.

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -679,6 +679,7 @@
   "setup.stickFsLine": "Stick ist {{fs}} formatiert.",
   "setup.stickFsHelp": "Der Bose-Lautsprecher liest nur FAT32. Der Stick wird beim Vorbereiten neu formatiert (Windows fragt einmal nach Administrator-Rechten). Alle Daten auf dem Stick gehen verloren.",
   "setup.stickCurrent": "Stick ist aktuell.",
+  "setup.stickRefreshHint": "Du kannst die STR-Dateien mit dem Aktualisieren-Button unten trotzdem neu auf den Stick schreiben (z.B. um run.sh nach einem STR-Update zu erneuern).",
   "setup.versionLabel": "Version {{version}}",
   "setup.stickUpdateAvail": "Aktualisierung verfügbar.",
   "setup.alreadyConfigured": "Bereits konfigurierter Stick. Wenn du ihn erneut benutzen willst (z.B. anderer Lautsprecher, neue WLAN-Daten oder neuer Name), wird die Konfiguration unten beim Speichern neu auf den Stick geschrieben.",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -663,6 +663,7 @@
   "setup.stickFsLine": "Stick is formatted as {{fs}}.",
   "setup.stickFsHelp": "The Bose speaker only reads FAT32. The stick will be reformatted during preparation (Windows prompts once for administrator rights). All data on the stick is lost.",
   "setup.stickCurrent": "Stick is up to date.",
+  "setup.stickRefreshHint": "You can still re-write the STR files to the stick with the update button below (e.g. to refresh run.sh after an STR update).",
   "setup.versionLabel": "Version {{version}}",
   "setup.stickUpdateAvail": "Update available.",
   "setup.alreadyConfigured": "Already configured stick. If you want to reuse it (different speaker, new Wi-Fi or new name), the configuration below is rewritten to the stick on save.",

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -5775,9 +5775,14 @@ async function updateDrivePanels() {
       // continue button. The version / update-available line goes last and
       // muted: shown too prominently at the top it pulls normal users into
       // clicking "update" mid-setup instead of continuing to the speaker.
-      const verLine = same
+      // The "Update USB stick" button (setupGo, label goBtnUpdate) re-writes the
+      // stick unconditionally, even when the version matches. Spell that out so a
+      // user who wants to refresh run.sh/agent on an already-current stick (e.g.
+      // after an STR update) sees that it is offered, not just "already done".
+      const verLine = (same
         ? `<b>${escapeHtml(t('setup.stickCurrent'))}</b> <small>${escapeHtml(t('setup.versionLabel', { version: fromShort }))}</small>`
-        : `<b>${escapeHtml(t('setup.stickUpdateAvail'))}</b> <small>${escapeHtml(fromShort)} &rarr; ${escapeHtml(toFull)}</small>`;
+        : `<b>${escapeHtml(t('setup.stickUpdateAvail'))}</b> <small>${escapeHtml(fromShort)} &rarr; ${escapeHtml(toFull)}</small>`)
+        + `<br><span class="muted small">${escapeHtml(t('setup.stickRefreshHint'))}</span>`;
       upd.innerHTML =
         `<div>${escapeHtml(t('setup.alreadyConfigured'))}</div>`
         + `<div style="margin-top:10px"><button class="btn btn-mini" id="setupContinue">${escapeHtml(t('setup.continueBtn'))}</button>`

--- a/docs/MODEL-VARIANTS.md
+++ b/docs/MODEL-VARIANTS.md
@@ -19,9 +19,9 @@ The final firmware Bose shipped before the cloud shutdown on 2026-02. Anything o
 
 | Model | Latest Bose `softwareVersion` (SCM) | Build date |
 | --- | --- | --- |
-| SoundTouch 10 | (to be confirmed from a diagnostic) | (to be confirmed) |
+| SoundTouch 10 | `27.0.6.46330.5043500 epdbuild.trunk.hepdswbld04.2022-08-04T11:20:29` | **2022-08-04** |
 | SoundTouch 20 | `27.0.6.46330.5043500 epdbuild.trunk.hepdswbld04.2022-08-04T11:20:29` | **2022-08-04** |
-| SoundTouch 30 | (to be confirmed from a diagnostic) | (to be confirmed) |
+| SoundTouch 30 | `27.0.6.46330.5043500 epdbuild.trunk.hepdswbld04.2022-08-04T11:20:29` | **2022-08-04** |
 | SoundTouch Portable | (to be confirmed from a diagnostic) | (to be confirmed) |
 
 ## SoundTouch 20
@@ -70,11 +70,22 @@ The final firmware Bose shipped before the cloud shutdown on 2026-02. Anything o
 
 ## SoundTouch 10
 
-Reference target. Detailed fingerprint not yet captured from a diagnostic bundle in this format; expected to be `moduleType=sm2`, `variant=rhino` based on prior bench observation.
+Reference target. Confirmed from a diagnostic bundle (2026-06-10, #123 box-1):
+
+| `moduleType` | SCM `softwareVersion` | Build year | Latest official? | `variant` | `variantMode` | Components present | WLAN interfaces | `countryCode` / `regionCode` samples |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `sm2` | `27.0.6.46330.5043500 epdbuild.trunk.hepdswbld04.2022-08-04T11:20:29` | 2022 | **yes** | `rhino` | `normal` | SCM, PackagedProduct | `wlan0`, `wlan1` | `GB` / `GB` |
 
 ## SoundTouch 30
 
-Not yet observed in a diagnostic bundle.
+Confirmed from a diagnostic bundle (2026-06-10, #123 box-0):
+
+| `moduleType` | SCM `softwareVersion` | Build year | Latest official? | `variant` | `variantMode` | Components present | WLAN interfaces | `countryCode` / `regionCode` samples |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `sm2` | `27.0.6.46330.5043500 epdbuild.trunk.hepdswbld04.2022-08-04T11:20:29` | 2022 | **yes** | `mojo` | `normal` | SCM, PackagedProduct | `wlan0`, `wlan1` | `GB` / `GB` |
+
+- Kernel: `Linux mojo 3.14.43+ #137 Wed Oct 25 21:06:53 EDT 2017 armv7l` (same kernel as ST10/ST20).
+- `is_series_one=0`: like the ST10 (`rhino`), the ST30 (`mojo`) is **not** chipset-whitelisted. STR's `:8888` is reached directly once the iptables INPUT ACCEPT rule opens it; the LD_PRELOAD SoftwareUpdate shim is unnecessary and is skipped for `sm2` chassis (the `.so` cannot even load on `mojo`). See `usb-stick/run.sh` `shim_stage_wrapper`.
 
 ## SoundTouch Portable
 

--- a/internal/spotify/manager.go
+++ b/internal/spotify/manager.go
@@ -103,8 +103,9 @@ type Manager struct {
 	mu        sync.Mutex
 	name      string    // device name currently written to config.yml
 	configVol int       // initial_volume currently written to config.yml
-	sink      io.Writer // current HTTP consumer, nil when none
-	cmd  *exec.Cmd
+	sink         io.Writer // current HTTP consumer, nil when none
+	lastAttachAt time.Time // when the box last attached to the Ogg stream (re-attach storm detection)
+	cmd          *exec.Cmd
 	// runCancel restarts the current go-librespot process when called: it
 	// cancels the per-process context so the supervise loop relaunches it.
 	// Used to re-apply a changed device_name (go-librespot reads its name only
@@ -1303,9 +1304,31 @@ func (m *Manager) ServeOgg(w http.ResponseWriter, r *http.Request) {
 	done := make(chan struct{})
 	cw := &closeNotifyWriter{w: w, done: done}
 	m.mu.Lock()
-	reattach := m.sink != nil // a consumer was already attached = box re-fetched
+	oldSink, _ := m.sink.(*closeNotifyWriter) // previous consumer, if any
+	reattach := m.sink != nil                 // a consumer was already attached = box re-fetched
 	m.sink = cw
+	sinceLast := time.Duration(0)
+	if !m.lastAttachAt.IsZero() {
+		sinceLast = time.Since(m.lastAttachAt)
+	}
+	m.lastAttachAt = time.Now()
 	m.mu.Unlock()
+	// Single-connection invariant: tear down the previous box connection now.
+	// A box stuck in INVALID_SOURCE re-fetches the stream repeatedly; if the old
+	// connections are left open they pile up and the box leaks decode/socket
+	// buffers per connection until it OOMs (garbled audio then reboot, live
+	// 2026-06-10). Closing the old sink makes its ServeOgg return and drop the
+	// stale connection, so the box only ever holds one Ogg stream at a time.
+	if oldSink != nil && oldSink != cw {
+		oldSink.closeConn()
+	}
+	// Surface a re-attach storm (the box re-fetching every few seconds, the
+	// crash signature) so it is visible in the log. The single-connection
+	// invariant above already prevents the per-connection buffer pile-up that
+	// used to OOM the box; this just records that it happened.
+	if reattach && sinceLast > 0 && sinceLast < 20*time.Second {
+		m.logger.Warn("spotify: rapid Ogg re-attach (possible INVALID_SOURCE re-point storm; old connection closed)", "sinceLastMs", sinceLast.Milliseconds())
+	}
 	// reattach=true means the box dropped and re-fetched the stream (the prime
 	// suspect for a track appearing to restart): it then gets the cached
 	// granule-0 headers again. Logged so the restart can be correlated.
@@ -1361,6 +1384,12 @@ func (c *closeNotifyWriter) Write(p []byte) (int, error) {
 		c.once.Do(func() { close(c.done) })
 	}
 	return n, err
+}
+
+// closeConn tears the connection down from the manager side, used to enforce
+// the single-connection invariant when a new box attaches. Idempotent.
+func (c *closeNotifyWriter) closeConn() {
+	c.once.Do(func() { close(c.done) })
 }
 
 func (c *closeNotifyWriter) Flush() {

--- a/sticksetup/sticksetup.go
+++ b/sticksetup/sticksetup.go
@@ -9,13 +9,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	usbstick "github.com/JRpersonal/streborn/usb-stick"
 )
+
+// Logger is the package logger. The desktop app points it at its file
+// logger (see NewApp) so drive-discovery timing lands in str.log; until
+// then it falls back to the default logger. Mirrors dlna.Logger.
+var Logger = slog.Default()
 
 // Drive beschreibt ein potenzielles Ziellaufwerk fuer den Stick Setup.
 type Drive struct {
@@ -33,14 +40,28 @@ type Drive struct {
 // Auf Windows: alle Drive Letters die nicht Fixed sind. Auf Mac/Linux:
 // alle Mounts unter /Volumes bzw /media die fat32 sind.
 func ListDrives() ([]Drive, error) {
+	start := time.Now()
+	var drives []Drive
+	var err error
 	switch runtime.GOOS {
 	case "windows":
-		return listDrivesWindows()
+		drives, err = listDrivesWindows()
 	case "darwin":
-		return listDrivesMac()
+		drives, err = listDrivesMac()
 	default:
-		return listDrivesLinux()
+		drives, err = listDrivesLinux()
 	}
+	// Timing matters: a freshly inserted stick can leave Windows still
+	// mounting it, so the per-drive volume queries block for seconds
+	// (user-reported 10-20s with nothing showing). Logged so a slow
+	// search is measurable instead of an invisible hang.
+	ms := time.Since(start).Milliseconds()
+	if err != nil {
+		Logger.Warn("ListDrives failed", "ms", ms, "err", err)
+	} else {
+		Logger.Info("ListDrives done", "ms", ms, "count", len(drives))
+	}
+	return drives, err
 }
 
 // MinStickBytes is the lower bound the desktop app enforces on an install

--- a/sticksetup/sticksetup_windows.go
+++ b/sticksetup/sticksetup_windows.go
@@ -44,6 +44,11 @@ func listDrivesWindows() ([]Drive, error) {
 			continue
 		}
 
+		// Time the per-drive volume queries: on a just-inserted stick
+		// these GetDiskFreeSpaceEx / GetVolumeInformation calls can block
+		// for seconds while Windows finishes mounting, which is the
+		// user-reported "search hangs 10-20s then the stick appears".
+		dstart := time.Now()
 		var freeBytesAvail, totalBytes, totalFreeBytes uint64
 		_, _, _ = getDiskFreeSpaceEx.Call(
 			uintptr(unsafe.Pointer(rootPtr)),
@@ -88,6 +93,8 @@ func listDrivesWindows() ([]Drive, error) {
 			HasStick:    hasStick,
 			Description: descForDrive(root, label, fs, int64(totalBytes)),
 		})
+		Logger.Info("drive probed", "drive", root, "fs", fs,
+			"ms", time.Since(dstart).Milliseconds(), "hasStick", hasStick)
 	}
 	return out, nil
 }

--- a/usb-stick/run.sh
+++ b/usb-stick/run.sh
@@ -227,15 +227,30 @@ ensure_sshd_running() {
         setup_log "sshd already running, leaving it alone"
         return 0
     fi
+    # Bose's /etc/init.d/sshd only starts sshd when the stick's
+    # remote_services marker is present, but it still `exit 0`s when it
+    # skips ("Not starting sshd"). So on a no-stick steady-state boot the
+    # init script is a silent no-op yet reports success. Never trust its
+    # exit code: try it, then VERIFY a real sshd process, and fall through
+    # to starting the daemon directly. Host keys ship in /etc/ssh, so the
+    # direct start works without the stick. Without this, :22 stays closed
+    # on stick-out boots and the SSH-based uninstall / diagnostics cannot
+    # reach the box (live taigan 2026-06-10).
     if [ -x /etc/init.d/sshd ]; then
-        /etc/init.d/sshd start >/dev/null 2>&1 \
-            && setup_log "sshd started via /etc/init.d/sshd" \
-            && return 0
+        /etc/init.d/sshd start >/dev/null 2>&1
+        if pidof sshd >/dev/null 2>&1; then
+            setup_log "sshd started via /etc/init.d/sshd"
+            return 0
+        fi
     fi
     if [ -x /usr/sbin/sshd ]; then
-        /usr/sbin/sshd >/dev/null 2>&1 \
-            && setup_log "sshd started via /usr/sbin/sshd direct" \
-            && return 0
+        /usr/sbin/sshd >/dev/null 2>&1
+        if pidof sshd >/dev/null 2>&1; then
+            setup_log "sshd started via /usr/sbin/sshd direct"
+            return 0
+        fi
+        setup_log "sshd start: /usr/sbin/sshd ran but no sshd process appeared"
+        return 1
     fi
     setup_log "sshd start: no init script and no /usr/sbin/sshd found"
     return 1

--- a/usb-stick/run.sh
+++ b/usb-stick/run.sh
@@ -651,6 +651,9 @@ shim_stage_wrapper() {
             *taigan*|*spotty*)
                 setup_log "shim stage: SKIP — BCO chassis (${VARIANT:-?}/${HOSTID:-?}). The LD_PRELOAD late-swap kills SoftwareUpdate, which on BCO boxes never actually forwards :8888 (spotty :17008 self-probe NOT STR) and races shepherdd's respawn, wedging scm_finalize / the Bose mesh init (live 2026-05-31: taigan boot bar stuck with NO setup-AP; spotty BoseApp never answers within 180s, M0 times out). External :8888 on BCO is served by the iptables PREROUTING REDIRECT path instead, which never touches SoftwareUpdate. STR_FORCE_SHIM_TAIGAN=1 overrides."
                 return 0 ;;
+            *rhino*|*mojo*)
+                setup_log "shim stage: SKIP — sm2 chassis (${VARIANT:-?}/${HOSTID:-?}). sm2 boxes (ST10 rhino, ST30 mojo) are not chipset-whitelisted; STR's :8888 is opened directly by the iptables INPUT ACCEPT path (iptables_install_streborn_fw), so the LD_PRELOAD shim is unnecessary here. Running it only kills/relaunches Bose SoftwareUpdate (racing shepherdd) for no gain, and on mojo the .so cannot even load (live ST30 2026-06-10, #123: box healthy, agent up, shim self-probe NOT STR). STR_FORCE_SHIM_TAIGAN=1 overrides."
+                return 0 ;;
         esac
     fi
     if [ -e "$SHIM_DISABLE" ]; then
@@ -748,6 +751,9 @@ shim_late_swap() {
         case "${VARIANT}|${HOSTID}" in
             *taigan*|*spotty*)
                 setup_log "shim late-swap: SKIP — BCO chassis (${VARIANT:-?}/${HOSTID:-?}); SoftwareUpdate left untouched so the Bose mesh init cannot wedge. External :8888 via the REDIRECT path. STR_FORCE_SHIM_TAIGAN=1 overrides."
+                return 0 ;;
+            *rhino*|*mojo*)
+                setup_log "shim late-swap: SKIP — sm2 chassis (${VARIANT:-?}/${HOSTID:-?}); :8888 is opened by the iptables INPUT ACCEPT path, so SoftwareUpdate is left untouched (no shepherdd race, no needless kill/relaunch). STR_FORCE_SHIM_TAIGAN=1 overrides."
                 return 0 ;;
         esac
     fi


### PR DESCRIPTION
Bundle for v0.7.19.

- **fix(spotify):** the real OOM-crash fix. Steady playback is stable; the crash is a re-attach storm (box stuck in INVALID_SOURCE re-fetches the Ogg stream, old connections piled up and leaked box buffers until OOM). ServeOgg now enforces a single-connection invariant (new attach closes the old), logs a re-attach storm, and the memory guard acts during playback at a critical floor (60s poll) as a last-resort controlled-reboot net.
- **fix(setup):** start sshd reliably on stick-out boots (Bose's init no-ops without the stick yet exits 0) so the SSH-based uninstall + diagnostics work, making the 'pull the stick first' uninstall instruction correct.
- **fix(setup):** skip the SoftwareUpdate shim on sm2 chassis (ST10 rhino, ST30 mojo); it is BCO-only and on mojo the .so cannot load (live ST30 #123). Records ST10/ST30 fingerprints in MODEL-VARIANTS.md.
- **feat(setup):** log USB-stick discovery timing (slow search while Windows mounts).
- **feat(setup):** make clear the stick can be re-written even when up to date.
- **feat(setup):** OTA now also refreshes the inserted stick (durable flush) so the boot sync cannot revert the OTA'd binary.

Refs #123 #131