### PR TITLE
fix(library): correct codec MIME so non-MP3 NAS tracks play (#139); demote bursty logs

### DIFF
--- a/desktop-app/app.go
+++ b/desktop-app/app.go
@@ -1714,12 +1714,13 @@ func (a *App) waitAgentReady(host string, port int) bool {
 // PlayURL triggert POST /api/play mit beliebigem Stream URL. icon ist
 // die Sender Logo URL (wird auf der Box angezeigt), uuid ermoeglicht
 // dass radio-browser den Klick zaehlt.
-func (a *App) PlayURL(host string, port int, streamURL, title, icon, uuid string) error {
+func (a *App) PlayURL(host string, port int, streamURL, title, icon, uuid, mime string) error {
 	body, _ := json.Marshal(map[string]string{
 		"url":   streamURL,
 		"title": title,
 		"icon":  icon,
 		"uuid":  uuid,
+		"mime":  mime,
 	})
 	resp, err := a.playPost(host, port, "/api/play", string(body))
 	if err != nil {

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -3399,7 +3399,7 @@ async function playStation(s) {
 
     let fail = null;
     try {
-      await PlayURL(box.host, box.port, url, s.name, chain, cur.stationuuid || '');
+      await PlayURL(box.host, box.port, url, s.name, chain, cur.stationuuid || '', '');
       if (cur.stationuuid) { try { RadioClick(cur.stationuuid); } catch {} }
       // Refresh the now-playing bar promptly on the happy path; the upstream
       // verdict (success vs 403/503) arrives asynchronously, so poll for it.
@@ -6704,8 +6704,10 @@ async function libraryPlay(item) {
     return;
   }
   try {
+    // Pass the track's real codec MIME so the box decodes FLAC/ALAC/M4A
+    // correctly instead of being told audio/mpeg and rejecting it (#139).
     await PlayURL(state.currentBox.host, state.currentBox.port,
-      item.streamURL, item.title || '', item.albumArtURL || '', '');
+      item.streamURL, item.title || '', item.albumArtURL || '', '', item.mimeType || '');
     showToast(t('library.toastPlaying') + ': ' + (item.title || ''));
     // Confirm it actually starts (see verifyLibraryPlayback, #139).
     verifyLibraryPlayback(item);

--- a/desktop-app/frontend/wailsjs/go/main/App.d.ts
+++ b/desktop-app/frontend/wailsjs/go/main/App.d.ts
@@ -73,7 +73,7 @@ export function Pause(arg1:string,arg2:number):Promise<void>;
 
 export function PlaySlot(arg1:string,arg2:number,arg3:number):Promise<void>;
 
-export function PlayURL(arg1:string,arg2:number,arg3:string,arg4:string,arg5:string,arg6:string):Promise<void>;
+export function PlayURL(arg1:string,arg2:number,arg3:string,arg4:string,arg5:string,arg6:string,arg7:string):Promise<void>;
 
 export function ProbeSetupAP():Promise<main.BoxInfo|boolean>;
 

--- a/desktop-app/frontend/wailsjs/go/main/App.js
+++ b/desktop-app/frontend/wailsjs/go/main/App.js
@@ -138,8 +138,8 @@ export function PlaySlot(arg1, arg2, arg3) {
   return window['go']['main']['App']['PlaySlot'](arg1, arg2, arg3);
 }
 
-export function PlayURL(arg1, arg2, arg3, arg4, arg5, arg6) {
-  return window['go']['main']['App']['PlayURL'](arg1, arg2, arg3, arg4, arg5, arg6);
+export function PlayURL(arg1, arg2, arg3, arg4, arg5, arg6, arg7) {
+  return window['go']['main']['App']['PlayURL'](arg1, arg2, arg3, arg4, arg5, arg6, arg7);
 }
 
 export function ProbeSetupAP() {

--- a/internal/boxws/boxws.go
+++ b/internal/boxws/boxws.go
@@ -523,7 +523,11 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 		for _, p := range f.PresetsUpdated.Presets {
 			slots = append(slots, p.ID)
 		}
-		c.logger.Info("box ws: presetsUpdated", "count", len(slots), "slots", strings.Join(slots, ","))
+		// DEBUG, not INFO: the box re-emits presetsUpdated in bursts (~20x around
+		// boot / a preset sync), and the MultiWriter logger appends every line to
+		// the NAND log, so an INFO burst is a stack of rapid NAND writes for no
+		// diagnostic gain. The slots are still captured at DEBUG when needed.
+		c.logger.Debug("box ws: presetsUpdated", "count", len(slots), "slots", strings.Join(slots, ","))
 	case f.ZoneUpdated != nil:
 		// The box's multiroom zone / stereo pair changed. Previously this frame
 		// fell through as an "unrecognized frame" (Klaus 2026-06-12), so STR was
@@ -598,7 +602,11 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 			if strings.Contains(pe.Inner, "DO_NOT_RESUME") {
 				c.logger.Info("box ws: standby wake / source teardown signalled DO_NOT_RESUME, not resuming")
 			} else {
-				c.logger.Info("box self-activation rejected preset (shows 'service unavailable')",
+				// DEBUG: the box emits this id=0 INVALID_SOURCE self-activation after
+				// EVERY hardware preset press (the actual press is logged at INFO
+				// just below), so at INFO it doubled the NAND writes per press for no
+				// extra signal.
+				c.logger.Debug("box self-activation rejected preset (shows 'service unavailable')",
 					"id", pe.ID, "source", pe.ContentItem.Source,
 					"location", pe.ContentItem.Location, "preview", preview(data, 240))
 			}

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -608,6 +608,10 @@ type playRequest struct {
 	Title string `json:"title"`
 	Icon  string `json:"icon"` // albumArtURI fuer Box Display
 	UUID  string `json:"uuid"` // optional, fuer Click Tracking
+	// Mime is the source codec MIME (audio/flac, audio/mp4, ...) for a network
+	// library track, so the box decodes it correctly. Empty for radio -> the
+	// renderer defaults to audio/mpeg.
+	Mime string `json:"mime"`
 }
 
 // handleWebhooks gets (GET) or replaces (PUT) the webhook config. The config
@@ -696,15 +700,26 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request) {
 	// HTTPS Quellen (Bose UPnP kann kein TLS) und Token Expiry wird
 	// transparent abgefangen. Bose sieht eine stabile loopback URL.
 	playURL := boxurl.RawStream(req.URL)
-	if err := s.renderer.PlayURL(r.Context(), playURL, req.Title, req.Icon); err != nil {
+	// Advertise the real codec to the box when the caller knows it (a network
+	// library track carries its DLNA-reported MIME, e.g. audio/flac, audio/mp4).
+	// Radio leaves it empty and defaults to audio/mpeg. The box keys its decoder
+	// off this protocolInfo MIME, so a FLAC/ALAC/M4A file mislabelled as
+	// audio/mpeg is rejected (AUDIO_ERROR_BAD_URL) while an MP3 plays (#139).
+	var playErr error
+	if req.Mime != "" {
+		playErr = s.renderer.PlayURLMime(r.Context(), playURL, req.Title, req.Icon, req.Mime)
+	} else {
+		playErr = s.renderer.PlayURL(r.Context(), playURL, req.Title, req.Icon)
+	}
+	if playErr != nil {
 		writeJSON(w, http.StatusBadGateway, map[string]string{
 			"error":  "Station could not be played",
-			"detail": guessErrorReason(err),
+			"detail": guessErrorReason(playErr),
 			"url":    req.URL,
 		})
 		return
 	}
-	s.setLastPlay(playURL, req.Title, req.Icon, "")
+	s.setLastPlay(playURL, req.Title, req.Icon, req.Mime)
 	// radio-browser click-tracking moved app-side (the app fires RadioClick
 	// when it starts playback) so the box no longer needs the radiobrowser pkg.
 	writeJSON(w, http.StatusOK, map[string]string{"status": "playing", "url": req.URL})


### PR DESCRIPTION
## #139: non-MP3 network-library tracks rejected
Library tracks were always announced to the speaker as audio/mpeg regardless of codec, so an MP3 played while a FLAC/ALAC/M4A of the same bit depth and sample rate was rejected (matches Rich's 'whole albums play or don't', codec confirmed as the differentiator). Thread the DLNA-reported MIME from the library browse through PlayURL to the renderer's MIME-aware DIDL; radio stays audio/mpeg. (PlayURL gained a mime arg; wailsjs regenerated.)

## NAND write reduction
Demote the box's presetsUpdated burst (~20 lines around boot/sync) and the per-press id=0 INVALID_SOURCE self-activation log to DEBUG. The logger appends every line to the NAND log, so these bursts were rapid NAND writes for no diagnostic gain. Idle now writes nothing; a preset press writes one line, not two.

(Profiling on a Portable: agent CPU <=3% for radio plain + HLS, RAM stable except a mild HLS downward trend to investigate, idle NAND log growth zero.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)