### PR TITLE
feat(app): translate an announcement into the chosen language before speaking

### DIFF
--- a/desktop-app/frontend/src/api.js
+++ b/desktop-app/frontend/src/api.js
@@ -63,6 +63,7 @@ export {
   SetDisplayTrack,
   AnnounceExample,
   SendAnnounce,
+  Translate,
   ResolveUpdateAsset,
   DownloadUpdate,
   ApplyUpdate,

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -968,5 +968,7 @@
   "update.inProgressTitle": "'{{name}}' wird aktualisiert ...",
   "settingsView.stickStillInserted": "Stick noch eingesteckt (SSH offen). Zum Absichern den Stick ziehen und neu starten.",
   "settingsView.announceDefault": "Vielen Dank, dass du S T Reborn nutzt!",
-  "settingsView.announceVolumeLabel": "Durchsage-Lautstärke"
+  "settingsView.announceVolumeLabel": "Durchsage-Lautstärke",
+  "settingsView.announceTranslate": "Übersetzen",
+  "settingsView.announceTranslateTitle": "Text in die gewählte Stimmen-Sprache übersetzen"
 }

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -968,5 +968,7 @@
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
   "settingsView.announceDefault": "Thank you for using S T Reborn!",
-  "settingsView.announceVolumeLabel": "Announcement volume"
+  "settingsView.announceVolumeLabel": "Announcement volume",
+  "settingsView.announceTranslate": "Translate",
+  "settingsView.announceTranslateTitle": "Translate the text into the selected voice language"
 }

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -924,5 +924,7 @@
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
   "settingsView.announceDefault": "¡Gracias por usar S T Reborn!",
-  "settingsView.announceVolumeLabel": "Volumen del aviso"
+  "settingsView.announceVolumeLabel": "Volumen del aviso",
+  "settingsView.announceTranslate": "Traducir",
+  "settingsView.announceTranslateTitle": "Traducir el texto al idioma de voz seleccionado"
 }

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -924,5 +924,7 @@
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
   "settingsView.announceDefault": "Merci d'utiliser S T Reborn !",
-  "settingsView.announceVolumeLabel": "Volume de l'annonce"
+  "settingsView.announceVolumeLabel": "Volume de l'annonce",
+  "settingsView.announceTranslate": "Traduire",
+  "settingsView.announceTranslateTitle": "Traduire le texte dans la langue de la voix sélectionnée"
 }

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -924,5 +924,7 @@
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
   "settingsView.announceDefault": "S T Rebornをご利用いただきありがとうございます！",
-  "settingsView.announceVolumeLabel": "アナウンスの音量"
+  "settingsView.announceVolumeLabel": "アナウンスの音量",
+  "settingsView.announceTranslate": "翻訳",
+  "settingsView.announceTranslateTitle": "選択した音声の言語にテキストを翻訳します"
 }

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -924,5 +924,7 @@
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
   "settingsView.announceDefault": "Ačiū, kad naudojate S T Reborn!",
-  "settingsView.announceVolumeLabel": "Pranešimo garsumas"
+  "settingsView.announceVolumeLabel": "Pranešimo garsumas",
+  "settingsView.announceTranslate": "Versti",
+  "settingsView.announceTranslateTitle": "Išversti tekstą į pasirinktą balso kalbą"
 }

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -924,5 +924,7 @@
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
   "settingsView.announceDefault": "Paldies, ka izmantojat S T Reborn!",
-  "settingsView.announceVolumeLabel": "Paziņojuma skaļums"
+  "settingsView.announceVolumeLabel": "Paziņojuma skaļums",
+  "settingsView.announceTranslate": "Tulkot",
+  "settingsView.announceTranslateTitle": "Tulkot tekstu izvēlētajā balss valodā"
 }

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -924,5 +924,7 @@
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
   "settingsView.announceDefault": "Bedankt dat je S T Reborn gebruikt!",
