### PR TITLE
Only append the speaker ID when names would collide (#133)

### DIFF
--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -487,7 +487,7 @@
   "settingsView.nameHeading": "Name",
   "settingsView.namePlaceholder": "Raum eintippen oder aus Liste wählen",
   "settingsView.nameShowList": "Liste anzeigen",
-  "settingsView.nameHelp": "Erscheint in Bose-Apps, mDNS und UPnP-Discovery. Eine Lautsprecher-ID ({{uid}}) wird beim Speichern automatisch angehängt, damit es keine Namensdopplungen im Netz gibt.",
+  "settingsView.nameHelp": "Erscheint in Bose-Apps, mDNS und UPnP-Discovery. Eine kurze Lautsprecher-ID ({{uid}}) wird nur angehängt, wenn ein anderer Lautsprecher sonst denselben Namen hätte.",
   "settingsView.muted": "Aktuell stummgeschaltet",
   "settingsView.bassHeading": "Bass",
   "settingsView.bassResetTitle": "Auf Werkseinstellung zurücksetzen",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -487,7 +487,7 @@
   "settingsView.nameHeading": "Name",
   "settingsView.namePlaceholder": "Type a room or pick from the list",
   "settingsView.nameShowList": "Show list",
-  "settingsView.nameHelp": "Appears in Bose apps, mDNS and UPnP discovery. A speaker ID ({{uid}}) gets appended on save so there are no name collisions on the network.",
+  "settingsView.nameHelp": "Appears in Bose apps, mDNS and UPnP discovery. A short speaker ID ({{uid}}) is added only if another speaker would otherwise have the same name.",
   "settingsView.muted": "Currently muted",
   "settingsView.bassHeading": "Bass",
   "settingsView.bassResetTitle": "Reset to factory default",

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -226,7 +226,7 @@
   "settingsView.nameHeading": "Nombre",
   "settingsView.namePlaceholder": "Escribe una sala o elige de la lista",
   "settingsView.nameShowList": "Mostrar lista",
-  "settingsView.nameHelp": "Aparece en las aplicaciones Bose y en la detección mDNS y UPnP. Al guardar se añade un identificador de altavoz ({{uid}}) para que no haya conflictos de nombres en la red.",
+  "settingsView.nameHelp": "Aparece en las aplicaciones Bose y en la detección mDNS y UPnP. Un identificador corto de altavoz ({{uid}}) se añade solo si otro altavoz tendría el mismo nombre.",
   "settingsView.muted": "Actualmente silenciado",
   "settingsView.bassHeading": "Graves",
   "settingsView.bassResetTitle": "Restablecer al valor de fábrica",

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -226,7 +226,7 @@
   "settingsView.nameHeading": "Nom",
   "settingsView.namePlaceholder": "Saisissez une pièce ou choisissez dans la liste",
   "settingsView.nameShowList": "Afficher la liste",
-  "settingsView.nameHelp": "Apparaît dans les applications Bose, la découverte mDNS et UPnP. Un identifiant d'enceinte ({{uid}}) est ajouté à l'enregistrement pour éviter les conflits de noms sur le réseau.",
+  "settingsView.nameHelp": "Apparaît dans les applications Bose, la découverte mDNS et UPnP. Un court identifiant d'enceinte ({{uid}}) n'est ajouté que si une autre enceinte aurait sinon le même nom.",
   "settingsView.muted": "Actuellement coupé",
   "settingsView.bassHeading": "Basses",
   "settingsView.bassResetTitle": "Réinitialiser au réglage d'usine",

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -226,7 +226,7 @@
   "settingsView.nameHeading": "名前",
   "settingsView.namePlaceholder": "部屋名を入力するか一覧から選択",
   "settingsView.nameShowList": "一覧を表示",
-  "settingsView.nameHelp": "Boseアプリ、mDNS、UPnP検出に表示されます。ネットワーク上で名前が重複しないよう、保存時にスピーカーID ({{uid}}) が付加されます。",
+  "settingsView.nameHelp": "Boseアプリ、mDNS、UPnP検出に表示されます。短いスピーカーID ({{uid}}) は、他のスピーカーと名前が重複する場合にのみ付加されます。",
   "settingsView.muted": "現在ミュート中",
   "settingsView.bassHeading": "低音",
   "settingsView.bassResetTitle": "工場出荷時の値に戻す",

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -229,7 +229,7 @@
   "settingsView.nameHeading": "Pavadinimas",
   "settingsView.namePlaceholder": "Įveskite kambarį arba pasirinkite iš sąrašo",
   "settingsView.nameShowList": "Rodyti sąrašą",
-  "settingsView.nameHelp": "Rodomas Bose programose, mDNS ir UPnP aptikime. Išsaugant pridedamas garsiakalbio ID ({{uid}}), kad tinkle nebūtų pavadinimų konfliktų.",
+  "settingsView.nameHelp": "Rodomas Bose programose, mDNS ir UPnP aptikime. Trumpas garsiakalbio ID ({{uid}}) pridedamas tik tada, jei kitas garsiakalbis turėtų tą patį pavadinimą.",
   "settingsView.muted": "Šiuo metu nutildyta",
   "settingsView.bassHeading": "Žemieji dažniai",
   "settingsView.bassResetTitle": "Atkurti gamyklinį nustatymą",

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -229,7 +229,7 @@
   "settingsView.nameHeading": "Nosaukums",
   "settingsView.namePlaceholder": "Ievadiet istabu vai atlasiet no saraksta",
   "settingsView.nameShowList": "Rādīt sarakstu",
-  "settingsView.nameHelp": "Tiek rādīts Bose lietotnēs, mDNS un UPnP atklāšanā. Saglabājot tiek pievienots skaļruņa ID ({{uid}}), lai tīklā nebūtu nosaukumu konfliktu.",
+  "settingsView.nameHelp": "Tiek rādīts Bose lietotnēs, mDNS un UPnP atklāšanā. Īss skaļruņa ID ({{uid}}) tiek pievienots tikai tad, ja citam skaļrunim citādi būtu tāds pats nosaukums.",
   "settingsView.muted": "Pašlaik izslēgts skaņa",
   "settingsView.bassHeading": "Basi",
   "settingsView.bassResetTitle": "Atjaunot rūpnīcas iestatījumu",

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -229,7 +229,7 @@
   "settingsView.nameHeading": "Naam",
   "settingsView.namePlaceholder": "Typ een ruimte of kies uit de lijst",
   "settingsView.nameShowList": "Lijst tonen",
-  "settingsView.nameHelp": "Verschijnt in Bose-apps, mDNS en UPnP-detectie. Bij het opslaan wordt een speaker-ID ({{uid}}) toegevoegd zodat er geen naamconflicten op het netwerk zijn.",
+  "settingsView.nameHelp": "Verschijnt in Bose-apps, mDNS en UPnP-detectie. Een korte speaker-ID ({{uid}}) wordt alleen toegevoegd als een andere speaker anders dezelfde naam zou hebben.",
   "settingsView.muted": "Momenteel gedempt",
   "settingsView.bassHeading": "Bas",
   "settingsView.bassResetTitle": "Terugzetten naar fabrieksinstelling",

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -229,7 +229,7 @@
   "settingsView.nameHeading": "Nazwa",
   "settingsView.namePlaceholder": "Wpisz pomieszczenie lub wybierz z listy",
   "settingsView.nameShowList": "Pokaż listę",
-  "settingsView.nameHelp": "Pojawia się w aplikacjach Bose, mDNS i wykrywaniu UPnP. Przy zapisie dodawany jest identyfikator głośnika ({{uid}}), aby nie było konfliktów nazw w sieci.",
+  "settingsView.nameHelp": "Pojawia się w aplikacjach Bose, mDNS i wykrywaniu UPnP. Krótki identyfikator głośnika ({{uid}}) jest dodawany tylko wtedy, gdy inny głośnik miałby taką samą nazwę.",
   "settingsView.muted": "Obecnie wyciszony",
   "settingsView.bassHeading": "Basy",
   "settingsView.bassResetTitle": "Przywróć ustawienie fabryczne",

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -229,7 +229,7 @@
   "settingsView.nameHeading": "Ad",
   "settingsView.namePlaceholder": "Bir oda girin veya listeden seçin",
   "settingsView.nameShowList": "Listeyi göster",
-  "settingsView.nameHelp": "Bose uygulamalarında, mDNS ve UPnP keşfinde gösterilir. Kaydederken, ağda ad çakışması olmaması için hoparlör kimliği ({{uid}}) eklenir.",
+  "settingsView.nameHelp": "Bose uygulamalarında, mDNS ve UPnP keşfinde gösterilir. Kısa bir hoparlör kimliği ({{uid}}) yalnızca başka bir hoparlör aynı ada sahip olacaksa eklenir.",
   "settingsView.muted": "Şu anda sessiz",
   "settingsView.bassHeading": "Bas",
   "settingsView.bassResetTitle": "Fabrika ayarını geri yükle",

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -226,7 +226,7 @@
   "settingsView.nameHeading": "Ім'я",
   "settingsView.namePlaceholder": "Введіть кімнату або виберіть зі списку",
   "settingsView.nameShowList": "Показати список",
-  "settingsView.nameHelp": "Відображається в застосунках Bose, під час виявлення mDNS і UPnP. Під час збереження додається ідентифікатор колонки ({{uid}}), щоб у мережі не було конфліктів імен.",
+  "settingsView.nameHelp": "Відображається в застосунках Bose, під час виявлення mDNS і UPnP. Короткий ідентифікатор колонки ({{uid}}) додається лише тоді, коли інша колонка інакше мала б таку саму назву.",
   "settingsView.muted": "Зараз без звуку",
   "settingsView.bassHeading": "Бас",
   "settingsView.bassResetTitle": "Скинути до заводського значення",

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -3592,7 +3592,21 @@ function ensureWithUID(desired, ownBox) {
   const suffix = uidSuffixFor(ownBox);
   if (!suffix) return trimmed;
   if (trimmed.toUpperCase().endsWith(suffix)) return trimmed;
-  return `${trimmed} ${suffix}`;
+  // #133: the ID suffix exists only to disambiguate multiple speakers that
+  // would otherwise share a name. The name is display-only (discovery matches
+  // on IP/DeviceID), so append the suffix ONLY when another known speaker would
+  // collide with this exact name. A single speaker, or a unique name, keeps the
+  // clean name the user chose.
+  const ownId = (ownBox && ownBox.deviceID) || '';
+  const want = trimmed.toUpperCase();
+  const collides = (state.boxes || []).some(b => {
+    if (!b || b.deviceID === ownId) return false;
+    const other = (b.friendlyName || b.name || '').trim();
+    if (!other) return false;
+    const otherBase = other.replace(/\s+[0-9A-Fa-f]{4}$/, '').trim().toUpperCase();
+    return otherBase === want || other.toUpperCase() === want;
+  });
+  return collides ? `${trimmed} ${suffix}` : trimmed;
 }
 
 function renderSettingsBoxSelect() {


### PR DESCRIPTION
The 4-hex device-ID suffix was appended to the speaker name on every save, cluttering a single user's chosen names with no opt-out (#133). The name is display-only (discovery matches on IP/DeviceID), so it is now appended only when another known speaker would otherwise have the exact same name. Help text updated in all 11 language bundles.

Closes #133