### PR TITLE
fix(recent): deleting one recently-played card no longer wipes older entries

### DIFF
--- a/desktop-app/frontend/src/views/recent.js
+++ b/desktop-app/frontend/src/views/recent.js
@@ -299,7 +299,7 @@ function wireCard(c, i) {
       if (!box) return;
       delBtn.disabled = true;
       try {
-        await DeleteRecentCard(box.host, box.port, c.cardKey);
+        await DeleteRecentCard(box.host, box.port, c.cardKey, c.ts);
         await refreshRecentList();
       } catch (err) { showError(err); delBtn.disabled = false; }
     };

--- a/desktop-app/frontend/wailsjs/go/main/App.d.ts
+++ b/desktop-app/frontend/wailsjs/go/main/App.d.ts
@@ -31,7 +31,7 @@ export function CurrentWiFi():Promise<string>;
 
 export function DeletePreset(arg1:string,arg2:number,arg3:number):Promise<void>;
 
-export function DeleteRecentCard(arg1:string,arg2:number,arg3:string):Promise<void>;
+export function DeleteRecentCard(arg1:string,arg2:number,arg3:string,arg4:string):Promise<void>;
 
 export function DiscoverBoxes(arg1:number):Promise<Array<main.BoxInfo>>;
 

--- a/desktop-app/frontend/wailsjs/go/main/App.js
+++ b/desktop-app/frontend/wailsjs/go/main/App.js
@@ -54,8 +54,8 @@ export function DeletePreset(arg1, arg2, arg3) {
   return window['go']['main']['App']['DeletePreset'](arg1, arg2, arg3);
 }
 
