### PR TITLE
fix(app): make hardware presets work on the first press after an overnight standby

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -413,6 +413,10 @@ func run() error {
 		// resumes the last station; ResumeLastPlay is gated by the per-box opt-out
 		// and a zone-membership guard so a stereo-pair self-wake never auto-resumes.
 		onPowerWake: webuiSrv.ResumeLastPlay,
+		// Recover a lost first press after a deep-standby wake (#183): when the box
+		// reappears awake-but-idle on a gabbo reconnect, re-push the last stream.
+		// Reuses the power-on resume guards (opt-out, zone, user-stop).
+		onBoxReconnect: webuiSrv.RecoverAfterReconnect,
 		// Surface the box's own presets (incl. foreign sources like Deezer) to the
 		// webui so the app can show/preserve them (Option C). Map boxws -> webui at
 		// the composition root to keep the two packages decoupled.
@@ -832,6 +836,12 @@ type presetWsHandler struct {
 	// is gated by the per-box opt-out and a zone-membership self-wake guard.
 	// nil-safe.
 	onPowerWake func()
+	// onBoxReconnect fires after the gabbo WS (re)connects. After a deep/overnight
+	// standby the box wakes and emits its first preset/now-selection frame before
+	// STR has reconnected, so the press is lost and nothing plays until a second
+	// press (#183). This recovers that stuck wake. Wired to
+	// webui.RecoverAfterReconnect, which reuses the power-on resume guards. nil-safe.
+	onBoxReconnect func()
 	// noteBoxPresets records the box's OWN preset list (gabbo presetsUpdated),
 	// including foreign sources like Deezer that STR did not set, into the webui
 	// so the app can show and preserve them (Option C). Wired to
@@ -1014,6 +1024,20 @@ func (h *presetWsHandler) OnPowerWake(_ context.Context) {
 	}
 }
 
+// OnConnected fires after the gabbo WebSocket (re)connects (boxws optional
+// hook). It recovers the lost-first-press case (#183): when the box wakes from a
+// deep/overnight standby it emits the preset/now-selection frame before STR has
+// reconnected, so OnPresetSelected never runs and the display shows "service
+// unavailable" until a second press. On reconnect STR checks the box and, if it
+// is awake but its restored STR selection is not playing, re-pushes the last
+// stream through the guarded resume (opt-out, zone, user-stop). A routine idle
+// reconnect (box in standby) or a box already playing is a no-op.
+func (h *presetWsHandler) OnConnected(_ context.Context) {
+	if h.onBoxReconnect != nil {
+		h.onBoxReconnect()
+	}
+}
+
 // OnSourceAux fires the configured "aux" webhook when the box switches to the
 // AUX input. Additional-only.
 func (h *presetWsHandler) OnSourceAux(ctx context.Context) {
@@ -1144,7 +1168,10 @@ func (h *presetWsHandler) playSpotifyPreset(ctx context.Context, slot int, p pre
 // re-issues it a few times if not, fixing the "first hardware press after
 // reboot does nothing" race for radio presets too.
 func (h *presetWsHandler) verifyPlayURL(slot int, url, name, icon string) {
-	for attempt := 1; attempt <= 3; attempt++ {
+	// Up to 5 attempts (~25s): a box waking from a deep/overnight standby can
+	// take longer than the old 3-attempt (~15s) window to finish bringing its
+	// network and playback subsystem back up before it accepts the stream (#183).
+	for attempt := 1; attempt <= 5; attempt++ {
 		time.Sleep(5 * time.Second)
 		if boxIsPlaying(h.boxHost) {
 			return

--- a/internal/boxws/boxws.go
+++ b/internal/boxws/boxws.go
@@ -249,7 +249,12 @@ func (c *Client) Run(ctx context.Context) {
 			return
 		case <-time.After(backoff):
 		}
-		if backoff < 30*time.Second {
+		// Cap kept low (8s, not 30s) so STR reattaches quickly after the box
+		// wakes from a deep/overnight standby. The lost first press after such a
+		// standby (#183) is recovered by the OnConnected hook below, but a short
+		// reconnect window shrinks how long the box shows "service unavailable"
+		// before STR takes over.
+		if backoff < 8*time.Second {
 			backoff *= 2
 		}
 	}
@@ -269,6 +274,17 @@ func (c *Client) runOnce(ctx context.Context) error {
 	// Phase marker at WARN so a reconnect after standby/resume is
 	// visible in the diagnostic bundle without raising log level.
 	c.logger.Warn("box websocket phase: connected", "url", c.url)
+
+	// After a deep/overnight standby the box wakes and emits its first
+	// preset/now-selection frame BEFORE this reconnect lands (the backoff had
+	// grown while the box was unreachable), so that first hardware press is lost
+	// and nothing plays until a second press (#183). Give the handler a chance to
+	// recover a stuck wake on every (re)connect. Optional interface so handlers
+	// that do not need it (tests) are unaffected; run in a goroutine so the probe
+	// never blocks the reader loop.
+	if oc, ok := c.handler.(interface{ OnConnected(context.Context) }); ok {
+		go oc.OnConnected(ctx)
+	}
 
 	// Reader Loop
 	for {

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -1468,6 +1468,102 @@ func (s *Server) ResumeLastPlay() {
 	}()
 }
 
+// RecoverAfterReconnect re-pushes the last stream when the gabbo WebSocket
+// reconnects and finds the box awake but stuck on an STR selection it is not
+// playing. This recovers the lost first press after a deep/overnight standby
+// (#183): the box wakes and emits the preset/now-selection frame before STR has
+// reconnected (the reconnect backoff had grown while the box was unreachable),
+// so OnPresetSelected never runs and the display shows "service unavailable"
+// until a second press.
+//
+// It reuses the power-on resume's safeguards so it can only ever resume, never
+// surprise: it honours the per-box opt-out, stands down inside a zone (a
+// stereo-pair self-wake looks identical on the wire), suppresses a deliberate
+// user stop, and acts only when the box is awake-and-idle on an STR source
+// (boxSelectionStuck). A routine idle reconnect (box in standby), a box already
+// playing, or a box on a native source (AUX/Bluetooth) is a no-op. Unlike
+// ResumeLastPlay it does NOT clear the user-stop: a reconnect is not the explicit
+// "play it again" a real power press is.
+func (s *Server) RecoverAfterReconnect() {
+	if s.renderer == nil {
+		return
+	}
+	if !s.resumeOnPowerOnEnabled() {
+		return
+	}
+	if s.userStoppedRecently() {
+		return
+	}
+	s.lastPlayMu.Lock()
+	lp := s.lastPlay
+	if lp == nil || time.Since(lp.ts) >= 12*time.Hour {
+		s.lastPlayMu.Unlock()
+		return
+	}
+	boxURL, title, art, mime := lp.boxURL, lp.title, lp.art, lp.mime
+	s.lastPlayMu.Unlock()
+
+	go func() {
+		// Let the wake settle so the box's reported state is unambiguous before
+		// we decide (the box can flip through transient states right after a
+		// reconnect/wake).
+		time.Sleep(2 * time.Second)
+		if s.boxInZone() {
+			s.logger.Info("reconnect recovery: box in a zone / stereo pair, standing down (self-wake guard)")
+			return
+		}
+		if !s.boxSelectionStuck() {
+			return // asleep, already playing, or on a native source: nothing to recover
+		}
+		s.boxCmdMu.Lock()
+		defer s.boxCmdMu.Unlock()
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		var err error
+		if mime != "" {
+			err = s.renderer.PlayURLMime(ctx, boxURL, title, art, mime)
+		} else {
+			err = s.renderer.PlayURL(ctx, boxURL, title, art)
+		}
+		if err != nil {
+			s.logger.Warn("reconnect recovery: play failed", "err", err, "url", boxURL)
+			return
+		}
+		s.logger.Info("reconnect recovery: resumed last stream after WS reconnect", "url", boxURL, "title", title)
+	}()
+}
+
+// boxSelectionStuck reports whether the box is awake with an STR selection it is
+// not playing: the state a lost preset-press / power-on wake leaves behind (the
+// box restored STR's UPNP source as INVALID_SOURCE and shows "service
+// unavailable"). It is the trigger for RecoverAfterReconnect (#183) and is
+// deliberately narrow: a box in standby, a box already playing/paused, or a box
+// on a native source (AUX, Bluetooth) all return false so the recovery never
+// fights them.
+func (s *Server) boxSelectionStuck() bool {
+	if s.boxHost == "" {
+		return false
+	}
+	cl := &http.Client{Timeout: 5 * time.Second}
+	resp, err := cl.Get("http://" + s.boxHost + ":8090/now_playing")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+	body := string(b)
+	if strings.Contains(body, "STANDBY") {
+		return false // box asleep: a routine idle reconnect, nothing to recover
+	}
+	if strings.Contains(body, "PLAY_STATE") || strings.Contains(body, "BUFFERING_STATE") || strings.Contains(body, "PAUSE_STATE") {
+		return false // already playing/paused
+	}
+	// Only recover an STR-owned selection (UPNP) or the box's failed
+	// self-activation of it (INVALID_SOURCE). A native source the user picked
+	// (AUX, BLUETOOTH, ...) is left alone.
+	return strings.Contains(body, `source="UPNP"`) || strings.Contains(body, "INVALID_SOURCE")
+}
+
 // defaultResumeOnPowerOnPath is the NAND flag file for the per-box power-on
 // resume opt-out. Absent or "1" means on (the default), "0" means off.
 const defaultResumeOnPowerOnPath = "/mnt/nv/streborn/resume-on-power-on"


### PR DESCRIPTION
## Problem (#183)
After the speaker had been in standby overnight, the first press of a hardware preset showed "preset not available" and only a second press worked.

On a deep standby the agent's gabbo WebSocket is disconnected and the reconnect backoff had grown to its cap, so the box's first preset/now-selection frame is emitted before STR reconnects. The frame is lost, `OnPresetSelected` never runs, and the box's own failed self-activation leaves "service unavailable" on the display until a second press.

## Fix
- **`boxws`**: lower the reconnect backoff cap (30s -> 8s) so STR reattaches quickly after a wake, and add an optional `OnConnected` hook fired on every (re)connect.
- **`cmd/agent`**: `OnConnected` -> guarded recovery; `verifyPlayURL` retries longer (3 -> 5) to cover a slow deep-standby bringup.
- **`webui`**: `RecoverAfterReconnect` re-pushes the last stream when the box is awake but stuck on an STR selection it is not playing. It reuses the power-on resume safeguards (per-box opt-out, zone self-wake guard, deliberate-stop suppression) and a narrow `boxSelectionStuck` check, so it never fights a box in standby, already playing, or on a native source (AUX/Bluetooth), and never clears a deliberate stop.

## Verification
- Cross-compiles for linux/arm; `go vet` clean; boxws tests pass.
- Deployed live to the taigan test box: agent boots clean, gabbo WS connects, and the recovery correctly no-ops on a fresh boot (empty last-play), so no spontaneous playback.
- Full confirmation of the lost-first-press recovery needs a real overnight deep-standby cycle.

Refs #183