### PR TITLE
fix(radio): "Bose-compatible only" no longer hides playable HLS stations

### DIFF
--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -3221,7 +3221,7 @@ function favMinimal(s) {
   return {
     stationuuid: s.stationuuid, name: s.name, url: s.url, url_resolved: s.url_resolved,
     bitrate: s.bitrate || 0, country: s.country, countrycode: s.countrycode,
-    codec: s.codec, tags: s.tags, votes: s.votes || 0, homepage: s.homepage,
+    codec: s.codec, hls: s.hls || 0, tags: s.tags, votes: s.votes || 0, homepage: s.homepage,
     favicon: s.favicon, lastcheckok: s.lastcheckok,
   };
 }
@@ -3376,18 +3376,27 @@ function cleanForSort(name) {
   return (stripped || raw).toLowerCase().trim();
 }
 
-// isBoseCompatible estimates whether the speaker can reliably play
-// the stream. Since stick-agent build 0132 every stream goes through
-// /stream/raw, which removes the TLS concerns. We only check the
-// codec now:
-//   - MP3 / AAC / AACP / MPEG work
-//   - Ogg / Opus / FLAC the Bose player cannot decode
-// Conservative: when the codec is unknown we let the station
-// through.
+// isBoseCompatible estimates whether the speaker can reliably play the stream.
+// Since stick-agent build 0132 every stream goes through /stream/raw (TLS is no
+// longer a concern), and since v0.7.21 STR converts HLS playlists on the fly, so
+// HLS stations play too. So:
+//   - HLS streams (radio-browser hls=1, or an .m3u8 URL) play via STR's HLS
+//     conversion, regardless of the segment codec
+//   - MP3 / AAC / AAC+ / AACP / MPEG the box decodes directly
+//   - Ogg / Opus / FLAC neither the box nor the proxy can decode
+//   - an unknown codec ("UNKNOWN" or empty) is let through, the box tries it
+// radio-browser reports the BBC HLS stations (Radio 2/4, which play since
+// v0.7.21) as codec "UNKNOWN" with hls=1, and the old check dropped both: it
+// only let an EMPTY codec through and knew nothing of HLS, so it treated the
+// literal "UNKNOWN" string as incompatible and hid every now-playable HLS
+// station when the filter was on (#124).
 function isBoseCompatible(s) {
+  const url = String(s.url_resolved || s.url || '');
+  if (s.hls === 1 || s.hls === '1' || /\.m3u8(\?|#|$)/i.test(url)) return true;
   const codec = String(s.codec || '').toUpperCase();
-  if (!codec) return true; // unknown - let the speaker try
-  return codec === 'MP3' || codec === 'AAC' || codec === 'AACP' || codec === 'MPEG';
+  if (!codec || codec === 'UNKNOWN') return true; // let the speaker try
+  return codec === 'MP3' || codec === 'AAC' || codec === 'AAC+' ||
+    codec === 'AACP' || codec === 'MPEG';
 }
 
 // streamErrorMessage maps a stream-status reason to a clear, human, localized

--- a/desktop-app/frontend/wailsjs/go/models.ts
+++ b/desktop-app/frontend/wailsjs/go/models.ts
@@ -465,6 +465,7 @@ export namespace radiobrowser {
 	    state: string;
 	    codec: string;
 	    bitrate: number;
+	    hls: number;
 	    votes: number;
 	    clickcount: number;
 	    clicktrend: number;
@@ -489,6 +490,7 @@ export namespace radiobrowser {
 	        this.state = source["state"];
 	        this.codec = source["codec"];
 	        this.bitrate = source["bitrate"];
+	        this.hls = source["hls"];
 	        this.votes = source["votes"];
 	        this.clickcount = source["clickcount"];
 	        this.clicktrend = source["clicktrend"];

--- a/radiobrowser/radiobrowser.go
+++ b/radiobrowser/radiobrowser.go
@@ -67,10 +67,15 @@ type Station struct {
 	State       string `json:"state"`
 	Codec       string `json:"codec"`
 	Bitrate     int    `json:"bitrate"`
-	Votes       int    `json:"votes"`
-	ClickCount  int    `json:"clickcount"`
-	ClickTrend  int    `json:"clicktrend"`
-	LastCheckOK int    `json:"lastcheckok"`
+	// Hls is radio-browser's flag for HLS (.m3u8) stations (1 = HLS). STR
+	// converts HLS playlists on the fly (v0.7.21), so the desktop's
+	// Bose-compatible filter treats these as playable; without the field the
+	// frontend could not tell HLS stations apart and hid them (#124).
+	Hls         int `json:"hls"`
+	Votes       int `json:"votes"`
+	ClickCount  int `json:"clickcount"`
+	ClickTrend  int `json:"clicktrend"`
+	LastCheckOK int `json:"lastcheckok"`
 }
 
 // Tag ist ein Genre Tag mit Anzahl der Stations.


### PR DESCRIPTION
## Problem

A user reported on #124 that BBC Radio 2/4 work since v0.7.21 but were hard to find, and suggested the "Bose-compatible only" filter needed updating. He's right.

`isBoseCompatible` judged a station by codec alone. Live radio-browser data for those stations:

```
BBC Radio 4 / Radio 2:   codec="UNKNOWN"   bitrate=0   hls=1     (some "AAC+")
```

The filter dropped all of them when "Bose-compatible only" was on:

- **No HLS awareness.** STR converts HLS playlists on the fly since v0.7.21, so these play, but the filter had no concept of HLS, and the Go `radiobrowser.Station` struct didn't even carry radio-browser's `hls` field to the frontend.
- **`"UNKNOWN"` codec.** radio-browser sends the literal string `"UNKNOWN"` (not empty) when it couldn't probe the codec, which is what it returns for the BBC HLS entries. The "let an unknown codec through" intent only matched an *empty* codec, so `"UNKNOWN"` was treated as incompatible.
- **`"AAC+"`** (radio-browser's spelling of the `AACP` the box also handles) wasn't in the accepted list.

## Fix

- `radiobrowser.Station`: add the `hls` field so it reaches the frontend (regenerated `wailsjs/go/models.ts`).
- `isBoseCompatible`: treat `hls=1` (or an `.m3u8` URL) as playable, let an `"UNKNOWN"`/empty codec through, accept `"AAC+"`.
- Persist `hls` in the favourites store so favourited HLS stations keep the flag.

Result: HLS stations like BBC Radio 4 now pass the "Bose-compatible only" filter instead of being hidden.

Refs #124