### PR TITLE
v0.7.20: OTA SSH fallback on HTTP failure + known-box-first refresh

### DIFF
--- a/desktop-app/app.go
+++ b/desktop-app/app.go
@@ -425,6 +425,58 @@ func (a *App) mergeDiscoveryCache(seen map[string]BoxInfo) {
 	}
 }
 
+// RefreshKnownBoxes re-probes only the speakers already in the discovery cache,
+// directly by their last-known IP, with NO mDNS browse and NO full /24 sweep.
+// The desktop refresh calls this FIRST so the boxes you already have update
+// their live values (reachable, version, name) within a second, then kicks off
+// the full DiscoverBoxes in the background to pick up new or moved speakers.
+// This is the common case ("I just want the current values of my known box")
+// and avoids making the user wait out the ~3 s mDNS + ~12 s LAN sweep for it.
+func (a *App) RefreshKnownBoxes() ([]BoxInfo, error) {
+	a.discMu.Lock()
+	known := make([]BoxInfo, 0, len(a.discCache))
+	for _, e := range a.discCache {
+		known = append(known, e.box)
+	}
+	a.discMu.Unlock()
+	if len(known) == 0 {
+		return []BoxInfo{}, nil
+	}
+	ctx, cancel := context.WithTimeout(a.ctx, 6*time.Second)
+	defer cancel()
+	seen := map[string]BoxInfo{}
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, kb := range known {
+		kb := kb
+		if kb.Host == "" {
+			continue
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Fall back to the cached record if the direct probe misses; the
+			// sticky cache merge below keeps it from being downgraded/evicted.
+			b := kb
+			if probed, ok := probeSTR(ctx, kb.Host); ok {
+				b = probed
+			}
+			b = a.enrichBoxWithStockInfo(ctx, b)
+			mu.Lock()
+			seen[b.Host] = b
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+	a.mergeDiscoveryCache(seen)
+	out := make([]BoxInfo, 0, len(seen))
+	for _, b := range seen {
+		out = append(out, b)
+	}
+	a.logger.Info("refresh known boxes done", "count", len(out))
+	return out, nil
+}
+
 // mergeBoxInfo keeps the richer of two records for the same physical box
 // so a thinner discovery cycle never downgrades the display. cur is this
 // cycle, prev the cached record. This is a safety net; the real fix is to
@@ -2641,7 +2693,16 @@ func (a *App) UpdateBoxAgent(host string, port int) error {
 		return nil
 	}
 	if err := a.updateAgentViaHTTP(host, port, bin); err != nil {
-		return err
+		// The small preflight GET can pass while the 10 MB POST still fails: on
+		// BCO the :17008 REDIRECT path closes the connection mid-upload (live
+		// 2026-06-11, "connection forcibly closed"). Fall back to SSH-OTA instead
+		// of surfacing the error. SSH writes .new and size-verifies before the
+		// atomic rename, so a mid-upload failure never corrupts the live binary.
+		a.logger.Warn("update agent: HTTP OTA failed, falling back to SSH-OTA", "host", host, "err", err)
+		if sshErr := a.updateAgentViaSSH(host, bin); sshErr != nil {
+			return fmt.Errorf("HTTP OTA failed (%v) and the SSH fallback also failed: %w", err, sshErr)
+		}
+		a.logger.Info("update agent: SSH-OTA succeeded after HTTP failure", "host", host, "bytes", len(bin))
 	}
 	a.refreshStickAfterOTA(host)
 	return nil

--- a/desktop-app/frontend/src/api.js
+++ b/desktop-app/frontend/src/api.js
@@ -7,6 +7,7 @@
 
 export {
   DiscoverBoxes,
+  RefreshKnownBoxes,
   GetPresets,
   SetPreset,
   DeletePreset,

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -1,6 +1,7 @@
 import './style.css';
 import {
   DiscoverBoxes,
+  RefreshKnownBoxes,
   GetPresets,
   SetPreset,
   DeletePreset,
@@ -1396,45 +1397,20 @@ async function discoverBoxes() {
     if (rb) rb.classList.add('spinning');
   }
   try {
-    const list = await DiscoverBoxes(4);
-    state.boxes = applyPendingNames(list || []);
-    saveCachedBoxes(state.boxes);
-    if (state.currentBox && state.currentBox.deviceID) {
-      const fresh = state.boxes.find(b => b.deviceID === state.currentBox.deviceID);
-      if (fresh) {
-        const changed = fresh.host !== state.currentBox.host
-                     || fresh.port !== state.currentBox.port
-                     || fresh.version !== state.currentBox.version
-                     || fresh.friendlyName !== state.currentBox.friendlyName;
-        state.currentBox = fresh;
-        if (changed) {
-          state.presets = [];
-          state.searchResults = [];
-          state.nowLocation = '';
-          state.nowPlayState = '';
-          state.presetErrors = {};
-          $('presets').innerHTML = '';
-          $('searchResults').innerHTML = '';
-          loadPresets();
-          refreshStatus();
-          checkBoxUpdate();
-        }
-        updateSourceButtonVisibility();
-      } else {
-        state.currentBox = null;
-        state.presets = [];
-        $('presets').innerHTML = '';
-      }
+    // Known-first refresh: re-probe the speakers we already have directly
+    // (no mDNS), so their live values update within ~1 s, THEN run the full
+    // discovery to catch new or moved speakers. Most refreshes just want the
+    // current values of a known box, so this makes the button feel instant.
+    if (hadBoxes) {
+      try {
+        const quick = await RefreshKnownBoxes();
+        if (quick && quick.length) applyBoxList(quick);
+      } catch {}
     }
-    renderBoxSelect();
-    updateSettingsTabBadge();
-    // Setup-tab target picker reuses the same state.boxes feed.
-    // Re-render so newly arrived speakers appear as choices without
-    // making the user leave and re-enter the Setup tab.
-    renderSetupTargetPicker();
-    // Auto retry: if a recently set up speaker has not yet
-    // re-announced its new name via mDNS, search again every 4 s for
-    // up to 90 s. Driven by pendingNames.
+    const list = await DiscoverBoxes(4);
+    applyBoxList(list || []);
+    // Auto retry: if a recently set up speaker has not yet re-announced its
+    // new name via mDNS, search again every 4 s (driven by pendingNames).
     scheduleNextAutoRefresh();
   } catch (e) {
     if (!hadBoxes) $('boxSelect').textContent = t('common.error') + ': ' + e;
@@ -1442,6 +1418,45 @@ async function discoverBoxes() {
     const rb = $('refreshBtn');
     if (rb) rb.classList.remove('spinning');
   }
+}
+
+// applyBoxList folds a freshly probed box list into state + the UI. Shared by
+// the known-first quick refresh and the full discovery so both render
+// identically (current-box re-bind, speaker select, badges, setup picker).
+function applyBoxList(list) {
+  state.boxes = applyPendingNames(list || []);
+  saveCachedBoxes(state.boxes);
+  if (state.currentBox && state.currentBox.deviceID) {
+    const fresh = state.boxes.find(b => b.deviceID === state.currentBox.deviceID);
+    if (fresh) {
+      const changed = fresh.host !== state.currentBox.host
+                   || fresh.port !== state.currentBox.port
+                   || fresh.version !== state.currentBox.version
+                   || fresh.friendlyName !== state.currentBox.friendlyName;
+      state.currentBox = fresh;
+      if (changed) {
+        state.presets = [];
+        state.searchResults = [];
+        state.nowLocation = '';
+        state.nowPlayState = '';
+        state.presetErrors = {};
+        $('presets').innerHTML = '';
+        $('searchResults').innerHTML = '';
+        loadPresets();
+        refreshStatus();
+        checkBoxUpdate();
+      }
+      updateSourceButtonVisibility();
+    } else {
+      state.currentBox = null;
+      state.presets = [];
+      $('presets').innerHTML = '';
+    }
+  }
+  renderBoxSelect();
+  updateSettingsTabBadge();
+  // Setup-tab target picker reuses the same state.boxes feed.
+  renderSetupTargetPicker();
 }
 
 let _autoRefreshTimer = null;

--- a/desktop-app/frontend/wailsjs/go/main/App.d.ts
+++ b/desktop-app/frontend/wailsjs/go/main/App.d.ts
@@ -91,6 +91,8 @@ export function RadioVote(arg1:string):Promise<void>;
 
 export function RebootBox(arg1:string,arg2:number):Promise<void>;
 
+export function RefreshKnownBoxes():Promise<Array<main.BoxInfo>>;
+
 export function RepairInstallViaSSH(arg1:string,arg2:string):Promise<main.InstallResult>;
 
 export function ResolveStationLogo(arg1:string,arg2:string,arg3:Array<string>):Promise<string>;

--- a/desktop-app/frontend/wailsjs/go/main/App.js
+++ b/desktop-app/frontend/wailsjs/go/main/App.js
@@ -174,6 +174,10 @@ export function RebootBox(arg1, arg2) {
   return window['go']['main']['App']['RebootBox'](arg1, arg2);
 }
 
+export function RefreshKnownBoxes() {
+  return window['go']['main']['App']['RefreshKnownBoxes']();
+}
+
 export function RepairInstallViaSSH(arg1, arg2) {
   return window['go']['main']['App']['RepairInstallViaSSH'](arg1, arg2);
 }


### PR DESCRIPTION
- **fix(ota):** UpdateBoxAgent now falls back to SSH-OTA when the HTTP POST fails (the :17008 REDIRECT path closing the 10 MB POST mid-upload on BCO, live 2026-06-11), not only on preflight rejection. SSH writes .new + size-verifies before the atomic rename, so a botched OTA cannot corrupt the live binary.
- **feat(discovery):** refresh re-probes already-known speakers directly first (App.RefreshKnownBoxes, no mDNS / no /24 sweep) so their live values update within ~1s, then runs the full discovery in the background. Frontend factored into applyBoxList.