### PR TITLE
fix(box): announcement no longer reports a false error after it plays

### DIFF
--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -603,7 +603,7 @@
   "settingsView.airplayOptConfirmTitle": "Zum Übernehmen neu starten?",
   "settingsView.airplayOptConfirmBody": "Das Ändern der AirPlay-Optimierung startet den Lautsprecher neu, damit er die Einstellung übernimmt (genau wie die Bose-App). Er ist kurz nicht erreichbar. Fortfahren?",
   "settingsView.airplayOptSavedToast": "Gespeichert. Der Lautsprecher startet neu, um es zu übernehmen.",
-  "settingsView.expertBadge": "Erweitert",
+  "settingsView.expertBadge": "Spielwiese",
   "settingsView.urlPresetHeading": "Eigene URL über ein Preset abspielen",
   "settingsView.urlPresetHelp": "Lege eine Audio-URL (zum Beispiel eine MP3) auf eine Preset-Taste. Beim Drücken, am Lautsprecher oder in der App, wird sie abgespielt. Die URL muss im Netzwerk erreichbar sein und mit http beginnen (https unterstützt der Lautsprecher nicht). Beim Drücken wird die aktuelle Wiedergabe ersetzt.",
   "settingsView.urlPresetNamePlaceholder": "Name (zum Beispiel Türklingel)",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -603,7 +603,7 @@
   "settingsView.airplayOptConfirmTitle": "Restart speaker to apply?",
   "settingsView.airplayOptConfirmBody": "Changing AirPlay optimization restarts the speaker so it can apply the setting (the same as the Bose app). It will be briefly unavailable. Continue?",
   "settingsView.airplayOptSavedToast": "Saved. The speaker is restarting to apply it.",
-  "settingsView.expertBadge": "Expert",
+  "settingsView.expertBadge": "Playground",
   "settingsView.urlPresetHeading": "Play a custom URL from a preset",
   "settingsView.urlPresetHelp": "Assign an audio URL (for example an MP3) to a preset key. Pressing the key, on the speaker or in the app, plays it. The URL must be reachable on your network and start with http (the speaker does not support https). Pressing it replaces what is currently playing.",
   "settingsView.urlPresetNamePlaceholder": "Name (for example Doorbell)",

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -552,7 +552,7 @@
   "settingsView.airplayOptConfirmTitle": "¿Reiniciar el altavoz para aplicarlo?",
   "settingsView.airplayOptConfirmBody": "Cambiar la optimización de AirPlay reinicia el altavoz para que pueda aplicar el ajuste (igual que la app Bose). Estará brevemente no disponible. ¿Continuar?",
   "settingsView.airplayOptSavedToast": "Guardado. El altavoz se está reiniciando para aplicarlo.",
-  "settingsView.expertBadge": "Experto",
+  "settingsView.expertBadge": "Zona de juego",
   "settingsView.webhookHeading": "Pulgares del mando → webhook",
   "settingsView.webhookUrlPlaceholder": "https://home.example/api/toggle",
   "settingsView.webhookBodyPlaceholder": "Cuerpo de la petición (para POST), opcional",

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -552,7 +552,7 @@
   "settingsView.airplayOptConfirmTitle": "Redémarrer l'enceinte pour appliquer ?",
   "settingsView.airplayOptConfirmBody": "Modifier l'optimisation AirPlay redémarre l'enceinte pour appliquer le réglage (comme l'application Bose). Elle sera brièvement indisponible. Continuer ?",
   "settingsView.airplayOptSavedToast": "Enregistré. L'enceinte redémarre pour l'appliquer.",
-  "settingsView.expertBadge": "Expert",
+  "settingsView.expertBadge": "Bac à sable",
   "settingsView.webhookHeading": "Pouces à distance → webhook",
   "settingsView.webhookUrlPlaceholder": "https://home.example/api/toggle",
   "settingsView.webhookBodyPlaceholder": "Corps de la requête (pour POST), facultatif",

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -552,7 +552,7 @@
   "settingsView.airplayOptConfirmTitle": "適用のためスピーカーを再起動しますか?",
   "settingsView.airplayOptConfirmBody": "AirPlay最適化を変更すると、設定を適用するためスピーカーが再起動します (Boseアプリと同じです)。短時間利用できなくなります。続行しますか?",
   "settingsView.airplayOptSavedToast": "保存しました。適用のためスピーカーを再起動しています。",