-  "settingsView.announceVolumeLabel": "Volume van de melding"
+  "settingsView.announceVolumeLabel": "Volume van de melding",
+  "settingsView.announceTranslate": "Vertalen",
+  "settingsView.announceTranslateTitle": "Vertaal de tekst naar de geselecteerde stemtaal"
 }

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -924,5 +924,7 @@
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
   "settingsView.announceDefault": "Dziękujemy, że korzystasz z S T Reborn!",
-  "settingsView.announceVolumeLabel": "Głośność komunikatu"
+  "settingsView.announceVolumeLabel": "Głośność komunikatu",
+  "settingsView.announceTranslate": "Przetłumacz",
+  "settingsView.announceTranslateTitle": "Przetłumacz tekst na wybrany język głosu"
 }

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -924,5 +924,7 @@
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
   "settingsView.announceDefault": "S T Reborn'u kullandığınız için teşekkürler!",
-  "settingsView.announceVolumeLabel": "Anons ses düzeyi"
+  "settingsView.announceVolumeLabel": "Anons ses düzeyi",
+  "settingsView.announceTranslate": "Çevir",
+  "settingsView.announceTranslateTitle": "Metni seçilen ses diline çevir"
 }

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -924,5 +924,7 @@
   "update.inProgressTitle": "Updating '{{name}}'...",
   "settingsView.stickStillInserted": "Stick still inserted (SSH is open). Pull it out and restart to secure the speaker.",
   "settingsView.announceDefault": "Дякуємо, що користуєтесь S T Reborn!",
-  "settingsView.announceVolumeLabel": "Гучність оголошення"
+  "settingsView.announceVolumeLabel": "Гучність оголошення",
+  "settingsView.announceTranslate": "Перекласти",
+  "settingsView.announceTranslateTitle": "Перекласти текст вибраною мовою голосу"
 }

