### PR TITLE
feat(app): multiroom group frames on the music tab + fix grouping XML

### DIFF
--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -79,6 +79,7 @@
   "multiroom.pickAtLeastOne": "Tippe mindestens einen weiteren Lautsprecher an, um ihn zur Gruppe hinzuzufügen.",
   "multiroom.mainBadge": "Haupt",
   "multiroom.makeMain": "Als Haupt",
+  "multiroom.groupMasterTitle": "Gruppen-Haupt (der Lautsprecher, von dem die Gruppe spielt)",
   "multiroom.liveInGroup": "in einer Gruppe",
   "multiroom.liveLeading": "Haupt von {{n}}",
   "multiroom.liveStandalone": "nicht gruppiert",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -79,6 +79,7 @@
   "multiroom.pickAtLeastOne": "Tap at least one other speaker to add it to the group.",
   "multiroom.mainBadge": "Main",
   "multiroom.makeMain": "Set as main",
+  "multiroom.groupMasterTitle": "Group main (the speaker the group plays from)",
   "multiroom.liveInGroup": "in a group",
   "multiroom.liveLeading": "main of {{n}}",
   "multiroom.liveStandalone": "not grouped",

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -86,6 +86,7 @@ import {
   BrowseLibrary,
   LogClientError,
   BrowserOpenURL,
+  GetZoneState,
   EventsOn,
 } from './api.js';
 
@@ -1282,6 +1283,9 @@ function applyBoxList(list) {
     }
   }
   renderBoxSelect();
+  // Refresh the live multiroom zones so the music-tab group frames are current.
+  // Debounced (not a tight loop) and best-effort; repaints the selector on result.
+  refreshMusicZones();
   updateSettingsTabBadge();
   // Re-evaluate the Favorites entry on every box-list refresh. This is the first
   // point after boot where localStorage is reliably restored in the WebView, so
@@ -1331,6 +1335,29 @@ function applyPendingNames(list) {
   });
 }
 
