### PR TITLE
fix(app): hand off to a newer build on manual launch, and hide the dead Alexa source

### DIFF
--- a/desktop-app/frontend/src/views/settings.js
+++ b/desktop-app/frontend/src/views/settings.js
@@ -1691,6 +1691,11 @@ function rollupSources(raw) {
   for (const src of raw) {
     if (!src || !src.source) continue;
     if (src.source === 'NOTIFICATION') continue;
+    // Alexa on the SoundTouch ran entirely through the Bose/Amazon cloud, which
+    // is gone, so the box still advertises ALEXA as READY but it cannot work.
+    // Showing it as "active" only confuses users (Discussion #170), so hide the
+    // dead source like NOTIFICATION rather than imply it is usable.
+    if (src.source === 'ALEXA') continue;
     const existing = grouped[src.source];
     if (!existing || (src.status === 'READY' && existing.status !== 'READY')) {
       grouped[src.source] = src;

--- a/desktop-app/main.go
+++ b/desktop-app/main.go
@@ -65,8 +65,16 @@ func main() {
 		// just raises and focuses its existing window.
 		SingleInstanceLock: &options.SingleInstanceLock{
 			UniqueId: "de.st-reborn.desktop.singleinstance",
-			OnSecondInstanceLaunch: func(_ options.SecondInstanceData) {
+			OnSecondInstanceLaunch: func(data options.SecondInstanceData) {
 				if app.ctx == nil {
+					return
+				}
+				// If the user double-clicked a freshly downloaded NEWER build while
+				// this older one is running, hand off to it (quit + start the new
+				// one) instead of just raising this old window, which would leave
+				// them stuck on the old version (#71 follow-up). Only triggers for a
+				// different file whose filename version is strictly newer.
+				if app.tryHandOffTo(resolveSecondInstanceExe(data.Args, data.WorkingDirectory)) {
 					return
 				}
 				runtime.WindowUnminimise(app.ctx)

--- a/desktop-app/update_app.go
+++ b/desktop-app/update_app.go
@@ -32,12 +32,81 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
 
 	wailsrt "github.com/wailsapp/wails/v2/pkg/runtime"
 )
+
+// versionFromFilenameRE pulls a vX.Y.Z out of a release asset filename, e.g.
+// "STR-Windows-v0.7.42.exe" -> "v0.7.42".
+var versionFromFilenameRE = regexp.MustCompile(`v\d+\.\d+\.\d+`)
+
+// resolveSecondInstanceExe turns the SingleInstanceLock second-instance args +
+// working dir into the absolute path of the binary the user just launched.
+func resolveSecondInstanceExe(args []string, wd string) string {
+	if len(args) == 0 || args[0] == "" {
+		return ""
+	}
+	p := args[0]
+	if !filepath.IsAbs(p) && wd != "" {
+		p = filepath.Join(wd, p)
+	}
+	if r, err := filepath.EvalSymlinks(p); err == nil {
+		p = r
+	}
+	if abs, err := filepath.Abs(p); err == nil {
+		p = abs
+	}
+	return p
+}
+
+// pathsEqual compares two file paths, case-insensitively on Windows.
+func pathsEqual(a, b string) bool {
+	ca, _ := filepath.Abs(filepath.Clean(a))
+	cb, _ := filepath.Abs(filepath.Clean(b))
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(ca, cb)
+	}
+	return ca == cb
+}
+
+// tryHandOffTo handles the case where the user double-clicks a freshly downloaded
+// NEWER build while this (older) one is running: the SingleInstanceLock would
+// otherwise just raise this old window and the new binary would exit, leaving the
+// user stuck on the old version. If the second instance is a different file whose
+// filename version is strictly newer than ours, quit this one and start that one
+// (via the same wait-for-our-pid helper), so the new version actually comes up.
+// Returns true when it took over (caller then skips the raise-to-front).
+//
+// Guard rails: the same binary path just raises the window (no-op handoff); an
+// unparseable or not-newer filename is NOT handed off, so a re-launch of the same
+// or an older copy never downgrades silently.
+func (a *App) tryHandOffTo(other string) bool {
+	if other == "" {
+		return false
+	}
+	self, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	if r, e := filepath.EvalSymlinks(self); e == nil {
+		self = r
+	}
+	if pathsEqual(self, other) {
+		return false
+	}
+	ov := versionFromFilenameRE.FindString(filepath.Base(other))
+	if ov == "" || !versionLess(appVersion, ov) {
+		return false
+	}
+	a.logger.Info("second instance is a newer build; handing off instead of just focusing",
+		"self", appVersion, "newVersion", ov, "path", other)
+	a.relaunchAndQuit(other)
+	return true
+}
 
 // newGETRequest builds a GET with STR's identifiable update user-agent, used for
 // the manifest and asset downloads through updateHTTPClient (the pure-Go TLS


### PR DESCRIPTION
Two small fixes.

## 1. Hand off when a newer build is launched manually
Follow-up to the in-app updater (#71). With the SingleInstanceLock, double-clicking a freshly downloaded **newer** version while an older one is running just raised the old window and the new binary exited, so the user stayed on the old version (reported after the v0.7.40 -> v0.7.41 manual step). The running instance now checks the second instance: if it is a different file whose filename version (`vX.Y.Z`) is strictly newer, it quits and starts that newer binary via the wait-for-our-pid helper, instead of only focusing itself. Same path / unparseable / not-newer launches keep the old "just focus" behaviour, so a re-launch never downgrades.

Note: only the *running* instance can do this, so it helps from this version forward (the already-shipped v0.7.40/v0.7.41 still have the old focus-only handler).

## 2. Hide the dead Alexa source (Discussion #170)
Alexa on the SoundTouch ran entirely through the Bose/Amazon cloud, which is gone, so the box still advertises `ALEXA` as READY but it cannot work. Speaker Settings showed it as "active", which confused a user. Hide it like the internal `NOTIFICATION` source.

## Verification
- desktop-app `go build ./...` + `go vet` + `go test ./...` clean; `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)