### PR TITLE
chore(app): announcement greeting speaks the name as S T Reborn

### DIFF
--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -967,6 +967,6 @@
   "worldMap.inviteTextAll": "Alle deine SoundTouch leben wieder 🎉",
   "update.inProgressTitle": "'{{name}}' wird aktualisiert ...",
   "settingsView.stickStillInserted": "Stick noch eingesteckt (SSH offen). Zum Absichern den Stick ziehen und neu starten.",
-  "settingsView.announceDefault": "Vielen Dank, dass du ST-Reborn nutzt!",
+  "settingsView.announceDefault": "Vielen Dank, dass du S T Reborn nutzt!",
   "settingsView.announceVolumeLabel": "Durchsage-Lautstärke"
 }

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -967,6 +967,6 @@
   "worldMap.inviteTextAll": "All your SoundTouch speakers are alive again 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
-  "settingsView.announceDefault": "Thank you for using ST-Reborn!",
+  "settingsView.announceDefault": "Thank you for using S T Reborn!",
   "settingsView.announceVolumeLabel": "Announcement volume"
 }

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -923,6 +923,6 @@
   "worldMap.inviteTextAll": "Todos tus SoundTouch vuelven a la vida 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
-  "settingsView.announceDefault": "¡Gracias por usar ST-Reborn!",
+  "settingsView.announceDefault": "¡Gracias por usar S T Reborn!",
   "settingsView.announceVolumeLabel": "Volumen del aviso"
 }

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -923,6 +923,6 @@
   "worldMap.inviteTextAll": "Toutes tes enceintes SoundTouch revivent 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
-  "settingsView.announceDefault": "Merci d'utiliser ST-Reborn !",
+  "settingsView.announceDefault": "Merci d'utiliser S T Reborn !",
   "settingsView.announceVolumeLabel": "Volume de l'annonce"
 }

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -923,6 +923,6 @@
   "worldMap.inviteTextAll": "あなたの SoundTouch がすべてまた動き出しました 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
-  "settingsView.announceDefault": "ST-Rebornをご利用いただきありがとうございます！",
+  "settingsView.announceDefault": "S T Rebornをご利用いただきありがとうございます！",
   "settingsView.announceVolumeLabel": "アナウンスの音量"
 }

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -923,6 +923,6 @@
   "worldMap.inviteTextAll": "Visi jūsų SoundTouch vėl veikia 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
-  "settingsView.announceDefault": "Ačiū, kad naudojate ST-Reborn!",
+  "settingsView.announceDefault": "Ačiū, kad naudojate S T Reborn!",
   "settingsView.announceVolumeLabel": "Pranešimo garsumas"
 }

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -923,6 +923,6 @@
   "worldMap.inviteTextAll": "Visi tavi SoundTouch atkal darbojas 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
-  "settingsView.announceDefault": "Paldies, ka izmantojat ST-Reborn!",
+  "settingsView.announceDefault": "Paldies, ka izmantojat S T Reborn!",
   "settingsView.announceVolumeLabel": "Paziņojuma skaļums"
 }

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -923,6 +923,6 @@
   "worldMap.inviteTextAll": "Al je SoundTouch-speakers leven weer 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
-  "settingsView.announceDefault": "Bedankt dat je ST-Reborn gebruikt!",
+  "settingsView.announceDefault": "Bedankt dat je S T Reborn gebruikt!",
   "settingsView.announceVolumeLabel": "Volume van de melding"
 }

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -923,6 +923,6 @@
   "worldMap.inviteTextAll": "Wszystkie Twoje SoundTouch znów działają 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
-  "settingsView.announceDefault": "Dziękujemy, że korzystasz z ST-Reborn!",
+  "settingsView.announceDefault": "Dziękujemy, że korzystasz z S T Reborn!",
   "settingsView.announceVolumeLabel": "Głośność komunikatu"
 }

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -923,6 +923,6 @@
   "worldMap.inviteTextAll": "Tüm SoundTouch hoparlörlerin yeniden hayatta 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
-  "settingsView.announceDefault": "ST-Reborn'u kullandığınız için teşekkürler!",
+  "settingsView.announceDefault": "S T Reborn'u kullandığınız için teşekkürler!",
   "settingsView.announceVolumeLabel": "Anons ses düzeyi"
 }

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -923,6 +923,6 @@
   "worldMap.inviteTextAll": "Усі ваші SoundTouch знову працюють 🎉",
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
-  "settingsView.announceDefault": "Дякуємо, що користуєтесь ST-Reborn!",
+  "settingsView.announceDefault": "Дякуємо, що користуєтесь S T Reborn!",
   "settingsView.announceVolumeLabel": "Гучність оголошення"
 }


### PR DESCRIPTION
ST-Reborn was read aloud as "Sankt Reborn" by TTS (ST = Saint/Straße abbreviation). Spaces the letters (S T Reborn) in the prefilled greeting in all locales so the TTS speaks them individually. Part of the v0.8.3 announcement work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)