### PR TITLE
fix(install): network install no longer fails with a false copy error

### DIFF
--- a/desktop-app/boxssh.go
+++ b/desktop-app/boxssh.go
@@ -84,6 +84,18 @@ var nullDevice = func() string {
 // re-flashed box; (b) the connection is over the user's home LAN
 // to a device whose IP they just selected from a discovery list —
 // there is no realistic MITM vector to defend against.
+//
+// LogLevel=ERROR is the necessary companion to those two and is also
+// in every set. With UserKnownHostsFile=/dev/null the host is never
+// remembered, so OpenSSH prints "Warning: Permanently added '<host>'
+// (<key>) to the list of known hosts." on stderr on EVERY connect.
+// CombinedOutput folds that INFO-level banner in ahead of the remote
+// command's stdout, and the SSH NAND-install fallback's byte-count
+// verify read the banner as part of the count and failed a
+// byte-perfect transfer as "truncated" (ST30 stick-power, 13.06). ERROR
+// drops that INFO banner while still surfacing every
+// negotiation/auth/host-key error classifySSHError keys on (those are
+// ERROR/FATAL level); QUIET would hide those too, so ERROR not QUIET.
 var sshFlagSets = [][]string{
 	// Set 1: full-legacy
 	{
@@ -94,6 +106,7 @@ var sshFlagSets = [][]string{
 		"-oStrictHostKeyChecking=no",
 		"-oUserKnownHostsFile=" + nullDevice,
 		"-oGlobalKnownHostsFile=" + nullDevice,
+		"-oLogLevel=ERROR",
 		"-oBatchMode=yes",
 		"-oConnectTimeout=8",
 		"-oServerAliveInterval=5",
@@ -105,6 +118,7 @@ var sshFlagSets = [][]string{
 		"-oStrictHostKeyChecking=no",
 		"-oUserKnownHostsFile=" + nullDevice,
 		"-oGlobalKnownHostsFile=" + nullDevice,
+		"-oLogLevel=ERROR",
 		"-oBatchMode=yes",
 		"-oConnectTimeout=8",
 	},
@@ -112,6 +126,7 @@ var sshFlagSets = [][]string{
 	{
 		"-oStrictHostKeyChecking=no",
 		"-oUserKnownHostsFile=" + nullDevice,
+		"-oLogLevel=ERROR",
 		"-oBatchMode=yes",
 		"-oConnectTimeout=8",
 	},

--- a/desktop-app/install_str.go
+++ b/desktop-app/install_str.go
@@ -570,13 +570,27 @@ func (a *App) stageRepairFiles(host, stageDir string, files map[string][]byte) e
 			}
 			// Byte-count check catches a truncated transfer, the common
 			// weak-Wi-Fi failure mode, without a full checksum the BusyBox on
-			// the box may not carry.
+			// the box may not carry. Parse the number out of the SSH output
+			// instead of string-matching the whole blob: OpenSSH folds its
+			// "Warning: Permanently added ... to the list of known hosts."
+			// banner (local stderr, forced every connect by
+			// UserKnownHostsFile=/dev/null) in ahead of wc's number via
+			// CombinedOutput, and an exact-match compare then read a
+			// byte-perfect upload as "truncated" and falsely failed the whole
+			// SSH NAND-install fallback for ST30 stick-power users (13.06).
+			// LogLevel=ERROR now suppresses that banner at the source,
+			// but parsing the count keeps the check correct against any
+			// residual stderr noise regardless.
 			got, _ := boxSSHOutput(host, "wc -c < "+dst+" 2>/dev/null", 10*time.Second)
-			if strings.TrimSpace(got) == strconv.Itoa(len(data)) {
+			if n, ok := lastIntField(got); ok && n == int64(len(data)) {
 				lastErr = nil
 				break
 			}
-			lastErr = fmt.Errorf("upload %s truncated: speaker received %s of %d bytes", name, strings.TrimSpace(got), len(data))
+			recv := "no byte count"
+			if n, ok := lastIntField(got); ok {
+				recv = strconv.FormatInt(n, 10)
+			}
+			lastErr = fmt.Errorf("upload %s truncated: speaker received %s of %d bytes", name, recv, len(data))
 		}
 		if lastErr != nil {
 			return lastErr
@@ -584,6 +598,32 @@ func (a *App) stageRepairFiles(host, stageDir string, files map[string][]byte) e
 	}
 	_, _ = boxSSHOutput(host, "chmod +x "+stageDir+"/install.sh "+stageDir+"/run.sh "+stageDir+"/streborn-armv7l 2>/dev/null", 15*time.Second)
 	return nil
+}
+
+// lastIntField returns the LAST whitespace-separated token in out that parses as
+// a non-negative integer. The box prints exactly one integer for the commands
+// that use this (`wc -c` for the upload byte-count verify, `grep -c` for the CPU
+// core count), so the last such token is that number even when local SSH noise
+// is folded in ahead of it by CombinedOutput: with UserKnownHostsFile=/dev/null
+// OpenSSH prints "Warning: Permanently added '<host>' (<key>) to the list of
+// known hosts." on stderr at connect time, which lands before the remote stdout.
+// Scanning for the last integer (rather than string-matching the whole blob or
+// trusting a fixed field index) keeps these checks correct against that banner
+// and any other pre-stdout noise; the banner's own tokens never parse as
+// integers (the host is quoted and dotted), so they are ignored regardless of
+// ordering. Returns (0, false) when no integer token is present, e.g. the remote
+// command produced nothing (a missing file, so the redirect failed), which
+// callers treat as "unreadable" / a failed transfer.
+func lastIntField(out string) (int64, bool) {
+	var n int64
+	var ok bool
+	for _, f := range strings.Fields(out) {
+		if v, err := strconv.ParseInt(f, 10, 64); err == nil && v >= 0 {
+			n = v
+			ok = true
+		}
+	}
+	return n, ok
 }
 
 // repairStageCandidates are the on-box staging targets for the SSH repair, in
@@ -845,12 +885,17 @@ func boxInstallDiag(host string) string {
 
 // boxCoreCount reads the CPU count from /proc/cpuinfo so the load threshold can
 // be scaled per core. Defaults to 1 on any read error (the SoundTouch SoCs are
-// single- or dual-core, so 1 is the safe conservative floor).
+// single- or dual-core, so 1 is the safe conservative floor). grep -c prints a
+// single integer, parsed with the banner-tolerant lastIntField rather than
+// Atoi(TrimSpace(out)): the latter chokes on the multi-line blob when the
+// known_hosts warning is folded in by CombinedOutput, which silently dropped
+// every box to the 1-core floor (an over-strict settle threshold) before
+// LogLevel=ERROR suppressed the banner.
 func boxCoreCount(host string) int {
 	out, err := boxSSHOutput(host, "grep -c ^processor /proc/cpuinfo", 8*time.Second)
 	if err == nil {
-		if n, e := strconv.Atoi(strings.TrimSpace(out)); e == nil && n > 0 {
-			return n
+		if n, ok := lastIntField(out); ok && n > 0 {
+			return int(n)
 		}
 	}
 	return 1
@@ -863,15 +908,36 @@ func boxLoad1(host string) (float64, bool) {
 	if err != nil {
 		return 0, false
 	}
-	fields := strings.Fields(out)
-	if len(fields) < 1 {
-		return 0, false
+	return parseLoadAvg(out)
+}
+
+// parseLoadAvg extracts the 1-minute load average from `cat /proc/loadavg`
+// output. /proc/loadavg is a single stdout line whose first field is the 1-min
+// average ("0.42 0.31 0.20 1/80 1234"), so this reads the first field of the
+// LAST non-empty line: any local SSH noise CombinedOutput folds in (the
+// "Warning: Permanently added ... to the list of known hosts." banner forced by
+// UserKnownHostsFile=/dev/null) lands on an earlier line and is skipped.
+// Returns (0, false) when the last non-empty line's first field is not a
+// non-negative float, e.g. /proc/loadavg was unreadable so only the banner
+// remains. The banner-tolerance matters: a (0, false) here makes waitForBoxLoad
+// skip the load-settle gate entirely (the #119 ST30 install-timeout mitigation),
+// so before LogLevel=ERROR the banner silently disabled that gate on every box.
+// LogLevel=ERROR suppresses the banner at the source now; parsing defensively
+// keeps the gate working if it ever reappears, matching lastIntField.
+func parseLoadAvg(out string) (float64, bool) {
+	lines := strings.Split(out, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		v, err := strconv.ParseFloat(strings.Fields(line)[0], 64)
+		if err != nil || v < 0 {
+			return 0, false
+		}
+		return v, true
 	}
-	v, err := strconv.ParseFloat(fields[0], 64)
-	if err != nil {
-		return 0, false
-	}
-	return v, true
+	return 0, false
 }
 
 // stickCopyFailureMarkers are the exact run.sh log lines that prove the agent

--- a/desktop-app/install_str_test.go
+++ b/desktop-app/install_str_test.go
@@ -106,6 +106,119 @@ func TestSSHFlagSetsAllSetBatchModeAndStrictHostKeyOff(t *testing.T) {
 	}
 }
 
+// TestSSHFlagSetsSuppressKnownHostsBanner locks -oLogLevel=ERROR onto every set
+// in the chain. Without it, UserKnownHostsFile=/dev/null makes OpenSSH print
+// "Warning: Permanently added '<host>' (<key>) to the list of known hosts." on
+// stderr every connect (the host is never remembered), and CombinedOutput folds
+// that INFO banner into the byte count the SSH NAND-install verify parses,
+// flipping a byte-perfect transfer to a false "truncated" and making the ST30
+// stick-power fallback useless (13.06). ERROR, not QUIET: it drops the
+// INFO banner while still surfacing the negotiation/auth/host-key errors
+// classifySSHError keys on (those are ERROR/FATAL level).
+func TestSSHFlagSetsSuppressKnownHostsBanner(t *testing.T) {
+	for i, set := range sshFlagSets {
+		joined := strings.ToLower(strings.Join(set, "\n"))
+		if !strings.Contains(joined, "-ologlevel=error") {
+			t.Errorf("sshFlagSets[%d] missing -oLogLevel=ERROR; the known_hosts banner "+
+				"will leak into parsed SSH output and falsely fail the NAND-install verify as 'truncated'", i)
+		}
+		if strings.Contains(joined, "-ologlevel=quiet") {
+			t.Errorf("sshFlagSets[%d] uses LogLevel=QUIET which also hides the real "+
+				"negotiation/auth/host-key errors classifySSHError needs; use ERROR", i)
+		}
+	}
+}
+
+// TestLastIntFieldIgnoresKnownHostsBanner guards the banner-tolerant integer
+// parse shared by the SSH NAND-install byte-count verify and the CPU core-count
+// read against the known_hosts banner leak (ST30 stick-power, 13.06): the box
+// reports a single integer (`wc -c` byte count, `grep -c` core count), but
+// OpenSSH's "Warning: Permanently added '192.0.2.47' (RSA) to the list of known
+// hosts." banner is folded in ahead of it by CombinedOutput. The parse must read
+// the actual integer, not string-match the whole blob, or the verify falsely
+// reports "truncated" (and the whole stick-power fallback is useless) and the
+// core count silently floors to 1. The "leading numeric noise" case pins the
+// load-bearing LAST-token contract: a first-token refactor must fail here.
+func TestLastIntFieldIgnoresKnownHostsBanner(t *testing.T) {
+	cases := []struct {
+		name   string
+		out    string
+		want   int64
+		wantOK bool
+	}{
+		{name: "clean number", out: "11600034\n", want: 11600034, wantOK: true},
+		{
+			name: "known_hosts banner then number (the bug)",
+			out:  "Warning: Permanently added '192.0.2.47' (RSA) to the list of known hosts.\r\n11600034\n",
+			want: 11600034, wantOK: true,
+		},
+		{
+			name: "small file with banner (version.txt, 23 bytes)",
+			out:  "Warning: Permanently added '192.0.2.47' (RSA) to the list of known hosts.\r\n23\n",
+			want: 23, wantOK: true,
+		},
+		{name: "leading whitespace from busybox wc", out: "      2931\n", want: 2931, wantOK: true},
+		// Pins LAST-token semantics: a stray integer line ahead of the count (a
+		// future verbose/DEBUG ssh notice, or an extra field in a changed verify
+		// command) must not be mistaken for the count. A first-token parser fails
+		// this case; the last-token parser the docstring promises passes it.
+		{name: "leading numeric noise before the count", out: "3\n11600034\n", want: 11600034, wantOK: true},
+		// grep -c core count: single small integer, same parse.
+		{name: "core count with banner", out: "Warning: Permanently added '192.0.2.47' (RSA) to the list of known hosts.\r\n2\n", want: 2, wantOK: true},
+		{
+			name: "banner only, remote file missing so wc produced nothing",
+			out:  "Warning: Permanently added '192.0.2.47' (RSA) to the list of known hosts.\r\n",
+			want: 0, wantOK: false,
+		},
+		{name: "empty output", out: "", want: 0, wantOK: false},
+		{name: "zero-byte file / grep -c no match", out: "0\n", want: 0, wantOK: true},
+	}
+	for _, c := range cases {
+		got, ok := lastIntField(c.out)
+		if got != c.want || ok != c.wantOK {
+			t.Errorf("%s: lastIntField(%q) = (%d, %v), want (%d, %v)",
+				c.name, c.out, got, ok, c.want, c.wantOK)
+		}
+	}
+}
+
+// TestParseLoadAvgIgnoresKnownHostsBanner guards the load-settle gate's
+// /proc/loadavg parse against the same banner leak. boxLoad1 read fields[0] of
+// the first line, so the folded-in "Warning: Permanently added ..." banner made
+// it return "can't read load" on every box, silently disabling the load-settle
+// gate (the #119 ST30 install-timeout mitigation). parseLoadAvg reads the first
+// field of the LAST non-empty line instead, so the gate keeps working even if
+// the banner ever reappears past LogLevel=ERROR.
+func TestParseLoadAvgIgnoresKnownHostsBanner(t *testing.T) {
+	cases := []struct {
+		name   string
+		out    string
+		want   float64
+		wantOK bool
+	}{
+		{name: "clean loadavg", out: "0.42 0.31 0.20 1/80 1234\n", want: 0.42, wantOK: true},
+		{
+			name: "banner then loadavg (the latent bug)",
+			out:  "Warning: Permanently added '192.0.2.47' (RSA) to the list of known hosts.\r\n0.42 0.31 0.20 1/80 1234\n",
+			want: 0.42, wantOK: true,
+		},
+		{name: "zero load", out: "0.00 0.01 0.05 1/60 900\n", want: 0.0, wantOK: true},
+		{
+			name: "banner only, loadavg unreadable",
+			out:  "Warning: Permanently added '192.0.2.47' (RSA) to the list of known hosts.\r\n",
+			want: 0, wantOK: false,
+		},
+		{name: "empty output", out: "", want: 0, wantOK: false},
+	}
+	for _, c := range cases {
+		got, ok := parseLoadAvg(c.out)
+		if ok != c.wantOK || got != c.want {
+			t.Errorf("%s: parseLoadAvg(%q) = (%v, %v), want (%v, %v)",
+				c.name, c.out, got, ok, c.want, c.wantOK)
+		}
+	}
+}
+
 // TestClassifySSHErrorRecognizesBadOption guards the user-facing
 // error path that was the single most useful diagnostic in #60:
 // when the local ssh refuses one of our flags with "Bad
@@ -148,7 +261,7 @@ func TestExtractBadOptionParsesOpenSSHFormat(t *testing.T) {
 
 // TestDetectStickCopyFailureMatchesRunShMarkers guards the install-time
 // diagnosis of the "agent never started because the binary could not be copied
-// off a flaky stick" failure (CHI Wong ST30, 13.06). install.sh succeeds, the
+// off a flaky stick" failure (ST30 stick-copy, 13.06). install.sh succeeds, the
 // box reboots, run.sh's stick->NAND copy hits an I/O error, and with no prior
 // NAND cache run.sh exits. Without this the desktop showed a generic "agent not
 // up". The strings here MUST stay byte-identical to what usb-stick/run.sh logs;


### PR DESCRIPTION
## Problem

When the USB stick can't be read during install (e.g. a SoundTouch 30 whose USB port can't keep the stick powered), STR falls back to installing directly over the network over SSH (#149). That fallback stages each file onto the box and verifies it by byte count. The verify failed with `upload streborn-armv7l truncated: speaker received ... 11600034 of 11600034 bytes` even though the received and expected counts were identical, so the rescue path was unusable for the whole ST30 stick-power class.

## Root cause

`boxSSHOutput` returns `exec.CombinedOutput`, which folds OpenSSH's local-stderr banner

```
Warning: Permanently added '<host>' (RSA) to the list of known hosts.
```

in front of the box's `wc -c` number. The flag sets use `UserKnownHostsFile=/dev/null` + `StrictHostKeyChecking=no`, so the host is never remembered and the banner prints on every connect. The verify compared `TrimSpace(got) == strconv.Itoa(len(data))`, which never matched once the banner was prepended.

## Fix (defense in depth)

- `boxssh.go`: add `-oLogLevel=ERROR` to all three SSH flag sets, suppressing the INFO banner at the source for every SSH call. `ERROR` (not `QUIET`) keeps the negotiation/auth/host-key errors `classifySSHError` depends on.
- `install_str.go`: verify by parsing the last integer token (`lastIntField`) instead of string-matching the whole blob, so any residual stderr noise can't flip a byte-perfect transfer to "truncated".

## Hardening

The same banner silently corrupted the sibling parsers in this SSH-output family. Notably `boxLoad1` returned "can't read load" on every box, which made the install load-settle gate (the #119 ST30 timeout mitigation) a no-op. Hardened `boxLoad1` (`parseLoadAvg`) and `boxCoreCount` (reuses `lastIntField`) to match.

## Tests

New regression tests pin the `LogLevel=ERROR` contract, the last-token parse semantics (a first-token refactor now fails CI), and the load-average parse against the banner. `go test ./...` green, `go vet` + `gofmt` clean.

Refs #149