### PR TITLE
ci(frontend): resync package-lock so npm ci passes again

### DIFF
--- a/desktop-app/frontend/package-lock.json
+++ b/desktop-app/frontend/package-lock.json
@@ -11,6 +11,31 @@
         "vite": "^8.0.16"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",


### PR DESCRIPTION
## Problem

The Vite 6 -> 8 upgrade (#154) left `package-lock.json` out of sync with `package.json`. The `build.yml` **Frontend build** job runs `npm ci`, which is strict and aborted:

```
npm error Missing: @emnapi/core@1.11.1 from lock file
npm error Invalid: lock file's @emnapi/wasi-threads@1.2.1 does not satisfy @emnapi/wasi-threads@1.2.2
```

So that check has been red on every `main` commit since the upgrade. `release.yml` was unaffected because it runs `wails build` (i.e. `npm install`), not `npm ci`.

## Fix

Regenerate the lockfile from `package.json` (no `package.json` change). Verified locally:

- `npm ci --no-audit --no-fund` -> success
- `npm run build` -> success