-  "settingsView.expertBadge": "エキスパート",
+  "settingsView.expertBadge": "遊び場",
   "settingsView.webhookHeading": "リモコンの評価ボタン → Webhook",
   "settingsView.webhookUrlPlaceholder": "https://home.example/api/toggle",
   "settingsView.webhookBodyPlaceholder": "リクエストボディ（POST 用）、任意",

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -552,7 +552,7 @@
   "settingsView.airplayOptConfirmTitle": "Paleisti garsiakalbį iš naujo, kad būtų pritaikyta?",
   "settingsView.airplayOptConfirmBody": "AirPlay optimizavimo keitimas paleidžia garsiakalbį iš naujo, kad pritaikytų nustatymą (kaip ir Bose programa). Jis trumpam bus nepasiekiamas. Tęsti?",
   "settingsView.airplayOptSavedToast": "Išsaugota. Garsiakalbis paleidžiamas iš naujo, kad pritaikytų.",
-  "settingsView.expertBadge": "Ekspertas",
+  "settingsView.expertBadge": "Eksperimentai",
   "settingsView.webhookHeading": "Nuotolinio valdymo nykščiai → tinklo nuoroda (webhook)",
   "settingsView.webhookUrlPlaceholder": "https://home.example/api/toggle",
   "settingsView.webhookBodyPlaceholder": "Užklausos turinys (POST atveju), nebūtina",

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -552,7 +552,7 @@
   "settingsView.airplayOptConfirmTitle": "Restartēt skaļruni, lai pielietotu?",
   "settingsView.airplayOptConfirmBody": "AirPlay optimizācijas maiņa restartē skaļruni, lai pielietotu iestatījumu (tāpat kā Bose lietotne). Tas uz brīdi nebūs pieejams. Turpināt?",
   "settingsView.airplayOptSavedToast": "Saglabāts. Skaļrunis tiek restartēts, lai pielietotu.",
-  "settingsView.expertBadge": "Eksperts",
+  "settingsView.expertBadge": "Smilšu kaste",
   "settingsView.webhookHeading": "Tālvadības īkšķi → tīmekļa āķis",
   "settingsView.webhookUrlPlaceholder": "https://home.example/api/toggle",
   "settingsView.webhookBodyPlaceholder": "Pieprasījuma saturs (priekš POST), neobligāti",

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -552,7 +552,7 @@
   "settingsView.airplayOptConfirmTitle": "Speaker herstarten om toe te passen?",
   "settingsView.airplayOptConfirmBody": "Het wijzigen van de AirPlay-optimalisatie herstart de speaker zodat de instelling kan worden toegepast (net als de Bose-app). Hij is kort niet beschikbaar. Doorgaan?",
   "settingsView.airplayOptSavedToast": "Opgeslagen. De speaker herstart om het toe te passen.",
-  "settingsView.expertBadge": "Geavanceerd",
+  "settingsView.expertBadge": "Speeltuin",
   "settingsView.webhookHeading": "Duim op afstandsbediening → webhook",
   "settingsView.webhookUrlPlaceholder": "https://home.example/api/toggle",
   "settingsView.webhookBodyPlaceholder": "Aanvraaginhoud (voor POST), optioneel",

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -552,7 +552,7 @@
   "settingsView.airplayOptConfirmTitle": "Uruchomić głośnik ponownie, aby zastosować?",
   "settingsView.airplayOptConfirmBody": "Zmiana optymalizacji AirPlay uruchamia głośnik ponownie, aby zastosować ustawienie (tak jak aplikacja Bose). Będzie chwilowo niedostępny. Kontynuować?",
   "settingsView.airplayOptSavedToast": "Zapisano. Głośnik się restartuje, aby to zastosować.",
-  "settingsView.expertBadge": "Ekspert",
+  "settingsView.expertBadge": "Piaskownica",
   "settingsView.webhookHeading": "Zdalne kciuki → webhook",
   "settingsView.webhookUrlPlaceholder": "https://home.example/api/toggle",
   "settingsView.webhookBodyPlaceholder": "Treść żądania (dla POST), opcjonalnie",

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -552,7 +552,7 @@
   "settingsView.airplayOptConfirmTitle": "Uygulamak için hoparlör yeniden başlatılsın mı?",
   "settingsView.airplayOptConfirmBody": "AirPlay optimizasyonunu değiştirmek ayarı uygulamak için hoparlörü yeniden başlatır (Bose uygulaması gibi). Kısa süre erişilemez olur. Devam edilsin mi?",
   "settingsView.airplayOptSavedToast": "Kaydedildi. Hoparlör uygulamak için yeniden başlatılıyor.",
-  "settingsView.expertBadge": "Uzman",
+  "settingsView.expertBadge": "Oyun alanı",
   "settingsView.webhookHeading": "Uzaktan kumanda beğeni tuşları → webhook",
   "settingsView.webhookUrlPlaceholder": "https://home.example/api/toggle",
   "settingsView.webhookBodyPlaceholder": "İstek gövdesi (POST için), isteğe bağlı",

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -552,7 +552,7 @@
   "settingsView.airplayOptConfirmTitle": "Перезапустити колонку, щоб застосувати?",
   "settingsView.airplayOptConfirmBody": "Зміна оптимізації AirPlay перезапускає колонку, щоб застосувати налаштування (так само, як застосунок Bose). Вона ненадовго стане недоступною. Продовжити?",
   "settingsView.airplayOptSavedToast": "Збережено. Колонка перезапускається, щоб застосувати це.",
