### PR TITLE
feat(app): announcement volume slider and a default greeting in every language

### DIFF
--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -966,5 +966,7 @@
   "spotify.nativeNote": "Hinweis: ein Spotify-Premium-Account ist nötig (Spotifys eigene Connect-Regel). Das frühere „Account in der Bose-App verknüpfen\" entfällt und wird nicht gebraucht.",
   "worldMap.inviteTextAll": "Alle deine SoundTouch leben wieder 🎉",
   "update.inProgressTitle": "'{{name}}' wird aktualisiert ...",
-  "settingsView.stickStillInserted": "Stick noch eingesteckt (SSH offen). Zum Absichern den Stick ziehen und neu starten."
+  "settingsView.stickStillInserted": "Stick noch eingesteckt (SSH offen). Zum Absichern den Stick ziehen und neu starten.",
+  "settingsView.announceDefault": "Vielen Dank, dass du STR nutzt!",
+  "settingsView.announceVolumeLabel": "Durchsage-Lautstärke"
 }

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -967,6 +967,6 @@
   "worldMap.inviteTextAll": "Alle deine SoundTouch leben wieder 🎉",
   "update.inProgressTitle": "'{{name}}' wird aktualisiert ...",
   "settingsView.stickStillInserted": "Stick noch eingesteckt (SSH offen). Zum Absichern den Stick ziehen und neu starten.",
-  "settingsView.announceDefault": "Vielen Dank, dass du STR nutzt!",
+  "settingsView.announceDefault": "Vielen Dank, dass du ST-Reborn nutzt!",
   "settingsView.announceVolumeLabel": "Durchsage-Lautstärke"
 }

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -967,6 +967,6 @@
   "worldMap.inviteTextAll": "All your SoundTouch speakers are alive again 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
-  "settingsView.announceDefault": "Thank you for using STR!",
+  "settingsView.announceDefault": "Thank you for using ST-Reborn!",
   "settingsView.announceVolumeLabel": "Announcement volume"
 }

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -966,5 +966,7 @@
   "spotify.nativeNote": "Note: a Spotify Premium account is required (Spotify's own rule for Connect). The old “link an account in the Bose app” step is gone and not needed.",
   "worldMap.inviteTextAll": "All your SoundTouch speakers are alive again 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
-  "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker."
+  "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
+  "settingsView.announceDefault": "Thank you for using STR!",
+  "settingsView.announceVolumeLabel": "Announcement volume"
 }

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -922,5 +922,7 @@
   "worldMap.countLine": "🌍 {{n}} altavoces SoundTouch rescatados en todo el mundo hasta ahora. ¡Añade el tuyo!",
   "worldMap.inviteTextAll": "Todos tus SoundTouch vuelven a la vida 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
-  "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker."
+  "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
+  "settingsView.announceDefault": "¡Gracias por usar STR!",
+  "settingsView.announceVolumeLabel": "Volumen del aviso"
 }

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -923,6 +923,6 @@
   "worldMap.inviteTextAll": "Todos tus SoundTouch vuelven a la vida 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
-  "settingsView.announceDefault": "¡Gracias por usar STR!",
+  "settingsView.announceDefault": "¡Gracias por usar ST-Reborn!",
   "settingsView.announceVolumeLabel": "Volumen del aviso"
 }

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -922,5 +922,7 @@
   "worldMap.countLine": "🌍 {{n}} enceintes SoundTouch sauvées dans le monde jusqu'ici. Ajoute la tienne !",
   "worldMap.inviteTextAll": "Toutes tes enceintes SoundTouch revivent 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
-  "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker."
+  "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
+  "settingsView.announceDefault": "Merci d'utiliser STR !",
+  "settingsView.announceVolumeLabel": "Volume de l'annonce"
 }

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -923,6 +923,6 @@
   "worldMap.inviteTextAll": "Toutes tes enceintes SoundTouch revivent 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
-  "settingsView.announceDefault": "Merci d'utiliser STR !",
+  "settingsView.announceDefault": "Merci d'utiliser ST-Reborn !",
   "settingsView.announceVolumeLabel": "Volume de l'annonce"
 }

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -922,5 +922,7 @@
   "worldMap.countLine": "🌍 これまでに世界中で {{n}} 台の SoundTouch スピーカーが復活しました。あなたのも追加しましょう！",
   "worldMap.inviteTextAll": "あなたの SoundTouch がすべてまた動き出しました 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
-  "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker."
+  "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
+  "settingsView.announceDefault": "STRをご利用いただきありがとうございます！",
+  "settingsView.announceVolumeLabel": "アナウンスの音量"
 }

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -923,6 +923,6 @@
   "worldMap.inviteTextAll": "あなたの SoundTouch がすべてまた動き出しました 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
