### PR TITLE
fix(app): tell the user when a Spotify preset needs the speaker logged in

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -362,6 +362,7 @@ func run() error {
 		webui.WithSpotifyMeta(spotifyMgr.PlaylistMeta),
 		webui.WithSpotifyStreaming(spotifyMgr.Streaming),
 		webui.WithSpotifyReady(spotifyMgr.Ready),
+		webui.WithSpotifyLoggedIn(spotifyMgr.LoggedIn),
 		webui.WithSpotifyPremiumRequired(spotifyMgr.PremiumRequired),
 		webui.WithSpotifySetRecalling(spotifyMgr.SetRecalling),
 		webui.WithSpotifyInfo(spotifyMgr.ServeInfo),
@@ -1032,6 +1033,13 @@ func (h *presetWsHandler) playSpotifyPreset(ctx context.Context, slot int, p pre
 	}
 	if p.URI == "" {
 		h.logger.Warn("spotify preset recall: preset has no Spotify URI, cannot autoplay", "slot", slot, "name", p.Name)
+		return
+	}
+	// No persisted Spotify login means go-librespot has no credential and cannot
+	// start playback on its own, so a hardware press would do nothing but thrash
+	// the box. Skip with a clear log instead of the silent retry loop (#45 Pierre).
+	if !h.spotify.LoggedIn() {
+		h.logger.Warn("spotify preset recall: speaker not logged into Spotify (no credential); log it into Spotify once first", "slot", slot, "name", p.Name)
 		return
 	}
 	if !h.spotify.Ready() {

--- a/internal/spotify/manager.go
+++ b/internal/spotify/manager.go
@@ -935,6 +935,30 @@ func (m *Manager) CurrentUsername(ctx context.Context) string {
 	return m.currentUsername(ctx)
 }
 
+// LoggedIn reports whether this speaker has ever completed a Spotify Connect
+// login, i.e. a reusable credential is persisted on disk. Recall needs this:
+// without a credential go-librespot cannot start playback on its own, so the
+// preset does nothing (#45 Pierre: the saved preset had account="" and
+// go-librespot was not running). It is a filesystem check (not a :3678 query), so
+// it stays true while go-librespot is mid-restart, distinguishing "never logged
+// in" (actionable: log the speaker into Spotify first) from "logged in but
+// momentarily down" (recovers on its own).
+func (m *Manager) LoggedIn() bool {
+	if _, err := os.Stat(filepath.Join(m.configDir, "credentials.json")); err == nil {
+		return true
+	}
+	// A per-account credential copy (multi-account swap store) also counts: the
+	// active credentials.json can be briefly absent during a SwitchAccount swap.
+	if entries, err := os.ReadDir(m.credStore); err == nil {
+		for _, e := range entries {
+			if strings.HasSuffix(e.Name(), ".json") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // sanitizeUser maps a Spotify username to a filesystem-safe credential filename.
 func sanitizeUser(s string) string {
 	var b strings.Builder

--- a/internal/spotify/manager_test.go
+++ b/internal/spotify/manager_test.go
@@ -4,6 +4,10 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/binary"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -86,5 +90,44 @@ func TestHeaderCapture(t *testing.T) {
 	want := append(append([]byte(nil), bos...), setup...)
 	if !bytes.Equal(committed, want) {
 		t.Errorf("captured headers = %d bytes, want %d (BOS+setup only)", len(committed), len(want))
+	}
+}
+
+// TestLoggedIn verifies the #45 recall guard: a speaker with no persisted Spotify
+// credential reports not-logged-in (so the recall returns a clear error), and
+// either the active credentials.json or a per-account stored copy counts as
+// logged in.
+func TestLoggedIn(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "cfg")
+	if err := os.MkdirAll(cfg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m := New("", cfg, "", nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	if m.LoggedIn() {
+		t.Fatal("LoggedIn should be false with no credential")
+	}
+	credFile := filepath.Join(cfg, "credentials.json")
+	if err := os.WriteFile(credFile, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !m.LoggedIn() {
+		t.Fatal("LoggedIn should be true once credentials.json exists")
+	}
+	if err := os.Remove(credFile); err != nil {
+		t.Fatal(err)
+	}
+	if m.LoggedIn() {
+		t.Fatal("LoggedIn should be false again after the credential is gone")
+	}
+	if err := os.MkdirAll(m.credStore, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(m.credStore, "user.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !m.LoggedIn() {
+		t.Fatal("LoggedIn should be true with a per-account stored credential")
 	}
 }

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -86,6 +86,13 @@ type Server struct {
 	// at a not-yet-flowing stream (which starves and detaches). nil when Spotify
 	// is not configured.
 	spotifyReady func() bool
+	// spotifyLoggedIn reports whether the speaker has ever completed a Spotify
+	// Connect login (a credential is persisted). Without it go-librespot cannot
+	// start playback on its own, so a recall does nothing; the handler returns a
+	// clear "log this speaker into Spotify first" error instead of optimistically
+	// reporting "playing" and failing silently in the background (#45 Pierre). nil
+	// until wired.
+	spotifyLoggedIn func() bool
 	// spotifyPremiumRequired reports whether the logged-in Spotify account is
 	// free/open and so cannot do the autonomous recall playback (#45). nil until
 	// wired; the recall handler uses it to return a clear "needs Premium" error.
@@ -351,6 +358,13 @@ func WithSpotifyReady(ready func() bool) Option {
 // clear "needs Premium" message instead of failing silently.
 func WithSpotifyPremiumRequired(f func() bool) Option {
 	return func(s *Server) { s.spotifyPremiumRequired = f }
+}
+
+// WithSpotifyLoggedIn registers the predicate that reports whether the speaker
+// has a persisted Spotify login, so a recall on a never-logged-in speaker fails
+// with a clear, actionable message instead of silently (#45).
+func WithSpotifyLoggedIn(f func() bool) Option {
+	return func(s *Server) { s.spotifyLoggedIn = f }
 }
 
 // WithSpotifySetRecalling registers the hook that marks an in-flight recall so
@@ -1010,6 +1024,20 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 			s.logger.Warn("spotify preset recall (app): Spotify not configured on this box", "slot", slot)
 			writeJSON(w, http.StatusServiceUnavailable, map[string]any{
 				"error": "Spotify not configured", "slot": slot, "name": p.Name,
+			})
+			return
+		}
+		// A speaker that has never been logged into Spotify has no credential for
+		// go-librespot, so it cannot start playback on its own and the recall would
+		// silently do nothing (#45 Pierre: saved preset account="" and go-librespot
+		// not running). Tell the user how to fix it instead of optimistically
+		// reporting "playing" and failing in the background.
+		if s.spotifyLoggedIn != nil && !s.spotifyLoggedIn() {
+			s.logger.Info("spotify preset recall (app): speaker not logged into Spotify", "slot", slot)
+			writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+				"error": "This speaker isn't logged into Spotify yet. Open Spotify, pick this speaker as the playback device and play something once, then this preset will work.",
+				"code":  "spotify-not-logged-in",
+				"slot":  slot, "name": p.Name,
 			})
 			return
 		}


### PR DESCRIPTION
Refs #45. A Spotify preset recall on a speaker never logged into Spotify did nothing (go-librespot has no credential, can't start playback; the app optimistically said "playing" while the real failure was only logged). The agent now checks for a persisted Spotify credential before a recall: if none, the app returns a clear, actionable message ("log this speaker into Spotify first") and a hardware press logs the same instead of silent retries. Pierre is Family Premium, so this (not premium-gating) is his case. Verified live: logged in -> plays; creds hidden -> 422 with the clear message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)