-export function DeleteRecentCard(arg1, arg2, arg3) {
-  return window['go']['main']['App']['DeleteRecentCard'](arg1, arg2, arg3);
+export function DeleteRecentCard(arg1, arg2, arg3, arg4) {
+  return window['go']['main']['App']['DeleteRecentCard'](arg1, arg2, arg3, arg4);
 }
 
 export function DiscoverBoxes(arg1) {

--- a/desktop-app/recent.go
+++ b/desktop-app/recent.go
@@ -44,10 +44,12 @@ func (a *App) RecentPlayed(host string, port int) ([]RecentItem, error) {
 	return out, nil
 }
 
-// ClearRecent empties one box's recently-played ring (DELETE /api/recent). Routed
-// through boxDo for the :8888<->:17008 self-heal.
+// ClearRecent empties one box's recently-played ring (DELETE /api/recent?all=1).
+// The explicit all=1 is required by the agent so a per-card delete can never fall
+// through to clearing everything. Routed through boxDo for the :8888<->:17008
+// self-heal.
 func (a *App) ClearRecent(host string, port int) error {
-	resp, err := a.boxDo(host, port, http.MethodDelete, "/api/recent", "", "")
+	resp, err := a.boxDo(host, port, http.MethodDelete, "/api/recent?all=1", "", "")
 	if err != nil {
 		return err
 	}
@@ -58,13 +60,16 @@ func (a *App) ClearRecent(host string, port int) error {
 	return nil
 }
 
-// DeleteRecentCard removes one card (every row sharing cardKey) from a box's
-// recently-played ring (DELETE /api/recent?cardKey=...).
-func (a *App) DeleteRecentCard(host string, port int, cardKey string) error {
-	if cardKey == "" {
-		return fmt.Errorf("cardKey required")
+// DeleteRecentCard removes the ONE card the user clicked from a box's
+// recently-played ring (DELETE /api/recent?cardKey=...&ts=...). Both cardKey and
+// ts identify the exact card so only that one listening session is removed, not
+// every other session of the same station.
+func (a *App) DeleteRecentCard(host string, port int, cardKey, ts string) error {
+	if cardKey == "" || ts == "" {
+		return fmt.Errorf("cardKey and ts required")
 	}
-	resp, err := a.boxDo(host, port, http.MethodDelete, "/api/recent?cardKey="+url.QueryEscape(cardKey), "", "")
+	path := "/api/recent?cardKey=" + url.QueryEscape(cardKey) + "&ts=" + url.QueryEscape(ts)
+	resp, err := a.boxDo(host, port, http.MethodDelete, path, "", "")
 	if err != nil {
 		return err
 	}

--- a/internal/recent/recent.go
+++ b/internal/recent/recent.go
@@ -220,6 +220,42 @@ func (s *Store) DeleteCard(key string) int {
 	return removed
 }
 
+// DeleteCardAt removes the ONE card the user clicked: the maximal run of
+// consecutive entries with CardKey == key that contains the entry timestamped ts
+// (cards in the app's view are exactly such consecutive runs). It deletes only
+// that single listening session, NOT every other session of the same station
+// elsewhere in the ring, which is what DeleteCard(key) did and why deleting one
+// entry wiped older same-station entries too. A non-matching (key, ts) is a no-op,
+// so a stale/empty id can never fall through to clearing the whole ring. Returns
+// the number of rows removed.
+func (s *Store) DeleteCardAt(key, ts string) int {
+	if key == "" || ts == "" {
+		return 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx := -1
+	for i, e := range s.data {
+		if e.CardKey == key && e.TS == ts {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return 0
+	}
+	lo, hi := idx, idx
+	for lo > 0 && s.data[lo-1].CardKey == key {
+		lo--
+	}
+	for hi < len(s.data)-1 && s.data[hi+1].CardKey == key {
+		hi++
+	}
+	s.data = append(s.data[:lo:lo], s.data[hi+1:]...)
+	s.markDirtyLocked()
+	return hi - lo + 1
+}
+
 // All returns a copy of the ring, oldest-first. The /api/recent handler serves
 // this; the app reverses/groups it.
 func (s *Store) All() []Entry {

--- a/internal/recent/recent_test.go
+++ b/internal/recent/recent_test.go
@@ -72,6 +72,47 @@ func TestDeleteCardRemovesOnlyThatCard(t *testing.T) {
 	}
 }
 
+// TestDeleteCardAtRemovesOnlyThatSession is the regression for the data-loss bug:
+// the same station listened to twice (with another station in between) is two
+// separate cards/sessions. Deleting one must remove ONLY that session's
+// consecutive run, not every row sharing the CardKey (which DeleteCard did, so
+// deleting the newer SWR3 card also wiped the older one).
+func TestDeleteCardAtRemovesOnlyThatSession(t *testing.T) {
+	s := New()
+	// Session A of swr3 (two tracks, one consecutive run), then 1live, then a
+	// second swr3 session B. Explicit TS so the runs are unambiguous.
+	s.Add(Entry{Source: "radio", CardKey: "swr3", Track: "Epic", TS: "t1"})
+	s.Add(Entry{Source: "radio", CardKey: "swr3", Track: "Yellow", TS: "t2"})
+	s.Add(Entry{Source: "radio", CardKey: "1live", Track: "Other", TS: "t3"})
+	s.Add(Entry{Source: "radio", CardKey: "swr3", Track: "Reborn", TS: "t4"})
+
+	// Delete session B by any of its timestamps: only the t4 run goes.
+	if n := s.DeleteCardAt("swr3", "t4"); n != 1 {
+		t.Fatalf("DeleteCardAt(swr3,t4) removed %d, want 1", n)
+	}
+	eq(t, rows(s), []string{"swr3/Epic", "swr3/Yellow", "1live/Other"})
+
+	// Delete session A by its head ts: the whole consecutive run (both tracks)
+	// goes, leaving 1live untouched.
+	if n := s.DeleteCardAt("swr3", "t1"); n != 2 {
+		t.Fatalf("DeleteCardAt(swr3,t1) removed %d, want 2", n)
+	}
+	eq(t, rows(s), []string{"1live/Other"})
+
+	// A non-matching (key, ts) and any empty id are no-ops; they must never fall
+	// through to clearing the ring.
+	if n := s.DeleteCardAt("swr3", "t1"); n != 0 {
+		t.Fatalf("DeleteCardAt on already-removed removed %d, want 0", n)
+	}
+	if n := s.DeleteCardAt("1live", "wrongts"); n != 0 {
+		t.Fatalf("DeleteCardAt with wrong ts removed %d, want 0", n)
+	}
+	if n := s.DeleteCardAt("", ""); n != 0 {
+		t.Fatalf("DeleteCardAt empty removed %d, want 0", n)
+	}
+	eq(t, rows(s), []string{"1live/Other"})
+}
+
 // TestAddAppendsNewTrackSameCard: a genuinely new song under the same station
 // is its own row, newest last.
 func TestAddAppendsNewTrackSameCard(t *testing.T) {

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -1273,15 +1273,21 @@ func (s *Server) handleRecent(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		writeJSON(w, http.StatusOK, s.recent.All())
 	case http.MethodDelete:
-		// DELETE /api/recent           -> clear the whole ring
-		// DELETE /api/recent?cardKey=X -> remove one card (all rows with that key)
-		// The user explicitly asked to forget this history, so Flush() now instead
-		// of waiting out the debounce, otherwise a quick reboot would resurrect it.
+		// DELETE /api/recent?all=1            -> clear the whole ring (explicit)
+		// DELETE /api/recent?cardKey=X&ts=Y   -> remove the ONE card at that ts
+		// "all=1" is REQUIRED to clear: a delete-card request with a missing/stale
+		// cardKey must never fall through to wiping everything (that was the bug
+		// where deleting one entry removed all older ones). Flush() now so the
+		// change survives an immediate reboot instead of waiting out the debounce.
 		removed := 0
-		if key := r.URL.Query().Get("cardKey"); key != "" {
-			removed = s.recent.DeleteCard(key)
-		} else {
+		switch {
+		case r.URL.Query().Get("all") == "1":
 			s.recent.Clear()
+		case r.URL.Query().Get("cardKey") != "":
+			removed = s.recent.DeleteCardAt(r.URL.Query().Get("cardKey"), r.URL.Query().Get("ts"))
+		default:
+			http.Error(w, "specify all=1 to clear, or cardKey+ts to remove one card", http.StatusBadRequest)
+			return
 		}
 		if err := s.recent.Flush(); err != nil {
 			s.logger.Warn("recent: flush after delete failed", "err", err)


### PR DESCRIPTION
## Problem

Removing a single card from the recently-played list deleted every other
listening session of the **same station** too, so deleting one entry took the
older ones down with it (reported in community feedback).

## Root cause

Two stacked causes:

1. The agent's per-card delete (`DeleteCard`) removed **all** rows sharing a
   `CardKey`. If the user listened to a station twice with another station in
   between, that is two separate cards; deleting the newer one also wiped the
   older one.
2. A delete request with a missing/stale card id silently fell through to
   `Clear()` (wipe the whole ring). A frontend hiccup could nuke everything.

## Fix

- New `recent.DeleteCardAt(key, ts)` removes only the one card the user
  clicked: the maximal consecutive run with that `CardKey` containing the
  entry at `ts`. Earlier sessions of the same station survive.
- The agent's `DELETE /api/recent` now requires an explicit `all=1` to clear;
  a per-card delete (`cardKey`+`ts`) can never fall through to wiping
  everything. A delete with neither is a `400`.
- The desktop app sends the card timestamp on delete and `all=1` for the
  "clear list" action.

## Tests

`TestDeleteCardAtRemovesOnlyThatSession` covers the regression: two SWR3
sessions split by a 1Live session, deleting one leaves the other; non-matching
and empty ids are no-ops and never clear the ring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)