-  "settingsView.announceDefault": "STRをご利用いただきありがとうございます！",
+  "settingsView.announceDefault": "ST-Rebornをご利用いただきありがとうございます！",
   "settingsView.announceVolumeLabel": "アナウンスの音量"
 }

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -922,5 +922,7 @@
   "worldMap.countLine": "🌍 Iki šiol pasaulyje išgelbėta {{n}} SoundTouch garsiakalbių. Pridėk savąjį!",
   "worldMap.inviteTextAll": "Visi jūsų SoundTouch vėl veikia 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
-  "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker."
+  "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
+  "settingsView.announceDefault": "Ačiū, kad naudojate STR!",
+  "settingsView.announceVolumeLabel": "Pranešimo garsumas"
 }

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -923,6 +923,6 @@
   "worldMap.inviteTextAll": "Visi jūsų SoundTouch vėl veikia 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
-  "settingsView.announceDefault": "Ačiū, kad naudojate STR!",
+  "settingsView.announceDefault": "Ačiū, kad naudojate ST-Reborn!",
   "settingsView.announceVolumeLabel": "Pranešimo garsumas"
 }

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -923,6 +923,6 @@
   "worldMap.inviteTextAll": "Visi tavi SoundTouch atkal darbojas 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
-  "settingsView.announceDefault": "Paldies, ka izmantojat STR!",
+  "settingsView.announceDefault": "Paldies, ka izmantojat ST-Reborn!",
   "settingsView.announceVolumeLabel": "Paziņojuma skaļums"
 }

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -922,5 +922,7 @@
   "worldMap.countLine": "🌍 Līdz šim pasaulē izglābti {{n}} SoundTouch skaļruņi. Pievieno arī savu!",
   "worldMap.inviteTextAll": "Visi tavi SoundTouch atkal darbojas 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
-  "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker."
+  "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
+  "settingsView.announceDefault": "Paldies, ka izmantojat STR!",
+  "settingsView.announceVolumeLabel": "Paziņojuma skaļums"
 }

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -922,5 +922,7 @@
   "worldMap.countLine": "🌍 {{n}} SoundTouch-speakers wereldwijd gered tot nu toe. Voeg die van jou toe!",
   "worldMap.inviteTextAll": "Al je SoundTouch-speakers leven weer 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
-  "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker."
+  "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
+  "settingsView.announceDefault": "Bedankt dat je STR gebruikt!",
+  "settingsView.announceVolumeLabel": "Volume van de melding"
 }

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -923,6 +923,6 @@
   "worldMap.inviteTextAll": "Al je SoundTouch-speakers leven weer 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
-  "settingsView.announceDefault": "Bedankt dat je STR gebruikt!",
+  "settingsView.announceDefault": "Bedankt dat je ST-Reborn gebruikt!",
   "settingsView.announceVolumeLabel": "Volume van de melding"
 }

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -923,6 +923,6 @@
   "worldMap.inviteTextAll": "Wszystkie Twoje SoundTouch znów działają 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
-  "settingsView.announceDefault": "Dziękujemy, że korzystasz z STR!",
+  "settingsView.announceDefault": "Dziękujemy, że korzystasz z ST-Reborn!",
   "settingsView.announceVolumeLabel": "Głośność komunikatu"
 }

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -922,5 +922,7 @@
   "worldMap.countLine": "🌍 Dotychczas uratowano {{n}} głośników SoundTouch na całym świecie. Dodaj swój!",
   "worldMap.inviteTextAll": "Wszystkie Twoje SoundTouch znów działają 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
-  "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker."
+  "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
+  "settingsView.announceDefault": "Dziękujemy, że korzystasz z STR!",
+  "settingsView.announceVolumeLabel": "Głośność komunikatu"
 }

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -923,6 +923,6 @@
   "worldMap.inviteTextAll": "Tüm SoundTouch hoparlörlerin yeniden hayatta 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
-  "settingsView.announceDefault": "STR'yi kullandığınız için teşekkürler!",
+  "settingsView.announceDefault": "ST-Reborn'u kullandığınız için teşekkürler!",
   "settingsView.announceVolumeLabel": "Anons ses düzeyi"
 }

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -922,5 +922,7 @@
   "worldMap.countLine": "🌍 Şimdiye kadar dünya genelinde {{n}} SoundTouch hoparlörü kurtarıldı. Seninkini de ekle!",
   "worldMap.inviteTextAll": "Tüm SoundTouch hoparlörlerin yeniden hayatta 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