-  "settingsView.expertBadge": "Експертне",
+  "settingsView.expertBadge": "Пісочниця",
   "settingsView.webhookHeading": "Кнопки лайків на пульті → вебхук",
   "settingsView.webhookUrlPlaceholder": "https://home.example/api/toggle",
   "settingsView.webhookBodyPlaceholder": "Тіло запиту (для POST), необов'язково",

--- a/desktop-app/frontend/src/views/settings.js
+++ b/desktop-app/frontend/src/views/settings.js
@@ -554,6 +554,16 @@ function renderBoxSettings(s, box) {
       <small class="muted small">${escapeHtml(t('settingsView.displayTrackHelp'))}</small>
     </div>
 
+    <div class="settings-section hidden" id="airplayOptSection">
+      <h3>${escapeHtml(t('settingsView.airplayOptHeading'))}</h3>
+      <div class="setting-row">
+        <button class="btn btn-mini toggle-btn" id="airplayOptOn">${escapeHtml(t('settingsView.clockOn'))}</button>
+        <button class="btn btn-mini toggle-btn" id="airplayOptOff">${escapeHtml(t('settingsView.clockOff'))}</button>
+      </div>
+      <small class="muted small">${escapeHtml(t('settingsView.airplayOptHelp'))}</small>
+      <small class="muted small" style="display:block;margin-top:6px">${escapeHtml(t('settingsView.airplayOptRecommend'))}</small>
+    </div>
+
     <details class="settings-section settings-expert" id="announceSection">
       <summary class="settings-expert-summary">${escapeHtml(t('settingsView.announceHeading'))} <span class="expert-badge">${escapeHtml(t('settingsView.expertBadge'))}</span></summary>
       <small class="muted small expert-intro">${escapeHtml(t('settingsView.announceHelp'))}</small>
@@ -585,16 +595,6 @@ function renderBoxSettings(s, box) {
         </div>
       </details>
     </details>
-
-    <div class="settings-section hidden" id="airplayOptSection">
-      <h3>${escapeHtml(t('settingsView.airplayOptHeading'))}</h3>
-      <div class="setting-row">
-        <button class="btn btn-mini toggle-btn" id="airplayOptOn">${escapeHtml(t('settingsView.clockOn'))}</button>
-        <button class="btn btn-mini toggle-btn" id="airplayOptOff">${escapeHtml(t('settingsView.clockOff'))}</button>
-      </div>
-      <small class="muted small">${escapeHtml(t('settingsView.airplayOptHelp'))}</small>
-      <small class="muted small" style="display:block;margin-top:6px">${escapeHtml(t('settingsView.airplayOptRecommend'))}</small>
-    </div>
 
     <details class="settings-section settings-expert">
       <summary class="settings-expert-summary">${escapeHtml(t('settingsView.webhookHeading'))} <span class="expert-badge">${escapeHtml(t('settingsView.expertBadge'))}</span></summary>

--- a/internal/webui/announce.go
+++ b/internal/webui/announce.go
@@ -114,37 +114,6 @@ func (s *Server) handleAnnounce(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadGateway, map[string]any{"error": "could not fetch announcement audio", "detail": err.Error()})
 		return
 	}
-	s.announceMu.Lock()
-	s.announceAudio = audio
-	s.announceMime = mime
-	s.announceMu.Unlock()
-
-	// Serialise against other box commands (play, volume) for the whole
-	// interrupt/resume cycle so nothing interleaves mid-sequence.
-	s.boxCmdMu.Lock()
-	defer s.boxCmdMu.Unlock()
-
-	// Remember what to restore.
-	prev := s.snapshotNowPlaying(r.Context())
-	wasStandby := prev.Source == "STANDBY" || prev.Source == ""
-	changedVol := body.Volume > 0
-	prevVol := -1
-	if changedVol {
-		prevVol = s.readVolume(r.Context())
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Second)
-	defer cancel()
-
-	if wasStandby {
-		if err := boxcli.WakeAndWait(ctx, s.boxHost, 8*time.Second, s.logger); err != nil {
-			s.logger.Warn("announce: wake failed, playing anyway", "err", err)
-		}
-	}
-	if changedVol {
-		_ = boxapi.New(s.boxHost).SetVolume(ctx, clampVolume(body.Volume))
-	}
-
 	title := body.Text
 	if title == "" {
 		title = "Announcement"
@@ -152,22 +121,65 @@ func (s *Server) handleAnnounce(w http.ResponseWriter, r *http.Request) {
 	if len(title) > 64 {
 		title = strings.TrimSpace(title[:64])
 	}
-	if err := s.renderer.PlayURLMime(ctx, announceAudioURL, title, "", mime); err != nil {
-		s.logger.Warn("announce: play failed", "err", err)
-		// Best-effort restore of volume before reporting.
-		if changedVol && prevVol >= 0 {
-			_ = boxapi.New(s.boxHost).SetVolume(ctx, prevVol)
+	volume := body.Volume
+
+	// Respond now and run the interrupt/play/resume cycle in the background. The
+	// cycle takes ~5 s (play + resume), and holding the HTTP response open that
+	// long made the desktop app's POST connection drop on BCO boxes: it arrives
+	// via the :17008 PREROUTING REDIRECT, the long-held connection was reset
+	// before the response, boxDo then fell through to :8888 (chipset-refused) and
+	// surfaced "connection refused" even though the announcement had played fine
+	// (Jens, 2026-06-17, taigan Portable). The audio fetch above stays
+	// synchronous so a bad URL / TTS failure is still reported to the caller.
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "queued": true, "bytes": len(audio)})
+
+	go func() {
+		// Serialise against other box commands (play, volume) for the whole
+		// interrupt/resume cycle so nothing interleaves mid-sequence. Publish the
+		// audio for the box to fetch under the same lock, so a second announcement
+		// cannot swap it out mid-play.
+		s.boxCmdMu.Lock()
+		defer s.boxCmdMu.Unlock()
+		s.announceMu.Lock()
+		s.announceAudio = audio
+		s.announceMime = mime
+		s.announceMu.Unlock()
+
+		// Detached from the request: r.Context() is cancelled once the handler
+		// returned above, so use a fresh background context for the whole cycle.
+		ctx, cancel := context.WithTimeout(context.Background(), 150*time.Second)
+		defer cancel()
+
+		prev := s.snapshotNowPlaying(ctx)
+		wasStandby := prev.Source == "STANDBY" || prev.Source == ""
+		changedVol := volume > 0
+		prevVol := -1
+		if changedVol {
+			prevVol = s.readVolume(ctx)
 		}
-		writeJSON(w, http.StatusBadGateway, map[string]any{"error": "could not play announcement", "detail": err.Error()})
-		return
-	}
-	estDur := mp3DurationSec(audio)
-	s.logger.Info("announce: playing", "bytes", len(audio), "estSec", fmt.Sprintf("%.1f", estDur), "title", title, "wasStandby", wasStandby)
 
-	s.waitAnnounceDone(ctx, estDur)
-	s.restoreAfterAnnounce(ctx, prev, prevVol, wasStandby, changedVol)
+		if wasStandby {
+			if err := boxcli.WakeAndWait(ctx, s.boxHost, 8*time.Second, s.logger); err != nil {
+				s.logger.Warn("announce: wake failed, playing anyway", "err", err)
+			}
+		}
+		if changedVol {
+			_ = boxapi.New(s.boxHost).SetVolume(ctx, clampVolume(volume))
+		}
 
-	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "bytes": len(audio)})
+		if err := s.renderer.PlayURLMime(ctx, announceAudioURL, title, "", mime); err != nil {
+			s.logger.Warn("announce: play failed", "err", err)
+			if changedVol && prevVol >= 0 {
+				_ = boxapi.New(s.boxHost).SetVolume(ctx, prevVol)
+			}
+			return
+		}
+		estDur := mp3DurationSec(audio)
+		s.logger.Info("announce: playing", "bytes", len(audio), "estSec", fmt.Sprintf("%.1f", estDur), "title", title, "wasStandby", wasStandby)
+
+		s.waitAnnounceDone(ctx, estDur)
+		s.restoreAfterAnnounce(ctx, prev, prevVol, wasStandby, changedVol)
+	}()
 }
 
 // snapshotNowPlaying reads the box's current now_playing so STR can restore it


### PR DESCRIPTION
## What

Found while testing v0.8.1 on a Portable (taigan):

### fix: announcement no longer shows a false connection error
The agent's `/api/announce` held the HTTP response open for the whole ~5 s interrupt/play/resume cycle. On BCO boxes the desktop app's POST arrives via the `:17008` PREROUTING REDIRECT, and that long-held connection was reset before the response, so `boxDo` fell through to `:8888` (chipset-refused) and showed a connection error even though the announcement had already played. The agent now responds immediately and plays in a background goroutine; the audio fetch stays synchronous so a bad URL / TTS failure is still reported.

### chore: Announcements grouped with the advanced settings, lighter badge
Moved the Announcements section below AirPlay optimisation, next to the other advanced sections, and renamed the advanced badge from Expert/Erweitert to a lighter Playground/Spielwiese (translated in all locales).

## Test
- agent cross-build (linux/arm v7) green; `wails build` green.
- Box log confirmed the announcement itself plays + resumes correctly; the fix removes the spurious error toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