--- a/desktop-app/frontend/src/views/settings.js
+++ b/desktop-app/frontend/src/views/settings.js
@@ -47,6 +47,7 @@ import {
   SetDisplayTrack,
   AnnounceExample,
   SendAnnounce,
+  Translate,
   GetAirplayOpt,
   SetAirplayOpt,
   GetWebhooks,
@@ -582,6 +583,7 @@ function renderBoxSettings(s, box) {
           <option value="uk">Українська</option>
           <option value="ja">日本語</option>
         </select>
+        <button class="btn btn-mini" id="announceTranslate" title="${escapeAttr(t('settingsView.announceTranslateTitle'))}">${escapeHtml(t('settingsView.announceTranslate'))}</button>
         <button class="btn btn-mini" id="announceSend">${escapeHtml(t('settingsView.announceSend'))}</button>
       </div>
       <div class="setting-row" style="align-items:center;gap:10px;margin-top:8px">
@@ -1280,6 +1282,7 @@ function renderBoxSettings(s, box) {
   const annCopy = $('announceCopy');
   const annVol = $('announceVolume');
   const annVolVal = $('announceVolumeVal');
+  const annTranslate = $('announceTranslate');
   if (annVol && annVolVal) {
     annVolVal.textContent = annVol.value;
     annVol.oninput = () => { annVolVal.textContent = annVol.value; };
@@ -1306,6 +1309,21 @@ function renderBoxSettings(s, box) {
         showToast(t('settingsView.announceSentToast'));
       } catch (e) { showError(e); }
       annSend.disabled = false;
+    };
+  }
+  if (annTranslate) {
+    // Translate the field text into the selected voice language (keyless Google
+    // Translate, app-side), then drop it back in the field so the user can
+    // review before sending. Same language picker doubles as the TTS voice.
+    annTranslate.onclick = async () => {
+      const text = ((annText && annText.value) || '').trim();
+      if (!text) return;
+      annTranslate.disabled = true;
+      try {
+        const translated = await Translate(text, (annLang && annLang.value) || 'en');
+        if (translated && annText) annText.value = translated;
+      } catch (e) { showError(e); }
+      annTranslate.disabled = false;
     };
   }
   if (annText) {

--- a/desktop-app/frontend/wailsjs/go/main/App.d.ts
+++ b/desktop-app/frontend/wailsjs/go/main/App.d.ts
@@ -185,6 +185,8 @@ export function TestWebhook(arg1:string,arg2:number,arg3:string,arg4:string,arg5
 
 export function TestWebhookAction(arg1:string,arg2:number,arg3:string):Promise<Record<string, any>>;
 
+export function Translate(arg1:string,arg2:string):Promise<string>;
+
 export function TrueFactoryReset(arg1:string):Promise<main.TrueFactoryResetResult>;
 
 export function TryWiFiPassword(arg1:string):Promise<string>;

--- a/desktop-app/frontend/wailsjs/go/main/App.js
+++ b/desktop-app/frontend/wailsjs/go/main/App.js
@@ -362,6 +362,10 @@ export function TestWebhookAction(arg1, arg2, arg3) {
   return window['go']['main']['App']['TestWebhookAction'](arg1, arg2, arg3);
 }
 
+export function Translate(arg1, arg2) {
+  return window['go']['main']['App']['Translate'](arg1, arg2);
+}
+
 export function TrueFactoryReset(arg1) {
   return window['go']['main']['App']['TrueFactoryReset'](arg1);
 }

--- a/desktop-app/translate.go
+++ b/desktop-app/translate.go
@@ -1,0 +1,77 @@
+// App-side text translation for the announcement composer, using Google's
+// keyless translate endpoint (the same no-API-key approach as the radio-browser
+// client). Source language is auto-detected; the target is the TTS voice the
+// user picked. Done app-side so the box stays minimal (app-first architecture).
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Translate returns text translated into targetLang (a 2-letter code like "de").
+// Keyless: it calls translate.googleapis.com/translate_a/single?client=gtx,
+// which needs no API key or billing. Source language is auto-detected. The
+// response is Google's nested-array shape: [ [ ["translated","orig",...], ... ],
+// ... ]; the translated segments are result[0][i][0], concatenated.
+func (a *App) Translate(text, targetLang string) (string, error) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return "", fmt.Errorf("no text to translate")
+	}
+	targetLang = strings.TrimSpace(targetLang)
+	if targetLang == "" {
+		targetLang = "en"
+	}
+	q := url.Values{}
+	q.Set("client", "gtx")
+	q.Set("sl", "auto")
+	q.Set("tl", targetLang)
+	q.Set("dt", "t")
+	q.Set("q", text)
+	u := "https://translate.googleapis.com/translate_a/single?" + q.Encode()
+	req, err := http.NewRequestWithContext(a.appCtx(), http.MethodGet, u, nil)
+	if err != nil {
+		return "", err
+	}
+	// A browser-ish UA avoids the occasional bot rejection on this endpoint.
+	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; STReborn)")
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("translation service returned status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 256<<10))
+	if err != nil {
+		return "", err
+	}
+	var outer []json.RawMessage
+	if err := json.Unmarshal(body, &outer); err != nil || len(outer) == 0 {
+		return "", fmt.Errorf("could not read the translation response")
+	}
+	var segs [][]any
+	if err := json.Unmarshal(outer[0], &segs); err != nil {
+		return "", fmt.Errorf("could not read the translation segments")
+	}
+	var b strings.Builder
+	for _, s := range segs {
+		if len(s) > 0 {
+			if str, ok := s[0].(string); ok {
+				b.WriteString(str)
+			}
+		}
+	}
+	res := strings.TrimSpace(b.String())
+	if res == "" {
+		return "", fmt.Errorf("the translation came back empty")
+	}
+	return res, nil
+}


### PR DESCRIPTION
## What (v0.8.4)

**Translate announcements** before they are spoken. The Announcements section gets a Translate button: it translates the text field into the selected voice language and puts it back in the field so you can review, then send. Source language is auto-detected.

- App-side, **keyless** Google Translate (the same no-API-key approach as the radio-browser client), so no key/billing and the box stays minimal.
- The existing language picker doubles as the translation target and the TTS voice.

## Test
- agent cross-build (linux/arm v7) + `desktop-app go build ./...` green; `wails build` green; app launched (v0.8.4).
- wailsjs bindings regenerated (Translate) and committed so the Vite build resolves the import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