-  "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker."
+  "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
+  "settingsView.announceDefault": "STR'yi kullandığınız için teşekkürler!",
+  "settingsView.announceVolumeLabel": "Anons ses düzeyi"
 }

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -923,6 +923,6 @@
   "worldMap.inviteTextAll": "Усі ваші SoundTouch знову працюють 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
-  "settingsView.announceDefault": "Дякуємо, що користуєтесь STR!",
+  "settingsView.announceDefault": "Дякуємо, що користуєтесь ST-Reborn!",
   "settingsView.announceVolumeLabel": "Гучність оголошення"
 }

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -922,5 +922,7 @@
   "worldMap.countLine": "🌍 Уже {{n}} колонок SoundTouch врятовано по всьому світу. Додай свою!",
   "worldMap.inviteTextAll": "Усі ваші SoundTouch знову працюють 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
-  "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker."
+  "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
+  "settingsView.announceDefault": "Дякуємо, що користуєтесь STR!",
+  "settingsView.announceVolumeLabel": "Гучність оголошення"
 }

--- a/desktop-app/frontend/src/views/settings.js
+++ b/desktop-app/frontend/src/views/settings.js
@@ -568,7 +568,7 @@ function renderBoxSettings(s, box) {
       <summary class="settings-expert-summary">${escapeHtml(t('settingsView.announceHeading'))} <span class="expert-badge">${escapeHtml(t('settingsView.expertBadge'))}</span></summary>
       <small class="muted small expert-intro">${escapeHtml(t('settingsView.announceHelp'))}</small>
       <div class="setting-row" style="margin-top:8px">
-        <input type="text" id="announceText" class="text-input" maxlength="200" placeholder="${escapeAttr(t('settingsView.announcePlaceholder'))}" style="flex:1" />
+        <input type="text" id="announceText" class="text-input" maxlength="200" value="${escapeAttr(t('settingsView.announceDefault'))}" placeholder="${escapeAttr(t('settingsView.announcePlaceholder'))}" style="flex:1" />
         <select id="announceLang" style="flex:0 0 130px;" title="${escapeAttr(t('settingsView.announceLangLabel'))}">
           <option value="de">Deutsch</option>
           <option value="en">English</option>
@@ -583,6 +583,11 @@ function renderBoxSettings(s, box) {
           <option value="ja">日本語</option>
         </select>
         <button class="btn btn-mini" id="announceSend">${escapeHtml(t('settingsView.announceSend'))}</button>
+      </div>
+      <div class="setting-row" style="align-items:center;gap:10px;margin-top:8px">
+        <label class="muted small" for="announceVolume" style="flex:0 0 auto">${escapeHtml(t('settingsView.announceVolumeLabel'))}</label>
+        <input type="range" id="announceVolume" min="1" max="100" value="25" style="flex:1" />
+        <span class="muted small" id="announceVolumeVal" style="flex:0 0 2.5em;text-align:right">25</span>
       </div>
       <small class="muted small">${escapeHtml(t('settingsView.announceCharHint'))}</small>
       <small class="muted small" style="display:block;margin-top:6px">&#9432; ${escapeHtml(t('settingsView.announcePrivacy'))}</small>
@@ -1273,6 +1278,12 @@ function renderBoxSettings(s, box) {
   const annLang = $('announceLang');
   const annCurl = $('announceCurl');
   const annCopy = $('announceCopy');
+  const annVol = $('announceVolume');
+  const annVolVal = $('announceVolumeVal');
+  if (annVol && annVolVal) {
+    annVolVal.textContent = annVol.value;
+    annVol.oninput = () => { annVolVal.textContent = annVol.value; };
+  }
   // Default the TTS voice to the app's UI language when it is one of the offered
   // voices, so e.g. a German user gets a German voice without having to pick.
   if (annLang) {
@@ -1290,7 +1301,8 @@ function renderBoxSettings(s, box) {
       if (!text) return;
       annSend.disabled = true;
       try {
-        await SendAnnounce(box.host, box.port, text, (annLang && annLang.value) || '', 0);
+        const vol = annVol ? (parseInt(annVol.value, 10) || 0) : 0;
+        await SendAnnounce(box.host, box.port, text, (annLang && annLang.value) || '', vol);
         showToast(t('settingsView.announceSentToast'));
       } catch (e) { showError(e); }
       annSend.disabled = false;


### PR DESCRIPTION
## What

Two announcement-section improvements (v0.8.3):

- **Volume slider** for announcements: the Announcements section now has a slider; its value is sent as the announcement volume (the agent sets it for the announcement and restores the previous volume afterwards). Previously the volume was hard-coded to "keep current".
- **Ready-made greeting**: the text field is prefilled with a translated "Thank you for using STR!" in all app languages, so a user can fire a working announcement in one click and see what the feature does.

## Test
- `wails build` green; app launched (v0.8.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
