### PR TITLE
docs: full repo doc refresh + Deezer roadmap (audit 2026-06-12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,26 +32,42 @@ them back **without any Bose cloud dependency**.
 ```
 Client (Browser / Desktop App)
   -- REST API --> Stick Agent webui :8888
-     (ST10 reached directly; BCO Portable/taigan + spotty ST20 reached via
-      iptables PREROUTING REDIRECT :17008 -> loopback :8888)
+     (sm2 boxes (ST10 rhino, ST30 mojo) reached directly; BCO/whitelisted
+      chassis (Portable/taigan, ST20 spotty/scm) reached via iptables
+      PREROUTING REDIRECT :17008 -> loopback :8888)
                             |
-                            +--> /api/presets    preset store on NAND
-                            +--> /api/play       upnp.PlayURL -> Box:8091/AVTransport
-                            +--> /api/radio      radiobrowser.Search/TopVote
-                            +--> /api/status     proxy Box:8090/now_playing
-                            +--> /stream/<slot>  streamproxy (survives CDN token expiry)
+                            +--> /api/presets        preset store on NAND
+                            +--> /api/play, /api/play/<slot>, /api/pause, /api/stop
+                            |     upnp.PlayURL -> Box:8091/AVTransport
+                            +--> /api/status         proxy Box:8090/now_playing (cached)
+                            +--> /api/box/*          speaker settings (name/volume/bass/
+                            |     source/wlan/reboot/airplay-opt/sync-presets/zone/group)
+                            +--> /api/region, /api/stick/status, /api/debug/*
+                            +--> /api/agent/version, /api/agent/update
+                            |     OTA (HTTP; the app falls back to SSH-OTA and
+                            |     refreshes a still-inserted stick before the reboot)
+                            +--> /api/webhooks, /api/webhooks/test
+                            |     user-configured HTTP triggers on box events (NAND)
+                            +--> /stream/<slot>, /stream/raw
+                            |     streamproxy (survives CDN token expiry; converts
+                            |     HLS playlists to one continuous ADTS/MP3 stream)
+                            +--> /api/stream/bitrate, /api/stream/title, /api/stream-status
+                            +--> /spotify/stream.ogg, /spotify/stream-1..6.ogg, /spotify/info
+                            |     Spotify Connect (beta): supervised go-librespot
+                            |     sidecar, raw Ogg passthrough (internal/spotify)
                             |
-                            +--> boxws  ws://127.0.0.1:8080/gabbo
+                            +--> boxws  ws://127.0.0.1:8080/ (gabbo protocol)
                             |     nowSelectionUpdated -> upnp.PlayURL
                             |
                             +--> autopair  POST /setMargeAccount every 5 min
                             |
                             +--> marge stub  :9080 (HTTP) / :443 (TLS)
-                            |     emulates streaming.bose.com
+                            |     emulates streaming.bose.com + content.api.bose.io
                             |     /streaming/account/.../device/  -> adddeviceresponse
                             |     /streaming/sourceproviders      -> source list
-                            +--> bmx stub    :8081  (content.api.bose.io)
                             |     /bmx/registry/v1/services       -> service list
+                            +--> bmx stub    :8081  (healthz-only placeholder; the
+                            |     registry route above is answered by marge)
                             |
                             +--> :17002 BatteryMonitor fallback (Portable only)
                             |     accepts BoseApp's battery client when the stock
@@ -62,18 +78,28 @@ Client (Browser / Desktop App)
 
 Bose firmware ports STR talks to / around:
   :8080 gabbo WS    :8090 BoseApp REST    :8091 UPnP AVTransport
-  :17008 SoftwareUpdate (BCO external entry, REDIRECT -> :8888)
-  :17002 BatteryMonitor    :40020 scmmond (battery MCU bridge)
+  :17000 TAP CLI (standby wake, provisioning probes)
+  :17008 SoftwareUpdate (external entry on whitelisted chassis, REDIRECT -> :8888)
+  :17002 BatteryMonitor
 ```
 
 Audio path: UPnP AVTransport directly to the speaker on port 8091.
 We never proxy audio through the dead Bose cloud.
 
-Radio source: `radio-browser.info` (free, no API key) replaces the
-discontinued Bose TuneIn integration.
+Radio search runs **app-side**: the desktop app queries
+`radio-browser.info` (free, no API key) directly via the top-level
+`radiobrowser/` package (`desktop-app/radio.go`); the agent no longer
+serves `/api/radio` and only receives the final stream URL to play.
+This replaces the discontinued Bose TuneIn integration.
 
 Hardware preset buttons 1 through 6 are re-enabled by hooking the
-Bose WebSocket bus (`/gabbo`).
+Bose WebSocket bus (gabbo protocol on `:8080`).
+
+Beyond radio, the desktop app ships a DLNA media library (top-level
+`dlna/` package), Spotify Connect (beta), multiroom zones (alpha),
+diagnostics export, and box maintenance (true factory reset,
+uninstall STR, setup-AP Wi-Fi push). The UI ships in 11 locales;
+English and German are first-class.
 
 ## Conventions in this repo
 
@@ -87,7 +113,7 @@ first-class; other languages welcome via PR.
 
 ### Style
 
-- Go 1.22+, `gofmt`, `golangci-lint` clean.
+- Go 1.25+, `gofmt`, `golangci-lint` clean.
 - Logging via `log/slog`.
 - Module path: `github.com/JRpersonal/streborn`.
 - Tests in `_test.go` files alongside the code they cover.
@@ -148,10 +174,11 @@ process are in [`SECURITY.md`](SECURITY.md).
 STR is pre-1.0. The bar to ship 1.0 is intentionally low and
 measurable, not aspirational:
 
-1. **At least two speaker models verified end to end.** ST10 is the
-   reference target today. One additional model (ST20 or ST30)
-   confirmed by a maintainer or a trusted contributor on real
-   hardware.
+1. **At least two speaker models verified end to end.** Met: ST10
+   (rhino) and Portable (taigan) are Verified, ST20 (spotty) is
+   contributor-confirmed with final stability confirmation in
+   progress, and a live ST30 (mojo) has run the agent successfully.
+   Current per-model state lives in [`docs/MODELS.md`](docs/MODELS.md).
 2. **Hardware presets 1 to 6 work after a cold boot, a standby cycle,
    and a Wi-Fi outage**: no manual reset required.
 3. **First-install experience is honest.** SmartScreen / Gatekeeper
@@ -213,8 +240,10 @@ the shared version stamp.
   remain ignored.
 - **`sticksetup/embedded/winformat.exe`** is also a `go:embed`
   target. Same pattern: empty stub tracked, CI overwrites. Local
-  developers can build the real one with:
-  `go build -ldflags "-s -w" -o sticksetup/embedded/winformat.exe ./cmd/winformat`
+  developers build the real embeds with `make winformat-embed` and
+  `make agent-embed`; both run automatically as dependencies of
+  `make wails-build` / `make wails-dev`. (Raw `go build` misses the
+  `GOOS`/`GOARCH` pins and the version stamp.)
 - Empty stubs mean `agentbin.Available()` correctly returns `false`
   on dev builds, so the desktop app falls back to a configured
   external path instead of writing zero bytes onto the stick.
@@ -242,13 +271,19 @@ the shared version stamp.
 ```
 cmd/
   agent/         Stick agent main
+  mdns-probe/    mDNS debug CLI
+  relnotes/      Release-notes generator (conventional commits -> notes)
   winformat/     FAT32 format helper for the Windows installer
-desktop-app/     Wails project (Vite frontend, Go backend)
+desktop-app/     Wails project (Vite frontend, Go backend; own Go module)
 discovery/       mDNS discovery (top-level so Wails can import it)
+dlna/            DLNA MediaServer client for the Library tab (top-level)
 docs/            Sanitised technical docs only
 internal/        Stick-agent-only packages (boxapi, marge, autopair, ...)
-setup/           Setup wizard helpers
+radiobrowser/    radio-browser.info client (app-side radio search)
+setup/           Legacy PowerShell setup wizard (superseded by the
+                 desktop app's in-app stick setup)
 sticksetup/      Embedded setup workflow
+tools/           Support diagnostics scripts
 usb-stick/       Stick filesystem layout and run.sh
 wifiprofiles/    Cross-platform Wi-Fi profile reader for the wizard
 .github/         Workflows, dependabot, CODEOWNERS, security policies
@@ -258,20 +293,26 @@ The website (st-reborn.de) lives in a separate repository
 (`JRpersonal/streborn-website`). A release here triggers a build
 there via `repository_dispatch`.
 
-`discovery/` lives at the top level on purpose. The desktop app
-imports it, and Go forbids importing from another module's
-`internal/`.
+`discovery/`, `dlna/`, `radiobrowser/`, `sticksetup/`, and
+`wifiprofiles/` live at the top level on purpose. The desktop app is
+its own Go module and imports them; Go forbids importing from another
+module's `internal/`.
 
 Hardware support state per model is tracked in
 [`docs/MODELS.md`](docs/MODELS.md).
 
 ## Workflows
 
-Workflows live in `.github/workflows/`. They cover source
-verification (lockfile consistency, vulnerability scan, tests),
-cross-platform builds, and release publication on signed tags.
-Dependabot, Secret Scanning, CodeQL, and Push Protection are enabled
-at the repository settings level.
+Workflows live in `.github/workflows/`: `build.yml` (source
+verification: lockfile consistency, vulnerability scan, tests,
+cross-compiles, shellcheck), `release.yml` (release publication on
+signed tags), `codeql.yml`, `scorecard.yml` (OSSF Scorecard),
+`dependabot-automerge.yml`, and two `workflow_dispatch` builds of the
+Spotify sidecar binaries (`go-librespot.yml` primary, with the STR
+Ogg-passthrough patch from `.github/patches/`; `librespot.yml`
+fallback), both Sigstore-attested. Dependabot, Secret Scanning, and
+Push Protection are additionally enabled at the repository settings
+level.
 
 ## How a new Claude session should start
 
@@ -286,10 +327,13 @@ at the repository settings level.
    per-variant fingerprint table (moduleType, firmware, kernel,
    components) that incoming diagnostics get matched against, and
    [`docs/THREAT-MODEL.md`](docs/THREAT-MODEL.md) for security
-   context.
-5. Run `go build ./...` and `cd desktop-app && wails dev` once to
-   confirm the local environment is healthy. The stick agent
-   contains Linux-only syscalls; on Windows or macOS hosts use
+   context. Before touching `internal/spotify/` or the go-librespot
+   workflows, also read
+   [`docs/streaming/spotify.md`](docs/streaming/spotify.md); for box
+   firmware quirks, [`docs/FIRMWARE-NOTES.md`](docs/FIRMWARE-NOTES.md).
+5. Run `go build ./...` and `make wails-dev` once to confirm the
+   local environment is healthy. The stick agent contains Linux-only
+   syscalls; on Windows or macOS hosts use
    `GOOS=linux GOARCH=arm GOARM=7 go build ./...` to cross-compile
    it for the actual target.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ every model we get tested by a real user makes it more useful.
 
 ## Local development
 
-Requirements: Go 1.22+, Node 20+, [Wails CLI v2][wails], `make`.
+Requirements: Go 1.25+, Node 20+, [Wails CLI v2][wails], `make`.
 Linux is the smoothest target; macOS and Windows work but have
 extra Wails toolchain dependencies.
 
@@ -46,22 +46,24 @@ extra Wails toolchain dependencies.
 git clone https://github.com/JRpersonal/streborn.git
 cd streborn
 
-# Sanity check
+# Sanity check (Linux). On Windows/macOS hosts the agent's Linux-only
+# syscalls make `go build ./...` fail in internal/webui; cross-compile
+# instead (GOOS=linux GOARCH=arm GOARM=7 go build ./... or make build-arm)
+# and run go test on the packages that build on your host.
 go build ./...
 go test ./...
 
 # Stick agent for the speaker hardware
 make build-arm
 
-# Desktop app, dev mode with hot reload
-cd desktop-app
-wails dev
-
-# Website
-cd ../website
-npm ci
-npm run dev
+# Desktop app, dev mode with hot reload AND the embedded helpers built
+# (raw `wails dev` runs with empty embed stubs: no stick formatting, no OTA)
+make wails-dev
 ```
+
+The website is a separate repository,
+[`JRpersonal/streborn-website`](https://github.com/JRpersonal/streborn-website);
+clone and run it there (`npm ci && npm run dev`).
 
 The `desktop-app/agentbin/streborn-armv7l` and
 `sticksetup/embedded/winformat.exe` files are empty stubs in the
@@ -78,7 +80,9 @@ the desktop app falls back to a configured external path.
   clean. Tests in `_test.go` next to the code they cover. Logging
   via `log/slog`.
 - **Frontend.** Whatever Wails generated. Small project, no extra
-  framework opinions.
+  framework opinions. If you add or change a Wails-bound Go method,
+  run `wails generate module` in `desktop-app/` and commit the
+  `wailsjs/` changes, otherwise the frontend CI build breaks.
 - **Commits.** Conventional Commits, imperative mood, present tense,
   one logical change per commit. Reference the Issue or Discussion if
   there is one: `fix(agent): preset reconcile loop on standby (#42)`.
@@ -111,7 +115,9 @@ the desktop app falls back to a configured external path.
 
 Tick these in your PR description:
 
-- [ ] `go vet ./...` and `go test ./...` pass locally.
+- [ ] `go vet ./...` and `go test ./...` pass locally (on
+      Windows/macOS: for the packages that build on your host, plus
+      the ARM cross-compile).
 - [ ] If the change touches the stick agent, I have either tested
       on real hardware or noted in the PR that I have not.
 - [ ] No personal data, real LAN IPs, MAC addresses, or device

--- a/README.md
+++ b/README.md
@@ -32,28 +32,33 @@ The desktop app: browse and assign presets, search internet radio, browse a DLNA
 | [![DLNA library](docs/screenshots/OS%20Hero/app-library.jpg)](docs/screenshots/OS%20Hero/app-library.jpg) | [![USB stick setup](docs/screenshots/OS%20Hero/app-stick-step1.jpg)](docs/screenshots/OS%20Hero/app-stick-step1.jpg) | [![Stick: Wi-Fi, name, region](docs/screenshots/OS%20Hero/app-stick-step2.jpg)](docs/screenshots/OS%20Hero/app-stick-step2.jpg) |
 | DLNA music library | USB stick setup | Wi-Fi, name, region |
 
-The interface is available in eleven languages (English, German, French, Spanish, Japanese, Ukrainian, Dutch, Polish, Lithuanian, Latvian, Turkish). The full per-language screenshot set lives in [`docs/screenshots/`](docs/screenshots/) and is regenerated automatically with `npm run screenshots`, a headless Playwright harness that mocks the backend with demo data, so no speaker is needed.
+The interface is available in eleven languages (English, German, French, Spanish, Japanese, Ukrainian, Dutch, Polish, Lithuanian, Latvian, Turkish). The full per-language screenshot set lives in [`docs/screenshots/`](docs/screenshots/) and is regenerated automatically with `npm run shoot` in `desktop-app/frontend/screenshots/`, a headless Playwright harness that mocks the backend with demo data, so no speaker is needed.
 
-## Status (May 2026)
+## Status (June 2026)
 
 STR is pre-1.0. This section is the honest snapshot. No marketing.
 
 ### What works
 
-- Discovery of installed sticks over mDNS, list view in the desktop app.
+- Discovery of installed sticks over mDNS, list view in the desktop app. Speakers without STR show up too, marked "ready for STR", and can be installed in-app.
 - Playback control: play / pause / stop / volume / bass / source switch (AUX, Bluetooth, Standby) via the speaker's existing UPnP AVTransport endpoint on port 8091. I never route audio through the dead Bose cloud.
-- Radio search via radio-browser.info. Replaces the dead Bose TuneIn integration. No API key.
-- Six preset slots, persisted on the stick agent. Hardware preset buttons 1 to 6 work after install via a hook into Bose's WebSocket bus (`/gabbo`).
-- OTA agent updates from the desktop app. Build stamp comparison catches version drift.
+- Radio search via radio-browser.info, queried directly by the desktop app (no API key); only the final stream URL goes to the speaker. HLS-only stations (BBC and co.) are converted on the fly by the agent's stream proxy. On a blocked or dead stream the app automatically tries another listing of the same station.
+- Six preset slots, persisted on the stick agent. Hardware preset buttons 1 to 6 work after install via a hook into Bose's WebSocket bus (gabbo). Existing non-STR presets (e.g. Deezer) are left untouched.
+- Spotify Connect (beta): a supervised go-librespot sidecar on the speaker; Spotify presets, multi-account, live now-playing.
+- DLNA music library: browse FRITZ!Box / Synology / Plex / miniDLNA servers and save tracks as presets.
+- Multiroom zones and stereo pairs (alpha).
+- Webhooks: user-configured HTTP triggers on box events (remote keys, power, AUX).
+- OTA agent updates from the desktop app, with an SSH fallback and a pre-reboot stick refresh so the update cannot be reverted by the boot sync. Build stamp comparison catches version drift.
 - WLAN reconfigure from the desktop app. I rewrite `/etc/wpa_supplicant.conf` in full because appending breaks Wi-Fi.
-- Setup wizard for the USB stick, including preset region, friendly name, and Wi-Fi credentials. FAT32 formatting helper bundled.
+- Setup wizard for the USB stick, including preset region, friendly name, box language, and Wi-Fi credentials. FAT32 formatting helper bundled.
+- Diagnostics export (anonymised), true factory reset, and a full "Uninstall STR" that returns the speaker to stock.
 
-Targets: SoundTouch 10, 20, 30, Portable. My reference target is the ST10. ST20 and ST30 I have touched on but not finalised against real hardware end to end.
+Targets: SoundTouch 10, 20, 30, Portable. ST10 and Portable are verified end to end; ST20 is contributor-confirmed; ST30 has run live with the final pass pending. Current per-model state: [`docs/MODELS.md`](./docs/MODELS.md).
 
 ### What I do for security
 
 - DNS pinning for the Bose hostnames (`streaming.bose.com`, `bmx-cloud.*`, TuneIn partner subdomain) to `127.0.0.1` via an `/etc/hosts` bind-mount. The speaker no longer makes outbound queries for these names. This closes the residual domain-squat risk if Bose lets the DNS lapse and someone re-registers it.
-- Per-box local TLS CA, generated on first boot, stored in `/mnt/nv/streborn/ca/`, installed in the speaker's own trust store. Only valid for the loopback-redirected hostnames. Never transmitted. TLS only on loopback.
+- Per-box local TLS CA, generated on first boot, stored in `/mnt/nv/streborn/ca/`, installed in the speaker's own trust store. Only valid for the loopback-redirected hostnames; the CA private key never leaves the speaker's NAND. The stand-in listeners themselves are LAN-reachable like the rest of the agent surface.
 
 ### What I do not do for security yet
 
@@ -65,19 +70,19 @@ Targets: SoundTouch 10, 20, 30, Portable. My reference target is the ST10. ST20 
 ### What is inherited from stock Bose firmware (and I do not change)
 
 - HTTP control on `:8090` and UPnP on `:8091` accept any LAN client without authentication. Standard SoundTouch behaviour, not added by me.
-- The speakers ship with `root` having no password set. SSH (port 22) is enabled by Bose's own init script when a `remote_services` file is present on a mounted USB stick. While the stick is in, any device on the LAN can reach a passwordless root shell. I remove the stick from the boot path after first install and stop `sshd` once the stick is unmounted, so in normal operation the port is closed. The window during which the stick sits in the speaker is the only time this is exposed. The desktop app shows a banner during that window.
+- The speakers ship with `root` having no password set. SSH (port 22) is enabled by Bose's own init script when a `remote_services` file is present on a mounted USB stick. **Pre-1.0, STR itself keeps `sshd` running on every boot** (stick or no stick): when an install or update leaves the agent down, SSH is the only channel that still lets the desktop app pull diagnostics and repair the box, and I currently weight that recovery path over closing the port. Any device on the LAN can reach a passwordless root shell while the speaker is on. The desktop app shows a banner reminding you to remove the stick after setup; it does not indicate SSH state. Making SSH opt-in (via a stick marker) is part of the v1.0 hardening. Until then: put the speaker on a trusted network.
 
 ### Factory reset
 
 A Bose factory reset clears only what Bose itself knows about: the Bose preset database, account, friendly name, Wi-Fi. It does not touch `/mnt/nv/streborn/`, which is where my agent binary, CA, preset store, region, name, and the `run-override.sh` hook live. After a factory reset, STR is still installed and boots automatically.
 
-Implication: a speaker being passed on or sold needs a separate "Uninstall STR" step that removes `/mnt/nv/streborn/` and the NAND override. I have that wizard step planned (see [`docs/ROADMAP.md`](./docs/ROADMAP.md), "Factory reset wizard"), not yet shipped.
+Implication: a speaker being passed on or sold needs a separate "Uninstall STR" step. That ships in the desktop app: Speaker Settings offers **Remove STR** (removes `/mnt/nv/streborn/` and the boot override, returns the speaker to stock Bose firmware) and a separate **True Factory Reset**. See [`docs/ROADMAP.md`](./docs/ROADMAP.md), "Factory reset wizard", for the remaining level (reset STR data only).
 
 ### Pre-1.0 gaps I still owe before tagging 1.0
 
 Per my own criteria in [`CLAUDE.md`](./CLAUDE.md):
 
-1. I have only verified ST10 end to end. A second model confirmed on real hardware (by me or a trusted contributor) is the explicit requirement.
+1. Two models verified end to end: met (ST10 and Portable verified, ST20 contributor-confirmed, ST30 live with the final pass pending; see [`docs/MODELS.md`](./docs/MODELS.md)).
 2. Hardware preset buttons need to survive cold boot, standby cycle, and Wi-Fi outage. I observe this working, but I do not yet have a regression test that pins it.
 3. First-install experience: SmartScreen and Gatekeeper documentation on the website Verify page with the exact click path and a linked SHA256 plus Sigstore attestation. Partially in place, not finalised.
 4. Threat model document published. Present in [`docs/THREAT-MODEL.md`](./docs/THREAT-MODEL.md). It does not yet cover the persistence-across-factory-reset point above, which I owe.
@@ -94,12 +99,12 @@ cd streborn
 # Build the stick agent for the speaker hardware (ARMv7l)
 make build-arm
 
-# Build the desktop app (requires Wails v2 CLI)
-cd desktop-app
-wails build
+# Build the desktop app with embedded helpers and version stamp
+# (requires Wails v2 CLI; raw `wails build` leaves the embeds empty)
+make wails-build
 ```
 
-Requirements: Go 1.22 or newer, Node 20 or newer, Wails CLI v2 for the desktop app.
+Requirements: Go 1.25 or newer, Node 20 or newer, Wails CLI v2 for the desktop app. Note: on Windows/macOS hosts the agent itself only cross-compiles (`make build-arm`); plain `go build ./...` fails on its Linux-only syscalls.
 
 The website (st-reborn.de) lives in a separate repository, [`JRpersonal/streborn-website`](https://github.com/JRpersonal/streborn-website). A release here triggers a build there via `repository_dispatch`.
 
@@ -111,11 +116,15 @@ If you want to understand how the agent, the desktop app, and the speaker's stoc
 
 | Path | Description |
 |------|-------------|
-| `cmd/agent/` | Stick agent entry point |
-| `internal/` | Marge cloud stub, BMX, UPnP, mDNS, WebSocket hook, preset store |
+| `cmd/` | Stick agent entry point, plus `winformat`, `relnotes`, `mdns-probe` helpers |
+| `internal/` | Agent-only packages: marge cloud stub, BMX, UPnP, WebSocket hook, preset store, stream proxy, Spotify manager, zones, webhooks |
+| `discovery/` | mDNS discovery (top level so the desktop app can import it) |
+| `dlna/` | DLNA MediaServer client for the Library tab (top level) |
+| `radiobrowser/` | radio-browser.info client for the app-side radio search (top level) |
+| `sticksetup/` / `wifiprofiles/` | Embedded stick provisioning + saved-Wi-Fi reader (top level) |
 | `usb-stick/` | Bootstrap and runtime scripts on the speaker |
-| `setup/` | Setup wizard (PowerShell) |
-| `desktop-app/` | Cross-platform Wails app |
+| `setup/` | Legacy PowerShell wizard (superseded by the in-app stick setup) |
+| `desktop-app/` | Cross-platform Wails app (own Go module) |
 | `.github/` | CI and release workflows |
 | `docs/` | Public documentation (architecture, threat model, models, roadmap) |
 
@@ -128,7 +137,7 @@ See [st-reborn.de](https://st-reborn.de).
 Every release on GitHub Releases is built by the official workflow and ships with build provenance attestations via Sigstore. You can verify any binary with:
 
 ```bash
-gh attestation verify STR-Setup-Windows.exe --owner JRpersonal
+gh attestation verify STR-Windows-vX.Y.Z.exe --owner JRpersonal
 ```
 
 For the threat model and the vulnerability reporting process see [SECURITY.md](./SECURITY.md) and [docs/THREAT-MODEL.md](./docs/THREAT-MODEL.md).
@@ -148,7 +157,7 @@ Findings from Dependabot, CodeQL, and Scorecard surface in the repository's [Sec
 
 ## Privacy
 
-STR has no accounts, no ads, and no third-party trackers in the app. The speaker never contacts the Bose cloud: STR answers it locally. The desktop app makes a single external call, an optional version check to st-reborn.de that sends only the app version, build, OS, architecture, and language, and is disablable with `STR_NO_UPDATE_CHECK=1`. The website uses cookieless GoatCounter analytics. Full breakdown: [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md#telemetry-analytics-and-privacy).
+STR has no accounts, no ads, and no third-party trackers in the app. The speaker never contacts the Bose cloud: STR answers it locally; with Spotify Connect enabled it talks to Spotify's servers. The desktop app talks to st-reborn.de (optional version check, disablable with `STR_NO_UPDATE_CHECK=1`; sends only the app version, build, OS, architecture, and language), to radio-browser.info for the station search, and to public favicon endpoints for station logos. The website uses cookieless GoatCounter analytics. Full breakdown: [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md#telemetry-analytics-and-privacy).
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,7 +62,7 @@ Users can verify a download with either:
 sha256sum -c SHA256SUMS
 
 # Method 2: GitHub CLI attestation verification
-gh attestation verify STR-Setup-Windows.exe \
+gh attestation verify STR-Windows-vX.Y.Z.exe \
     --owner JRpersonal
 ```
 
@@ -104,7 +104,7 @@ The attestation proves:
 
 ### Website
 
-- Static HTML, no server side code on the website.
+- Static site plus one small server-side endpoint (`api/update-check.php`) that serves version metadata for the app update check.
 - Download links point exclusively to GitHub Releases, never to the webspace.
 - SHA256 hashes are shown on the download page for verification.
 - CSP header restricts script sources to self plus GoatCounter analytics.
@@ -121,14 +121,15 @@ The attestation proves:
 
 STR has no user accounts, no advertising, and no third-party trackers in the app.
 
-- **The speaker never contacts the Bose cloud.** STR redirects the Bose cloud hostnames to localhost and answers them itself. The speaker only reaches your LAN, radio-browser.info (station search), and the radio station's own stream.
-- **The desktop app makes one external call:** a version check to `st-reborn.de` at startup, sending only the app version, build, OS, CPU architecture, and UI language so the right download can be offered. No account, no device identifier, no personal data. Disable it entirely with `STR_NO_UPDATE_CHECK=1`.
+- **The speaker never contacts the Bose cloud.** STR redirects the Bose cloud hostnames to localhost and answers them itself. The speaker reaches your LAN, the radio station's own stream, and, only if you enable Spotify Connect, Spotify's servers (the bundled go-librespot client). Station search moved to the desktop app; the speaker no longer contacts radio-browser.info.
+- **The desktop app talks to:** `st-reborn.de` (optional version check at startup, sending only the app version, build, OS, CPU architecture, and UI language; disable with `STR_NO_UPDATE_CHECK=1`), radio-browser.info (station search), and public favicon endpoints (station logos). No account, no device identifier, no personal data.
 - **The website** uses GoatCounter, a privacy-friendly analytics tool: no cookies, no cross-site tracking, the visitor IP is not stored.
 
 The full breakdown is in [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md#telemetry-analytics-and-privacy).
 
 ## Known Limitations
 
+- **Pre-1.0 SSH posture (hardening pending):** the agent keeps the speaker's SSH service running on every boot so diagnostics and repair work even when the agent is down; the firmware root account uses a well-known default with no password. Any LAN device can reach a root shell on the speaker while it is powered. Planned v1.0 hardening makes SSH opt-in via a stick marker. Until then, run the speaker on a trusted network or its own VLAN.
 - Windows installers are currently **not code signed** with an EV certificate. Windows SmartScreen may warn on first download. Plans exist to acquire an EV code signing certificate once donations cover the annual cost.
 - macOS builds are **not notarized** yet. Same reason.
 - The desktop app does not implement application sandboxing. Future versions may use OS provided sandboxing.
@@ -137,3 +138,4 @@ The full breakdown is in [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md#telemetry
 
 - 2026 May 15: initial security policy.
 - 2026 Jun 03: documented the privacy/telemetry posture, added OpenSSF Scorecard, and listed the per-push checks (golangci-lint, govulncheck, CodeQL, Secret Scanning + Push Protection).
+- 2026 Jun 12: corrected the privacy section (app-side radio search, Spotify sidecar), documented the pre-1.0 SSH posture, noted the update-check endpoint, fixed the attestation example to the versioned asset name.

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -468,7 +468,7 @@
   "banner.recommendationShort": "Empfehlung",
   "speaker.rebootNow": "Lautsprecher jetzt neu starten",
   "speaker.rebootGenericBody": "Der Lautsprecher wird in 1 Sekunde neu gestartet. Aktuelle Wiedergabe wird unterbrochen. Fortfahren?",
-  "speaker.rebootConfirmDetailedBody": "Hast du den USB-Stick bereits gezogen?<br><br><b>Stick noch drin</b> &rarr; SSH bleibt nach dem Reboot offen.<br><b>Stick gezogen</b> &rarr; SSH ist nach dem Reboot zu.<br><br>Aktuelle Wiedergabe wird unterbrochen.",
+  "speaker.rebootConfirmDetailedBody": "Hast du den USB-Stick entfernt? Es wird empfohlen, ihn nach der Einrichtung zu entfernen, damit er nicht im Lautsprecher stecken bleibt. (Hinweis: STR haelt SSH bis zum v1.0-Hardening bei jedem Start fuer Diagnose offen; das Entfernen des Sticks schliesst es nicht.)<br><br>Die aktuelle Wiedergabe wird unterbrochen.",
   "signal.excellent": "Ausgezeichnet",
   "signal.good": "Gut",
   "signal.marginal": "Mittelmäßig",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -468,7 +468,7 @@
   "banner.recommendationShort": "Recommendation",
   "speaker.rebootNow": "Restart speaker now",
   "speaker.rebootGenericBody": "The speaker will restart in 1 second. Current playback will be interrupted. Continue?",
-  "speaker.rebootConfirmDetailedBody": "Have you removed the USB stick?<br><br><b>Stick still in</b> &rarr; SSH stays open after the reboot.<br><b>Stick removed</b> &rarr; SSH is closed after the reboot.<br><br>Current playback will be interrupted.",
+  "speaker.rebootConfirmDetailedBody": "Have you removed the USB stick? Removing it after setup is recommended so the stick is not left in the speaker. (Note: STR keeps SSH available for diagnostics on every boot until the v1.0 hardening; removing the stick does not close it.)<br><br>Current playback will be interrupted.",
   "signal.excellent": "Excellent",
   "signal.good": "Good",
   "signal.marginal": "Marginal",

--- a/desktop-app/radio.go
+++ b/desktop-app/radio.go
@@ -1,9 +1,9 @@
 // App-side internet-radio search. Per the app-first direction, radio-browser
 // queries run in the desktop app (reliable internet, real CPU) instead of on
 // the constrained box. The box only ever receives the final stream URL to play.
-// The agent keeps its own /api/radio for the browser-direct-to-box case, but
-// the desktop app no longer routes search through the box (that made the box's
-// flaky internet/DNS gate search, the HTTP 502s in #121).
+// The agent no longer serves /api/radio at all and no longer compiles the
+// radiobrowser package (see internal/webui Run): routing search through the
+// box made its flaky internet/DNS gate search, the HTTP 502s in #121.
 package main
 
 import (

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,7 +15,7 @@ flowchart LR
     User["User"]
     Desktop["ST Reborn (desktop app)<br/>Wails: Go backend + Vite/vanilla JS frontend"]
 
-    subgraph Speaker["Bose SoundTouch (rhino ST10 / BCO: Portable, spotty ST20)"]
+    subgraph Speaker["Bose SoundTouch (sm2: ST10 rhino, ST30 mojo / whitelisted: Portable taigan, ST20 spotty+scm)"]
       direction TB
       BoseFW["Bose firmware (stock)<br/>gabbo :8080, BoseApp :8090, UPnP :8091,<br/>SoftwareUpdate :17008, BatteryMonitor :17002, scmmond :40020"]
       Agent["STR stick agent (Go, ARMv7l)<br/>webui+streamproxy+/spotify/stream :8888, marge :9080/:443, BMX :8081,<br/>:17002 battery fallback, mDNS, gabbo hook, iptables REDIRECTs"]
@@ -34,7 +34,7 @@ flowchart LR
   end
 
   User -- click --> Desktop
-  Desktop <-- "REST :8888 (ST10 direct)<br/>or :17008 (BCO, iptables REDIRECT to :8888)" --> Agent
+  Desktop <-- "REST :8888 (sm2 direct)<br/>or :17008 (whitelisted chassis, iptables REDIRECT to :8888)" --> Agent
   Desktop -- "mDNS _streborn._tcp" --> Agent
   Agent -- "WebSocket :8080 (gabbo)" --> BoseFW
   Agent -- "AVTransport :8091 (UPnP)" --> BoseFW
@@ -62,11 +62,13 @@ station's audio bytes.
 
 | Component | Lives in | Runtime | Job |
 |---|---|---|---|
-| **Stick agent** | `cmd/agent/`, `internal/` | Go binary on the speaker NAND, started by `/mnt/nv/streborn/run-override.sh` from Bose `rc.local` | Emulates the Bose cloud (marge, BMX), proxies radio streams, owns the preset store, announces over mDNS, hooks the speaker's WebSocket bus to re-enable hardware preset buttons. On BCO boxes it also installs the iptables PREROUTING REDIRECTs that make it LAN-reachable, and serves the `:17002` BatteryMonitor fallback on the Portable. |
+| **Stick agent** | `cmd/agent/`, `internal/` | Go binary on the speaker NAND, started by `/mnt/nv/streborn/run-override.sh` from Bose `rc.local` | Emulates the Bose cloud (marge, BMX), proxies radio streams (incl. HLS conversion), owns the preset store, announces over mDNS, hooks the speaker's WebSocket bus to re-enable hardware preset buttons, manages multiroom zones (NAND `zones.json`, auto-reform), and fires user-configured webhooks on box events (NAND `webhooks.json`). On whitelisted chassis it also installs the iptables PREROUTING REDIRECTs that make it LAN-reachable, and serves the `:17002` BatteryMonitor fallback on the Portable. |
 | **Spotify plane (beta)** | `internal/spotify/`, `go-librespot` binary on NAND | go-librespot runs as a Spotify Connect receiver, supervised by the agent's `spotify.Manager` | Spotify Connect on the speaker without the Bose cloud. go-librespot decodes nothing: with the fork's `audio_output_pipe_passthrough` it writes the raw Ogg/Vorbis bitstream to a pipe; the agent serves it at `/spotify/stream.ogg` on :8888 and points the box's UPnP renderer there. Preset recall drives go-librespot's local play API (no token plane). Multi-account is done by swapping credentials + restarting go-librespot (fragile, see fork issue #1). |
-| **Desktop app** | `desktop-app/` | Wails app (Go backend + Vite frontend), built for Windows, macOS, Linux | Discovers agents over mDNS, talks to them by REST, ships a UI for radio search, presets, playback (with the live now-playing track + bitrate), settings, OTA agent updates, USB stick provisioning. |
-| **Setup wizard** | `setup/`, `sticksetup/`, `cmd/winformat/` | PowerShell scripts + embedded helper `winformat.exe` | Prepares a FAT32 USB stick with Wi-Fi credentials, region, friendly name, and the bootstrap shell scripts. Wraps the in-app install button. |
-| **USB stick filesystem** | `usb-stick/` | Files written to a FAT32 stick by the wizard | Boot-time bootstrap (`rc.local`, `run.sh`, `install.sh`), one-shot config (`wlan.conf`, `name.txt`, `region.txt`, `presets.json`), the agent binary itself. |
+| **Desktop app** | `desktop-app/` | Wails app (Go backend + Vite frontend), built for Windows, macOS, Linux | Discovers agents over mDNS, talks to them by REST, ships a UI for radio search (app-side, direct to radio-browser.info), presets, playback (with the live now-playing track + bitrate), a DLNA media library, Spotify Connect (beta), multiroom (alpha), settings, webhooks, diagnostics export, OTA agent updates, USB stick provisioning, and box maintenance (true factory reset, uninstall STR, setup-AP Wi-Fi push). |
+| **Local library (DLNA)** | `dlna/` (top level so Wails can import it) | Imported by the desktop app | SSDP discovery + ContentDirectory browse of LAN media servers (FRITZ!Box, Synology, Plex, miniDLNA). The app saves a track's stream URL as a normal preset; the box pulls it via the streamproxy. |
+| **Multiroom (alpha)** | `internal/zones/`, `internal/boxapi` zone primitives | Agent endpoints `/api/box/zone` + `/api/box/group` | Groups speakers via the box's native `/setZone` (firmware-synced) or a per-agent mirror fallback, plus stereo pairs. Membership persists in `/mnt/nv/streborn/zones.json` and auto-reforms after reboot/standby/Wi-Fi outage. |
+| **Setup wizard** | `sticksetup/`, `cmd/winformat/` (in-app); `setup/` (legacy PowerShell) | Embedded in the desktop app; `winformat.exe` handles FAT32 formatting | Prepares a FAT32 USB stick with Wi-Fi credentials, region, friendly name, language, and the bootstrap shell scripts, then drives the install over SSH. The standalone PowerShell wizard in `setup/` is legacy. |
+| **USB stick filesystem** | `usb-stick/` | Files written to a FAT32 stick by the wizard | Boot-time bootstrap (`rc.local`, `run.sh`, `install.sh`), one-shot config (`wlan.conf`, `name.conf`, `region.conf`, `lang.conf`, `presets.json`), `str-shim.so`, `version.txt`, and the agent binary itself. `run.sh` persists name/region to NAND as `name.txt`/`region.txt`. |
 | **mDNS discovery** | `discovery/` (top level on purpose, see `CLAUDE.md`) | Imported by both the agent and the desktop app | Service type `_streborn._tcp.local`. TXT record carries deviceID, model, friendly name, version. |
 | **Website** | separate repo `JRpersonal/streborn-website` | Astro static site, EN and DE | Downloads, FAQ, Verify page with SHA256 and Sigstore click-paths, legal pages. Built on `repository_dispatch` from this repo's release workflow. |
 
@@ -74,16 +76,16 @@ station's audio bytes.
 
 | Layer | Choice | Why |
 |---|---|---|
-| Stick agent language | Go 1.22+ (module `github.com/JRpersonal/streborn`) | Static single binary cross-compiles to `linux/arm/v7` from any host. No runtime on the speaker beyond BusyBox. |
-| Desktop backend | Go via Wails v2 (`github.com/wailsapp/wails/v2`) | Same language as the agent, can import `discovery/` and `internal/boxapi` for free. |
-| Desktop frontend | Vite 6 + vanilla JS (no framework), i18n layer (EN, DE, FR, ES, JA, UK, NL, PL) | Keeps the binary small and the build chain dependency-light. No React/Vue tax for the UI. |
+| Stick agent language | Go 1.25+ (module `github.com/JRpersonal/streborn`) | Static single binary cross-compiles to `linux/arm/v7` from any host. No runtime on the speaker beyond BusyBox. |
+| Desktop backend | Go via Wails v2 (`github.com/wailsapp/wails/v2`); own module, imports the shared top-level packages `discovery/`, `dlna/`, `radiobrowser/`, `sticksetup/`, `wifiprofiles/` | Same language as the agent. Go forbids importing the agent module's `internal/`, which is why the shared packages are top-level. |
+| Desktop frontend | Vite 6 + vanilla JS (no framework), i18n layer with 11 locales (EN, DE, ES, FR, JA, LT, LV, NL, PL, TR, UK) | Keeps the binary small and the build chain dependency-light. No React/Vue tax for the UI. |
 | mDNS | `github.com/grandcat/zeroconf` | Pure Go, dual stack, works on all three desktop OSes and on the speaker. |
 | WebSocket | `github.com/gorilla/websocket` | Reuses the gabbo subprotocol the Bose firmware expects on `:8080`. |
 | Radio source | `radio-browser.info` HTTP API | Free, no key, community-maintained. Replaces the dead Bose TuneIn integration. The stream proxy also reads the live ICY `StreamTitle` so the app can show the current track. |
 | Spotify | `go-librespot` (fork `JRpersonal/go-librespot`, Ogg passthrough patch) | Open-source Spotify Connect client in Go. Passthrough avoids decoding on the weak ARM CPU: the raw Ogg/Vorbis is handed straight to the box, which decodes it. The passthrough patch is offered upstream as `devgianlu/go-librespot` PR #316. |
 | Setup wizard host script | PowerShell 5.1 on Windows | Ships with every Windows; no Python install required for the user. |
 | FAT32 helper | Custom Go tool (`cmd/winformat`) | Avoids elevation prompts and shell quoting around `diskutil` / `format`. |
-| Installers | InnoSetup (Windows), `.dmg` via Wails (macOS), AppImage (Linux) | Standard per-platform distribution, no exotic dependencies. |
+| Distribution | Portable `.exe` + `.zip` (Windows), `.dmg` via `hdiutil` (macOS), `.tar.gz` with a per-user `install.sh` (Linux) | No installer framework; code signing is deferred on cost (#72), so the Verify page documents the SmartScreen/Gatekeeper click-paths instead. |
 | CI | GitHub Actions, all actions SHA-pinned | Build provenance via Sigstore (`actions/attest-build-provenance`). |
 | Verification | SHA256 + Sigstore today; code signing deferred on cost (see #72) | Verify page documents the click-paths through SmartScreen and Gatekeeper. |
 
@@ -92,29 +94,37 @@ station's audio bytes.
 ### On the speaker (when STR is running)
 
 STR's own ports are bound on loopback and the LAN interface; the Bose
-firmware ports are stock. On the newer **BCO** chassis (Portable/taigan,
-spotty ST20) the network chipset accepts inbound external TCP only to
-listeners owned by a Bose binary, so STR's own ports are **not** reachable
-from the LAN directly. STR therefore installs iptables PREROUTING
-`REDIRECT` rules that map a Bose-owned external port onto the loopback STR
-listener. On Series-I ST10 (rhino) the STR ports are reachable directly.
+firmware ports are stock. External reachability splits by chassis:
+
+- **sm2 chassis (ST10 `rhino`, ST30 `mojo`)**: STR's ports are reachable
+  directly, but only because `run.sh` punches `INPUT ACCEPT` rules for
+  them past the Bose stock firewall (`iptables-setup.sh`).
+- **Whitelisted chassis (Portable `taigan`, ST20 `spotty` and `scm`)**:
+  the network chipset accepts inbound external TCP only to listeners
+  owned by a Bose binary, so STR's own ports are **not** reachable from
+  the LAN directly. STR installs an iptables PREROUTING `REDIRECT` that
+  maps the Bose-owned external port `:17008` onto the loopback STR
+  listener `:8888`. Where NAT is unavailable, an LD_PRELOAD shim on
+  `/opt/Bose/SoftwareUpdate` (`usb-stick/shim/shim.c`) is the fallback
+  entry path; today the shim is skipped on every catalogued chassis and
+  remains only for uncatalogued variants.
 
 | Port | Listener | Role | LAN reachable |
 |---|---|---|---|
-| 22 | sshd (Bose) | Open only while the stick is inserted; closed once it is unmounted. | stick only |
+| 22 | sshd (Bose, started by STR) | **Pre-1.0: open on every boot.** `run.sh` (`ensure_sshd_running`) starts sshd unconditionally and deliberately never stops it, so diagnostics and SSH repair work even when the agent is down. Becomes opt-in via a stick marker as part of the v1.0 hardening (see `THREAT-MODEL.md`). | LAN |
 | 80 | _(nobody , firmware OUTBOUND)_ | **Not a listener.** This is the firmware's **outbound** HTTP cloud call (to `streaming.bose.com`). iptables NAT-redirects it to STR's :9080; **STR never binds :80** and the firmware does not listen on it. Listed only because STR claims this outbound traffic. | outbound (firmware) -> redirected to :9080 |
 | 443 | STR marge HTTPS | TLS cloud-stub for `streaming.bose.com` after the Hosts redirect. | loopback (firmware) |
 | 3678 | go-librespot local API (started by STR) | The agent's `spotify.Manager` drives playback here (`/player/play`, shuffle, next, volume) and reads track events. | loopback |
 | 7000 | STSCertified (Bose) | TLS endpoint inside the firmware. Untouched. | internal |
 | 8080 | WebServer / gabbo (Bose) | Hosts the `/gabbo` WebSocket bus. STR connects as a client. | internal |
-| 8081 | STR BMX stub | Cloud-stub for `content.api.bose.io`. | via :8081 REDIRECT (BCO) |
+| 8081 | STR BMX stub | Healthz-only placeholder for `content.api.bose.io`; the `/bmx/registry/v1/services` route is answered by marge via the hosts rewrite. | sm2: direct (INPUT ACCEPT) / whitelisted chassis: loopback |
 | 8090 | BoseApp (Bose) | REST: `/info`, `/now_playing`, `/presets`, `/select`, `/volume`, zones, ... STR reads and writes here. | internal |
 | 8091 | UPnP AVTransport (Bose) | STR sets the stream URL via SetURI; the speaker fetches and decodes. | internal |
-| 8443 | STR marge HTTPS (alt) | Same handler as :443; used when :443 cannot be claimed. | via :8443 REDIRECT (BCO) |
-| 8888 | STR webui + streamproxy | `/api/*` for the desktop app, the `/stream/<slot>` radio reverse proxy that survives CDN token expiry, and `/spotify/stream.ogg` (the raw Ogg the box pulls for Spotify). | direct (ST10) / via :17008 REDIRECT (BCO) |
-| 9080 | STR marge HTTP | Plain-text marge target after the firmware's outbound :80 is NAT-redirected. | via :9080 REDIRECT (BCO) |
+| 8443 | STR marge HTTPS (alt) | Same handler as :443; used when :443 cannot be claimed. | sm2: direct (INPUT ACCEPT) / whitelisted chassis: loopback |
+| 8888 | STR webui + streamproxy | `/api/*` for the desktop app, the `/stream/<slot>` radio reverse proxy that survives CDN token expiry, and `/spotify/stream.ogg` (the raw Ogg the box pulls for Spotify). HLS playlists are converted to one continuous ADTS/MP3 stream; `/api/stream-status` reports upstream failures. | sm2: direct (INPUT ACCEPT) / whitelisted chassis: via :17008 REDIRECT |
+| 9080 | STR marge HTTP | Plain-text marge target after the firmware's outbound :80 is NAT-redirected. | sm2: direct (INPUT ACCEPT) / whitelisted chassis: loopback |
 | 17002 | STR BatteryMonitor fallback | **Portable only.** Bound when the Bose `BatteryMonitor` service is wedged, so BoseApp's battery client connects instead of connect-storming a dead port. This is the ~27 min reboot fix (v0.6.18); see [`FIRMWARE-NOTES.md`](./FIRMWARE-NOTES.md). | loopback (firmware) |
-| 17008 | SoftwareUpdate (Bose) | On BCO this is STR's external entry point: the PREROUTING REDIRECT sends external :17008 to loopback :8888, which is how the desktop app reaches the agent. | external entry (BCO) |
+| 17008 | SoftwareUpdate (Bose) | On whitelisted chassis (taigan, spotty, scm) this is STR's external entry point: the PREROUTING REDIRECT sends external :17008 to loopback :8888, which is how the desktop app reaches the agent. | external entry (whitelisted chassis) |
 | 40020 | scmmond (Bose) | System-control / battery-MCU manager that feeds `BatteryMonitor`. STR does not bind it. | internal |
 
 > **Reading the table:** every row is a port some process *listens on*, with the
@@ -145,13 +155,18 @@ sequenceDiagram
   Agent->>Net: Announce _streborn._tcp.local<br/>TXT: deviceID, model, version, name
   App->>Net: Browse _streborn._tcp.local
   Net-->>App: Service records
-  App->>App: Deduplicate by host<br/>(discovery/dedup.go)
-  App->>Agent: GET /api/status (over LAN, port 8888)
-  Agent-->>App: JSON: now_playing, presets, agent version
+  App->>App: Deduplicate + classify str/stock<br/>(desktop-app/app.go)
+  App->>Agent: GET /api/status (over LAN)
+  Agent-->>App: XML now_playing (proxied from the box :8090, cached)
+  Note over App,Agent: presets and agent version are separate calls<br/>(/api/presets, /api/agent/version)
 ```
 
 Agents are also picked up as legacy `_soundtouchstick._tcp` so old
-sticks built before the rename keep working.
+sticks built before the rename keep working. The app additionally
+browses the stock Bose service types (`_soundtouch._tcp` and the
+`_bose-soundtouch._tcp` alias) so speakers that do NOT yet run STR
+appear as "stock, needs install" next to STR boxes; an STR record
+always wins over a stock record for the same box.
 
 ### 2. Radio search and playback
 
@@ -183,6 +198,17 @@ the speaker noticing. It also requests ICY metadata from the upstream,
 de-interleaves it so the box still gets clean audio, and exposes the live
 `StreamTitle` at `/api/stream/title`, which the desktop app shows as the
 now-playing track next to the station name (with a marquee when too long).
+
+HLS-only stations (the BBC nationals, Radio France, ...) are converted
+on the fly: the proxy follows the live media playlist, demuxes the
+MPEG-TS segments, and serves one continuous ADTS/MP3 stream, because
+the box can neither follow playlists nor read TS containers (#124).
+Failures are asynchronous (the box accepts the URI; a 403/503 only
+surfaces when bytes are pulled), so the agent records the last terminal
+upstream failure at `/api/stream-status`; the app polls it for a few
+seconds after each play and silently retries with an alternative
+radio-browser entry of the same station before showing a reason-classed
+error.
 
 ### 3. Hardware preset button (short press)
 
@@ -289,7 +315,7 @@ sequenceDiagram
   participant Box as Speaker (cold boot)
   participant NAND as /mnt/nv/streborn/
   User->>App: Prepare stick<br/>pick speaker, Wi-Fi, name
-  App->>Stick: winformat.exe (FAT32)<br/>write run.sh, install.sh, rc.local,<br/>streborn-armv7l, wlan.conf,<br/>name.conf, region.conf, remote_services
+  App->>Stick: winformat.exe (FAT32)<br/>write run.sh, install.sh, rc.local,<br/>streborn-armv7l, str-shim.so, wlan.conf,<br/>name.conf, region.conf, lang.conf, remote_services
   User->>Box: Insert stick, power on
   Box->>Box: Bose init sees remote_services<br/>opens sshd, mounts /media/sda1
   App->>Box: SSH (passwordless root):<br/>sh /media/sda1/install.sh install
@@ -323,6 +349,7 @@ sequenceDiagram
   participant User
   participant App as Desktop app
   participant Embed as agentbin (go:embed)
+  participant Stick as USB stick (if inserted)
   participant Agent as Running stick agent
   participant NAND as /mnt/nv/streborn/
   Note over App,Embed: The desktop app ships<br/>the matching ARM agent inside its binary.
@@ -331,10 +358,13 @@ sequenceDiagram
   App->>App: compare to embedded version
   alt newer embedded
     User->>App: Click "Update agent"
-    App->>Agent: POST /api/agent/update<br/>multipart upload of streborn-armv7l
+    App->>Stick: refresh stick over SSH FIRST<br/>(mount + fsck, rewrite program files, durable flush)
+    Note over App,Stick: otherwise the next boot's stick->NAND sync<br/>would revert the freshly updated binary
+    App->>Agent: HTTP preflight, then POST /api/agent/update<br/>(raw ARM binary, ELF-checked; SSH-OTA fallback<br/>on preflight rejection or mid-upload failure)
     Agent->>NAND: write new binary, chmod +x
-    Agent->>Agent: restart self
-    App->>Agent: poll /api/agent/version<br/>until version flips
+    Agent->>Agent: respond {action: reboot},<br/>reboot the whole box ~1.5 s later<br/>(self-restart only if reboot fails)
+    App->>Agent: poll /api/agent/version<br/>until the new build answers
+    Note over App: discovery pins the host as STR through the reboot<br/>so the stock announcement answering first cannot<br/>relabel it "needs install" (#108)
   end
 ```
 
@@ -396,7 +426,7 @@ the app. The complete picture of what talks to what:
 
 | Component | Talks to | What is sent |
 |---|---|---|
-| Speaker (agent + firmware) | **Never** the Bose cloud | STR redirects the Bose cloud hostnames to localhost and answers them itself (marge). The speaker only reaches the LAN and the upstream radio CDN (audio, proxied). Radio search/metadata is no longer fetched by the speaker; the desktop app queries radio-browser.info directly (app-first). |
+| Speaker (agent + firmware) | **Never** the Bose cloud | STR redirects the Bose cloud hostnames to localhost and answers them itself (marge). The speaker reaches the LAN, the upstream radio CDN (audio, proxied), and, only when the user enables them, Spotify access points (go-librespot) and the user's own configured webhook URLs. Radio search/metadata is no longer fetched by the speaker; the desktop app queries radio-browser.info directly (app-first). |
 | Desktop app | `st-reborn.de` update-check, once at startup | Running version, build stamp, OS, CPU arch, UI locale. No account, no device ID, no personal data. Opt-out: `STR_NO_UPDATE_CHECK=1`. Radio search runs in the app (direct to radio-browser.info); only the audio CDN stream flows through the speaker agent. |
 | Desktop app webview | `icons.duckduckgo.com` | Only a radio station's own domain, to fetch its logo when the station ships no usable artwork. No user data, no account, no identifier. When DuckDuckGo also has nothing, a local letter monogram is drawn with no network call. Google's favicon service was deliberately not used. |
 | Website (`st-reborn.de`) | GoatCounter | Privacy-friendly, cookieless page analytics: no cookies, no cross-site tracking, the visitor IP is not stored. |
@@ -415,6 +445,10 @@ to Bose.
   run-override.sh             NAND copy that takes priority over the stick's run.sh
   ca/                         STR's local TLS CA + server cert (regenerated on first boot)
   presets.json                preset store; same schema as /media/sda1/presets.json
+  zones.json                  multiroom group membership (auto-reformed after reboot)
+  webhooks.json               webhook trigger config
+  lib/                        str-shim.so + SoftwareUpdate-real backup + SU-wrapper.sh
+                              (chipset-whitelist shim; skipped on all catalogued chassis)
   region.txt                  ISO country code from the setup wizard
   name.txt                    pending box name to apply once
   sp-cache/                   go-librespot config.yml + zeroconf credentials.json,
@@ -436,13 +470,16 @@ configuration plus the agent binary that gets copied into NAND.
 | You want to... | Read this |
 |---|---|
 | ...trace a hardware button press end to end | `internal/boxws/boxws.go`, then `internal/upnp/upnp.go` |
-| ...understand the marge cloud emulation | `internal/marge/marge.go` + `templates.go`; check the spy log on `:8081/__spy/log` and `:9080/__spy/log` |
+| ...understand the marge cloud emulation | `internal/marge/marge.go` + `templates.go`; check the spy log on `:9080/__spy/log` (same handler on the marge TLS port; the BMX stub on `:8081` serves `/healthz` only) |
 | ...see how presets are stored | `internal/presets/presets.go` |
 | ...follow a Spotify recall (play, shuffle, multi-account, Ogg serve) | `internal/spotify/manager.go`; the recall hook is in `cmd/agent/main.go` (`playSpotifyPreset`, `verifySpotifyPlaying`) |
-| ...trace the radio stream proxy + ICY title | `internal/streamproxy/streamproxy.go` |
+| ...trace the radio stream proxy + ICY title | `internal/streamproxy/streamproxy.go` (HLS conversion: `hls.go` + `mpegts.go`) |
 | ...follow the desktop-app boot | `desktop-app/main.go`, then `desktop-app/frontend/src/main.js` |
 | ...inspect the stick boot sequence | `usb-stick/rc.local`, `usb-stick/run.sh`, `usb-stick/install.sh` |
 | ...understand discovery semantics | `discovery/` (top level so Wails can import it) |
+| ...follow the app-side radio search | `desktop-app/radio.go` -> `radiobrowser/` |
+| ...browse the DLNA library | `dlna/dlna.go`, App methods in `desktop-app/app.go` |
+| ...trace multiroom zones | `internal/zones/zones.go`, `/api/box/zone` in `internal/webui` |
 | ...check the release pipeline | `.github/workflows/release.yml`, `Makefile` (`wails-build`, `agent-embed`) |
 
 ## What this document is not

--- a/docs/FIRMWARE-NOTES.md
+++ b/docs/FIRMWARE-NOTES.md
@@ -83,12 +83,20 @@ reachable from the LAN as-is. STR works around this two ways:
   Bose-owned port to the agent (the path STR uses on BCO today).
 - An `LD_PRELOAD` shim (`usb-stick/shim/shim.c`, built from source on
   every release) can hook `accept()` inside a Bose process to forward
-  connections. The shim is deliberately **skipped** on the Portable
-  chassis, where it raced the firmware's service-init and wedged it; the
-  iptables path is used instead.
+  connections. It is **skipped on every catalogued chassis today**: on
+  whitelisted chassis (Portable `taigan` AND ST20 `spotty`) it races the
+  firmware's service-init and wedges boot, and on the SM2 chassis
+  (`rhino`, `mojo`) it is unnecessary and cannot even load on `mojo`
+  (live ST30, #123). The iptables REDIRECT is the production path
+  everywhere it matters; the shim remains only as a fallback for
+  uncatalogued variants (`STR_FORCE_SHIM_TAIGAN=1` to force it).
 
-Older "Series-I" ST10 (rhino) does not need this; its agent is reachable
-directly.
+The SM2 chassis (ST10 `rhino`, ST30 `mojo` — labelled "Series-II" in
+`MODELS.md`, `is_series_one=0` in `run.sh`) does not need the REDIRECT;
+its agent is reachable directly once `run.sh` opens `:8888` with an
+`INPUT ACCEPT` rule. Note the label inversion: `run.sh`'s
+`detect_series_one` returns 1 for the *whitelisted* chassis
+(`taigan`/`spotty`/`scm`), not for `rhino`.
 
 ## Bose internal HTTP buffer cap
 

--- a/docs/MODEL-VARIANTS.md
+++ b/docs/MODEL-VARIANTS.md
@@ -49,14 +49,6 @@ The final firmware Bose shipped before the cloud shutdown on 2026-02. Anything o
 - `networkInfo` emits two entries (SCM + SMSC) with separate MACs but the same Layer-3 IP. The speaker bridges internally; STR sees one address per box.
 - Root `/etc` is read-only (ubifs `ro,relatime`); `/mnt/nv` is read-write (ubifs `rw,relatime`); `/tmp` is tmpfs.
 
-### Common to both ST20 variants
-
-- Bose `/etc/version`: `201507061523`
-- Kernel: `Linux spotty 3.14.43+ #137 Wed Oct 25 21:06:53 EDT 2017 armv7l`
-- `MemTotal`: ~122 MB (`122 484 kB`)
-- Last Bose firmware build epoch: 2022-08-04 (the final SoundTouch firmware before Bose cloud shutdown on 2026-02)
-- `networkInfo` emits two entries (SCM + SMSC) with separate MACs but the same Layer-3 IP. The speaker bridges internally; STR sees one address per box.
-- Root `/etc` is read-only (ubifs `ro,relatime`); `/mnt/nv` is read-write (ubifs `rw,relatime`); `/tmp` is tmpfs.
 
 ### Variant-specific notes
 

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -15,8 +15,8 @@ been validated.
 | **SoundTouch 10** | TI AM335x ARMv7l, module SM2, variant `rhino` (Series-II) | **Verified** |
 | **SoundTouch Portable** | TI AM335x ARMv7l, BCO coprocessor, variant `taigan` | **Verified** |
 | **SoundTouch 20** | TI AM335x ARMv7l, module `scm` + SMSC, variant `spotty` (BCO) | **Working (contributor-confirmed; final stability confirmation in progress)** |
-| **SoundTouch 20** | TI AM335x ARMv7l, module SM2 (Series-II) | **Expected** (same path as ST10; awaiting a live report) |
-| **SoundTouch 30** | TI AM335x ARMv7l (SM2 or scm) | **Expected** (untested) |
+| **SoundTouch 20** | TI AM335x ARMv7l, module SM2 (codename still `spotty`) | **Expected**: provisions Wi-Fi the Series-II way (real `wlan0`), but `run.sh` still applies the whitelisted-chassis reachability path (REDIRECT `:17008`->`:8888`) because the codename is `spotty`. Awaiting a live SM2-ST20 report. |
+| **SoundTouch 30** | TI AM335x ARMv7l, module SM2, variant `mojo` | **Working** (live-confirmed via the #123 diagnostic, 2026-06-10: box healthy, agent up; full end-to-end pass pending) |
 | Wave SoundTouch IV | unknown, possibly different CPU | **Unknown** |
 | other (Soundbar, ST300, ...) | unknown | **Unknown** |
 
@@ -41,12 +41,17 @@ SoundTouch speakers on AM335x split into two families that STR has to
 provision and reach completely differently. Both run the same agent
 binary; the difference is in how Wi-Fi and external reachability work.
 
-### Series-II (classic): `rhino` / SM2 , ST10, and SM2 ST20/30
+### Series-II (classic): `rhino` (ST10) and `mojo` (ST30), module SM2
 
 - Real `wlan0` interface; STR provisions Wi-Fi the documented way
   (`/addWirelessProfile` over the box's HTTP API, or `wpa_supplicant`).
-- The STR agent's port `:8888` is reachable directly from the LAN.
+- The STR agent's port `:8888` is reachable directly from the LAN
+  (once `run.sh` punches the `INPUT ACCEPT` rule past the Bose firewall).
 - This is the original, simplest path. ST10 is the reference target.
+- Caveat for the SM2 ST20: its codename is `spotty`, and `run.sh` keys
+  the reachability treatment off the codename, so an SM2 ST20 still gets
+  the `:17008` REDIRECT (a harmless no-op if its chipset does not need
+  it). Wi-Fi provisioning still follows the `wlan0` path.
 
 ### BCO (AirPlay-capable): `taigan` (Portable) / `scm`+`spotty` (ST20)
 
@@ -91,7 +96,7 @@ while the app UI itself never offers Russian).
 
 ```sh
 uname -m              # CPU, e.g. armv7l
-cat /proc/variant     # Bose variant: rhino (ST10), taigan (Portable), spotty (ST20)
+cat /proc/variant     # Bose variant: rhino (ST10), mojo (ST30), taigan (Portable), spotty (ST20)
 hostname              # Bose hostname, often equals the variant
 # Series-II vs BCO: a real wlan0 means Series-II; Wi-Fi via eth0 + a
 # <componentCategory>SCM</componentCategory> in /info means BCO.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,7 +10,9 @@ For the security-specific roadmap see
 ## Post-1.0 (already named in CLAUDE.md)
 
 - Code signing and notarization for Windows and macOS installers.
-- Additional verified speaker models (ST20, ST30, Portable).
+- Promote the remaining model statuses to Verified (Portable is
+  Verified, ST20 spotty contributor-confirmed, ST30 live-confirmed;
+  see [`MODELS.md`](MODELS.md)).
 - Wails sandboxing on macOS and Windows.
 
 ## In-flight engineering
@@ -22,21 +24,87 @@ work. Distinct from the post-1.0 items above: scheduling here is
 
 ### Frontend refactor of `desktop-app/frontend/src/main.js`
 
-Started 2026-05-17. Goal: split the ~3500-line monolith into
-focused modules, add i18n, switch the default UI to English.
+Started 2026-05-17. Goal: split the `main.js` monolith (~3500 lines
+then, **6892 lines as of 2026-06-12**) into focused modules, add
+i18n, switch the default UI to English.
 
 | Phase | Scope | Status |
 |-------|-------|--------|
-| A | Extract leaf modules (`state`, `utils`, `localization`, `logos`, `api`) out of `main.js`. All comments and identifiers English. | merged via [#40](https://github.com/JRpersonal/streborn/pull/40) (or about to be, check the branch) |
-| B | Extract view modules: `views/box-discovery.js`, `views/presets.js`, `views/playback.js`, `views/search.js`, `views/settings.js`, `views/setup.js`, `views/footer.js`. After this `main.js` shrinks to the DOM skeleton + view dispatcher (~150 lines). | not started |
-| C | i18n system: minimal `t()` helper plus `en` and `de` bundles in `desktop-app/frontend/src/i18n/`. Locale detected from `navigator.language`, with explicit override stored in `localStorage`. **Default is English** per the global-audience rule; German remains a first-class supported locale but is no longer the implicit fallback. | not started |
-| D | Translate the remaining inline German comments and the few mixed-language handler strings still sitting in `main.js` (and any view module that ends up holding them after Phase B). Closes the CLAUDE.md "all code/comments/identifiers in English" rule. | not started, naturally falls out of Phase B+C |
+| A | Extract leaf modules (`state`, `utils`, `localization`, `logos`, `api`) out of `main.js`. All comments and identifiers English. | **done** — merged via [#40](https://github.com/JRpersonal/streborn/pull/40) |
+| B | Extract view modules + shared services along the existing section-comment seams (see the refactoring backlog below for the concrete module cut). After this `main.js` shrinks to the DOM skeleton + router + bootstrap (~600 lines; the old ~150-line estimate predates the feature growth). | not started — `src/views/` exists but is empty; `main.js` has grown to 6892 lines, which makes this the highest-leverage refactor in the repo |
+| C | i18n system: minimal `t()` helper plus `en` and `de` bundles in `desktop-app/frontend/src/i18n/`. Locale detected from `navigator.language`, with explicit override stored in `localStorage`. **Default is English** per the global-audience rule; German remains a first-class supported locale but is no longer the implicit fallback. | **done** — shipped in #46 and grown to 11 locale bundles. Caveat: 9 of the 10 non-English bundles are ~285-301 keys behind `en.json` (silent English fallback); a CI completeness check is in the refactoring backlog |
+| D | Translate the remaining inline German comments and the few mixed-language handler strings still sitting in `main.js` (and any view module that ends up holding them after Phase B). Closes the CLAUDE.md "all code/comments/identifiers in English" rule. | mostly done via the #46 i18n sweep; ~a dozen German comments remain in `main.js` (and the older on-stick scripts are still German, tracked in the backlog below) — finish when Phase B touches those regions |
 
 Why this is on the roadmap rather than just done: Phase A alone
 was ~600 lines of careful diff and surfaced six unrelated bugs
 that we durably fixed in flight (see #40). Phase B+C are bigger
 still; the right move is one PR per phase so each is reviewable
 and any regression can be bisected to its phase.
+
+### Refactoring backlog (audited 2026-06-12)
+
+Result of a full-repo refactor audit, prioritized by payoff/risk.
+Each item is a single reviewable PR; line numbers as of v0.7.21.
+
+**Correctness-adjacent (do first, small):**
+
+1. `runSSHWithFlags`/`runSSHWithFlagsStdin` race on `c.Process` and
+   can nil-deref panic when the timeout beats `Start()` (4-8 s
+   timeouts in use). Rewrite both on `exec.CommandContext`
+   (`desktop-app/install_str.go:669-732`). Same PR: nil-ctx guard
+   (`appCtx()` helper) for the five `a.ctx` parents, and start the
+   LAN-sweep drain before spawning (`app.go:737-784`).
+2. Unify the six hand-rolled reboot variants and five SSH-handshake
+   policies on the hardened forms (`sync; /sbin/reboot` detached;
+   4x retry handshake) — the #114 lesson is currently unapplied on
+   the uninstall/factory-reset/OTA paths.
+3. `webui.handleBoxSyncPresets` pushes the raw `StreamURL` instead of
+   the proxy slot URL (`webui.go:2071-2102`) — latent bug the
+   stream-URL single-source below would have prevented.
+4. Replace `boxws`'s whole-frame `strings.Contains` sniffing with one
+   typed `xml.Unmarshal` per frame: a track title containing
+   `STOP_STATE` can fire the user-stop suppressor today. This is also
+   the landing spot for the planned `presetsUpdated` parsing.
+5. Extend the SSRF dial guard to `internal/upnp`'s playlist fetches
+   (currently naked clients) via a shared `netutil` guarded-client
+   helper; fixes a short-read bug in `extractStreamFromPlaylist` on
+   the way.
+
+**Structure (mechanical, medium):**
+
+6. Single source for the box-facing loopback URLs
+   (`/stream/<slot>`, `/spotify/stream-<slot>.ogg`, `/stream/raw?u=`):
+   today stamped out at 9+ sites across `cmd/agent`, `webui`, and the
+   frontend; the v0.7.21 self-proxy regression was this class.
+7. Unify the dual Spotify recall paths (hardware
+   `playSpotifyPreset` vs app `handlePlaySlot`) into one orchestrator:
+   they have already drifted (the soft verify still carries the
+   restart-on-re-Play bug the hardware path fixed in v0.7.4).
+8. File splits, pure moves, no behavior change: `desktop-app/app.go`
+   (3158 lines -> ~10 files incl. `boxssh.go` for the SSH transport
+   shared by 6 features), `cmd/agent/main.go` (2026 lines),
+   `internal/webui/webui.go` (2485 lines), `internal/spotify/manager.go`
+   (1510 lines), `internal/streamproxy/streamproxy.go` (1052 lines).
+9. Frontend Phase B (see table above): cut `main.js` along its
+   existing section comments into ~9 view modules + 6 services;
+   pre-step: decompose the 910-line `renderBoxSettings`. Delete the
+   dead `checkBoxUpdate` (its banner element no longer exists).
+
+**Guardrails (CI, small):**
+
+10. CI is blind to the `desktop-app` Go module (no vet/test/lint runs
+    there; a live `go vet` finding exists) — add working-directory
+    steps. Add a `wails generate module` freshness check (known
+    recurring gotcha) and an i18n key-completeness report. Run
+    `busybox sh -n` over `run.sh` next to shellcheck.
+11. Tests for the privacy sanitizers in `logexport.go`
+    (anonymize IP/MAC/SSID/serial) — a silent regression there leaks
+    user data into public issue attachments. Then: boxws frame
+    parser, upnp SOAP golden tests, version helpers.
+12. `usb-stick/run.sh` (3461 lines): keep single-file (the
+    rc.local copy chain forbids sourcing siblings) but add a
+    table-of-contents header, the BusyBox parse gate above, and a
+    parity test for the duplicated `lang_int_for_cc` table.
 
 ## Under consideration
 
@@ -131,25 +199,30 @@ Hard requirements that must hold before this ships:
 
 Tracked as a GitHub issue under the `enhancement` label.
 
-**Status:** Level 2 was partially shipped in v0.5.17 as
-`TrueFactoryReset` (commit `5ddc6e8`). The button lives at Speaker
-Settings → Actions and wipes Bose's persistence files plus STR's
-NAND wlan-creds before rebooting, so the speaker returns to clean
-OOB state. The bigger wizard with level 1 (presets reset) and
-level 3 (full STR uninstall) is still open.
+**Status:** Level 2 shipped in v0.5.17 as `TrueFactoryReset`
+(commit `5ddc6e8`); level 3 shipped as `UninstallSTR` (Speaker
+Settings → Remove STR, with a stick-present safeguard; removes
+`/mnt/nv/streborn/` and the boot override). Only level 1 (reset STR
+data only) is still open. Both shipped levels currently ride the
+pre-1.0 SSH channel; before the v1.0 SSH hardening lands they must
+migrate to a dedicated agent reset endpoint (see the requirement
+above), after which SSH becomes opt-in.
 
 ### Other ideas (loose)
 
 - Android version of the same PWA, with the same feasibility caveats
   except Android allows arbitrary CA install slightly more easily.
-- Multi-room grouping across speakers using the speaker's existing
-  local zone API on port 8090 (no cloud involved). Tracked as a
-  separate issue with a research write-up.
-- Spotify Connect on the speaker, tracked in
-  [#78](https://github.com/JRpersonal/streborn/issues/78). Several
-  plausible paths (librespot on-box, librespot in the Wails backend,
-  Spotify Web API). Post-1.0 spike, all paths blocked by the loss of
-  the Bose-Spotify OEM partner credentials.
+- Multi-room grouping: **shipped as alpha** since the v0.7.x line
+  ([#70](https://github.com/JRpersonal/streborn/issues/70)) — native
+  `/setZone` plus a per-agent mirror fallback, NAND-persisted zones
+  with auto-reform, stereo pairs. Remaining: promote out of alpha
+  after broader hardware feedback.
+- Spotify Connect: **shipped as beta** since the v0.7.x line
+  ([#78](https://github.com/JRpersonal/streborn/issues/78)) via a
+  supervised go-librespot sidecar with Ogg passthrough, per-slot
+  stream URLs, Spotify presets and multi-account. Remaining: promote
+  out of beta (stability), native multi-account upstream (fork issue
+  #1), upstreaming the passthrough patch (devgianlu PR #316).
 - Additional streaming providers, tracked in
   [#103](https://github.com/JRpersonal/streborn/issues/103). STR plays
   radio and Spotify today; SoundCloud, Amazon Music and **Deezer** are

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -150,3 +150,21 @@ level 3 (full STR uninstall) is still open.
   plausible paths (librespot on-box, librespot in the Wails backend,
   Spotify Web API). Post-1.0 spike, all paths blocked by the loss of
   the Bose-Spotify OEM partner credentials.
+- Additional streaming providers, tracked in
+  [#103](https://github.com/JRpersonal/streborn/issues/103). STR plays
+  radio and Spotify today; SoundCloud, Amazon Music and **Deezer** are
+  candidates. **Deezer is wanted** by users whose existing Deezer
+  station-key presets still work after the Bose shutdown (the cloud
+  source survived where radio did not). Two distinct pieces:
+  - **Preserve, then import.** As of v0.7.21 an STR install no longer
+    overwrites existing speaker presets, so Deezer keys survive an
+    install untouched. The next step is reading the existing Deezer
+    `ContentItem` location out of the box's preset XML (visible over the
+    box API / in `presetsUpdated` frames) so STR can show and keep them
+    even when the user has not set them in STR. This is the same
+    box-side preset-state parsing that would also help preset recall and
+    box/app sync, so it is worth doing once, generally.
+  - **Create new Deezer presets** from STR. This needs a Deezer
+    integration (auth + the playable URL shape) and is the larger,
+    later piece. First action is collecting an anonymised example of a
+    working Deezer preset URL from a user's box XML to learn the format.

--- a/docs/STICK-INSTALL-WITHOUT-SSH.md
+++ b/docs/STICK-INSTALL-WITHOUT-SSH.md
@@ -1,6 +1,6 @@
 # Proposal: first install over the stick boot path instead of app SSH
 
-Status: evaluation, not yet decided. Tracked in a GitHub issue.
+Status: Track 1 (gated in-app auto-install) shipped; Track 2 (true no-SSH first-boot bootstrap) still open, hardware experiment pending. Tracked in a GitHub issue.
 
 ## Problem
 
@@ -35,7 +35,7 @@ region, name and presets, announces over mDNS on :8888, and mirrors a
 `setup.log` back to the stick every 25 s.
 
 The **SSH `install.sh` does almost nothing on top of that.** It copies
-four things to NAND: `rc.local`, `run-override.sh`, and (first install
+three things to NAND: `rc.local`, `run-override.sh`, and (first install
 only) `presets.json`. Everything else is the boot path's job.
 
 But the one thing it does is the decisive one: it **seeds the first-boot
@@ -107,9 +107,12 @@ is the ceiling and SSH stays.
 - **Status without an SSH channel:** already solved. `run.sh` mirrors
   `setup.log` to the stick every 25 s, and the agent answers on :8888
   once up. The app can read both without SSH.
-- **Security:** an automatic/boot-path install does not widen the SSH
-  window; `run.sh` already stops sshd after unmount. Track 1 keeps the
-  same window; Track 2 would shrink it further.
+- **Security:** an automatic/boot-path install changes nothing about the
+  current SSH exposure. Pre-1.0, `run.sh` (`ensure_sshd_running`) keeps
+  sshd running on every boot as a deliberate debug-visibility choice (so
+  diagnostics and repair work when the agent is down); the planned v1.0
+  hardening flips this to opt-in via a stick marker. Track 1 and Track 2
+  are both neutral to that window.
 - **Fallback:** keep the manual SSH install as an expert path in case the
   automatic path does not engage.
 


### PR DESCRIPTION
Documentation refresh: a full audit of every repo doc against the current code (a 19-agent audit on 2026-06-12), plus the Deezer/additional-providers roadmap entry.

## What drifted and is now corrected
- **CLAUDE.md / docs/ARCHITECTURE.md**: the diagram and component map predated Spotify Connect (beta), HLS radio conversion, `/api/stream-status` + alternative-source retry, the real ~28-route REST surface, the OTA flow (HTTP + SSH fallback, pre-reboot stick refresh, post-OTA STR pin), webhooks, multiroom zones, the DLNA library, and app-side radio search. The chassis model is fixed (sm2 direct vs whitelisted `:17008` REDIRECT, not "BCO only"), along with `/api/status` (cached XML), distribution formats (no InnoSetup/AppImage), Go 1.25, 11 locales, stick config filenames, and the NAND storage layout.
- **README / SECURITY / THREAT-MODEL**: the pre-1.0 SSH posture is now documented honestly (STR keeps `sshd` up on every boot; the yellow banner is a stick-removal reminder, not an SSH-state indicator), the "loopback-only" framing is corrected, the privacy sections reflect app-side radio + Spotify + favicon traffic, Uninstall STR is shipped, asset names are versioned, and the `safeHTTPURL` + `isLocalLAN` mitigations and the go-librespot trust boundary are added.
- **ROADMAP**: Spotify (beta), multiroom (alpha), i18n phase C, and Uninstall STR are marked shipped; `main.js` size refreshed; a prioritized **refactoring backlog** from the audit is added. Plus the Deezer / additional-providers entry (Refs #103).
- **MODELS / MODEL-VARIANTS / FIRMWARE-NOTES / STICK-INSTALL**: ST30 `mojo` live-confirmed, the `spotty`-vs-sm2 reachability nuance, the broadened shim-skip, the Series-I/II label-inversion note, a deduped repeated block, and the corrected SSH/"four files" claims.

## Small code-accuracy fixes riding along
- `desktop-app/radio.go`: stale header comment claimed the agent still serves `/api/radio` (it does not).
- `fix(settings)`: the reboot dialog falsely claimed removing the stick closes SSH; reworded (EN/DE).

Docs-only plus two tiny accuracy fixes. The refactoring backlog in ROADMAP.md is the actionable output for follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
