### PR TITLE
fix(spotify): save the playing playlist to a preset even when the live context is momentarily empty

### DIFF
--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -2132,6 +2132,26 @@ function decodeProxyUrl(loc) {
   return loc;
 }
 
+// spotifyURIFromContainer recovers the spotify: context URI from a box
+// now-playing location of the form "/playback/container/<base64 spotify:...>"
+// (STR writes this when it plays a Spotify selection; the agent encodes it
+// URL-safe, see internal/webui legacySpotifyURI). Used as a save-time fallback
+// when go-librespot's /spotify/info reports no context even though a real
+// playlist is playing (#45). Returns "" when the location is not a container or
+// does not decode to a spotify: URI.
+function spotifyURIFromContainer(loc) {
+  const marker = '/playback/container/';
+  const i = (loc || '').indexOf(marker);
+  if (i < 0) return '';
+  let enc = loc.slice(i + marker.length);
+  const j = enc.search(/[/?#]/);
+  if (j >= 0) enc = enc.slice(0, j);
+  try {
+    const uri = atob(enc.replace(/-/g, '+').replace(/_/g, '/'));
+    return uri.startsWith('spotify:') ? uri : '';
+  } catch { return ''; }
+}
+
 // SPOTIFY_LOGO moved to logos.js (shared with the Recently-played view).
 
 // presetStateLabel returns the small state line shown on a preset tile: an
@@ -2436,6 +2456,14 @@ async function saveCurrentToSlot(slot) {
         if (np.account) acct = np.account;
       }
     } catch {}
+    // Fallback: go-librespot's /spotify/info can report an empty context even
+    // while a real playlist is playing (it depends on how playback was started).
+    // The box's own now-playing still carries the URI STR wrote into its
+    // /playback/container/<base64 spotify:...> location, so decode that before
+    // giving up (Pierre, #45: Premium, a playlist was playing, the box location
+    // held spotify:playlist:..., but np.context came back empty so the save
+    // wrongly failed).
+    if (!ctxUri) ctxUri = spotifyURIFromContainer(state.nowLocation);
     if (!ctxUri) {
       // Spotify is playing but the speaker reported no playlist/album/track
       // context. This is NOT the same as a non-replayable station: a real


### PR DESCRIPTION
## Problem (Discussion [#45](https://github.com/JRpersonal/streborn/discussions/45))

A Premium user on an ST20, v0.7.39, with a Spotify playlist clearly playing, could not save it to a preset. The app showed *"Impossible de lire une playlist Spotify depuis l'enceinte... ouvre une playlist ou un album, puis réessaie."* (could not read a Spotify playlist from the speaker).

The save path read the context URI only from go-librespot's `/spotify/info` (`np.context`). That endpoint can report an **empty** context even while a real playlist is playing, depending on how playback was started, so a legitimate save failed.

His diagnostic confirms the box knew the playlist all along: the Bose now-playing carried `location="/playback/container/c3BvdGlmeTpwbGF5bGlzdDozN2k5ZFFaRjFEV1g3cmRSak9FQ1BX"`, which base64-decodes to `spotify:playlist:37i9dQZF1DWX7rdRjOECPW`.

## Fix

When `/spotify/info` reports no context, decode the URI from the box's own now-playing `/playback/container/<base64 spotify:...>` location (STR wrote it there; the agent encodes it URL-safe, matching `legacySpotifyURI`). New helper `spotifyURIFromContainer`. The agent's save-gate `playableSpotifyURI` still rejects a genuinely non-replayable selection (a Spotify radio/station), so this only recovers real, replayable contexts.

## Verification

- Decoded the two container locations from the reporter's diagnostic: `spotify:playlist:37i9dQZF1DWX7rdRjOECPW` and `spotify:show:6NsIUcTCFBIPT7TxP87zdF` (a podcast), both valid.
- `npm run build` and full `wails build` clean; frontend-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)