+// refreshMusicZones fetches every STR speaker's live multiroom zone so the
+// music-tab group frames are accurate, then repaints the selector. Debounced to
+// at most once per 8s (NOT a tight loop) and shares state.zoneLive with the
+// Multi-Room tab. Best-effort: on error the frames simply stay as they were.
+let _musicZoneFetchAt = 0;
+async function refreshMusicZones() {
+  const strBoxes = (state.boxes || []).filter(b => b && b.kind !== 'stock' && b.deviceID && b.host);
+  if (strBoxes.length < 2) { return; } // a zone needs at least two speakers
+  const now = Date.now();
+  if (state.zoneLiveBusy || now - _musicZoneFetchAt < 8000) return;
+  _musicZoneFetchAt = now;
+  state.zoneLiveBusy = true;
+  try {
+    const results = await Promise.allSettled(strBoxes.map(b => GetZoneState(b.host, b.port)));
+    const map = {};
+    results.forEach((r, i) => { map[strBoxes[i].deviceID] = (r.status === 'fulfilled' && r.value) ? r.value : null; });
+    state.zoneLive = map;
+  } catch { /* keep previous frames */ } finally {
+    state.zoneLiveBusy = false;
+  }
+  renderBoxSelect();
+}
+
 function renderBoxSelect() {
   const sel = $('boxSelect');
   if (state.boxes.length === 0) {
@@ -1354,8 +1381,29 @@ function renderBoxSelect() {
     updateBoxUiVisibility();
     return;
   }
-  sel.innerHTML = state.boxes.map(b => {
+  // Cluster speakers that share a live multiroom zone into a colored frame
+  // (display only; grouping is done in the Multi-Room tab). Defensive: with no
+  // live group of >=2 discovered speakers the selector renders exactly as before.
+  const zlMap = state.zoneLive || {};
+  const masterOf = (b) => {
+    if (b.kind === 'stock') return '';
+    const zl = zlMap[b.deviceID];
+    return (zl && zl.master) ? zl.master.toUpperCase() : '';
+  };
+  const memberCount = {};
+  state.boxes.forEach(b => { const m = masterOf(b); if (m) memberCount[m] = (memberCount[m] || 0) + 1; });
+  // A box is a framed master only when its group actually renders a frame, i.e.
+  // >=2 of its members are discovered here. This keeps the master star and the
+  // frame in lock-step (never a lone star on an unframed pill).
+  const isFramedMaster = (b) => {
+    const m = masterOf(b);
+    return !!m && m === (b.deviceID || '').toUpperCase() && memberCount[m] >= 2;
+  };
+  const pill = (b) => {
     const isStock = b.kind === 'stock';
+    const groupMark = isFramedMaster(b)
+      ? `<span class="box-group-master" title="${escapeAttr(t('multiroom.groupMasterTitle'))}">&#9733;</span>`
+      : '';
     const active = state.currentBox && state.currentBox.host === b.host && !isStock ? ' active' : '';
     const stockCls = isStock ? ' stock' : '';
     const label = b.friendlyName || b.name || b.host;
@@ -1387,8 +1435,24 @@ function renderBoxSelect() {
     const updDot = boxNeedsUpdate(b)
       ? `<span class="box-update-dot" title="${escapeAttr(t('speaker.updateBadgeTitle'))}" aria-label="${escapeAttr(t('speaker.updateBadgeTitle'))}"></span>`
       : '';
-    return `<span class="box-btn${active}${updCls}" data-host="${b.host}" data-port="${b.port}" role="button" tabindex="0">${escapeHtml(label)}${model} <small>${b.host}</small>${ver}${updDot}<span class="box-edit" data-host="${b.host}" data-port="${b.port}" title="${escapeAttr(t('speaker.editTitle'))}">&#9881;</span></span>`;
-  }).join('');
+    return `<span class="box-btn${active}${updCls}" data-host="${b.host}" data-port="${b.port}" role="button" tabindex="0">${groupMark}${escapeHtml(label)}${model} <small>${b.host}</small>${ver}${updDot}<span class="box-edit" data-host="${b.host}" data-port="${b.port}" title="${escapeAttr(t('speaker.editTitle'))}">&#9881;</span></span>`;
+  };
+  const groups = Object.keys(memberCount).filter(m => memberCount[m] >= 2).sort();
+  if (groups.length === 0) {
+    sel.innerHTML = state.boxes.map(pill).join('');
+  } else {
+    const colorOf = {};
+    groups.forEach((m, i) => { colorOf[m] = (i % 4) + 1; });
+    let html = '';
+    for (const m of groups) {
+      const members = state.boxes.filter(b => masterOf(b) === m);
+      // master first inside the frame
+      members.sort((a, b) => (((b.deviceID || '').toUpperCase() === m ? 1 : 0) - ((a.deviceID || '').toUpperCase() === m ? 1 : 0)));
+      html += `<div class="box-group box-group-c${colorOf[m]}">${members.map(pill).join('')}</div>`;
+    }
+    html += state.boxes.filter(b => { const mm = masterOf(b); return !(mm && memberCount[mm] >= 2); }).map(pill).join('');
+    sel.innerHTML = html;
+  }
   sel.querySelectorAll('.box-btn').forEach(btn => {
     btn.onclick = async (e) => {
       // A click on the gear icon opens the settings view rather than

--- a/desktop-app/frontend/src/style.css
+++ b/desktop-app/frontend/src/style.css
@@ -438,6 +438,17 @@ body {
 .box-edit:hover { color: var(--brand); background: rgba(102, 187, 221, 0.12); }
 .box-ver { background: #333; color: #aaa; font-size: 10px; padding: 1px 5px; border-radius: 8px; margin-left: 6px; }
 .box-model { color: #888; font-size: 11px; font-weight: 500; margin-left: 8px; }
+/* Multiroom group frame (#70): speakers sharing a live zone are clustered and
+   wrapped in a colored border so the group reads as one block on the music tab.
+   Display only; grouping is done in the Multi-Room tab. Four fixed, globally
+   neutral colors; a 5th group would reuse color 1. */
+.box-group { display: inline-flex; flex-wrap: wrap; gap: 6px; align-items: center; padding: 5px 7px; border: 2px solid var(--bg-color, #555); border-radius: 8px; }
+.box-group-c1 { --bg-color: #d64545; }
+.box-group-c2 { --bg-color: #3d7fd6; }
+.box-group-c3 { --bg-color: #3fae5a; }
+.box-group-c4 { --bg-color: #d6a23d; }
+/* Star on the group's master speaker pill. */
+.box-group-master { color: var(--brand); margin-right: 4px; font-size: 12px; }
 /* Notification dot on a speaker button whose agent is out of date
    (#108). Same blue as the settings-tab badge (.tab-btn.has-update) on
    purpose: both mean "update available", so one colour, one meaning. Red

--- a/desktop-app/frontend/src/views/multiroom.js
+++ b/desktop-app/frontend/src/views/multiroom.js
@@ -31,7 +31,10 @@ function zoneLabel(b) { return b.friendlyName || b.name || b.host; }
 export function renderMultiroom(fetchLive) {
   const root = $('view-multiroom');
   if (!root) return;
-  const strBoxes = (state.boxes || []).filter(b => b && b.kind !== 'stock' && b.host);
+  // Require deviceID too: the live-zone map is keyed by deviceID, so a box
+  // without one (very early discovery) would key an entry under undefined and
+  // collide with the music-tab group frames that share state.zoneLive.
+  const strBoxes = (state.boxes || []).filter(b => b && b.kind !== 'stock' && b.host && b.deviceID);
   const enough = strBoxes.length >= 2;
   if (!state.zoneLive) state.zoneLive = {};
   if (!state.zoneSlaves) state.zoneSlaves = {};

--- a/internal/boxapi/boxapi.go
+++ b/internal/boxapi/boxapi.go
@@ -373,8 +373,17 @@ func (c *Client) GetZone(ctx context.Context) (Zone, error) {
 		Members:  make([]ZoneMember, 0, len(raw.Members)),
 	}
 	for _, m := range raw.Members {
+		dev := strings.TrimSpace(m.DeviceID)
+		// The firmware /getZone body lists the master as a member too (and STR now
+		// sends it that way in /setZone). Members here means the SLAVES, so drop the
+		// master entry: keeps len(Members)==len(slaves) for every consumer (the
+		// reconcile guard, the "main of {n}" label, the box-selector group count),
+		// regardless of whether a given model echoes the master back.
+		if z.Master != "" && strings.EqualFold(dev, z.Master) {
+			continue
+		}
 		z.Members = append(z.Members, ZoneMember{
-			DeviceID: strings.TrimSpace(m.DeviceID),
+			DeviceID: dev,
 			IP:       strings.TrimSpace(m.IP),
 			Role:     strings.TrimSpace(m.Role),
 		})
@@ -508,7 +517,14 @@ func zoneXML(master ZoneMember, slaves []ZoneMember) string {
 // produce sound (see #70 design notes), so callers should start playback on
 // the master first.
 func (c *Client) SetZone(ctx context.Context, master ZoneMember, slaves []ZoneMember) error {
-	return c.postXML(ctx, "/setZone", zoneXML(master, slaves))
+	// /setZone's member list must include the MASTER itself as the first <member>,
+	// then each slave. Confirmed across the Bose Web API doc, thlucas1's
+	// bosesoundtouchapi, the Home Assistant integration and gesellix/AfterTouch.
+	// STR previously sent only the slaves, diverging from every documented body,
+	// the likely cause of flaky native grouping (#70). addZoneSlave/removeZoneSlave
+	// stay deltas that list only the affected members (no master member).
+	members := append([]ZoneMember{master}, slaves...)
+	return c.postXML(ctx, "/setZone", zoneXML(master, members))
 }
 
 // AddZoneSlave adds slaves to the zone already led by master. The master must

--- a/internal/boxapi/zone_test.go
+++ b/internal/boxapi/zone_test.go
@@ -119,6 +119,32 @@ func TestGetZoneWithMembers(t *testing.T) {
 	}
 }
 
+// TestGetZoneDropsMasterMember: the firmware /getZone body lists the master as a
+// member too, but Zone.Members must mean the slaves only, so the master entry is
+// filtered out (keeps len(Members)==len(slaves) for every consumer).
+func TestGetZoneDropsMasterMember(t *testing.T) {
+	xml := `<?xml version="1.0" encoding="UTF-8" ?>` +
+		`<zone master="AAAAAAAAAAAA" senderIPAddress="192.0.2.10">` +
+		`<member ipaddress="192.0.2.10">AAAAAAAAAAAA</member>` +
+		`<member ipaddress="192.0.2.11">BBBBBBBBBBBB</member>` +
+		`</zone>`
+	c, stop := newFakeBox(t, map[string]string{"/getZone": xml})
+	defer stop()
+	z, err := c.GetZone(context.Background())
+	if err != nil {
+		t.Fatalf("GetZone error: %v", err)
+	}
+	if z.Master != "AAAAAAAAAAAA" {
+		t.Errorf("master: got %q", z.Master)
+	}
+	if len(z.Members) != 1 {
+		t.Fatalf("master must be filtered from members, got %d: %+v", len(z.Members), z.Members)
+	}
+	if z.Members[0].DeviceID != "BBBBBBBBBBBB" {
+		t.Errorf("remaining member wrong: %+v", z.Members[0])
+	}
+}
+
 func TestZoneXML(t *testing.T) {
 	got := zoneXML(
 		ZoneMember{DeviceID: "AAAA", IP: "192.0.2.10"},
@@ -179,6 +205,18 @@ func TestSetZonePostsCorrectly(t *testing.T) {
 	if !strings.Contains(gotBody, `master="AAAA"`) ||
 		!strings.Contains(gotBody, `<member ipaddress="192.0.2.11">BBBB</member>`) {
 		t.Errorf("setZone body wrong: %q", gotBody)
+	}
+	// The /setZone member list MUST include the master itself as the FIRST
+	// member (Bose API + thlucas1 + HA + gesellix all agree), then the slaves.
+	if !strings.Contains(gotBody, `<member ipaddress="192.0.2.10">AAAA</member>`) {
+		t.Errorf("setZone body must include the master as a member: %q", gotBody)
+	}
+	wantBody := `<zone master="AAAA" senderIPAddress="192.0.2.10">` +
+		`<member ipaddress="192.0.2.10">AAAA</member>` +
+		`<member ipaddress="192.0.2.11">BBBB</member>` +
+		`</zone>`
+	if gotBody != wantBody {
+		t.Errorf("setZone body:\n got %q\nwant %q", gotBody, wantBody)
 	}
 }
 


### PR DESCRIPTION
Refs #70. Two changes from the grouping-mechanics research + design panel:

1. **fix**: `/setZone` now includes the zone master as the first `<member>` (matches the Bose API doc, thlucas1, Home Assistant and gesellix/AfterTouch). STR previously sent only the slaves, the likely cause of flaky native grouping. `GetZone` filters the master back out of the member list so every consumer's count stays right.
2. **feat**: speakers sharing a live zone are clustered into a colored frame on the music-tab speaker selector, with a star on the master. Display only (grouping stays in the Multi-Room tab); defensive (no live group => selector unchanged).

Adversarially reviewed (3 reviewers); both must-fix items folded in (GetZone master-filter, star gated on the frame). Master-reassign + the full Multi-Room-tab rewrite are deferred until verified on a 2+-speaker setup (deqw, #70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)