### PR TITLE
fix(library): play NAS and DLNA tracks directly so FLAC files no longer stall or break up

### DIFF
--- a/internal/webui/library_play_test.go
+++ b/internal/webui/library_play_test.go
@@ -1,0 +1,45 @@
+package webui
+
+import "testing"
+
+// A LAN library file (plain http://) is played by the box directly; radio and
+// HTTPS sources keep going through the stream proxy (#139).
+func TestIsPlainHTTPURL(t *testing.T) {
+	cases := map[string]bool{
+		"http://192.0.2.10:50002/track.flac":  true,
+		"HTTP://192.0.2.10/track.flac":        true, // scheme is case-insensitive
+		"https://192.0.2.10/track.flac":       false,
+		"http://stream.example.com/radio":     true,
+		"spotify:playlist:37i9dQZF1DWX7rdRjO": false,
+		"":                                    false,
+	}
+	for in, want := range cases {
+		if got := isPlainHTTPURL(in); got != want {
+			t.Errorf("isPlainHTTPURL(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// A saved library preset does not record its codec MIME, so recall re-derives it
+// from the file extension to advertise the right protocolInfo to the box.
+func TestMimeFromURL(t *testing.T) {
+	cases := map[string]string{
+		"http://nas/music/song.flac":          "audio/flac",
+		"http://nas/music/song.FLAC":          "audio/flac", // case-insensitive
+		"http://nas/music/song.wav":           "audio/wav",
+		"http://nas/music/song.m4a":           "audio/mp4",
+		"http://nas/music/song.aac":           "audio/mp4",
+		"http://nas/music/song.ogg":           "audio/ogg",
+		"http://nas/music/song.aiff":          "audio/aiff",
+		"http://nas/music/song.mp3":           "audio/mpeg",
+		"http://nas/music/song.flac?sid=abc":  "audio/flac", // query stripped
+		"http://nas/music/song.flac#frag":     "audio/flac", // fragment stripped
+		"http://nas/stream/raw":               "",           // no extension
+		"http://nas/music/cover.png":          "",           // not audio
+	}
+	for in, want := range cases {
+		if got := mimeFromURL(in); got != want {
+			t.Errorf("mimeFromURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -703,6 +703,40 @@ func isHTTPURL(s string) bool {
 	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
 }
 
+// isPlainHTTPURL reports whether s is a plaintext http:// URL (not https). A LAN
+// media server reachable this way can be played by the box directly, skipping
+// the stream proxy: the proxy exists to give Bose UPnP HTTPS and radio token
+// resilience, neither of which a plain-HTTP LAN file needs (#139).
+func isPlainHTTPURL(s string) bool {
+	return strings.HasPrefix(strings.ToLower(s), "http://")
+}
+
+// mimeFromURL guesses an audio MIME from a stream URL's file extension. Used to
+// recall a library preset that did not record its codec MIME. Returns "" for an
+// unknown or missing extension, in which case the caller leaves the box on its
+// audio/mpeg default.
+func mimeFromURL(raw string) string {
+	u := strings.ToLower(raw)
+	if i := strings.IndexAny(u, "?#"); i >= 0 {
+		u = u[:i]
+	}
+	switch {
+	case strings.HasSuffix(u, ".flac"):
+		return "audio/flac"
+	case strings.HasSuffix(u, ".wav"):
+		return "audio/wav"
+	case strings.HasSuffix(u, ".m4a"), strings.HasSuffix(u, ".mp4"), strings.HasSuffix(u, ".aac"):
+		return "audio/mp4"
+	case strings.HasSuffix(u, ".ogg"), strings.HasSuffix(u, ".oga"):
+		return "audio/ogg"
+	case strings.HasSuffix(u, ".aif"), strings.HasSuffix(u, ".aiff"):
+		return "audio/aiff"
+	case strings.HasSuffix(u, ".mp3"):
+		return "audio/mpeg"
+	}
+	return ""
+}
+
 // looksLikeSpotifyStreamURL reports whether a stored stream URL points at a
 // Spotify source, so a non-spotify preset carrying it is really a mis-saved
 // Spotify preset (#45/#105).
@@ -834,10 +868,28 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request) {
 	if s.spotifySwitchedAway != nil {
 		s.spotifySwitchedAway(r.Context())
 	}
-	// Stream durch unseren Proxy schicken — damit klappen auch
-	// HTTPS Quellen (Bose UPnP kann kein TLS) und Token Expiry wird
-	// transparent abgefangen. Bose sieht eine stabile loopback URL.
+	// Decide how the box reaches the audio.
+	//
+	// Radio and any HTTPS source go through our loopback stream proxy: it hands
+	// the box a stable URL, lets Bose UPnP play HTTPS (which it cannot do
+	// itself), and reconnects transparently on CDN token expiry.
+	//
+	// A network library track is different. It carries its codec MIME (set by
+	// the caller) and is a finite file on a LAN media server that supports HTTP
+	// range requests, exactly the case the Bose app played directly. Routing it
+	// through the radio proxy breaks it two ways: the proxy ignores the box's
+	// Range requests, so the box cannot read a FLAC's stream header and sits at
+	// "stream starting", and, built for endless radio, it treats the upstream
+	// EOF that ends a file as a dropout and reconnects, replaying or garbling
+	// the track (the mid-track noise). So a plain-HTTP library file is handed to
+	// the box directly, like the Bose app did; only radio or an HTTPS library
+	// source still needs the proxy (#139).
+	playDirect := req.Mime != "" && isPlainHTTPURL(req.URL)
 	playURL := boxurl.RawStream(req.URL)
+	if playDirect {
+		playURL = req.URL
+	}
+	s.logger.Info("play request", "direct", playDirect, "mime", req.Mime, "url", req.URL)
 	// Advertise the real codec to the box when the caller knows it (a network
 	// library track carries its DLNA-reported MIME, e.g. audio/flac, audio/mp4).
 	// Radio leaves it empty and defaults to audio/mpeg. The box keys its decoder
@@ -1006,6 +1058,33 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 	// does not yank the box back to a still-advancing go-librespot.
 	if s.spotifySwitchedAway != nil {
 		s.spotifySwitchedAway(r.Context())
+	}
+	// A library preset (saved from the Library tab, so Source is set) points at a
+	// finite file on a LAN media server. Recall it like the Library play path:
+	// hand the box the file directly with its codec MIME, bypassing the radio
+	// stream proxy that stalls a FLAC on Range and garbles it on EOF (#139). The
+	// MIME is re-derived from the URL because the preset store does not keep it;
+	// an unknown extension falls through to the proxy path unchanged.
+	if p.Source != "" && isPlainHTTPURL(p.StreamURL) {
+		if mime := mimeFromURL(p.StreamURL); mime != "" {
+			directURL := p.StreamURL
+			s.logger.Info("preset slot recall (app): direct library file", "slot", slot, "mime", mime)
+			if err := s.renderer.PlayURLMime(r.Context(), directURL, p.Name, p.Art, mime); err != nil {
+				writeJSON(w, http.StatusBadGateway, map[string]any{
+					"error": "Track could not be played", "detail": guessErrorReason(err),
+					"slot": slot, "name": p.Name,
+				})
+				return
+			}
+			s.setLastPlay(directURL, p.Name, p.Art, mime)
+			s.recentNoteCard("upnp", p.StreamURL, p.Name, p.Art, p.StreamURL, "", "") // #135
+			name, art := p.Name, p.Art
+			go s.verifyRecall(func(ctx context.Context, _ bool) {
+				_ = s.renderer.PlayURLMime(ctx, directURL, name, art, mime)
+			}, nil)
+			writeJSON(w, http.StatusOK, map[string]any{"status": "playing", "slot": slot, "name": p.Name})
+			return
+		}
 	}
 	// Stream Proxy URL nutzen damit auch nach Token Expiry weitergespielt
 	// wird (Bose sieht die stabile loopback URL).


### PR DESCRIPTION
## Problem (#139)

Library/DLNA playback routed every track through the loopback stream proxy (`boxurl.RawStream` -> `/stream/raw`). That proxy is built for endless radio:

- It ignores the box's HTTP **Range** requests, so the Bose renderer cannot read a FLAC stream header and sits at "stream starting" forever.
- On the upstream **EOF** that marks a file's end it reconnects and re-fetches from byte 0 (radio token-expiry logic), replaying or splicing the track. That is the mid-track noise the reporter heard once they worked around the stall with a NAS-side FLAC->LPCM conversion.

MP3 survived because it tolerates a pure sequential stream; FLAC/WAV/LPCM did not. The Bose app always played files directly (box <-> NAS), which is why it never needed the NAS "convert FLAC" setting. The earlier v0.7.30 `pickPlayableRes` and v0.7.32 MIME-passthrough fixes chose the right resource/codec but could not fix the proxy mangling.

## Fix

- A plain-`http://` library file (it carries its DLNA codec MIME and is a finite, range-capable file on the LAN) is now handed to the box **directly**, bypassing the proxy.
- Radio and HTTPS sources still go through the proxy (the box cannot do TLS; radio needs token resilience).
- Library **preset** recall takes the same direct path, re-deriving the MIME from the URL extension since the preset store does not keep it.
- New helpers `isPlainHTTPURL` / `mimeFromURL` with unit tests.

## Known remaining (rare)

An `https://` NAS file still goes through the proxy and would hit the same Range/EOF issue. Home DLNA (Synology) serves plain http, so this is not the reported case; if it ever bites, make the proxy file-aware (forward Range, 206, no reconnect-on-EOF) instead.

## Verification

- `GOOS=linux GOARCH=arm GOARM=7 go build ./...` and `go vet` clean.
- Library/DLNA play path code-reviewed end to end (frontend -> `/api/play` -> renderer).
- Reporter to confirm on ST20 + Synology after the release.

Refs #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)