### PR TITLE
fix: AirPlay/Bluetooth source label + install diagnostics; translate remaining German to English

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1,5 +1,5 @@
-// Command streborn ist der Agent, der direkt auf der Bose SoundTouch
-// Box läuft und die Bose Cloud Endpunkte lokal emuliert.
+// Command streborn is the agent that runs directly on the Bose SoundTouch
+// box and emulates the Bose cloud endpoints locally.
 package main
 
 import (
@@ -53,9 +53,9 @@ import (
 	usbstick "github.com/JRpersonal/streborn/usb-stick"
 )
 
-// version ist die Semver Version. Build Datum wird separat ueber -ldflags
-// gesetzt damit man "1.0.0" anzeigen kann und das Build Datum trotzdem
-// verfuegbar ist.
+// version is the semver version. The build date is set separately via
+// -ldflags so that "1.0.0" can be shown while the build date is still
+// available.
 var (
 	version    = "1.0.0"
 	buildStamp = "dev"
@@ -67,8 +67,8 @@ func init() {
 }
 
 func main() {
-	// Subcommands vor flag.Parse() abhandeln, damit ihre eigenen Flags
-	// nicht vom globalen flag Set verschluckt werden.
+	// Handle subcommands before flag.Parse() so their own flags are not
+	// swallowed by the global flag set.
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
 		case "shepherd":
@@ -86,22 +86,22 @@ func main() {
 	}
 }
 
-// runShepherdCmd haendlet das shepherd Subcommand.
-// Aufrufe:
+// runShepherdCmd handles the shepherd subcommand.
+// Invocations:
 //
-//	streborn shepherd install   -- /mnt/nv/shepherd aufsetzen
-//	streborn shepherd remove    -- /mnt/nv/shepherd entfernen
-//	streborn shepherd status    -- aktuellen Stand zeigen
+//	streborn shepherd install   -- set up /mnt/nv/shepherd
+//	streborn shepherd remove    -- remove /mnt/nv/shepherd
+//	streborn shepherd status    -- show the current state
 func runShepherdCmd(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("verwendung: shepherd {install|remove|status}")
+		return fmt.Errorf("usage: shepherd {install|remove|status}")
 	}
 
 	fs := flag.NewFlagSet("shepherd", flag.ContinueOnError)
-	shepherdDir := fs.String("dir", shepherd.DefaultShepherdDir, "Shepherd Override Verzeichnis")
-	boseDir := fs.String("bose-config", shepherd.DefaultBoseConfigDir, "Bose Config Verzeichnis")
-	bin := fs.String("binary", shepherd.DefaultStickBin, "Pfad zum Agent Binary")
-	presetsPath := fs.String("presets", shepherd.DefaultPresetsPath, "Pfad zur presets.json")
+	shepherdDir := fs.String("dir", shepherd.DefaultShepherdDir, "Shepherd override directory")
+	boseDir := fs.String("bose-config", shepherd.DefaultBoseConfigDir, "Bose config directory")
+	bin := fs.String("binary", shepherd.DefaultStickBin, "Path to the agent binary")
+	presetsPath := fs.String("presets", shepherd.DefaultPresetsPath, "Path to presets.json")
 
 	cmd := args[0]
 	if err := fs.Parse(args[1:]); err != nil {
@@ -134,7 +134,7 @@ func runShepherdCmd(args []string) error {
 		fmt.Printf("Healthy       : %v\n", st.IsHealthy())
 		return nil
 	default:
-		return fmt.Errorf("unbekanntes Subcommand: %s", cmd)
+		return fmt.Errorf("unknown subcommand: %s", cmd)
 	}
 }
 
@@ -170,20 +170,20 @@ func canonicalPresetsPath(p string, logger *slog.Logger) string {
 
 func run() error {
 	var (
-		presetsPath     = flag.String("presets", "/media/sda1/presets.json", "Pfad zur presets.json auf dem USB Stick")
-		webuiAddr       = flag.String("listen-webui", ":8888", "Adresse für das Config Web UI")
-		margeAddr       = flag.String("listen-marge", ":80", "Adresse für die Marge Emulation HTTP (streaming.bose.com)")
-		margeTLSAddr    = flag.String("listen-marge-tls", ":8443", "Adresse für die Marge Emulation HTTPS")
-		bmxAddr         = flag.String("listen-bmx", ":81", "Adresse für die BMX Emulation HTTP (content.api.bose.io)")
-		hostsPath       = flag.String("hosts", "/etc/hosts", "Pfad zur hosts Datei")
-		applyHosts      = flag.Bool("apply-hosts", true, "Hosts Datei beim Start manipulieren und beim Stop wiederherstellen")
-		tlsDir          = flag.String("tls-dir", tlsgen.DefaultCADir, "Verzeichnis fuer CA und Server Cert")
-		tlsEnabled      = flag.Bool("tls", true, "TLS Termination aktivieren auf listen-marge-tls")
-		logLevel        = flag.String("log-level", "info", "Log Level: debug, info, warn, error")
-		boxHost         = flag.String("box-host", "127.0.0.1", "Bose Box IP fuer UPnP Calls (Webui /api/play). 127.0.0.1 wenn Agent auf Box laeuft, sonst LAN IP.")
-		regionFile      = flag.String("region-file", "", "Pfad zur region.txt mit ISO Country Code (vom Setup Wizard). Default Radio Land und Sprache leiten wir daraus ab.")
-		pendingNameFile = flag.String("pending-name-file", "", "Pfad zur name.txt vom Setup Wizard. Inhalt wird einmalig als Box Name angewendet (plus UID Suffix) und die Datei danach geloescht.")
-		printVersion    = flag.Bool("version", false, "Version ausgeben und beenden")
+		presetsPath     = flag.String("presets", "/media/sda1/presets.json", "Path to presets.json on the USB stick")
+		webuiAddr       = flag.String("listen-webui", ":8888", "Address for the config web UI")
+		margeAddr       = flag.String("listen-marge", ":80", "Address for the marge emulation HTTP (streaming.bose.com)")
+		margeTLSAddr    = flag.String("listen-marge-tls", ":8443", "Address for the marge emulation HTTPS")
+		bmxAddr         = flag.String("listen-bmx", ":81", "Address for the BMX emulation HTTP (content.api.bose.io)")
+		hostsPath       = flag.String("hosts", "/etc/hosts", "Path to the hosts file")
+		applyHosts      = flag.Bool("apply-hosts", true, "Modify the hosts file on start and restore it on stop")
+		tlsDir          = flag.String("tls-dir", tlsgen.DefaultCADir, "Directory for the CA and server certificate")
+		tlsEnabled      = flag.Bool("tls", true, "Enable TLS termination on listen-marge-tls")
+		logLevel        = flag.String("log-level", "info", "Log level: debug, info, warn, error")
+		boxHost         = flag.String("box-host", "127.0.0.1", "Bose box IP for UPnP calls (webui /api/play). 127.0.0.1 when the agent runs on the box, otherwise the LAN IP.")
+		regionFile      = flag.String("region-file", "", "Path to region.txt with the ISO country code (from the setup wizard). The default radio country and language are derived from it.")
+		pendingNameFile = flag.String("pending-name-file", "", "Path to name.txt from the setup wizard. Its contents are applied once as the box name (plus a UID suffix) and the file is deleted afterwards.")
+		printVersion    = flag.Bool("version", false, "Print the version and exit")
 	)
 	flag.Parse()
 
@@ -230,8 +230,8 @@ func run() error {
 
 	ensureSshdRunning(logger)
 
-	// DeviceID aus MAC ermitteln, damit Marge Antworten die echte Box ID
-	// zurueckgeben. Wenn keine MAC gefunden wird, weiter mit leerer ID.
+	// Determine the DeviceID from the MAC so marge responses return the
+	// real box ID. If no MAC is found, continue with an empty ID.
 	deviceID, err := sysinfo.DeviceID(nil)
 	if err != nil {
 		logger.Warn("could not determine DeviceID", "err", err)
@@ -240,8 +240,8 @@ func run() error {
 		logger.Info("DeviceID detected", "deviceID", deviceID)
 	}
 
-	// Presets laden. Bei Fehler nicht crashen sondern mit leerer Liste weitermachen,
-	// damit der Agent zumindest auf seinen Listenern lebt und korrigierbar bleibt.
+	// Load presets. On error do not crash but continue with an empty list, so
+	// the agent at least stays alive on its listeners and remains correctable.
 	//
 	// Phase-marker logs at WARN level so a remote diagnostic bundle shows
 	// exactly which path was taken — was the file there? was it empty?
@@ -300,7 +300,7 @@ func run() error {
 		logger.Warn("recent history load failed, starting empty", "err", rErr)
 	}
 
-	// Hosts Datei manipulieren
+	// Modify the hosts file
 	var hostsMgr *hosts.Manager
 	if *applyHosts {
 		hostsMgr = hosts.New(*hostsPath, logger)
@@ -310,33 +310,32 @@ func run() error {
 		}
 	}
 
-	// Subsysteme initialisieren
+	// Initialize subsystems
 	margeSrv := marge.New(logger.With("comp", "marge"),
 		marge.WithDeviceID(deviceID),
 		marge.WithReflectSourcesPath(boxsnapshot.ReflectPath()))
 	bmxSrv := bmx.New(logger.With("comp", "bmx"))
-	// AutoPair Manager wird oben angelegt damit er auch im WS und Webui
-	// Handler genutzt werden kann.
+	// The AutoPair manager is created up here so it can also be used in the
+	// WS and webui handlers.
 	autoPair := autopair.New(logger.With("comp", "autopair"), autopair.Config{
 		BoxHost: *boxHost,
 	})
 
-	// Initial Preset Sync zur Box im Hintergrund. Box muss alle Presets
-	// als UPNP ContentItems kennen damit Hardware Tasten den
-	// nowSelectionUpdated WebSocket Event mit Location ausloesen koennen.
-	// Plus periodischer Reconciler (alle 5 min) damit Inkonsistenzen
-	// die durch Box Reboot oder Bose State Resets entstehen, automatisch
-	// geheilt werden — der User braucht den "Hardware Tasten reparieren"
-	// Button im Normalfall nie zu druecken.
+	// Initial preset sync to the box in the background. The box must know all
+	// presets as UPnP ContentItems so the hardware buttons can trigger the
+	// nowSelectionUpdated WebSocket event with a location. Plus a periodic
+	// reconciler (every 5 min) so inconsistencies caused by a box reboot or
+	// Bose state resets are healed automatically — the user normally never
+	// needs to press the "repair hardware buttons" button.
 	go initialBoxPresetSync(store, *boxHost, logger)
 	go periodicPresetReconcile(store, *boxHost, logger)
 
-	// Region beim Start aus Datei lesen (vom Setup Wizard provisioniert).
+	// Read the region from a file on start (provisioned by the setup wizard).
 	region := loadRegion(*regionFile, logger)
 
-	// Stream Proxy macht Bose ContentItems gegen Token Expiry resistent:
-	// statt der echten CDN URL bekommt Bose http://127.0.0.1:8888/stream/<slot>
-	// und der Stick Agent reconnectet intern bei Drops.
+	// The stream proxy makes Bose ContentItems resistant to token expiry:
+	// instead of the real CDN URL, Bose gets http://127.0.0.1:8888/stream/<slot>
+	// and the stick agent reconnects internally on drops.
 	streamProxySrv := streamproxy.New(store, logger.With("comp", "streamproxy"))
 
 	// Spotify preset audio plane (#78, P1): the agent supervises
@@ -404,9 +403,9 @@ func run() error {
 	// the mid-stream re-set is verified not to glitch audio on real hardware.
 	streamProxySrv.SetOnTitle(webuiSrv.HandleStreamTitle)
 
-	// Hardware Preset Tasten: Box sendet via WebSocket auf 8080 (gabbo Protocol)
-	// einen presetSelectionUpdated event wenn der User physisch eine Taste
-	// drueckt. Wir hooken den Event und triggern unseren UPnP Player.
+	// Hardware preset buttons: the box sends a presetSelectionUpdated event via
+	// WebSocket on 8080 (gabbo protocol) when the user physically presses a
+	// button. We hook the event and trigger our UPnP player.
 	renderer := upnp.NewBoseRenderer(*boxHost)
 	wsHandler := &presetWsHandler{
 		logger:   logger.With("comp", "boxws"),
@@ -501,7 +500,7 @@ func run() error {
 		}
 	}()
 
-	// Box WebSocket Listener fuer Hardware Preset Tasten
+	// Box WebSocket listener for hardware preset buttons
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -520,10 +519,10 @@ func run() error {
 	// the user and show what was there. See internal/boxsnapshot.
 	go boxsnapshot.Capture(ctx, *boxHost, boxsnapshot.DefaultPath(), logger.With("comp", "boxsnapshot"))
 
-	// Auto Pair Background: pairt die Box automatisch beim Start. Re-pairt
-	// alle 5 Minuten falls die Box mal verloren geht. Plus: WS Handler
-	// triggert TriggerNow bei Preset Press damit Pair sofort kommt nach
-	// Standby Aufwachen.
+	// Auto-pair background: pairs the box automatically on start. Re-pairs
+	// every 5 minutes in case the box is ever lost. Plus: the WS handler
+	// triggers TriggerNow on a preset press so pairing happens immediately
+	// after waking from standby.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -643,15 +642,14 @@ func run() error {
 		go applyPendingBoxName(context.Background(), *boxHost, *pendingNameFile, deviceID, logger)
 	}
 
-	// Wenn der USB Stick ein neueres run.sh hat als das NAND
-	// run-override.sh: kopieren. Das ist der Selbst-Update-Pfad fuer
-	// den Bootstrap. Ohne das laeuft die alte run-override.sh aus dem
-	// allerersten Setup auf ewig und neue Setup Wizard Configs werden
-	// ignoriert.
+	// If the USB stick has a newer run.sh than the NAND run-override.sh:
+	// copy it. This is the self-update path for the bootstrap. Without it
+	// the old run-override.sh from the very first setup runs forever and new
+	// setup wizard configs are ignored.
 	go syncRunOverrideFromStick(logger)
 
-	// TLS Termination fuer Marge auf 8443. iptables redirected die echte
-	// Box Anfrage von 443 dorthin. Wenn TLS deaktiviert wird, ueberspringen.
+	// TLS termination for marge on 8443. iptables redirects the real box
+	// request from 443 to it. Skip when TLS is disabled.
 	// EnsureBundle generates a per-box CA on the very first boot, which
 	// touches NAND and can take several seconds — keep this off the
 	// listener-boot path.
@@ -745,7 +743,7 @@ func run() error {
 	return firstErr
 }
 
-// startHTTP startet einen HTTP Server in einer Goroutine und meldet Fehler an errs.
+// startHTTP starts an HTTP server in a goroutine and reports errors to errs.
 //
 // The listener is opened via netutil.ListenTCP, which sets SO_REUSEADDR on
 // the socket. Without that, a watchdog-driven respawn while the previous
@@ -788,8 +786,8 @@ func startHTTP(ctx context.Context, wg *sync.WaitGroup, errs chan<- error, name,
 	}()
 }
 
-// startHTTPS startet einen HTTPS Server analog zu startHTTP, mit der
-// uebergebenen TLS Konfiguration.
+// startHTTPS starts an HTTPS server analogous to startHTTP, with the
+// supplied TLS configuration.
 func startHTTPS(ctx context.Context, wg *sync.WaitGroup, errs chan<- error, name, addr string, handler http.Handler, tlsConfig *tls.Config, logger *slog.Logger) {
 	logger.Warn("listener phase: spawn TLS", "comp", name, "addr", addr)
 	wg.Add(1)
@@ -828,8 +826,8 @@ func startHTTPS(ctx context.Context, wg *sync.WaitGroup, errs chan<- error, name
 	}()
 }
 
-// presetWsHandler implementiert boxws.Handler und ruft bei Hardware Preset
-// Tasten den UPnP Renderer mit der Stream URL aus dem Preset Store auf.
+// presetWsHandler implements boxws.Handler and, on a hardware preset
+// button press, calls the UPnP renderer with the stream URL from the preset store.
 type presetWsHandler struct {
 	logger   *slog.Logger
 	store    *presets.Store
@@ -896,12 +894,12 @@ func (h *presetWsHandler) OnPresetSelected(ctx context.Context, slot int, locati
 			return
 		}
 	}
-	// URL bleibt die Proxy URL (location = http://127.0.0.1:8888/stream/N)
-	// damit der Stream Proxy den Reconnect bei Token Expiry uebernimmt.
-	// Name + Icon kommen aus dem Stick Preset Store — die Bose ContentItem
-	// Metadata hat keinen Art Eintrag, daher muessen wir die Album Art
-	// URL aktiv ueber unser PlayURL Aufruf ins DIDL Lite Metadata
-	// reinpacken, sonst zeigt das Display (ST20/30) kein Logo.
+	// The URL stays the proxy URL (location = http://127.0.0.1:8888/stream/N)
+	// so the stream proxy handles the reconnect on token expiry. Name + icon
+	// come from the stick preset store — the Bose ContentItem metadata has no
+	// art entry, so we must actively pack the album art URL into the DIDL-Lite
+	// metadata via our PlayURL call, otherwise the display (ST20/30) shows no
+	// logo.
 	url := location
 	name := title
 	icon := ""
@@ -934,7 +932,7 @@ func (h *presetWsHandler) OnPresetSelected(ctx context.Context, slot int, locati
 		}
 	}
 	if url == "" {
-		h.logger.Info("hardware preset gedrueckt, kein Mapping", "slot", slot)
+		h.logger.Info("hardware preset pressed, no mapping", "slot", slot)
 		return
 	}
 
@@ -946,11 +944,11 @@ func (h *presetWsHandler) OnPresetSelected(ctx context.Context, slot int, locati
 		h.spotify.SwitchedAway(ctx)
 	}
 
-	// Box aufwecken aus Standby + Pair sicherstellen.
+	// Wake the box from standby + ensure pairing.
 	if h.boxHost != "" {
 		wakeCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
 		if err := boxcli.WakeAndWait(wakeCtx, h.boxHost, 6*time.Second, h.logger); err != nil {
-			h.logger.Warn("Box konnte nicht aus STANDBY geholt werden", "err", err)
+			h.logger.Warn("could not bring box out of STANDBY", "err", err)
 		}
 		cancel()
 	}
@@ -975,7 +973,7 @@ func (h *presetWsHandler) OnPresetSelected(ctx context.Context, slot int, locati
 	// boot can race the box/agent bringup so nothing plays until a second
 	// press. This re-issues until the box actually plays. Affects radio too.
 	go h.verifyPlayURL(slot, url, name, icon)
-	h.logger.Info("hardware preset zu upnp gemapped", "slot", slot, "name", name)
+	h.logger.Info("hardware preset mapped to upnp", "slot", slot, "name", name)
 }
 
 // OnRemoteSkip handles the SoundTouch remote's next/prev track keys during
@@ -1166,7 +1164,7 @@ func (h *presetWsHandler) playSpotifyPreset(ctx context.Context, slot int, p pre
 	if h.boxHost != "" {
 		wakeCtx, c := context.WithTimeout(ctx, 8*time.Second)
 		if err := boxcli.WakeAndWait(wakeCtx, h.boxHost, 6*time.Second, h.logger); err != nil {
-			h.logger.Warn("Box konnte nicht aus STANDBY geholt werden", "err", err)
+			h.logger.Warn("could not bring box out of STANDBY", "err", err)
 		}
 		c()
 	}
@@ -1244,9 +1242,9 @@ func (h *presetWsHandler) verifySpotifyPlaying(slot int, p presets.Preset) {
 	h.logger.Warn("spotify recall still not playing after retries", "slot", slot)
 }
 
-// loadRegion liest den Country Code aus der region.txt vom Stick. Leer
-// wenn die Datei nicht existiert oder leer ist; in dem Fall faellt die
-// App spaeter auf Browser/User Default zurueck.
+// loadRegion reads the country code from region.txt on the stick. Empty
+// if the file does not exist or is empty; in that case the app later falls
+// back to the browser/user default.
 func loadRegion(path string, logger *slog.Logger) string {
 	if path == "" {
 		return ""
@@ -1274,21 +1272,21 @@ func loadRegion(path string, logger *slog.Logger) string {
 		}
 		out += string(r)
 	}
-	logger.Info("Region geladen", "country", out)
+	logger.Info("region loaded", "country", out)
 	return out
 }
 
-// syncRunOverrideFromStick haelt das NAND run-override.sh aktuell mit
-// dem run.sh auf dem Stick. Wichtig: rc.local priorisiert NAND vor
-// Stick, daher wuerde ein veraltetes NAND Script die neuen Setup
-// Wizard Features (name.conf, region.conf etc) ignorieren.
+// syncRunOverrideFromStick keeps the NAND run-override.sh in sync with
+// the run.sh on the stick. Important: rc.local prioritises NAND over the
+// stick, so a stale NAND script would ignore the new setup wizard features
+// (name.conf, region.conf, etc.).
 //
-// Wenn die Files identisch sind: no-op (keine Flash Writes).
+// If the files are identical: no-op (no flash writes).
 func syncRunOverrideFromStick(logger *slog.Logger) {
 	const stickPath = "/media/sda1/run.sh"
 	const nandPath = "/mnt/nv/streborn/run-override.sh"
 
-	time.Sleep(5 * time.Second) // dem Stick Zeit zum mounten geben
+	time.Sleep(5 * time.Second) // give the stick time to mount
 
 	stickData, err := os.ReadFile(stickPath)
 	if err != nil {
@@ -1297,7 +1295,7 @@ func syncRunOverrideFromStick(logger *slog.Logger) {
 	}
 	nandData, _ := os.ReadFile(nandPath)
 	if len(nandData) > 0 && bytesEqual(stickData, nandData) {
-		return // schon identisch
+		return // already identical
 	}
 	tmp := nandPath + ".new"
 	if err := os.WriteFile(tmp, stickData, 0o755); err != nil {
@@ -1324,17 +1322,17 @@ func bytesEqual(a, b []byte) bool {
 	return true
 }
 
-// applyPendingBoxName wendet einen vom Setup Wizard hinterlegten Box
-// Namen einmalig auf die Bose Box an und haengt die letzten 4 Hex der
-// DeviceID als UID Suffix an damit Dopplungen in mehreren Boxen im LAN
-// ausgeschlossen sind. Bei Erfolg wird die Datei geloescht.
+// applyPendingBoxName applies a box name left by the setup wizard once to
+// the Bose box and appends the last 4 hex digits of the DeviceID as a UID
+// suffix so duplicates across multiple boxes on the LAN are ruled out. On
+// success the file is deleted.
 func applyPendingBoxName(ctx context.Context, boxHost, path, deviceID string, logger *slog.Logger) {
 	if boxHost == "" || path == "" {
 		return
 	}
 	b, err := os.ReadFile(path)
 	if err != nil {
-		// keine Datei, nichts anzuwenden
+		// no file, nothing to apply
 		return
 	}
 	raw := strings.TrimSpace(string(b))
@@ -1350,7 +1348,7 @@ func applyPendingBoxName(ctx context.Context, boxHost, path, deviceID string, lo
 	if suffix != "" && !strings.HasSuffix(strings.ToUpper(wanted), suffix) {
 		wanted = raw + " " + suffix
 	}
-	// Box muss erreichbar sein. Warten bis BoseApp Webserver hochgefahren.
+	// The box must be reachable. Wait until the BoseApp web server is up.
 	time.Sleep(10 * time.Second)
 	c := boxapi.New(boxHost)
 	for attempt := 0; attempt < 12; attempt++ {
@@ -1358,7 +1356,7 @@ func applyPendingBoxName(ctx context.Context, boxHost, path, deviceID string, lo
 		err := c.SetName(callCtx, wanted)
 		cancel()
 		if err == nil {
-			logger.Info("Setup Wizard Box Name angewendet", "name", wanted)
+			logger.Info("setup wizard box name applied", "name", wanted)
 			_ = os.Remove(path)
 			return
 		}
@@ -1369,23 +1367,22 @@ func applyPendingBoxName(ctx context.Context, boxHost, path, deviceID string, lo
 		case <-time.After(5 * time.Second):
 		}
 	}
-	logger.Warn("Box Name aus Setup konnte nicht gesetzt werden, gebe auf", "path", path)
+	logger.Warn("could not set box name from setup, giving up", "path", path)
 }
 
-// pollBoxInfo fragt regelmaessig die Box /info ab und haelt die mDNS TXT
-// Felder fuer FriendlyName und Model aktuell. Damit:
+// pollBoxInfo polls the box /info regularly and keeps the mDNS TXT fields
+// for FriendlyName and Model up to date. This way:
 //
-//  1. Der Desktop App kennt den Namen sobald der User die Box umbenennt
-//     (z.B. via BoseApp HTTP), ohne Box Reboot.
-//  2. Das model TXT Feld wird auf den echten Wert ("SoundTouch 10" etc)
-//     hochgezogen, sobald die Bose Firmware /info auf :8090 ausliefert.
-//     Beim ersten Announce steht dort noch der generische Fallback
-//     "SoundTouch" weil :8090 typisch 20+ Sekunden nach dem Agent-Start
-//     hochkommt — der Loop hier dichtet die Race ab ohne den Boot zu
-//     blockieren.
+//  1. The desktop app knows the name as soon as the user renames the box
+//     (e.g. via BoseApp HTTP), without a box reboot.
+//  2. The model TXT field is promoted to the real value ("SoundTouch 10",
+//     etc.) as soon as the Bose firmware serves /info on :8090. On the first
+//     announce it still holds the generic fallback "SoundTouch" because :8090
+//     typically comes up 20+ seconds after the agent start — the loop here
+//     seals that race without blocking the boot.
 //
-// Erste Runde nach kurzem Delay, dann mit kurzem Ticker bis Model
-// erkannt ist (race-Recovery), danach geht der Ticker auf 30s zurueck.
+// First round after a short delay, then with a short ticker until the model
+// is detected (race recovery), after which the ticker drops back to 30s.
 func pollBoxInfo(ctx context.Context, boxHost, region string, ann *discovery.Announcer, logger *slog.Logger) {
 	if boxHost == "" || ann == nil {
 		return
@@ -1408,7 +1405,7 @@ func pollBoxInfo(ctx context.Context, boxHost, region string, ann *discovery.Ann
 		}
 		if model := strings.TrimSpace(s.Info.Type); model != "" {
 			if !modelEverFound {
-				logger.Info("Box Modell erkannt", "type", model)
+				logger.Info("box model detected", "type", model)
 				modelEverFound = true
 			}
 			if model != lastModel {
@@ -1470,10 +1467,10 @@ func pollBoxInfo(ctx context.Context, boxHost, region string, ann *discovery.Ann
 	}
 }
 
-// proxyStreamURL gibt die stabile loopback URL fuer ein Preset zurueck.
-// Bose UPnP Player oeffnet die — der Stream Proxy im Stick Agent loest
-// dahinter den echten Sender Redirect auf und reconnectet bei Token
-// Expiry, ohne dass Bose etwas merkt.
+// proxyStreamURL returns the stable loopback URL for a preset. The Bose
+// UPnP player opens it — the stream proxy in the stick agent resolves the
+// real station redirect behind it and reconnects on token expiry without
+// Bose noticing.
 func proxyStreamURL(slot int) string {
 	return boxurl.StreamSlot(slot)
 }
@@ -1491,17 +1488,16 @@ func boxPresetURL(p presets.Preset) string {
 	return boxurl.Preset(p.Slot, p.Type == "spotify")
 }
 
-// initialBoxPresetSync wartet auf den Box Boot und synct alle Stick
-// Presets an den Box internen Preset Store. Mit Retry Loop: bei
-// fehlgeschlagenen Slots wird nach 10s erneut versucht, bis zu 12 mal.
-// Hintergrund: die Bose Firmware ist beim Boot manchmal noch nicht
-// bereit fuer AddPreset Calls (autopair noch nicht durch, marge state
-// noch nicht initialisiert). Ohne Retry blieben Slots dauerhaft ohne
-// Box Eintrag — Hardware Tasten 1-6 wuerden dann nichts ausloesen.
-// Initial 30 s Warten (war 12 s): in der Praxis gemessen, dass die
-// Bose Firmware nach einem Cold Boot ~60 s braucht bis /info auf 8090
-// antwortet und marge State steht. 12 s war optimistisch.
-// 12 Retry Slots mit je 10 s Pause = ~2 Minuten gesamter Runway.
+// initialBoxPresetSync waits for the box to boot and syncs all stick
+// presets to the box's internal preset store. With a retry loop: failed
+// slots are retried after 10s, up to 12 times. Background: the Bose
+// firmware is sometimes not yet ready for AddPreset calls at boot (autopair
+// not done, marge state not initialised). Without retries, slots would stay
+// permanently without a box entry — hardware buttons 1-6 would then trigger
+// nothing. Initial 30 s wait (was 12 s): measured in practice that the Bose
+// firmware needs ~60 s after a cold boot before /info on 8090 responds and
+// the marge state is ready. 12 s was optimistic.
+// 12 retry slots with a 10 s pause each = ~2 minutes of total runway.
 func initialBoxPresetSync(store *presets.Store, boxHost string, logger *slog.Logger) {
 	time.Sleep(30 * time.Second)
 	specs := make([]boxcli.PresetSpec, 0, 6)
@@ -1513,7 +1509,7 @@ func initialBoxPresetSync(store *presets.Store, boxHost string, logger *slog.Log
 	if len(specs) == 0 {
 		return
 	}
-	logger.Info("starte initial box preset sync", "anzahl", len(specs))
+	logger.Info("starting initial box preset sync", "count", len(specs))
 
 	pending := make(map[int]boxcli.PresetSpec, len(specs))
 	for _, p := range specs {
@@ -1545,11 +1541,11 @@ func initialBoxPresetSync(store *presets.Store, boxHost string, logger *slog.Log
 	}
 }
 
-// periodicPresetReconcile prueft alle 5 Minuten ob die Box noch alle
-// Stick Presets in ihrer eigenen Liste hat. Fehlende Slots werden via
-// boxcli.AddPreset nachgepflegt. Damit greift der Fix automatisch ohne
-// User Aktion wenn z.B. die Bose Firmware nach einem Standby Cycle
-// einzelne Eintraege verloren hat.
+// periodicPresetReconcile checks every 5 minutes whether the box still has
+// all stick presets in its own list. Missing slots are restored via
+// boxcli.AddPreset. This way the fix applies automatically without user
+// action when, e.g., the Bose firmware has lost individual entries after a
+// standby cycle.
 func periodicPresetReconcile(store *presets.Store, boxHost string, logger *slog.Logger) {
 	// fullDone tracks whether we have done a full re-sync since the box
 	// last became ready. The boot-time preset sync can run before the
@@ -1565,7 +1561,7 @@ func periodicPresetReconcile(store *presets.Store, boxHost string, logger *slog.
 	//
 	// Converge FAST after a cold boot, then idle. A blind 90s pre-wait
 	// meant the hardware buttons stayed unregistered for ~90s+ after every
-	// reboot, so an early press hit "Taste nicht belegt" (#4). The box
+	// reboot, so an early press hit "button not assigned" (#4). The box
 	// /info / preset subsystem comes up ~20-45s in, so polling every 10s from
 	// 15s wins that first full re-sync as soon as the box is ready, then the
 	// loop drops to a 5 min maintenance cadence. reconcileOnce is gated on the
@@ -1622,19 +1618,19 @@ func reconcileOnce(store *presets.Store, boxHost string, logger *slog.Logger, fo
 	if forceFull {
 		logger.Info("preset reconcile: full re-sync after box became ready (registers hardware buttons)", "slots", len(missing))
 	} else {
-		logger.Info("preset reconcile: fehlende Slots auf Box, sync", "fehlend", len(missing))
+		logger.Info("preset reconcile: missing slots on box, syncing", "missing", len(missing))
 	}
 	errs := boxcli.SyncAllPresets(context.Background(), boxHost, missing)
 	for slot, err := range errs {
 		if err == nil {
-			logger.Info("preset reconcile geheilt", "slot", slot)
+			logger.Info("preset reconcile healed", "slot", slot)
 		}
 	}
 	return true
 }
 
-// fetchBoxPresetSlots liest GET /presets von der Bose API und liefert
-// eine Map welcher Slot in der Box Liste gesetzt ist.
+// fetchBoxPresetSlots reads GET /presets from the Bose API and returns a
+// map of which slot is set in the box's list.
 func fetchBoxPresetSlots(boxHost string) (map[int]bool, error) {
 	client := http.Client{Timeout: 4 * time.Second}
 	resp, err := client.Get(fmt.Sprintf("http://%s:8090/presets", boxHost))
@@ -1644,7 +1640,7 @@ func fetchBoxPresetSlots(boxHost string) (map[int]bool, error) {
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	out := map[int]bool{}
-	// Bose Format: <presets><preset id="1" ...> ... </preset></presets>
+	// Bose format: <presets><preset id="1" ...> ... </preset></presets>
 	for _, m := range presetIDRegex.FindAllStringSubmatch(string(body), -1) {
 		slot := 0
 		fmt.Sscanf(m[1], "%d", &slot)
@@ -1674,7 +1670,7 @@ func boxInSetupOOB(boxHost string) bool {
 	return strings.Contains(string(body), "SETUP_AP_OOB")
 }
 
-// lastN gibt die letzten n Zeichen von s zurueck.
+// lastN returns the last n characters of s.
 func lastN(s string, n int) string {
 	if len(s) <= n {
 		return s

--- a/cmd/winformat/fat32.go
+++ b/cmd/winformat/fat32.go
@@ -1,19 +1,18 @@
-// fat32.go — nativer FAT32 Quick Formatter.
+// fat32.go — native FAT32 quick formatter.
 //
-// FmIfs.dll FormatEx verweigert Quick Format auf einem Volume mit
-// NTFS Resten (Packet 9 = FmIfsCantQuickFormat) und ist auch sonst
-// schwer zu kontrollieren. Wir schreiben die FAT32 Strukturen daher
-// selbst direkt auf das gelockte, dismounted Volume — das ist exakt
-// was Rufus + fat32format intern tun.
+// FmIfs.dll FormatEx refuses a quick format on a volume with NTFS remnants
+// (packet 9 = FmIfsCantQuickFormat) and is hard to control otherwise. So we
+// write the FAT32 structures ourselves directly to the locked, dismounted
+// volume — which is exactly what Rufus + fat32format do internally.
 //
-// Was wir schreiben:
-//   Sektor 0       Boot Sector mit BPB (BIOS Parameter Block)
-//   Sektor 1       FSInfo
-//   Sektor 6       Backup Boot Sector
-//   Sektor 7       Backup FSInfo
-//   Sektor 32..    FAT 1 (gross, mit 3 init Eintraegen)
-//   nach FAT 1     FAT 2 (identisch zu FAT 1)
-//   nach FAT 2     Root Directory Cluster (Cluster 2, mit Volume Label)
+// What we write:
+//   Sector 0       boot sector with BPB (BIOS parameter block)
+//   Sector 1       FSInfo
+//   Sector 6       backup boot sector
+//   Sector 7       backup FSInfo
+//   Sector 32..    FAT 1 (large, with 3 init entries)
+//   after FAT 1    FAT 2 (identical to FAT 1)
+//   after FAT 2    root directory cluster (cluster 2, with volume label)
 //
 //go:build windows
 
@@ -28,19 +27,19 @@ import (
 	"unsafe"
 )
 
-// fat32QuickFormat schreibt die FAT32 Strukturen direkt auf das
-// gelockte + dismounted Volume Handle. Erwartet:
-//   - h ist das CreateFile Handle auf \\.\X: aus lockAndDismount
-//   - totalBytes ist die Volume Groesse
-//   - clusterSize ist die gewuenschte Cluster Size in Bytes
-//   - label ist das Volume Label (max 11 Zeichen, in ASCII konvertiert)
+// fat32QuickFormat writes the FAT32 structures directly to the locked +
+// dismounted volume handle. Expects:
+//   - h is the CreateFile handle on \\.\X: from lockAndDismount
+//   - totalBytes is the volume size
+//   - clusterSize is the desired cluster size in bytes
+//   - label is the volume label (max 11 characters, converted to ASCII)
 func fat32QuickFormat(h uintptr, totalBytes uint64, clusterSize uint32, label string) error {
 	const sectorSize = uint32(512)
 	if clusterSize == 0 {
 		clusterSize = 32 * 1024
 	}
 	if clusterSize%sectorSize != 0 {
-		return fmt.Errorf("clusterSize %d nicht Vielfaches von 512", clusterSize)
+		return fmt.Errorf("clusterSize %d is not a multiple of 512", clusterSize)
 	}
 	if totalBytes < 64*1024*1024 {
 		return fmt.Errorf("volume too small (%d bytes), minimum size is 64 MB", totalBytes)
@@ -50,25 +49,25 @@ func fat32QuickFormat(h uintptr, totalBytes uint64, clusterSize uint32, label st
 	reservedSectors := uint16(32)
 	numFATs := uint8(2)
 
-	// Iterative FAT Groesse: erste Schaetzung, dann genauer.
+	// Iterative FAT size: first estimate, then more precise.
 	approxClusters := (totalSectors - uint32(reservedSectors)) / uint32(sectorsPerCluster)
-	fatEntries := approxClusters + 2 // 2 reservierte Eintraege
+	fatEntries := approxClusters + 2 // 2 reserved entries
 	fatBytes := fatEntries * 4
 	fatSectors := (fatBytes + sectorSize - 1) / sectorSize
 
-	// Refinement: rechne mit FAT Belegung erneut
+	// Refinement: recompute with the FAT footprint included
 	dataSectors := totalSectors - uint32(reservedSectors) - uint32(numFATs)*fatSectors
 	clusterCount := dataSectors / uint32(sectorsPerCluster)
 	if clusterCount < 65525 {
-		return fmt.Errorf("zu wenig Cluster fuer FAT32: %d (min 65525)", clusterCount)
+		return fmt.Errorf("too few clusters for FAT32: %d (min 65525)", clusterCount)
 	}
 	if clusterCount > 0x0FFFFFF5 {
-		return fmt.Errorf("zu viele Cluster fuer FAT32: %d (max 268435445)", clusterCount)
+		return fmt.Errorf("too many clusters for FAT32: %d (max 268435445)", clusterCount)
 	}
 
 	asciiLabel := makeASCIILabel(label)
 
-	// Boot Sector + FSInfo aufbauen.
+	// Build the boot sector + FSInfo.
 	bootSector := makeFAT32BootSector(totalSectors, sectorsPerCluster, fatSectors, reservedSectors, numFATs, asciiLabel)
 	fsInfo := makeFAT32FSInfo()
 
@@ -82,9 +81,9 @@ func fat32QuickFormat(h uintptr, totalBytes uint64, clusterSize uint32, label st
 		var newPos int64
 		r, _, e := setFilePointerEx.Call(h, uintptr(offset),
 			uintptr(unsafe.Pointer(&newPos)), 0)
-		_ = setFilePointer // ggf. spaeter fuer 32 Bit Fallback
+		_ = setFilePointer // possibly later for a 32-bit fallback
 		if r == 0 {
-			return fmt.Errorf("SetFilePointerEx auf %d: %v", offset, e)
+			return fmt.Errorf("SetFilePointerEx to %d: %v", offset, e)
 		}
 		return nil
 	}
@@ -99,15 +98,15 @@ func fat32QuickFormat(h uintptr, totalBytes uint64, clusterSize uint32, label st
 			uintptr(unsafe.Pointer(&written)),
 			0)
 		if r == 0 {
-			return fmt.Errorf("WriteFile bei offset %d: %v", offset, e)
+			return fmt.Errorf("WriteFile at offset %d: %v", offset, e)
 		}
 		if written != uint32(len(data)) {
-			return fmt.Errorf("WriteFile bei offset %d: %d von %d geschrieben", offset, written, len(data))
+			return fmt.Errorf("WriteFile at offset %d: wrote %d of %d", offset, written, len(data))
 		}
 		return nil
 	}
 
-	// 1. Boot Sector + FSInfo + Backups.
+	// 1. Boot sector + FSInfo + backups.
 	if err := writeAt(0, bootSector); err != nil {
 		return err
 	}
@@ -122,24 +121,24 @@ func fat32QuickFormat(h uintptr, totalBytes uint64, clusterSize uint32, label st
 	}
 
 	// 2. FAT 1 + FAT 2.
-	// Erste 12 Bytes haben spezielle Eintraege:
-	//   Cluster 0: Media Descriptor (0x0FFFFFF8) + reserved
-	//   Cluster 1: End of Chain Marker (0x0FFFFFFF)
-	//   Cluster 2: End of Chain — markiert Root Dir als allokiert
+	// The first 12 bytes have special entries:
+	//   Cluster 0: media descriptor (0x0FFFFFF8) + reserved
+	//   Cluster 1: end-of-chain marker (0x0FFFFFFF)
+	//   Cluster 2: end-of-chain — marks the root dir as allocated
 	fatFirstSector := make([]byte, sectorSize)
 	binary.LittleEndian.PutUint32(fatFirstSector[0:4], 0x0FFFFFF8)
 	binary.LittleEndian.PutUint32(fatFirstSector[4:8], 0xFFFFFFFF)
 	binary.LittleEndian.PutUint32(fatFirstSector[8:12], 0x0FFFFFFF)
 
-	// Statt sektorweise zu schreiben (langsam): in 1 MB Bloecken zero
-	// hochladen.
+	// Instead of writing sector by sector (slow): upload zeros in 1 MB
+	// blocks.
 	zeroBlock := make([]byte, 1024*1024)
 	writeFATRegion := func(startSector uint32) error {
-		// Erster Sektor mit init Eintraegen
+		// First sector with init entries
 		if err := writeAt(int64(startSector)*int64(sectorSize), fatFirstSector); err != nil {
 			return err
 		}
-		// Rest mit Nullen in MB Chunks
+		// Rest with zeros in MB chunks
 		remaining := int64(fatSectors-1) * int64(sectorSize)
 		offset := int64(startSector+1) * int64(sectorSize)
 		for remaining > 0 {
@@ -147,7 +146,7 @@ func fat32QuickFormat(h uintptr, totalBytes uint64, clusterSize uint32, label st
 			if n > remaining {
 				n = remaining
 			}
-			// n auf sectorSize Vielfaches
+			// round n to a multiple of sectorSize
 			n = (n / int64(sectorSize)) * int64(sectorSize)
 			if n == 0 {
 				n = int64(sectorSize)
@@ -170,25 +169,25 @@ func fat32QuickFormat(h uintptr, totalBytes uint64, clusterSize uint32, label st
 		return err
 	}
 
-	// 3. Root Directory Cluster (Cluster 2 = erstes Daten Cluster).
+	// 3. Root directory cluster (cluster 2 = first data cluster).
 	rootDirSector := fat1Start + uint32(numFATs)*fatSectors
 	rootDir := make([]byte, clusterSize)
 	if len(asciiLabel) > 0 {
 		copy(rootDir[0:11], asciiLabel)
-		rootDir[11] = 0x08 // Volume Label Attribute
+		rootDir[11] = 0x08 // volume label attribute
 	}
 	if err := writeAt(int64(rootDirSector)*int64(sectorSize), rootDir); err != nil {
 		return err
 	}
 
-	// Flush damit das alles auf der Hardware landet bevor wir das
-	// Handle freigeben und Windows automount startet.
+	// Flush so all of this lands on the hardware before we release the
+	// handle and Windows starts its automount.
 	flushFileBuffers.Call(h)
 	return nil
 }
 
-// makeASCIILabel konvertiert das Label in 11 Bytes ASCII upper case
-// mit Space Padding wie FAT32 das erwartet.
+// makeASCIILabel converts the label to 11 bytes of upper-case ASCII with
+// space padding, as FAT32 expects.
 func makeASCIILabel(label string) []byte {
 	label = strings.ToUpper(label)
 	out := make([]byte, 11)
@@ -208,66 +207,66 @@ func makeASCIILabel(label string) []byte {
 	return out
 }
 
-// makeFAT32BootSector erzeugt einen 512 Byte Boot Sector mit FAT32 BPB.
-// Layout nach Microsoft FAT32 Spec.
+// makeFAT32BootSector creates a 512-byte boot sector with a FAT32 BPB.
+// Layout per the Microsoft FAT32 spec.
 func makeFAT32BootSector(totalSectors uint32, secPerCluster uint8, fatSectors uint32, reservedSectors uint16, numFATs uint8, asciiLabel []byte) []byte {
 	bs := make([]byte, 512)
 
-	// Jump Instruction (EB 58 90 = jmp +0x58)
+	// Jump instruction (EB 58 90 = jmp +0x58)
 	bs[0] = 0xEB
 	bs[1] = 0x58
 	bs[2] = 0x90
 
-	// OEM Name (8 Bytes)
+	// OEM name (8 bytes)
 	copy(bs[3:11], []byte("MSWIN4.1"))
 
 	// BPB
-	binary.LittleEndian.PutUint16(bs[11:13], 512)             // Bytes per Sector
-	bs[13] = secPerCluster                                    // Sectors per Cluster
-	binary.LittleEndian.PutUint16(bs[14:16], reservedSectors) // Reserved Sectors
-	bs[16] = numFATs                                          // Number of FATs
-	binary.LittleEndian.PutUint16(bs[17:19], 0)               // Root Entries (0 bei FAT32)
-	binary.LittleEndian.PutUint16(bs[19:21], 0)               // Total Sectors 16 (0 bei FAT32)
-	bs[21] = 0xF8                                             // Media Descriptor (fixed disk)
-	binary.LittleEndian.PutUint16(bs[22:24], 0)               // Sectors per FAT 16 (0 bei FAT32)
-	binary.LittleEndian.PutUint16(bs[24:26], 63)              // Sectors per Track
-	binary.LittleEndian.PutUint16(bs[26:28], 255)             // Heads
-	binary.LittleEndian.PutUint32(bs[28:32], 0)               // Hidden Sectors
-	binary.LittleEndian.PutUint32(bs[32:36], totalSectors)    // Total Sectors 32
+	binary.LittleEndian.PutUint16(bs[11:13], 512)             // bytes per sector
+	bs[13] = secPerCluster                                    // sectors per cluster
+	binary.LittleEndian.PutUint16(bs[14:16], reservedSectors) // reserved sectors
+	bs[16] = numFATs                                          // number of FATs
+	binary.LittleEndian.PutUint16(bs[17:19], 0)               // root entries (0 for FAT32)
+	binary.LittleEndian.PutUint16(bs[19:21], 0)               // total sectors 16 (0 for FAT32)
+	bs[21] = 0xF8                                             // media descriptor (fixed disk)
+	binary.LittleEndian.PutUint16(bs[22:24], 0)               // sectors per FAT 16 (0 for FAT32)
+	binary.LittleEndian.PutUint16(bs[24:26], 63)              // sectors per track
+	binary.LittleEndian.PutUint16(bs[26:28], 255)             // heads
+	binary.LittleEndian.PutUint32(bs[28:32], 0)               // hidden sectors
+	binary.LittleEndian.PutUint32(bs[32:36], totalSectors)    // total sectors 32
 
-	// FAT32 specific Extended BPB
-	binary.LittleEndian.PutUint32(bs[36:40], fatSectors) // Sectors per FAT 32
-	binary.LittleEndian.PutUint16(bs[40:42], 0)          // Flags (Mirror Active FAT)
-	binary.LittleEndian.PutUint16(bs[42:44], 0)          // Filesystem Version
-	binary.LittleEndian.PutUint32(bs[44:48], 2)          // Root Cluster
-	binary.LittleEndian.PutUint16(bs[48:50], 1)          // FSInfo Sector
-	binary.LittleEndian.PutUint16(bs[50:52], 6)          // Backup Boot Sector
-	// bs[52:64] = 12 Reserved Bytes (bleiben 0)
-	bs[64] = 0x80 // Drive Number (Hard Disk)
-	bs[65] = 0    // Reserved
-	bs[66] = 0x29 // Extended Boot Signature
-	// Volume Serial
+	// FAT32-specific extended BPB
+	binary.LittleEndian.PutUint32(bs[36:40], fatSectors) // sectors per FAT 32
+	binary.LittleEndian.PutUint16(bs[40:42], 0)          // flags (mirror active FAT)
+	binary.LittleEndian.PutUint16(bs[42:44], 0)          // filesystem version
+	binary.LittleEndian.PutUint32(bs[44:48], 2)          // root cluster
+	binary.LittleEndian.PutUint16(bs[48:50], 1)          // FSInfo sector
+	binary.LittleEndian.PutUint16(bs[50:52], 6)          // backup boot sector
+	// bs[52:64] = 12 reserved bytes (stay 0)
+	bs[64] = 0x80 // drive number (hard disk)
+	bs[65] = 0    // reserved
+	bs[66] = 0x29 // extended boot signature
+	// volume serial
 	binary.LittleEndian.PutUint32(bs[67:71], uint32(time.Now().Unix()))
-	// Volume Label (11 Bytes)
+	// volume label (11 bytes)
 	copy(bs[71:82], asciiLabel)
-	// Filesystem Type (8 Bytes "FAT32   ")
+	// filesystem type (8 bytes "FAT32   ")
 	copy(bs[82:90], []byte("FAT32   "))
 
-	// Boot Signature
+	// boot signature
 	bs[510] = 0x55
 	bs[511] = 0xAA
 	return bs
 }
 
-// makeFAT32FSInfo erzeugt den FSInfo Sektor (512 Bytes).
+// makeFAT32FSInfo creates the FSInfo sector (512 bytes).
 func makeFAT32FSInfo() []byte {
 	fsi := make([]byte, 512)
-	binary.LittleEndian.PutUint32(fsi[0:4], 0x41615252) // Lead Signature "RRaA"
-	// fsi[4..484] = 480 Reserved Bytes (bleiben 0)
-	binary.LittleEndian.PutUint32(fsi[484:488], 0x61417272) // Struct Signature "rrAa"
-	binary.LittleEndian.PutUint32(fsi[488:492], 0xFFFFFFFF) // Free Cluster Count (unbekannt)
-	binary.LittleEndian.PutUint32(fsi[492:496], 0xFFFFFFFF) // Next Free Cluster (unbekannt)
-	// fsi[496..508] = 12 Reserved Bytes (bleiben 0)
-	binary.LittleEndian.PutUint32(fsi[508:512], 0xAA550000) // Trail Signature
+	binary.LittleEndian.PutUint32(fsi[0:4], 0x41615252) // lead signature "RRaA"
+	// fsi[4..484] = 480 reserved bytes (stay 0)
+	binary.LittleEndian.PutUint32(fsi[484:488], 0x61417272) // struct signature "rrAa"
+	binary.LittleEndian.PutUint32(fsi[488:492], 0xFFFFFFFF) // free cluster count (unknown)
+	binary.LittleEndian.PutUint32(fsi[492:496], 0xFFFFFFFF) // next free cluster (unknown)
+	// fsi[496..508] = 12 reserved bytes (stay 0)
+	binary.LittleEndian.PutUint32(fsi[508:512], 0xAA550000) // trail signature
 	return fsi
 }

--- a/cmd/winformat/main.go
+++ b/cmd/winformat/main.go
@@ -1,18 +1,18 @@
-// winformat ist ein kleines Helper Programm das Windows Volumes
-// nativ als FAT32 quick formatiert — ohne FmIfs.dll, ohne 32 GB Limit,
-// ohne dass Microsoft uns reinredet.
+// winformat is a small helper program that quick-formats Windows volumes
+// natively as FAT32 — without FmIfs.dll, without the 32 GB limit, without
+// Microsoft getting in our way.
 //
-// Vorgehen:
-//   1. Volume \\.\X: oeffnen, locken, dismounten (NTFS Treiber aus)
-//   2. FAT32 Boot Sector + FSInfo + FAT Tabellen + Root Dir direkt
-//      auf das gelockte Handle schreiben (siehe fat32.go)
-//   3. Handle schliessen — Windows mountet automatisch als FAT32
+// Procedure:
+//   1. Open, lock, dismount the volume \\.\X: (NTFS driver off)
+//   2. Write the FAT32 boot sector + FSInfo + FAT tables + root dir directly
+//      to the locked handle (see fat32.go)
+//   3. Close the handle — Windows mounts it automatically as FAT32
 //
-// Wird vom Desktop App Setup Wizard via Start-Process -Verb RunAs
-// elevated gestartet (einmaliger UAC Prompt). Exit Codes:
-//   0  Erfolg
-//   1  Argumente fehlerhaft
-//   2  Format fehlgeschlagen (Details im Status File)
+// Started elevated by the desktop app setup wizard via Start-Process -Verb
+// RunAs (single UAC prompt). Exit codes:
+//   0  success
+//   1  bad arguments
+//   2  format failed (details in the status file)
 //
 //go:build windows
 
@@ -26,10 +26,10 @@ import (
 	"unsafe"
 )
 
-// writeStatus schreibt Status in eine Datei. So koennen wir die echte
-// Erfolgs/Fehlermeldung ueber die UAC Elevation Boundary hinweg
-// zurueckliefern (Start-Process -Verb RunAs erlaubt KEIN
-// -RedirectStandardError, die App liest stattdessen diese Datei).
+// writeStatus writes the status to a file. This lets us return the real
+// success/error message across the UAC elevation boundary (Start-Process
+// -Verb RunAs does NOT allow -RedirectStandardError, so the app reads this
+// file instead).
 func writeStatus(path, status string) {
 	if path == "" {
 		return
@@ -37,9 +37,9 @@ func writeStatus(path, status string) {
 	_ = os.WriteFile(path, []byte(status), 0o644)
 }
 
-// volumeTotalBytes liefert die Volume Groesse in Bytes via
-// GetDiskFreeSpaceEx. 0 bei Fehler (passiert wenn Volume kein
-// erkanntes Filesystem hat — dann nutze volumeLengthFromHandle).
+// volumeTotalBytes returns the volume size in bytes via GetDiskFreeSpaceEx.
+// 0 on error (happens when the volume has no recognised filesystem — then
+// use volumeLengthFromHandle).
 func volumeTotalBytes(rootPtr *uint16) uint64 {
 	kernel := syscall.NewLazyDLL("kernel32.dll")
 	proc := kernel.NewProc("GetDiskFreeSpaceExW")
@@ -56,9 +56,8 @@ func volumeTotalBytes(rootPtr *uint16) uint64 {
 	return total
 }
 
-// volumeLengthFromHandle liefert die Groesse via
-// IOCTL_DISK_GET_LENGTH_INFO. Funktioniert auch auf raw / dismounted
-// Volume Handles, anders als GetDiskFreeSpaceEx.
+// volumeLengthFromHandle returns the size via IOCTL_DISK_GET_LENGTH_INFO.
+// Works on raw / dismounted volume handles too, unlike GetDiskFreeSpaceEx.
 func volumeLengthFromHandle(h uintptr) (uint64, error) {
 	const ioctlDiskGetLengthInfo = 0x0007405C
 	k32 := syscall.NewLazyDLL("kernel32.dll")
@@ -78,15 +77,14 @@ func volumeLengthFromHandle(h uintptr) (uint64, error) {
 		return 0, fmt.Errorf("IOCTL_DISK_GET_LENGTH_INFO: %v", e)
 	}
 	if length <= 0 {
-		return 0, fmt.Errorf("IOCTL_DISK_GET_LENGTH_INFO lieferte %d", length)
+		return 0, fmt.Errorf("IOCTL_DISK_GET_LENGTH_INFO returned %d", length)
 	}
 	return uint64(length), nil
 }
 
-// openLockDismount oeffnet \\.\X: exklusiv, sperrt das Volume,
-// dismountet den FS Treiber. Returnt das offene Handle damit der
-// Caller direkt weiter darauf schreiben kann (FAT32 Strukturen).
-// Caller muss CloseHandle aufrufen.
+// openLockDismount opens \\.\X: exclusively, locks the volume, dismounts
+// the FS driver. Returns the open handle so the caller can write to it
+// directly (FAT32 structures). The caller must call CloseHandle.
 func openLockDismount(letter string) (uintptr, error) {
 	drivePath := `\\.\` + letter + ":"
 	const (
@@ -140,10 +138,9 @@ func openLockDismount(letter string) (uintptr, error) {
 	return h, nil
 }
 
-// chooseClusterSize gibt die Windows Standard FAT32 Cluster Size fuer
-// die gegebene Volume Groesse zurueck. 0 = Standard von FmIfs (klappt
-// fuer kleine Volumes, aber bei > 32 GB resultiert das in zu vielen
-// Clustern).
+// chooseClusterSize returns the Windows default FAT32 cluster size for the
+// given volume size. 0 = FmIfs default (works for small volumes, but for
+// > 32 GB results in too many clusters).
 func chooseClusterSize(totalBytes uint64) uint32 {
 	const GB = uint64(1) << 30
 	switch {
@@ -154,12 +151,12 @@ func chooseClusterSize(totalBytes uint64) uint32 {
 	case totalBytes > 8*GB:
 		return 8 * 1024
 	default:
-		return 0 // FmIfs Default
+		return 0 // FmIfs default
 	}
 }
 
 func main() {
-	// Argumente: <drive_letter> <label> <status_file>
+	// Arguments: <drive_letter> <label> <status_file>
 	if len(os.Args) < 2 {
 		fmt.Fprintln(os.Stderr, "usage: winformat <drive_letter> [label] [status_file]")
 		os.Exit(1)
@@ -183,12 +180,12 @@ func main() {
 
 	driveRoot := letter + ":\\"
 	rootPtr, _ := syscall.UTF16PtrFromString(driveRoot)
-	// Erste Schaetzung via Drive Letter — funktioniert nur wenn FS
-	// erkannt ist. Bei "raw" Volume liefert das 0, dann holen wir die
-	// echte Groesse vom Handle.
+	// First estimate via the drive letter — only works when the FS is
+	// recognised. For a "raw" volume this returns 0, then we get the real
+	// size from the handle.
 	totalBytes := volumeTotalBytes(rootPtr)
 
-	// Volume oeffnen, sperren, dismounten — Handle bleibt offen.
+	// Open, lock, dismount the volume — the handle stays open.
 	h, err := openLockDismount(letter)
 	if err != nil {
 		writeStatus(statusFile, fmt.Sprintf("ERR openLockDismount: %v [totalBytes=%d]",
@@ -200,12 +197,12 @@ func main() {
 	closeHandle := k32.NewProc("CloseHandle")
 	defer closeHandle.Call(h)
 
-	// Fallback: Groesse vom Handle holen (funktioniert auch auf raw).
+	// Fallback: get the size from the handle (works on raw too).
 	if totalBytes == 0 {
 		if sz, lerr := volumeLengthFromHandle(h); lerr == nil {
 			totalBytes = sz
 		} else {
-			writeStatus(statusFile, fmt.Sprintf("ERR Volume Groesse: %v", lerr))
+			writeStatus(statusFile, fmt.Sprintf("ERR volume size: %v", lerr))
 			fmt.Fprintln(os.Stderr, lerr)
 			os.Exit(2)
 		}

--- a/desktop-app/announce.go
+++ b/desktop-app/announce.go
@@ -23,7 +23,7 @@ func (a *App) AnnounceExample(host string, port int) string {
 	if p == 0 {
 		p = 17008
 	}
-	return fmt.Sprintf(`curl -X POST "http://%s:%d/api/announce" -H "Content-Type: application/json" -d "{\"text\":\"Es klingelt an der Tuer\",\"volume\":20}"`, host, p)
+	return fmt.Sprintf(`curl -X POST "http://%s:%d/api/announce" -H "Content-Type: application/json" -d "{\"text\":\"Someone is at the door\",\"volume\":20}"`, host, p)
 }
 
 // SendAnnounce fires an announcement at the box (POST /api/announce). lang is the

--- a/desktop-app/app.go
+++ b/desktop-app/app.go
@@ -2708,8 +2708,9 @@ func friendlyError(resp *http.Response) string {
 }
 
 // Pause / Stop pro Box.
-func (a *App) Pause(host string, port int) error { return a.doAction(host, port, "pause") }
-func (a *App) Stop(host string, port int) error  { return a.doAction(host, port, "stop") }
+func (a *App) Pause(host string, port int) error  { return a.doAction(host, port, "pause") }
+func (a *App) Resume(host string, port int) error { return a.doAction(host, port, "resume") }
+func (a *App) Stop(host string, port int) error   { return a.doAction(host, port, "stop") }
 
 func (a *App) doAction(host string, port int, action string) error {
 	resp, err := a.boxDo(host, port, http.MethodPost, "/api/"+action, "application/json", "")

--- a/desktop-app/app.go
+++ b/desktop-app/app.go
@@ -1,5 +1,5 @@
-// STR Desktop App: findet alle Sticks im LAN via mDNS, listet sie
-// und steuert sie via REST API. Wails App, Backend ist Go, Frontend HTML/JS.
+// STR Desktop App: finds all sticks on the LAN via mDNS, lists them
+// and controls them via REST API. Wails app, backend is Go, frontend HTML/JS.
 package main
 
 import (
@@ -29,7 +29,7 @@ import (
 	"streborn-app/agentbin"
 )
 
-// App ist die zentrale State Struktur.
+// App is the central state struct.
 type App struct {
 	ctx        context.Context
 	logger     *slog.Logger
@@ -118,7 +118,7 @@ const discoverySTRStickyTTL = 6 * time.Minute
 // would correct itself soon after. See otaPinned and mergeDiscoveryCache (#108).
 const otaRebootGrace = 4 * time.Minute
 
-// NewApp erstellt eine neue App Instance.
+// NewApp creates a new App instance.
 func NewApp() *App {
 	logger, logFile := newFileLogger(slog.LevelInfo)
 	return &App{
@@ -214,13 +214,13 @@ type BoxInfo struct {
 	PortVerified bool `json:"portVerified"`
 }
 
-// DiscoverBoxes durchsucht das LAN nach Sticks via mDNS. Wenn mDNS
-// nichts findet (z.B. Windows Firewall blockt 5353, oder die Stock
-// Firmware announct unter einem Service Namen den wir noch nicht
-// kennen), startet ein einmaliger leichter HTTP Probe Sweep auf Port
-// 8090 als Fallback. Der Fallback laeuft NICHT bei jeder Discovery
-// und nur auf einem Port, damit ein erfolgreicher mDNS Lauf kein
-// Portscan auf dem lokalen Netz triggert.
+// DiscoverBoxes scans the LAN for sticks via mDNS. When mDNS
+// finds nothing (e.g. Windows Firewall blocks 5353, or the stock
+// firmware announces under a service name we do not know yet),
+// a one-time lightweight HTTP probe sweep on port 8090 runs as a
+// fallback. The fallback does NOT run on every discovery and only
+// on a single port, so that a successful mDNS run does not trigger
+// a port scan on the local network.
 func (a *App) DiscoverBoxes(timeoutSec int) ([]BoxInfo, error) {
 	if timeoutSec <= 0 {
 		timeoutSec = 6
@@ -1218,9 +1218,9 @@ type Preset struct {
 	Type      string `json:"type"`
 	Art       string `json:"art,omitempty"`
 	Bitrate   int    `json:"bitrate,omitempty"`
-	URI       string `json:"uri,omitempty"`     // Spotify presets: playlist/album URI
-	Account   string `json:"account,omitempty"` // Spotify presets: owning account
-	Source    string `json:"source,omitempty"`  // DLNA presets: media server name (cosmetic badge)
+	URI       string `json:"uri,omitempty"`      // Spotify presets: playlist/album URI
+	Account   string `json:"account,omitempty"`  // Spotify presets: owning account
+	Source    string `json:"source,omitempty"`   // DLNA presets: media server name (cosmetic badge)
 	Homepage  string `json:"homepage,omitempty"` // radio presets: station website (recent "website" link)
 }
 
@@ -1559,7 +1559,7 @@ func (a *App) SyncSpotifyLogin(boxes []SpotifySyncTarget) (map[string]any, error
 	return map[string]any{"source": sourceName, "synced": synced, "failed": failed}, nil
 }
 
-// GetPresets ruft GET /api/presets des angegebenen Sticks.
+// GetPresets calls GET /api/presets of the given stick.
 // latestBoseFirmware is the final firmware Bose shipped for every SoundTouch
 // model (27.0.6, 2022-08-04). There is nothing newer; an older box can be
 // brought up to it with the Bose app.
@@ -1691,8 +1691,8 @@ func (a *App) GetPresets(host string, port int) ([]Preset, error) {
 	return out, nil
 }
 
-// SetPreset macht PUT /api/presets/<slot>. art ist die Sender Logo URL,
-// wird beim Play als upnp:albumArtURI an die Box geschickt. Routed through
+// SetPreset does PUT /api/presets/<slot>. art is the station logo URL,
+// sent to the box as upnp:albumArtURI on play. Routed through
 // boxPut so a preset save gets the same :8888<->:17008 port fallback as the
 // other box commands.
 func (a *App) SetPreset(host string, port int, slot int, name, streamURL, art string, bitrate int, homepage string) error {
@@ -1756,7 +1756,7 @@ func (a *App) CopyPresetsAcrossBoxes(srcHost string, srcPort int, dstHost string
 	return copied, nil
 }
 
-// DeletePreset macht DELETE /api/presets/<slot>.
+// DeletePreset does DELETE /api/presets/<slot>.
 func (a *App) DeletePreset(host string, port int, slot int) error {
 	resp, err := a.boxDo(host, port, http.MethodDelete, fmt.Sprintf("/api/presets/%d", slot), "", "")
 	if err != nil {
@@ -1865,9 +1865,9 @@ func (a *App) waitAgentReady(host string, port int) bool {
 	}
 }
 
-// PlayURL triggert POST /api/play mit beliebigem Stream URL. icon ist
-// die Sender Logo URL (wird auf der Box angezeigt), uuid ermoeglicht
-// dass radio-browser den Klick zaehlt.
+// PlayURL triggers POST /api/play with an arbitrary stream URL. icon is
+// the station logo URL (shown on the box), uuid lets
+// radio-browser count the click.
 func (a *App) PlayURL(host string, port int, streamURL, title, icon, uuid, mime, homepage string) error {
 	body, _ := json.Marshal(map[string]string{
 		"url":      streamURL,
@@ -1888,7 +1888,7 @@ func (a *App) PlayURL(host string, port int, streamURL, title, icon, uuid, mime,
 	return nil
 }
 
-// BoxSettings holt name/volume/bass/network/sources der Box via Stick.
+// BoxSettings fetches name/volume/bass/network/sources of the box via the stick.
 func (a *App) BoxSettings(host string, port int) (map[string]any, error) {
 	resp, err := a.boxDo(host, port, http.MethodGet, "/api/box/settings", "", "")
 	if err != nil {
@@ -1905,24 +1905,24 @@ func (a *App) BoxSettings(host string, port int) (map[string]any, error) {
 	return out, nil
 }
 
-// SetBoxName aendert den Anzeigenamen der Bose Box.
+// SetBoxName changes the display name of the Bose box.
 func (a *App) SetBoxName(host string, port int, name string) error {
 	return a.boxPut(host, port, "/api/box/name", map[string]string{"name": name})
 }
 
-// SetBoxVolume setzt die Lautstaerke (0-100).
+// SetBoxVolume sets the volume (0-100).
 func (a *App) SetBoxVolume(host string, port int, value int) error {
 	return a.boxPut(host, port, "/api/box/volume", map[string]int{"value": value})
 }
 
-// SetBoxBass setzt den Bass Wert (Range pro Box, ST10 z.B. -9..0).
+// SetBoxBass sets the bass value (range per box, ST10 e.g. -9..0).
 func (a *App) SetBoxBass(host string, port int, value int) error {
 	return a.boxPut(host, port, "/api/box/bass", map[string]int{"value": value})
 }
 
-// SelectBoxSource schaltet die Box auf eine andere Quelle: "AUX",
-// "BLUETOOTH", "STANDBY". Stick Agent uebersetzt das in den passenden
-// /select bzw /key Aufruf an die Bose REST API.
+// SelectBoxSource switches the box to a different source: "AUX",
+// "BLUETOOTH", "STANDBY". The Stick Agent translates that into the matching
+// /select or /key call to the Bose REST API.
 func (a *App) SelectBoxSource(host string, port int, source string) error {
 	return a.boxPut(host, port, "/api/box/source", map[string]string{"source": source})
 }
@@ -2617,9 +2617,9 @@ func (a *App) SpotifyNowPlaying(host string, port int) SpotifyNow {
 	return out
 }
 
-// SyncBoxPresets schickt alle Stick Presets erneut an die Box damit
-// die Hardware Preset Tasten 1-6 funktionieren. Wird vom "Hardware
-// Tasten reparieren" Button im Settings Tab benutzt.
+// SyncBoxPresets re-sends all stick presets to the box so that
+// the hardware preset buttons 1-6 work. Used by the "Repair hardware
+// buttons" button in the Settings tab.
 func (a *App) SyncBoxPresets(host string, port int) (map[string]any, error) {
 	// boxDo so the :8888<->:17008 self-heal applies (BCO/Portable boxes only
 	// answer on the REDIRECTed :17008; a baseURL+raw POST pinned to :8888 failed).
@@ -2631,9 +2631,9 @@ func (a *App) SyncBoxPresets(host string, port int) (map[string]any, error) {
 	if resp.StatusCode >= 400 {
 		return nil, readHTTPError(resp)
 	}
-	// Wenn der Stick Agent zu alt ist und den Endpoint nicht kennt,
-	// fallback auf den Default Handler liefert HTML statt JSON. Pruefen
-	// und freundlich melden.
+	// If the Stick Agent is too old and does not know the endpoint,
+	// the fallback to the default handler returns HTML instead of JSON. Check
+	// and report it nicely.
 	ct := resp.Header.Get("Content-Type")
 	if !strings.Contains(ct, "json") {
 		return nil, fmt.Errorf("stick agent is too old for this operation; please update the stick first (update banner at the top)")
@@ -2645,9 +2645,9 @@ func (a *App) SyncBoxPresets(host string, port int) (map[string]any, error) {
 	return out, nil
 }
 
-// RebootBox loest einen Neustart der Bose Box aus (via Stick Agent
-// shell `reboot`). Damit greifen frische Setup Wizard Configs auf dem
-// USB Stick sofort, ohne dauerhaftes Polling im Agent.
+// RebootBox triggers a restart of the Bose box (via the Stick Agent
+// shell `reboot`). This makes fresh setup-wizard configs on the
+// USB stick take effect immediately, without continuous polling in the agent.
 func (a *App) RebootBox(host string, port int) error {
 	resp, err := a.boxDo(host, port, http.MethodPost, "/api/box/reboot", "application/json", "")
 	if err != nil {
@@ -2660,8 +2660,8 @@ func (a *App) RebootBox(host string, port int) error {
 	return nil
 }
 
-// VoteStation gibt einem Sender bei radio-browser einen Daumen hoch.
-// Best Effort; Fehler wird zurueckgegeben aber muss nicht angezeigt werden.
+// VoteStation gives a station a thumbs-up on radio-browser.
+// Best effort; the error is returned but does not have to be shown.
 func (a *App) VoteStation(host string, port int, uuid string) error {
 	if uuid == "" {
 		return nil
@@ -2677,8 +2677,8 @@ func (a *App) VoteStation(host string, port int, uuid string) error {
 	return nil
 }
 
-// friendlyError extrahiert das `detail` Feld aus der Stick API Fehler
-// Antwort, falls vorhanden. Fallback: der Rohbody.
+// friendlyError extracts the `detail` field from the Stick API error
+// response, if present. Fallback: the raw body.
 func friendlyError(resp *http.Response) string {
 	b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	var m map[string]any
@@ -2723,19 +2723,19 @@ func (a *App) doAction(host string, port int, action string) error {
 	return nil
 }
 
-// pickReachableIP waehlt aus den IPs die der Stick via mDNS announct die
-// vom aktuellen LAN aus erreichbare. Box's USB Gadget Interface
-// (203.0.113.x) ist nicht aus dem WLAN routbar; dieselbe Box announct
-// auch ihre echte WLAN IP, die nehmen wir.
+// pickReachableIP selects, from the IPs the stick announces via mDNS, the one
+// reachable from the current LAN. The box's USB gadget interface
+// (203.0.113.x) is not routable from the Wi-Fi; the same box also announces
+// its real Wi-Fi IP, which is the one we take.
 //
-// Priorisierung:
+// Prioritization:
 //
-//  1. Private LAN Ranges (RFC 1918): 192.168/16, 10/8, 172.16/12
-//  2. Link Local: 169.254/16
-//  3. Public IPs (unwahrscheinlich)
+//  1. Private LAN ranges (RFC 1918): 192.168/16, 10/8, 172.16/12
+//  2. Link local: 169.254/16
+//  3. Public IPs (unlikely)
 //
-// Skip: 203.0.113/24 (Documentation TEST-NET-3, Box USB Gadget),
-// 127/8 Loopback.
+// Skip: 203.0.113/24 (Documentation TEST-NET-3, box USB gadget),
+// 127/8 loopback.
 func pickReachableIP(ips []string) string {
 	if len(ips) == 0 {
 		return ""
@@ -2746,7 +2746,7 @@ func pickReachableIP(ips []string) string {
 		if ip == nil || ip.IsLoopback() {
 			continue
 		}
-		// USB Gadget TEST-NET-3 ist nicht routbar
+		// USB gadget TEST-NET-3 is not routable
 		if strings.HasPrefix(ipStr, "203.0.113.") {
 			continue
 		}
@@ -2786,15 +2786,15 @@ func pickReachableIP(ips []string) string {
 
 // ---- Stick Setup ----
 
-// ListDrives liefert alle entfernbaren Volumes die als Stick Ziel taugen.
-// Frontend nutzt das im Setup Wizard.
+// ListDrives returns all removable volumes that are suitable as a stick target.
+// The frontend uses this in the setup wizard.
 func (a *App) ListDrives() ([]sticksetup.Drive, error) {
 	return sticksetup.ListDrives()
 }
 
-// FormatStick formatiert den Stick neu als FAT32. ACHTUNG: alle Daten
-// gehen verloren. Wird vor WriteStickFiles aufgerufen wenn der User die
-// "Stick zuerst formatieren" Checkbox aktiviert hat.
+// FormatStick reformats the stick as FAT32. WARNING: all data
+// is lost. Called before WriteStickFiles when the user has enabled the
+// "Format stick first" checkbox.
 func (a *App) FormatStick(targetPath string) error {
 	// Log the prepare step so a stick-boot install (the ST10 path, which
 	// never touches the SSH installer that does log) leaves a trail in the
@@ -2808,12 +2808,12 @@ func (a *App) FormatStick(targetPath string) error {
 	return err
 }
 
-// WriteStickFiles bestueckt das angegebene Volume mit allen noetigen
-// Files (Templates plus eingebettetes Stick Agent Binary). Das Binary
-// ist beim App Build embedded und braucht keinen Pfad vom User.
-// Die App Version PLUS Build Stamp wird in version.txt geschrieben
-// (Format "1.0.0+2026-05-15-2202") damit der Update Detector auch
-// bei gleicher Versionsnummer Build Unterschiede erkennt.
+// WriteStickFiles populates the given volume with all the necessary
+// files (templates plus the embedded Stick Agent binary). The binary
+// is embedded at app build time and needs no path from the user.
+// The app version PLUS build stamp is written to version.txt
+// (format "1.0.0+2026-05-15-2202") so that the update detector also
+// recognizes build differences when the version number is the same.
 func (a *App) WriteStickFiles(targetPath string) ([]string, error) {
 	v := appVersion
 	if appBuild != "" && appBuild != "dev" {
@@ -2830,122 +2830,122 @@ func (a *App) WriteStickFiles(targetPath string) ([]string, error) {
 	return files, err
 }
 
-// WriteWLANConfig schreibt eine WLAN Konfig auf den Stick. Optional vor
-// dem Eject; Box's run.sh erkennt das beim ersten Boot.
+// WriteWLANConfig writes a Wi-Fi config onto the stick. Optional before
+// the eject; the box's run.sh detects it on first boot.
 func (a *App) WriteWLANConfig(targetPath, ssid, password string) error {
 	return sticksetup.WriteWLANConfig(targetPath, sticksetup.WLANConfig{
 		SSID: ssid, Password: password,
 	})
 }
 
-// WriteRegionConfig schreibt eine region.conf JSON Datei (ISO 3166-1
-// alpha-2 Country Code) auf den Stick. Stick persistiert das beim Boot
-// nach NAND und nutzt es als Default fuer Radio Suche und Sprache.
+// WriteRegionConfig writes a region.conf JSON file (ISO 3166-1
+// alpha-2 country code) onto the stick. The stick persists it on boot
+// to NAND and uses it as the default for radio search and language.
 func (a *App) WriteRegionConfig(targetPath, country string) error {
 	return sticksetup.WriteRegionConfig(targetPath, sticksetup.RegionConfig{Country: country})
 }
 
-// WriteNameConfig schreibt eine name.conf JSON Datei mit dem vom User
-// gewuenschten Box Namen auf den Stick. Stick wendet den beim ersten
-// Boot via Bose REST API auf die Box an und haengt die UID Box ID an.
+// WriteNameConfig writes a name.conf JSON file with the box name
+// requested by the user onto the stick. The stick applies it on first
+// boot to the box via the Bose REST API and appends the UID box ID.
 func (a *App) WriteNameConfig(targetPath, name string) error {
 	return sticksetup.WriteNameConfig(targetPath, sticksetup.NameConfig{Name: name})
 }
 
-// WriteLangConfig schreibt lang.conf auf den Stick. locale + country
-// sind die Wizard-Signale, sysLanguage der vom User im Sprach-Dropdown
-// gewaehlte Bose-Wert. Die Box's run.sh liest den Integer beim ersten
-// Boot als OOB-Gate-Sprache UND Display-Sprache, statt weltweit Deutsch
-// zu erzwingen. Siehe project_bose_language_enum.
+// WriteLangConfig writes lang.conf onto the stick. locale + country
+// are the wizard signals, sysLanguage the Bose value chosen by the user
+// in the language dropdown. The box's run.sh reads the integer on first
+// boot as the OOB-gate language AND display language, instead of forcing
+// German worldwide. See project_bose_language_enum.
 func (a *App) WriteLangConfig(targetPath, locale, country string, sysLanguage int) error {
 	return sticksetup.WriteLangConfig(targetPath, locale, country, sysLanguage)
 }
 
-// SuggestBoxLanguage liefert die Bose-sysLanguage, die der Setup-Wizard
-// im Sprach-Dropdown vorbelegen soll: primaer aus dem gewaehlten Land
-// abgeleitet, mit der aktiven App-Sprache als bewusster Override, sonst
-// Englisch. Das Frontend ruft es beim Laden und bei jeder Laenderaenderung.
+// SuggestBoxLanguage returns the Bose sysLanguage that the setup wizard
+// should preselect in the language dropdown: derived primarily from the
+// chosen country, with the active app language as a deliberate override,
+// otherwise English. The frontend calls it on load and on every country change.
 func (a *App) SuggestBoxLanguage(locale, country string) int {
 	return sticksetup.SuggestBoxLanguage(locale, country)
 }
 
-// SetAppLocale merkt sich die im UI aktive Sprache des Users (BCP-47,
-// z.B. "de"/"en"). Das Frontend ruft das beim Start und bei jedem
-// Sprachwechsel auf. Server-seitige Provisioning-Pfade (Setup-AP Push)
-// leiten daraus die Box-Display-Sprache ab.
+// SetAppLocale remembers the user's UI-active language (BCP-47,
+// e.g. "de"/"en"). The frontend calls it at startup and on every
+// language change. Server-side provisioning paths (setup-AP push)
+// derive the box display language from it.
 func (a *App) SetAppLocale(locale string) {
 	a.localeMu.Lock()
 	a.userLocale = strings.TrimSpace(locale)
 	a.localeMu.Unlock()
 }
 
-// appLocale liefert das zuletzt gemeldete UI-Locale (leer wenn noch
-// keins gesetzt wurde).
+// appLocale returns the most recently reported UI locale (empty if none
+// has been set yet).
 func (a *App) appLocale() string {
 	a.localeMu.RLock()
 	defer a.localeMu.RUnlock()
 	return a.userLocale
 }
 
-// ListWiFiProfiles liefert die gespeicherten WLAN Profile vom Host OS.
-// Frontend nutzt das als Dropdown im Setup damit der User die SSID nicht
-// abtippen muss.
+// ListWiFiProfiles returns the saved Wi-Fi profiles from the host OS.
+// The frontend uses this as a dropdown in setup so the user does not have
+// to type the SSID.
 func (a *App) ListWiFiProfiles() ([]wifiprofiles.Profile, error) {
 	return wifiprofiles.List()
 }
 
-// TryWiFiPassword versucht das gespeicherte Passwort fuer eine SSID
-// auszulesen. Auf Windows funktioniert das fuer Profile die der User
-// selbst gespeichert hat ohne Admin Rechte. Auf Mac/Linux braucht es ggf.
-// User Consent. Returns leer wenn nichts gefunden.
+// TryWiFiPassword tries to read the saved password for an SSID.
+// On Windows this works for profiles the user saved themselves
+// without admin rights. On Mac/Linux it may need user consent.
+// Returns empty when nothing is found.
 func (a *App) TryWiFiPassword(ssid string) string {
 	pw, _ := wifiprofiles.TryPassword(ssid)
 	return pw
 }
 
-// CurrentWiFi liefert die SSID des aktuell verbundenen WLAN. Wird im UI
-// als Default in der Dropdown ausgewaehlt.
+// CurrentWiFi returns the SSID of the currently connected Wi-Fi. Used in the UI
+// as the default selection in the dropdown.
 func (a *App) CurrentWiFi() string {
 	return wifiprofiles.CurrentSSID()
 }
 
-// IsBoseStick true wenn auf dem Volume schon ein STR liegt.
+// IsBoseStick true when the volume already holds an STR install.
 func (a *App) IsBoseStick(path string) bool {
 	return sticksetup.IsBoseStick(path)
 }
 
-// StickVersion liest die version.txt vom Stick.
+// StickVersion reads version.txt from the stick.
 func (a *App) StickVersion(path string) string {
 	return sticksetup.StickVersion(path)
 }
 
-// CheckStick prueft technisch ob das Volume als Install-Stick taugt
-// (vorhanden, FAT32, gross genug, beschreibbar). Der Setup-Wizard ruft das
-// bevor er den User weitergehen laesst, damit ein NTFS/exFAT-, zu kleiner oder
-// schreibgeschuetzter Stick frueh mit klarer Meldung abgefangen wird statt in
-// einen spaeteren kryptischen Fehler zu laufen.
+// CheckStick technically checks whether the volume is suitable as an install stick
+// (present, FAT32, large enough, writable). The setup wizard calls this
+// before letting the user proceed, so that an NTFS/exFAT, too-small or
+// write-protected stick is caught early with a clear message instead of
+// running into a later cryptic error.
 func (a *App) CheckStick(path string) sticksetup.StickCheck {
 	return sticksetup.CheckStick(path)
 }
 
-// StickConfigs liefert noch nicht applizierte Setup Konfigs vom Stick
-// (wlan, region, name). Wird zum Vorbefuellen des Wizards genutzt.
+// StickConfigs returns not-yet-applied setup configs from the stick
+// (wlan, region, name). Used to pre-fill the wizard.
 func (a *App) StickConfigs(path string) sticksetup.StickConfigs {
 	return sticksetup.ReadStickConfigs(path)
 }
 
-// AppVersion liefert die Semver Version der laufenden App.
+// AppVersion returns the semver version of the running app.
 func (a *App) AppVersion() string { return appVersion }
 
-// AppInfo liefert App Metadaten (Version, Build, Autor, URLs) fuer
-// About Dialog, Footer und Auto Update Check.
+// AppInfo returns app metadata (version, build, author, URLs) for
+// the About dialog, footer and auto-update check.
 //
-// UpdateManifestURL zeigt auf eine kleine JSON Datei der Form
+// UpdateManifestURL points to a small JSON file of the form
 //
 //	{"version":"1.1.0","build":"2026-06-01-0900","downloadUrl":"https://.../app-windows-amd64.exe","notes":"..."}
 //
-// Die App prueft beim Start ob die remote Version groesser ist als ihre
-// eigene und zeigt dann ein Update Banner. Leer = Auto Update aus.
+// On startup the app checks whether the remote version is greater than its
+// own and then shows an update banner. Empty = auto-update off.
 type AppInfo struct {
 	Version           string `json:"version"`
 	Build             string `json:"build"`
@@ -2957,8 +2957,8 @@ type AppInfo struct {
 	UpdateManifestURL string `json:"updateManifestUrl"`
 }
 
-// Versionen werden ueber -ldflags X im Build gesetzt; defaults nur zum
-// Entwickeln.
+// Versions are set via -ldflags X in the build; defaults are for
+// development only.
 var (
 	appVersion = "1.0.0"
 	appBuild   = "dev"
@@ -3212,13 +3212,13 @@ func (a *App) headStatusType(url string) (int, string) {
 	return resp.StatusCode, resp.Header.Get("Content-Type")
 }
 
-// EjectDrive wirft den Stick aus damit der User ihn entnehmen kann.
+// EjectDrive ejects the stick so the user can remove it.
 func (a *App) EjectDrive(path string) error {
 	return sticksetup.Eject(path)
 }
 
-// Status liefert das now_playing XML als String. Frontend kann selber
-// regex-parsen.
+// Status returns the now_playing XML as a string. The frontend can
+// regex-parse it itself.
 func (a *App) Status(host string, port int) (string, error) {
 	resp, err := a.boxDo(host, port, http.MethodGet, "/api/status", "", "")
 	if err != nil {

--- a/desktop-app/app.go
+++ b/desktop-app/app.go
@@ -157,7 +157,7 @@ func (a *App) startup(ctx context.Context) {
 	// Verbose startup line so users always see SOMETHING in the
 	// log when they hit "Save diagnostic logs", even on a session
 	// where they did not poke any features that emit further logs.
-	a.logger.Info("Desktop App startet",
+	a.logger.Info("Desktop App started",
 		"version", appVersion,
 		"build", appBuild,
 		"logFile", LogFilePath(),
@@ -2796,7 +2796,16 @@ func (a *App) ListDrives() ([]sticksetup.Drive, error) {
 // gehen verloren. Wird vor WriteStickFiles aufgerufen wenn der User die
 // "Stick zuerst formatieren" Checkbox aktiviert hat.
 func (a *App) FormatStick(targetPath string) error {
-	return sticksetup.FormatFAT32(targetPath, "REBORN")
+	// Log the prepare step so a stick-boot install (the ST10 path, which
+	// never touches the SSH installer that does log) leaves a trail in the
+	// diagnostic bundle. Without this a failed self-install shows only
+	// discovery noise and the cause is invisible (see #195).
+	a.logger.Info("FormatStick", "comp", "sticksetup", "target", targetPath)
+	err := sticksetup.FormatFAT32(targetPath, "REBORN")
+	if err != nil {
+		a.logger.Warn("FormatStick failed", "comp", "sticksetup", "target", targetPath, "err", err)
+	}
+	return err
 }
 
 // WriteStickFiles bestueckt das angegebene Volume mit allen noetigen
@@ -2810,7 +2819,15 @@ func (a *App) WriteStickFiles(targetPath string) ([]string, error) {
 	if appBuild != "" && appBuild != "dev" {
 		v = appVersion + "+" + appBuild
 	}
-	return sticksetup.WriteStickFiles(targetPath, agentbin.Bytes(), agentbin.GoLibrespotBytes(), v)
+	files, err := sticksetup.WriteStickFiles(targetPath, agentbin.Bytes(), agentbin.GoLibrespotBytes(), v)
+	// Record what was staged onto the stick. agentBytes confirms the embedded
+	// agent is present (0 on a dev build, which is itself the cause of a
+	// non-starting agent), and the file count/version pins the attempt in the
+	// bundle so a later stick-boot failure is traceable (see #195).
+	a.logger.Info("WriteStickFiles",
+		"comp", "sticksetup", "target", targetPath, "version", v,
+		"agentBytes", len(agentbin.Bytes()), "fileCount", len(files), "err", err)
+	return files, err
 }
 
 // WriteWLANConfig schreibt eine WLAN Konfig auf den Stick. Optional vor

--- a/desktop-app/frontend/src/api.js
+++ b/desktop-app/frontend/src/api.js
@@ -24,6 +24,7 @@ export {
   GetBoxFirmware,
   BoxInstallReachable,
   Pause,
+  Resume,
   Stop,
   Status,
   ListDrives,

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -664,6 +664,7 @@
   "settingsView.sourceActive": "aktiv",
   "settingsView.sourceInactive": "inaktiv",
   "settingsView.sourceViaSTR": "über STR",
+  "settingsView.sourceAvailable": "verfügbar",
   "settingsView.spotifyHint": "Spotify Connect ohne Bose-Cloud aktuell nicht aktivierbar. Implementierung via Spotify Web API folgt.",
   "settingsView.airplayHint": "AirPlay 2 ist hardwareseitig da, wird aber erst durch Bose-Setup mit Cloud-Account aktiviert. Wenn der Lautsprecher vorher nie mit einem Bose-Konto verbunden war, bleibt es inaktiv.",
   "settingsView.regionHeading": "Region",

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -181,6 +181,7 @@
   "speaker.stockConfirmBody": "<b>{{label}}</b> läuft noch mit der Original-Bose-Firmware. Mit einem einmaligen USB-Stick installierst du STR direkt auf dem Lautsprecher. Danach steuerst du ihn komplett aus dieser App: Internetradio, Presets, Multi-Room.<br><br>Jetzt die USB-Stick-Einrichtung öffnen?",
   "speaker.stockConfirmCta": "USB-Stick-Einrichtung öffnen",
   "controls.pause": "Pause",
+  "controls.play": "Wiedergabe",
   "controls.stop": "Stop",
   "controls.auxTitle": "AUX-Klinkeneingang",
   "controls.bluetoothTitle": "Bluetooth",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -181,6 +181,7 @@
   "speaker.stockConfirmBody": "<b>{{label}}</b> still runs the stock Bose firmware. A one-time USB stick installs STR directly on the speaker. After that you control it entirely from this app: internet radio, presets, multi-room.<br><br>Open the USB stick setup now?",
   "speaker.stockConfirmCta": "Open USB stick setup",
   "controls.pause": "Pause",
+  "controls.play": "Play",
   "controls.stop": "Stop",
   "controls.auxTitle": "Aux jack input",
   "controls.bluetoothTitle": "Bluetooth",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -664,6 +664,7 @@
   "settingsView.sourceActive": "active",
   "settingsView.sourceInactive": "inactive",
   "settingsView.sourceViaSTR": "via STR",
+  "settingsView.sourceAvailable": "available",
   "settingsView.spotifyHint": "Spotify Connect cannot be enabled without the Bose cloud. A Spotify Web API integration is on the roadmap.",
   "settingsView.airplayHint": "AirPlay 2 is present in hardware but only enabled by the original Bose setup with a Bose account. If the speaker was never paired with a Bose account, it stays inactive.",
   "settingsView.regionHeading": "Region",

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -161,6 +161,7 @@
   "speaker.stockConfirmBody": "<b>{{label}}</b> aún usa el firmware original de Bose. Una memoria USB única instala STR directamente en el altavoz. Después lo controlas por completo desde esta aplicación: radio por internet, preajustes, multisala.<br><br>¿Abrir la preparación de la memoria USB ahora?",
   "speaker.stockConfirmCta": "Abrir preparación de la memoria USB",
   "controls.pause": "Pausa",
+  "controls.play": "Reproducir",
   "controls.stop": "Detener",
   "controls.auxTitle": "Entrada de clavija Aux",
   "controls.bluetoothTitle": "Bluetooth",

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -599,6 +599,7 @@
   "settingsView.sourceActive": "activa",
   "settingsView.sourceInactive": "inactiva",
   "settingsView.sourceViaSTR": "via STR",
+  "settingsView.sourceAvailable": "disponible",
   "settingsView.spotifyHint": "Spotify Connect no puede activarse sin la nube de Bose. Una integración con la API web de Spotify está en la hoja de ruta.",
   "settingsView.airplayHint": "AirPlay 2 está presente en el hardware pero solo lo activa la configuración Bose original con una cuenta Bose. Si el altavoz nunca se emparejó con una cuenta Bose, permanece inactivo.",
   "settingsView.regionHeading": "Región",

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -161,6 +161,7 @@
   "speaker.stockConfirmBody": "<b>{{label}}</b> utilise encore le firmware Bose d'origine. Une clé USB unique installe STR directement sur l'enceinte. Ensuite vous la contrôlez entièrement depuis cette application : radio internet, préréglages, multiroom.<br><br>Ouvrir la préparation de la clé USB maintenant ?",
   "speaker.stockConfirmCta": "Ouvrir la préparation de la clé USB",
   "controls.pause": "Pause",
+  "controls.play": "Lecture",
   "controls.stop": "Arrêt",
   "controls.auxTitle": "Entrée jack Aux",
   "controls.bluetoothTitle": "Bluetooth",

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -599,6 +599,7 @@
   "settingsView.sourceActive": "active",
   "settingsView.sourceInactive": "inactive",
   "settingsView.sourceViaSTR": "via STR",
+  "settingsView.sourceAvailable": "disponible",
   "settingsView.spotifyHint": "Spotify Connect ne peut pas être activé sans le cloud Bose. Une intégration de l'API Web Spotify est prévue dans la feuille de route.",
   "settingsView.airplayHint": "AirPlay 2 est présent matériellement mais n'est activé que par la configuration Bose d'origine avec un compte Bose. Si l'enceinte n'a jamais été associée à un compte Bose, il reste inactif.",
   "settingsView.regionHeading": "Région",

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -161,6 +161,7 @@
   "speaker.stockConfirmBody": "<b>{{label}}</b> はまだBose純正ファームウェアです。一度USBメモリを使うとSTRがスピーカーに直接インストールされます。その後はこのアプリだけで操作できます: インターネットラジオ、プリセット、マルチルーム。<br><br>今すぐUSBメモリの準備を開きますか?",
   "speaker.stockConfirmCta": "USBメモリの準備を開く",
   "controls.pause": "一時停止",
+  "controls.play": "再生",
   "controls.stop": "停止",
   "controls.auxTitle": "Auxジャック入力",
   "controls.bluetoothTitle": "Bluetooth",

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -599,6 +599,7 @@
   "settingsView.sourceActive": "有効",
   "settingsView.sourceInactive": "無効",
   "settingsView.sourceViaSTR": "via STR",
+  "settingsView.sourceAvailable": "利用可能",
   "settingsView.spotifyHint": "Boseクラウドなしでは Spotify Connect を有効にできません。Spotify Web API連携はロードマップにあります。",
   "settingsView.airplayHint": "AirPlay 2 はハードウェアに搭載されていますが、Boseアカウントによる純正セットアップでのみ有効になります。Boseアカウントと一度もペアリングしていない場合は無効のままです。",
   "settingsView.regionHeading": "地域",

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -599,6 +599,7 @@
   "settingsView.sourceActive": "aktyvus",
   "settingsView.sourceInactive": "neaktyvus",
   "settingsView.sourceViaSTR": "via STR",
+  "settingsView.sourceAvailable": "prieinama",
   "settingsView.spotifyHint": "Spotify Connect negalima įjungti be Bose debesies. Integracija per Spotify Web API yra planuose.",
   "settingsView.airplayHint": "AirPlay 2 yra aparatinėje įrangoje, bet jį įjungia tik originali Bose sąranka su Bose paskyra. Jei garsiakalbis niekada nebuvo susietas su Bose paskyra, jis lieka neaktyvus.",
   "settingsView.regionHeading": "Regionas",

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -161,6 +161,7 @@
   "speaker.stockConfirmBody": "<b>{{label}}</b> vis dar veikia su originalia Bose programine įranga. Vienkartinė USB atmintinė įdiegia STR tiesiai į garsiakalbį. Po to jį visiškai valdote iš šios programos: interneto radijas, parinktys, multiroom.<br><br>Atverti USB atmintinės paruošimą dabar?",
   "speaker.stockConfirmCta": "Atverti USB atmintinės paruošimą",
   "controls.pause": "Pauzė",
+  "controls.play": "Groti",
   "controls.stop": "Stabdyti",
   "controls.auxTitle": "Aux įvestis",
   "controls.bluetoothTitle": "Bluetooth",

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -599,6 +599,7 @@
   "settingsView.sourceActive": "aktīvs",
   "settingsView.sourceInactive": "neaktīvs",
   "settingsView.sourceViaSTR": "via STR",
+  "settingsView.sourceAvailable": "pieejams",
   "settingsView.spotifyHint": "Spotify Connect nevar ieslēgt bez Bose mākoņa. Integrācija caur Spotify Web API ir plānos.",
   "settingsView.airplayHint": "AirPlay 2 ir aparatūrā, bet to ieslēdz tikai oriģinālā Bose iestatīšana ar Bose kontu. Ja skaļrunis nekad nav bijis savienots ar Bose kontu, tas paliek neaktīvs.",
   "settingsView.regionHeading": "Reģions",

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -161,6 +161,7 @@
   "speaker.stockConfirmBody": "<b>{{label}}</b> joprojām darbojas ar oriģinālo Bose programmatūru. Vienreizēja USB zibatmiņa instalē STR tieši skaļrunī. Pēc tam jūs to pilnībā vadāt no šīs lietotnes: interneta radio, iestatījumi, multiroom.<br><br>Atvērt USB zibatmiņas sagatavošanu tagad?",
   "speaker.stockConfirmCta": "Atvērt USB zibatmiņas sagatavošanu",
   "controls.pause": "Pauze",
+  "controls.play": "Atskaņot",
   "controls.stop": "Apturēt",
   "controls.auxTitle": "Aux ieeja",
   "controls.bluetoothTitle": "Bluetooth",

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -161,6 +161,7 @@
   "speaker.stockConfirmBody": "<b>{{label}}</b> draait nog de originele Bose-firmware. Een eenmalige USB-stick installeert STR rechtstreeks op de speaker. Daarna bedien je hem volledig vanuit deze app: internetradio, voorkeuzes, multiroom.<br><br>De USB-stick-voorbereiding nu openen?",
   "speaker.stockConfirmCta": "USB-stick-voorbereiding openen",
   "controls.pause": "Pauze",
+  "controls.play": "Afspelen",
   "controls.stop": "Stop",
   "controls.auxTitle": "Aux-ingang",
   "controls.bluetoothTitle": "Bluetooth",

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -599,6 +599,7 @@
   "settingsView.sourceActive": "actief",
   "settingsView.sourceInactive": "inactief",
   "settingsView.sourceViaSTR": "via STR",
+  "settingsView.sourceAvailable": "beschikbaar",
   "settingsView.spotifyHint": "Spotify Connect kan niet worden ingeschakeld zonder de Bose-cloud. Een integratie via de Spotify Web API staat op de roadmap.",
   "settingsView.airplayHint": "AirPlay 2 is in de hardware aanwezig maar wordt alleen ingeschakeld door de originele Bose-setup met een Bose-account. Als de speaker nooit met een Bose-account is gekoppeld, blijft het inactief.",
   "settingsView.regionHeading": "Regio",

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -161,6 +161,7 @@
   "speaker.stockConfirmBody": "<b>{{label}}</b> nadal działa na oryginalnym oprogramowaniu Bose. Jednorazowy pendrive USB instaluje STR bezpośrednio na głośniku. Potem sterujesz nim w pełni z tej aplikacji: radio internetowe, zaprogramowane stacje, multiroom.<br><br>Otworzyć teraz przygotowanie pendrive'a USB?",
   "speaker.stockConfirmCta": "Otwórz przygotowanie pendrive'a USB",
   "controls.pause": "Pauza",
+  "controls.play": "Odtwórz",
   "controls.stop": "Stop",
   "controls.auxTitle": "Wejście Aux",
   "controls.bluetoothTitle": "Bluetooth",

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -599,6 +599,7 @@
   "settingsView.sourceActive": "aktywne",
   "settingsView.sourceInactive": "nieaktywne",
   "settingsView.sourceViaSTR": "via STR",
+  "settingsView.sourceAvailable": "dostępne",
   "settingsView.spotifyHint": "Spotify Connect nie można włączyć bez chmury Bose. Integracja przez Spotify Web API jest na mapie drogowej.",
   "settingsView.airplayHint": "AirPlay 2 jest obecne w sprzęcie, ale włącza je tylko oryginalna konfiguracja Bose z kontem Bose. Jeśli głośnik nigdy nie był sparowany z kontem Bose, pozostaje nieaktywne.",
   "settingsView.regionHeading": "Region",

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -161,6 +161,7 @@
   "speaker.stockConfirmBody": "<b>{{label}}</b> hâlâ orijinal Bose yazılımıyla çalışıyor. Tek seferlik bir USB bellek STR'yi doğrudan hoparlöre kurar. Sonrasında onu tamamen bu uygulamadan kontrol edersiniz: internet radyosu, ön ayarlar, multiroom.<br><br>USB bellek hazırlamayı şimdi açayım mı?",
   "speaker.stockConfirmCta": "USB bellek hazırlamayı aç",
   "controls.pause": "Duraklat",
+  "controls.play": "Oynat",
   "controls.stop": "Durdur",
   "controls.auxTitle": "Aux girişi",
   "controls.bluetoothTitle": "Bluetooth",

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -599,6 +599,7 @@
   "settingsView.sourceActive": "etkin",
   "settingsView.sourceInactive": "etkin değil",
   "settingsView.sourceViaSTR": "via STR",
+  "settingsView.sourceAvailable": "kullanılabilir",
   "settingsView.spotifyHint": "Spotify Connect, Bose bulutu olmadan açılamaz. Spotify Web API üzerinden entegrasyon planlanmaktadır.",
   "settingsView.airplayHint": "AirPlay 2 donanımdadır, ancak yalnızca bir Bose hesabıyla orijinal Bose kurulumu onu açar. Hoparlör hiç bir Bose hesabıyla eşleştirilmediyse, etkin değil kalır.",
   "settingsView.regionHeading": "Bölge",

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -599,6 +599,7 @@
   "settingsView.sourceActive": "активне",
   "settingsView.sourceInactive": "неактивне",
   "settingsView.sourceViaSTR": "via STR",
+  "settingsView.sourceAvailable": "доступне",
   "settingsView.spotifyHint": "Spotify Connect не можна увімкнути без хмари Bose. Інтеграція зі Spotify Web API в планах розвитку.",
   "settingsView.airplayHint": "AirPlay 2 присутній на рівні обладнання, але вмикається лише заводським налаштуванням Bose з обліковим записом Bose. Якщо колонка ніколи не зв'язувалася з обліковим записом Bose, він залишається неактивним.",
   "settingsView.regionHeading": "Регіон",

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -161,6 +161,7 @@
   "speaker.stockConfirmBody": "<b>{{label}}</b> усе ще працює на заводській прошивці Bose. Одноразова підготовка USB-накопичувача встановить STR прямо на колонку. Після цього ви керуєте нею повністю з цього застосунку: інтернет-радіо, пресети, мультирум.<br><br>Відкрити підготовку USB-накопичувача зараз?",
   "speaker.stockConfirmCta": "Відкрити підготовку USB-накопичувача",
   "controls.pause": "Пауза",
+  "controls.play": "Відтворити",
   "controls.stop": "Стоп",
   "controls.auxTitle": "Вхід Aux (роз'єм)",
   "controls.bluetoothTitle": "Bluetooth",

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -17,6 +17,7 @@ import {
   GetBoxFirmware,
   BoxInstallReachable,
   Pause,
+  Resume,
   Stop,
   Status,
   ListDrives,
@@ -976,7 +977,7 @@ if (gsb) gsb.onclick = async () => {
     setTimeout(discoverBoxes, 35000);
   } catch (e) { showError(e); }
 };
-$('pauseBtn').onclick = () => action('pause');
+$('pauseBtn').onclick = () => action(state.nowPlayState === 'PAUSE_STATE' ? 'resume' : 'pause');
 $('stopBtn').onclick = () => action('stop');
 
 // Source Buttons (AUX / Bluetooth / Standby) im Musik-Hoeren Tab —
@@ -3139,7 +3140,7 @@ function scheduleLiveTitle() {
 
 async function action(kind) {
   if (!state.currentBox) return;
-  const fn = kind === 'pause' ? Pause : Stop;
+  const fn = kind === 'pause' ? Pause : kind === 'resume' ? Resume : Stop;
   try { await fn(state.currentBox.host, state.currentBox.port); } catch (e) { showError(e); }
   setTimeout(refreshStatus, 1000);
 }
@@ -3156,6 +3157,15 @@ function renderNowPlayingBar() {
   const src = state.nowSource || '';
   const loc = state.nowLocation || '';
   const name = state.nowName || '';
+  // Transport button doubles as Play/Pause: when the box is paused it offers
+  // Play (resume from the paused position, like the Bose remote), otherwise
+  // Pause (#202).
+  const ppBtn = $('pauseBtn');
+  if (ppBtn) {
+    ppBtn.innerHTML = ps === 'PAUSE_STATE'
+      ? '&#9654; ' + escapeHtml(t('controls.play'))
+      : '&#9208; ' + escapeHtml(t('controls.pause'));
+  }
   let displayName = name;
   if (/\/spotify\/stream/.test(loc) && state.nowSpotifyTrack) {
     const song = state.nowSpotifyArtist

--- a/desktop-app/frontend/src/views/settings.js
+++ b/desktop-app/frontend/src/views/settings.js
@@ -720,9 +720,15 @@ function renderBoxSettings(s, box) {
           // via the app. Showing those as "inactive" was misleading; mark them
           // "via STR". QPlay and the like stay inactive (STR does not revive them).
           const viaSTR = !ready && (su === 'UPNP' || su === 'SPOTIFY' || su.startsWith('STORED_MUSIC') || su === 'LOCAL_MUSIC');
-          const cls = ready ? 'src-ok' : (viaSTR ? 'src-ok src-via-str' : 'src-unav');
+          // AirPlay and Bluetooth are local firmware features that work without
+          // the Bose cloud. The box's /sources READY flag is unreliable for them
+          // post-cloud (it tracked the original Bose-account setup), so a working
+          // AirPlay can report not-READY and was shown as "inactive" (#200). Label
+          // these "available" instead, with the hint below for the nuance.
+          const localFw = !ready && (su === 'AIRPLAY' || su === 'BLUETOOTH');
+          const cls = ready ? 'src-ok' : (viaSTR ? 'src-ok src-via-str' : (localFw ? 'src-ok' : 'src-unav'));
           const label = sourceLabel(src.source);
-          const statusLabel = ready ? t('settingsView.sourceActive') : (viaSTR ? t('settingsView.sourceViaSTR') : t('settingsView.sourceInactive'));
+          const statusLabel = ready ? t('settingsView.sourceActive') : (viaSTR ? t('settingsView.sourceViaSTR') : (localFw ? t('settingsView.sourceAvailable') : t('settingsView.sourceInactive')));
           return `<div class="source-pill ${cls}" title="${escapeAttr(sourceHint(src.source) || src.sourceAccount || '')}">${escapeHtml(label)} <small>${escapeHtml(statusLabel)}</small></div>`;
         }).join('')}
       </div>

--- a/desktop-app/frontend/wailsjs/go/main/App.d.ts
+++ b/desktop-app/frontend/wailsjs/go/main/App.d.ts
@@ -91,8 +91,6 @@ export function LogClientError(arg1:string):Promise<void>;
 
 export function Pause(arg1:string,arg2:number):Promise<void>;
 
-export function Resume(arg1:string,arg2:number):Promise<void>;
-
 export function PlaySlot(arg1:string,arg2:number,arg3:number):Promise<void>;
 
 export function PlayURL(arg1:string,arg2:number,arg3:string,arg4:string,arg5:string,arg6:string,arg7:string,arg8:string):Promise<void>;
@@ -128,6 +126,8 @@ export function ResolveStationLogo(arg1:string,arg2:string,arg3:Array<string>):P
 export function ResolveUpdateAsset(arg1:string):Promise<main.UpdateAsset>;
 
 export function RestoreBoxSnapshot(arg1:string,arg2:number,arg3:string):Promise<Record<string, any>>;
+
+export function Resume(arg1:string,arg2:number):Promise<void>;
 
 export function RevealUpdateFile(arg1:string):Promise<void>;
 

--- a/desktop-app/frontend/wailsjs/go/main/App.d.ts
+++ b/desktop-app/frontend/wailsjs/go/main/App.d.ts
@@ -91,6 +91,8 @@ export function LogClientError(arg1:string):Promise<void>;
 
 export function Pause(arg1:string,arg2:number):Promise<void>;
 
+export function Resume(arg1:string,arg2:number):Promise<void>;
+
 export function PlaySlot(arg1:string,arg2:number,arg3:number):Promise<void>;
 
 export function PlayURL(arg1:string,arg2:number,arg3:string,arg4:string,arg5:string,arg6:string,arg7:string,arg8:string):Promise<void>;

--- a/desktop-app/frontend/wailsjs/go/main/App.js
+++ b/desktop-app/frontend/wailsjs/go/main/App.js
@@ -174,10 +174,6 @@ export function Pause(arg1, arg2) {
   return window['go']['main']['App']['Pause'](arg1, arg2);
 }
 
-export function Resume(arg1, arg2) {
-  return window['go']['main']['App']['Resume'](arg1, arg2);
-}
-
 export function PlaySlot(arg1, arg2, arg3) {
   return window['go']['main']['App']['PlaySlot'](arg1, arg2, arg3);
 }
@@ -248,6 +244,10 @@ export function ResolveUpdateAsset(arg1) {
 
 export function RestoreBoxSnapshot(arg1, arg2, arg3) {
   return window['go']['main']['App']['RestoreBoxSnapshot'](arg1, arg2, arg3);
+}
+
+export function Resume(arg1, arg2) {
+  return window['go']['main']['App']['Resume'](arg1, arg2);
 }
 
 export function RevealUpdateFile(arg1) {

--- a/desktop-app/frontend/wailsjs/go/main/App.js
+++ b/desktop-app/frontend/wailsjs/go/main/App.js
@@ -174,6 +174,10 @@ export function Pause(arg1, arg2) {
   return window['go']['main']['App']['Pause'](arg1, arg2);
 }
 
+export function Resume(arg1, arg2) {
+  return window['go']['main']['App']['Resume'](arg1, arg2);
+}
+
 export function PlaySlot(arg1, arg2, arg3) {
   return window['go']['main']['App']['PlaySlot'](arg1, arg2, arg3);
 }

--- a/desktop-app/ota.go
+++ b/desktop-app/ota.go
@@ -21,7 +21,7 @@ import (
 	"streborn-app/agentbin"
 )
 
-// BoxAgentVersion fragt die Stick Agent Version der Box ab.
+// BoxAgentVersion queries the box's Stick Agent version.
 // Returns {version, build}. Uses boxDo so it tries BOTH agent ports (:8888 and
 // the :17008 redirect) with the self-healing cache, instead of forcing one port.
 // This matters on rhino ST10s where the Bose firewall blocks :8888: the version

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -5,14 +5,15 @@
 // app can offer to flash them.
 //
 // Service types:
-//   _streborn._tcp.local         current STR service
-//   _soundtouchstick._tcp.local  legacy STR pre-rename, still in use
-//                                on speakers that have not been
-//                                OTA-updated yet
-//   _soundtouch._tcp.local       stock Bose speakers, primary name
-//                                observed in the wild (ST10/20/30)
-//   _bose-soundtouch._tcp.local  alternate stock spelling seen on
-//                                some firmware variants
+//
+//	_streborn._tcp.local         current STR service
+//	_soundtouchstick._tcp.local  legacy STR pre-rename, still in use
+//	                             on speakers that have not been
+//	                             OTA-updated yet
+//	_soundtouch._tcp.local       stock Bose speakers, primary name
+//	                             observed in the wild (ST10/20/30)
+//	_bose-soundtouch._tcp.local  alternate stock spelling seen on
+//	                             some firmware variants
 //
 // Multiple speakers on the same network are supported. The desktop
 // app lists every announced stick via DNS-SD browse plus every
@@ -82,20 +83,20 @@ type Announcer struct {
 	cfg          Config
 }
 
-// Config beschreibt was im mDNS Record steht.
+// Config describes what goes into the mDNS record.
 type Config struct {
-	// InstanceName ist der menschen-lesbare Name. Default:
+	// InstanceName is the human-readable name. Default:
 	// "STR <deviceID>".
 	InstanceName string
-	// Port ist der TCP Port des Webui/REST API (default 8888).
+	// Port is the TCP port of the webui/REST API (default 8888).
 	Port int
-	// DeviceID ist die Bose Box MAC im uppercase ohne Trenner.
+	// DeviceID is the Bose box MAC in uppercase without separators.
 	DeviceID string
-	// FriendlyName ist der Bose Box Display Name, z.B. "Wohnzimmer Bose".
+	// FriendlyName is the Bose box display name, e.g. "Living Room Bose".
 	FriendlyName string
-	// Model ist der Bose Modellname, z.B. "SoundTouch 10".
+	// Model is the Bose model name, e.g. "SoundTouch 10".
 	Model string
-	// Version ist die Stick Agent Version.
+	// Version is the stick agent version.
 	Version string
 	// Build is the agent build stamp (YYYY-MM-DD-HHMM). Announced
 	// alongside Version so the desktop app's "update available"
@@ -104,7 +105,7 @@ type Config struct {
 	Build string
 }
 
-// Announce startet einen mDNS Server der den Stick announciert. Stop mit
+// Announce starts an mDNS server that announces the stick. Stop with
 // Close().
 func Announce(logger *slog.Logger, cfg Config) (*Announcer, error) {
 	if cfg.Port == 0 {
@@ -269,8 +270,8 @@ func (a *Announcer) Close() {
 	}
 }
 
-// Run blockiert bis ctx abgebrochen wird und schliesst dann den Announcer.
-// Convenience fuer Use in goroutines.
+// Run blocks until ctx is cancelled and then closes the Announcer.
+// Convenience for use in goroutines.
 func (a *Announcer) Run(ctx context.Context) {
 	<-ctx.Done()
 	a.Close()
@@ -503,9 +504,9 @@ func stockModelLabel(code string) string {
 	}
 }
 
-// pickAnnounceIfaces filtert net.Interfaces auf die Interfaces auf denen
-// wir announcen wollen. Excludiert Loopback, Down, usb0 (Bose USB Gadget
-// mit TEST-NET-3 IP).
+// pickAnnounceIfaces filters net.Interfaces down to the interfaces we
+// want to announce on. Excludes loopback, down, usb0 (Bose USB gadget
+// with TEST-NET-3 IP).
 func pickAnnounceIfaces(logger *slog.Logger) []net.Interface {
 	all, err := net.Interfaces()
 	if err != nil {
@@ -520,10 +521,10 @@ func pickAnnounceIfaces(logger *slog.Logger) []net.Interface {
 			continue
 		}
 		if iface.Name == "usb0" || strings.HasPrefix(iface.Name, "usb") {
-			logger.Debug("mDNS skip USB Gadget Interface", slog.String("iface", iface.Name))
+			logger.Debug("mDNS skip USB gadget interface", slog.String("iface", iface.Name))
 			continue
 		}
-		// Extra Sicherheit: pruefen ob nur TEST-NET-3 IPs zugewiesen sind
+		// Extra safety: check whether only TEST-NET-3 IPs are assigned
 		addrs, _ := iface.Addrs()
 		hasUsable := false
 		for _, a := range addrs {
@@ -546,13 +547,13 @@ func pickAnnounceIfaces(logger *slog.Logger) []net.Interface {
 			// and this fires for each of them on every discovery cycle.
 			// At Info it floods str.log (the dominant source of log
 			// growth reported by users).
-			logger.Debug("mDNS skip Interface ohne brauchbare IP", slog.String("iface", iface.Name))
+			logger.Debug("mDNS skip interface without usable IP", slog.String("iface", iface.Name))
 			continue
 		}
 		out = append(out, iface)
 	}
 	if len(out) == 0 {
-		// Fallback: zeroconf default mit allen Interfaces
+		// Fallback: zeroconf default with all interfaces
 		return nil
 	}
 	return out

--- a/internal/autopair/autopair.go
+++ b/internal/autopair/autopair.go
@@ -1,13 +1,13 @@
-// Package autopair sorgt dafuer dass die Bose Box immer mit dem Stick
-// gepaart ist. Wird beim Agent Start ausgefuehrt und kann auch nach
-// Box Reboots aktiv getriggert werden.
+// Package autopair makes sure the Bose box is always paired with the
+// stick. Runs at agent start and can also be actively triggered after
+// box reboots.
 //
-// Pair Flow:
-//  1. GET http://<box>:8090/info um margeAccountUUID zu lesen
-//  2. Wenn leer: POST http://<box>:8090/setMargeAccount mit PairDeviceWithAccount XML
-//  3. Box ruft Stick's Marge Stub /streaming/account/.../device/ auf
-//  4. Stub antwortet mit adddeviceresponse (wrap201 Format)
-//  5. Box State Machine wechselt nach MargeStateAssociated
+// Pair flow:
+//  1. GET http://<box>:8090/info to read margeAccountUUID
+//  2. If empty: POST http://<box>:8090/setMargeAccount with PairDeviceWithAccount XML
+//  3. Box calls the stick's marge stub /streaming/account/.../device/
+//  4. Stub answers with adddeviceresponse (wrap201 format)
+//  5. Box state machine transitions to MargeStateAssociated
 package autopair
 
 import (
@@ -27,15 +27,15 @@ const (
 	defaultEmail     = "stick@local"
 )
 
-// Config beschreibt die Pair Identitaet.
+// Config describes the pair identity.
 type Config struct {
-	BoxHost   string // z.B. "127.0.0.1" oder Box LAN IP
-	AccountID string // z.B. "stick@local"
-	AuthToken string // wird als userAuthToken gesendet
+	BoxHost   string // e.g. "127.0.0.1" or box LAN IP
+	AccountID string // e.g. "stick@local"
+	AuthToken string // sent as userAuthToken
 	Email     string // optional
 }
 
-// Manager kann den Pair Status pruefen und triggern.
+// Manager can check and trigger the pair status.
 type Manager struct {
 	logger *slog.Logger
 	cfg    Config
@@ -50,7 +50,7 @@ type Manager struct {
 	tickCount  int
 }
 
-// New erstellt einen Manager mit sinnvollen Defaults.
+// New creates a Manager with sensible defaults.
 func New(logger *slog.Logger, cfg Config) *Manager {
 	if cfg.BoxHost == "" {
 		cfg.BoxHost = "127.0.0.1"
@@ -71,7 +71,7 @@ func New(logger *slog.Logger, cfg Config) *Manager {
 	}
 }
 
-// IsPaired liest /info und prueft ob margeAccountUUID gesetzt ist.
+// IsPaired reads /info and checks whether margeAccountUUID is set.
 func (m *Manager) IsPaired(ctx context.Context) (bool, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
 		fmt.Sprintf("http://%s:8090/info", m.cfg.BoxHost), nil)
@@ -97,8 +97,8 @@ func hasMargeUUID(body []byte) bool {
 	return len(m) == 2 && len(strings.TrimSpace(string(m[1]))) > 0
 }
 
-// Pair triggert den Pair Flow durch POST an /setMargeAccount.
-// Erfolg = Box antwortet 200 OK (margeAccountUUID wird danach gesetzt).
+// Pair triggers the pair flow via POST to /setMargeAccount.
+// Success = box answers 200 OK (margeAccountUUID is set afterwards).
 func (m *Manager) Pair(ctx context.Context) error {
 	body := buildPairXML(m.cfg.AccountID, m.cfg.AuthToken, m.cfg.Email)
 	url := fmt.Sprintf("http://%s:8090/setMargeAccount", m.cfg.BoxHost)
@@ -119,8 +119,8 @@ func (m *Manager) Pair(ctx context.Context) error {
 	return nil
 }
 
-// EnsurePaired prueft den Status und triggert Pair falls noetig.
-// Idempotent: laeuft Box bereits gepaart, macht es nichts.
+// EnsurePaired checks the status and triggers Pair if needed.
+// Idempotent: if the box is already paired, it does nothing.
 //
 // Before the first Pair attempt this also checks that the box's own
 // clock is past 2024. The Bose firmware's RTC reads 2015 right after
@@ -139,7 +139,7 @@ func (m *Manager) EnsurePaired(ctx context.Context) error {
 		// will retry, because "box silent for N ticks" is exactly the
 		// signal we need for #60.
 		m.logger.Warn("autopair phase: /info read failed", "err", err)
-		return fmt.Errorf("status pruefen: %w", err)
+		return fmt.Errorf("check status: %w", err)
 	}
 	m.recordPairedState(paired)
 	if paired {
@@ -215,12 +215,12 @@ func (m *Manager) boxClockSane(ctx context.Context) (bool, string) {
 	return true, t.UTC().Format(time.RFC3339)
 }
 
-// RunBackground laeuft im Hintergrund, paart einmal beim Start nach delay,
-// und re-paart wenn Box den Status verliert (alle "interval"). Stop via
-// ctx Cancel.
+// RunBackground runs in the background, pairs once at start after delay,
+// and re-pairs when the box loses the status (every "interval"). Stop via
+// ctx cancel.
 //
-// Das delay beim Start gibt der Box Zeit BoseApp Webserver hochzufahren
-// nach einem Box Reboot.
+// The delay at start gives the box time to bring up the BoseApp web
+// server after a box reboot.
 func (m *Manager) RunBackground(ctx context.Context, startDelay, interval time.Duration) {
 	if startDelay > 0 {
 		select {
@@ -262,8 +262,8 @@ func (m *Manager) RunBackground(ctx context.Context, startDelay, interval time.D
 	}
 }
 
-// TriggerNow forciert ein Pair-Check Cycle, unabhaengig vom RunBackground
-// Ticker. Nuetzlich z.B. wenn boxws ein Reconnect signalisiert.
+// TriggerNow forces a pair-check cycle, independent of the RunBackground
+// ticker. Useful e.g. when boxws signals a reconnect.
 func (m *Manager) TriggerNow(ctx context.Context) {
 	if err := m.EnsurePaired(ctx); err != nil {
 		m.logger.Warn("auto pair trigger failed", "err", err)

--- a/internal/bmx/bmx.go
+++ b/internal/bmx/bmx.go
@@ -1,6 +1,6 @@
-// Package bmx emuliert den Bose BMX Broker Server (content.api.bose.io).
-// BMX löst TuneIn Station IDs in echte Stream URLs auf. Diese Emulation
-// nutzt die offene TuneIn API und die Radio Browser API als Backend.
+// Package bmx emulates the Bose BMX broker server (content.api.bose.io).
+// BMX resolves TuneIn station IDs into real stream URLs. This emulation
+// uses the open TuneIn API and the Radio Browser API as backend.
 package bmx
 
 import (
@@ -8,23 +8,23 @@ import (
 	"net/http"
 )
 
-// Resolver löst Station IDs in Stream URLs auf.
+// Resolver resolves station IDs into stream URLs.
 type Resolver struct {
 	logger *slog.Logger
 }
 
-// New erstellt einen neuen BMX Resolver.
+// New creates a new BMX resolver.
 func New(logger *slog.Logger) *Resolver {
 	return &Resolver{logger: logger}
 }
 
-// Handler liefert den HTTP Handler für die BMX Endpunkte.
+// Handler returns the HTTP handler for the BMX endpoints.
 func (r *Resolver) Handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})
-	// Resolver Endpunkte folgen in einer späteren Aufgabe.
+	// Resolver endpoints follow in a later task.
 	return mux
 }

--- a/internal/boxapi/boxapi.go
+++ b/internal/boxapi/boxapi.go
@@ -1,9 +1,9 @@
-// Package boxapi ist ein duenner Client fuer die Bose BoseApp REST API
-// auf Port 8090. Die Box selbst hostet die — wir proxien sie via Stick
-// damit die Desktop App eine simple JSON Schnittstelle hat.
+// Package boxapi is a thin client for the Bose BoseApp REST API
+// on port 8090. The box itself hosts it — we proxy it via the stick
+// so the desktop app has a simple JSON interface.
 //
-// Die meisten Endpoints sind XML (Format: <feld>wert</feld>); wir
-// parsen das in Go Structs und liefern JSON nach aussen.
+// Most endpoints are XML (format: <field>value</field>); we
+// parse that into Go structs and return JSON to the outside.
 package boxapi
 
 import (
@@ -17,13 +17,13 @@ import (
 	"time"
 )
 
-// Client kapselt http.Client + Box Host.
+// Client wraps http.Client + box host.
 type Client struct {
-	Host string // z.B. "127.0.0.1" oder die Box IP
+	Host string // e.g. "127.0.0.1" or the box IP
 	HTTP *http.Client
 }
 
-// New erzeugt einen Client mit defaults.
+// New creates a client with defaults.
 func New(host string) *Client {
 	return &Client{
 		Host: host,
@@ -31,9 +31,9 @@ func New(host string) *Client {
 	}
 }
 
-// ---------- Datenmodell ----------
+// ---------- Data model ----------
 
-// Info enthaelt die statische Beschreibung der Box.
+// Info contains the static description of the box.
 type Info struct {
 	DeviceID         string `json:"deviceID"`
 	Name             string `json:"name"`
@@ -46,22 +46,22 @@ type Info struct {
 	CountryCode      string `json:"countryCode"`
 }
 
-// SetupStatus ist die Antwort von /setup. State ist z.B. "SETUP_AP_OOB"
-// (Box spannt den Bose Setup-AP auf) oder "SETUP_INACTIVE" (Setup beendet);
-// SystemState z.B. "SETUP_LANG_NOT_SET" / "SETUP_LANG_SET".
+// SetupStatus is the response from /setup. State is e.g. "SETUP_AP_OOB"
+// (box opens the Bose setup AP) or "SETUP_INACTIVE" (setup finished);
+// SystemState e.g. "SETUP_LANG_NOT_SET" / "SETUP_LANG_SET".
 type SetupStatus struct {
 	State       string `json:"state"`
 	SystemState string `json:"systemState"`
 }
 
-// Volume ist aktueller Lautstaerke Zustand.
+// Volume is the current volume state.
 type Volume struct {
 	Target int  `json:"target"`
 	Actual int  `json:"actual"`
 	Muted  bool `json:"muted"`
 }
 
-// Bass + Capabilities zusammengefasst.
+// Bass + capabilities combined.
 type Bass struct {
 	Target  int  `json:"target"`
 	Actual  int  `json:"actual"`
@@ -71,26 +71,26 @@ type Bass struct {
 	Avail   bool `json:"available"`
 }
 
-// Network ist der aktive WLAN Zustand.
+// Network is the active Wi-Fi state.
 type Network struct {
 	WifiProfileCount int                `json:"wifiProfileCount"`
 	Interfaces       []NetworkInterface `json:"interfaces"`
 }
 
-// NetworkInterface ein WLAN Adapter.
+// NetworkInterface is a Wi-Fi adapter.
 type NetworkInterface struct {
-	Type       string `json:"type"`
-	Name       string `json:"name"`
-	MAC        string `json:"macAddress"`
-	IP         string `json:"ipAddress"`
-	SSID       string `json:"ssid"`
-	Frequency  int    `json:"frequencyKHz"`
-	State      string `json:"state"`
-	Signal     string `json:"signal"`
-	Mode       string `json:"mode"`
+	Type      string `json:"type"`
+	Name      string `json:"name"`
+	MAC       string `json:"macAddress"`
+	IP        string `json:"ipAddress"`
+	SSID      string `json:"ssid"`
+	Frequency int    `json:"frequencyKHz"`
+	State     string `json:"state"`
+	Signal    string `json:"signal"`
+	Mode      string `json:"mode"`
 }
 
-// Source ist ein Eintrag aus /sources (Spotify, AirPlay etc).
+// Source is an entry from /sources (Spotify, AirPlay etc).
 type Source struct {
 	Source        string `json:"source"`
 	SourceAccount string `json:"sourceAccount"`
@@ -100,7 +100,7 @@ type Source struct {
 	DisplayName   string `json:"displayName"`
 }
 
-// Settings ist die kombinierte Antwort fuer den Box Einstellungen Tab.
+// Settings is the combined response for the box settings tab.
 type Settings struct {
 	Info    Info     `json:"info"`
 	Volume  Volume   `json:"volume"`
@@ -111,8 +111,8 @@ type Settings struct {
 
 // ---------- Read ----------
 
-// LoadSettings holt alle relevanten Zustaende mit einem Aufruf parallel.
-// Bei Fehlern einzelner Endpoints werden die Felder leer gelassen.
+// LoadSettings fetches all relevant states in parallel with one call.
+// On errors from individual endpoints the fields are left empty.
 func (c *Client) LoadSettings(ctx context.Context) (Settings, error) {
 	var s Settings
 	type result struct{ err error }
@@ -199,10 +199,10 @@ func (c *Client) LoadSettings(ctx context.Context) (Settings, error) {
 	return s, nil
 }
 
-// GetInfo liest /info und liefert die statische Box-Beschreibung inkl.
-// margeAccountUUID (leer = nicht gepaart / nach Factory-Reset),
-// moduleType/variant (taigan/scm/...) und der LAN-IP aus dem
-// networkInfo-Block (bevorzugt eine echte Adresse vor "0.0.0.0").
+// GetInfo reads /info and returns the static box description incl.
+// margeAccountUUID (empty = not paired / after factory reset),
+// moduleType/variant (taigan/scm/...) and the LAN IP from the
+// networkInfo block (prefers a real address over "0.0.0.0").
 func (c *Client) GetInfo(ctx context.Context) (Info, error) {
 	var raw struct {
 		DeviceID         string `xml:"deviceID,attr"`
@@ -235,8 +235,8 @@ func (c *Client) GetInfo(ctx context.Context) (Info, error) {
 	}
 	for _, comp := range raw.Components {
 		if comp.Category == "SCM" || info.Version == "" {
-			// Software Version hat oft Trailing Buildinfo —
-			// nur die ersten Zahlen Punkte Zahlen behalten.
+			// Software version often has trailing build info —
+			// keep only the leading numbers.dots.numbers.
 			info.Version = stripBuildSuffix(comp.SwVer)
 		}
 	}
@@ -245,14 +245,14 @@ func (c *Client) GetInfo(ctx context.Context) (Info, error) {
 		if ip != "" && ip != "0.0.0.0" {
 			info.IP = ip
 			if n.Type == "SCM" {
-				break // SCM ist die maßgebliche Adresse
+				break // SCM is the authoritative address
 			}
 		}
 	}
 	return info, nil
 }
 
-// GetNetwork liest /networkInfo (Interface-Zustand, IP, Profilanzahl).
+// GetNetwork reads /networkInfo (interface state, IP, profile count).
 func (c *Client) GetNetwork(ctx context.Context) (Network, error) {
 	var raw struct {
 		Count      int `xml:"wifiProfileCount,attr"`
@@ -282,8 +282,8 @@ func (c *Client) GetNetwork(ctx context.Context) (Network, error) {
 	return net, nil
 }
 
-// GetSetupStatus liest /setup. Auf einer Box im Auslieferungszustand
-// liefert das z.B. state="SETUP_AP_OOB" systemstate="SETUP_LANG_NOT_SET".
+// GetSetupStatus reads /setup. On a box in factory state this
+// returns e.g. state="SETUP_AP_OOB" systemstate="SETUP_LANG_NOT_SET".
 func (c *Client) GetSetupStatus(ctx context.Context) (SetupStatus, error) {
 	var raw struct {
 		State       string `xml:"state,attr"`
@@ -298,11 +298,11 @@ func (c *Client) GetSetupStatus(ctx context.Context) (SetupStatus, error) {
 	}, nil
 }
 
-// GetActiveWirelessProfile liest /getActiveWirelessProfile und liefert
-// die SSID des gespeicherten WLAN-Profils ("" wenn keins gesetzt ist).
-// Achtung: ein gesetztes Profil heißt NICHT, dass die Box auch
-// assoziiert ist (auf BCO/taigan kann ein Profil persistiert sein,
-// ohne dass der AP->STA-Wechsel je vollzogen wird).
+// GetActiveWirelessProfile reads /getActiveWirelessProfile and returns
+// the SSID of the stored Wi-Fi profile ("" if none is set).
+// Caution: a set profile does NOT mean the box is also
+// associated (on BCO/taigan a profile can be persisted
+// without the AP->STA switch ever being completed).
 func (c *Client) GetActiveWirelessProfile(ctx context.Context) (string, error) {
 	var raw struct {
 		SSID string `xml:"ssid"`
@@ -317,34 +317,34 @@ func (c *Client) GetActiveWirelessProfile(ctx context.Context) (string, error) {
 
 // ---------- Multiroom (read-only) ----------
 
-// ZoneMember beschreibt einen Slave in einer SoundTouch Zone.
-// Die Bose Firmware liefert je Member die deviceID als Element-Text
-// und die LAN-IP als Attribut.
+// ZoneMember describes a slave in a SoundTouch zone.
+// The Bose firmware returns per member the deviceID as element text
+// and the LAN IP as an attribute.
 type ZoneMember struct {
 	DeviceID string `json:"deviceID"`
 	IP       string `json:"ip"`
 	Role     string `json:"role,omitempty"`
 }
 
-// Zone ist der Zustand der klassischen SoundTouch Multiroom Gruppe.
-// Master ist die deviceID des Boxes die den Stream broadcasts; Members
-// sind alle Boxen die dem Stream folgen. SenderIP ist die LAN-IP des
-// Masters. Bei einer alleine stehenden Box liefert die Firmware ein
-// leeres `<zone />` Element — dann sind Master und Members leer.
+// Zone is the state of the classic SoundTouch multiroom group.
+// Master is the deviceID of the box that broadcasts the stream; Members
+// are all boxes that follow the stream. SenderIP is the LAN IP of the
+// master. For a standalone box the firmware returns an
+// empty `<zone />` element — then Master and Members are empty.
 type Zone struct {
 	Master   string       `json:"master,omitempty"`
 	SenderIP string       `json:"senderIP,omitempty"`
 	Members  []ZoneMember `json:"members"`
 }
 
-// Group ist der Zustand des Stereo-Pair-Group-Konzepts (zwei ST10 als L/R
-// Paar). Bei einer einzelnen, ungepairten Box liefert die Firmware einen
-// leeren Body (live verifiziert: NICHT `<group />`); getXML faengt das ab
-// und liefert dann eine leere Group ohne Fehler.
+// Group is the state of the stereo-pair group concept (two ST10 as an L/R
+// pair). For a single, unpaired box the firmware returns an
+// empty body (live verified: NOT `<group />`); getXML catches that
+// and then returns an empty Group without error.
 //
-// Nur die SoundTouch 10 unterstuetzt echte Stereo-Paare. Alle Modelle listen
-// /addGroup in /supportedURLs (live an taigan verifiziert), das taugt also
-// NICHT als Gate; die Firmware der Box ist die letzte Instanz.
+// Only the SoundTouch 10 supports real stereo pairs. All models list
+// /addGroup in /supportedURLs (live verified on taigan), so that does
+// NOT work as a gate; the box firmware is the final authority.
 type Group struct {
 	ID             string       `json:"id,omitempty"`
 	Name           string       `json:"name,omitempty"`
@@ -352,8 +352,8 @@ type Group struct {
 	Members        []ZoneMember `json:"members"`
 }
 
-// GetZone liest /getZone und liefert die aktuelle Multiroom Zone.
-// Bei einer alleinstehenden Box ist Zone leer (Master == "").
+// GetZone reads /getZone and returns the current multiroom zone.
+// For a standalone box the zone is empty (Master == "").
 func (c *Client) GetZone(ctx context.Context) (Zone, error) {
 	var raw struct {
 		Master   string `xml:"master,attr"`
@@ -391,12 +391,12 @@ func (c *Client) GetZone(ctx context.Context) (Zone, error) {
 	return z, nil
 }
 
-// GetGroup liest /getGroup (Stereo Pair). Bei einer ungepairten Box ist die
-// Antwort leer und es kommt eine leere Group zurueck (kein Fehler).
+// GetGroup reads /getGroup (stereo pair). For an unpaired box the
+// response is empty and an empty Group is returned (no error).
 //
-// Schema (live aus der Firmware-Doku abgeleitet, NICHT das frueher geratene
-// <groupMember>): die Member stehen als <roles><groupRole> mit deviceId/role/
-// ipAddress als Kind-Elementen, plus <masterDeviceId> auf Group-Ebene.
+// Schema (derived live from the firmware docs, NOT the earlier guessed
+// <groupMember>): the members are <roles><groupRole> with deviceId/role/
+// ipAddress as child elements, plus <masterDeviceId> at the group level.
 func (c *Client) GetGroup(ctx context.Context) (Group, error) {
 	var raw struct {
 		ID             string `xml:"id,attr"`
@@ -427,10 +427,10 @@ func (c *Client) GetGroup(ctx context.Context) (Group, error) {
 	return g, nil
 }
 
-// groupXML baut den <group>-Request-Body fuer AddGroup. masterDeviceID ist die
-// deviceID des Master-Speakers (per Bose-Konvention typisch der LINKE); members
-// listet beide Speaker mit je deviceId/role(LEFT|RIGHT)/ipAddress. Schema live
-// aus der Firmware-Doku:
+// groupXML builds the <group> request body for AddGroup. masterDeviceID is the
+// deviceID of the master speaker (by Bose convention typically the LEFT one); members
+// lists both speakers with deviceId/role(LEFT|RIGHT)/ipAddress each. Schema live
+// from the firmware docs:
 //
 //	<group><name>..</name><masterDeviceId>..</masterDeviceId>
 //	  <roles>
@@ -457,17 +457,17 @@ func groupXML(name, masterDeviceID string, members []ZoneMember) string {
 	return b.String()
 }
 
-// AddGroup erzeugt ein echtes L/R-Stereo-Paar (POST /addGroup an den Master).
-// name ist ein Anzeigelabel; masterDeviceID die deviceID des Masters; members
-// MUSS genau zwei Speaker enthalten, jeder mit Role "LEFT" bzw. "RIGHT",
-// deviceID und LAN-IP. Nur die ST10 paart wirklich; bei anderen Modellen
-// antwortet die Firmware mit Fehler, den der Aufrufer an die App durchreicht.
+// AddGroup creates a real L/R stereo pair (POST /addGroup to the master).
+// name is a display label; masterDeviceID the deviceID of the master; members
+// MUST contain exactly two speakers, each with role "LEFT" or "RIGHT",
+// deviceID and LAN IP. Only the ST10 actually pairs; on other models
+// the firmware responds with an error, which the caller passes through to the app.
 func (c *Client) AddGroup(ctx context.Context, name, masterDeviceID string, members []ZoneMember) error {
 	return c.postXML(ctx, "/addGroup", groupXML(name, masterDeviceID, members))
 }
 
-// RemoveGroup loest das Stereo-Paar dieser Box auf. Die Firmware dokumentiert
-// das als GET (Antwort ist die nun leere Group); an den Master gerichtet.
+// RemoveGroup dissolves the stereo pair of this box. The firmware documents
+// this as a GET (response is the now-empty Group); directed at the master.
 func (c *Client) RemoveGroup(ctx context.Context) error {
 	var ignore struct{}
 	return c.getXML(ctx, "/removeGroup", &ignore)
@@ -542,24 +542,28 @@ func (c *Client) RemoveZoneSlave(ctx context.Context, master ZoneMember, slaves 
 	return c.postXML(ctx, "/removeZoneSlave", zoneXML(master, slaves))
 }
 
-// SetName aendert den Anzeigenamen der Box. Achtung: Bose setzt
-// dabei in der Box State auch die margeURL zurueck auf den Default
-// Update Server. Unser autoPair haengt das im naechsten Tick wieder ein.
+// SetName changes the display name of the box. Caution: Bose also resets
+// the margeURL in the box state to the default update server in the
+// process. Our autoPair re-attaches it on the next tick.
 func (c *Client) SetName(ctx context.Context, name string) error {
 	body := fmt.Sprintf(`<name>%s</name>`, xmlEscape(name))
 	return c.postXML(ctx, "/name", body)
 }
 
-// SetVolume setzt den Ziel Volume (0-100).
+// SetVolume sets the target volume (0-100).
 func (c *Client) SetVolume(ctx context.Context, v int) error {
-	if v < 0 { v = 0 }
-	if v > 100 { v = 100 }
+	if v < 0 {
+		v = 0
+	}
+	if v > 100 {
+		v = 100
+	}
 	body := fmt.Sprintf(`<volume>%d</volume>`, v)
 	return c.postXML(ctx, "/volume", body)
 }
 
-// SetBass setzt den Bass Wert (Range aus bassCapabilities — typischer
-// ST10 Bereich -9..0).
+// SetBass sets the bass value (range from bassCapabilities — typical
+// ST10 range -9..0).
 func (c *Client) SetBass(ctx context.Context, b int) error {
 	body := fmt.Sprintf(`<bass>%d</bass>`, b)
 	return c.postXML(ctx, "/bass", body)
@@ -621,7 +625,7 @@ func xmlEscape(s string) string {
 	return r.Replace(s)
 }
 
-// stripBuildSuffix kuerzt "27.0.6.46330.5043500 epdbuild.trunk..." auf
+// stripBuildSuffix shortens "27.0.6.46330.5043500 epdbuild.trunk..." to
 // "27.0.6.46330.5043500".
 func stripBuildSuffix(s string) string {
 	if i := strings.Index(s, " "); i >= 0 {

--- a/internal/boxcli/boxcli.go
+++ b/internal/boxcli/boxcli.go
@@ -1,6 +1,6 @@
-// Package boxcli sendet Kommandos an Bose's lokalen CLI Server auf Port
-// 17000. Wir nutzen das um die Box aus dem Standby zu wecken bevor wir
-// UPnP Play schicken.
+// Package boxcli sends commands to Bose's local CLI server on port
+// 17000. We use it to wake the box from standby before we send a UPnP
+// play.
 package boxcli
 
 import (
@@ -14,8 +14,8 @@ import (
 	"time"
 )
 
-// Send schickt einen einzelnen Command an Port 17000 und sammelt bis zu
-// 200 ms Output. Box antwortet typischerweise sofort.
+// Send sends a single command to port 17000 and collects up to 200 ms
+// of output. The box typically answers immediately.
 func Send(ctx context.Context, host, cmd string) (string, error) {
 	if host == "" {
 		host = "127.0.0.1"
@@ -45,17 +45,17 @@ func Send(ctx context.Context, host, cmd string) (string, error) {
 	return sb.String(), nil
 }
 
-// PowerOn weckt die Box aus dem Standby. Idempotent: wenn Box schon an
-// ist, gibt sie OK zurueck und macht nichts.
+// PowerOn wakes the box from standby. Idempotent: if the box is already
+// on, it returns OK and does nothing.
 func PowerOn(ctx context.Context, host string) error {
 	_, err := Send(ctx, host, "sys power")
 	return err
 }
 
-// WakeAndWait stellt sicher dass die Box aus dem Standby ist. Sendet
-// `sys power` und pollt `/now_playing` bis source != STANDBY oder Timeout.
-// Box reagiert manchmal verzoegert oder ignoriert sys power komplett wenn
-// sie in Deep Standby ist; in dem Fall wird mehrmals gesendet.
+// WakeAndWait makes sure the box is out of standby. Sends `sys power`
+// and polls `/now_playing` until source != STANDBY or timeout. The box
+// sometimes reacts with a delay or ignores sys power entirely when it is
+// in deep standby; in that case it is sent multiple times.
 //
 // logger may be nil; when present, per-iteration phase markers are emitted
 // so a diagnostic bundle shows the standby-exit timeline (#60).
@@ -81,7 +81,7 @@ func WakeAndWait(ctx context.Context, host string, maxWait time.Duration, logger
 	logPhase("wake phase: start", "host", host, "max_wait", maxWait.String())
 
 	for i := 0; ; i++ {
-		// Erst pruefen: ist Box vielleicht schon wach?
+		// Check first: is the box maybe already awake?
 		state, err := readSource(ctx, client, infoURL)
 		if err == nil && state != "STANDBY" {
 			logPhase("wake phase: already awake", "attempt", i, "source", state)
@@ -92,18 +92,18 @@ func WakeAndWait(ctx context.Context, host string, maxWait time.Duration, logger
 		} else {
 			logPhase("wake phase: STANDBY, sending sys power", "attempt", i, "source", state)
 		}
-		// Standby oder unklarer State -> power on senden.
+		// Standby or unclear state -> send power on.
 		if pwrErr := PowerOn(ctx, host); pwrErr != nil {
 			logPhase("wake phase: sys power write failed", "attempt", i, "err", pwrErr.Error())
 		}
-		// Kurze Pause damit Box den Befehl verarbeiten kann.
+		// Short pause so the box can process the command.
 		select {
 		case <-ctx.Done():
 			logPhase("wake phase: ctx cancelled", "attempt", i, "err", ctx.Err().Error())
 			return ctx.Err()
 		case <-time.After(800 * time.Millisecond):
 		}
-		// Nochmal checken
+		// Check again
 		state, err = readSource(ctx, client, infoURL)
 		if err == nil && state != "STANDBY" {
 			logPhase("wake phase: woke", "attempt", i, "source", state)
@@ -111,7 +111,7 @@ func WakeAndWait(ctx context.Context, host string, maxWait time.Duration, logger
 		}
 		if time.Now().After(deadline) {
 			logPhase("wake phase: timeout", "attempts", i+1, "last_source", state)
-			return fmt.Errorf("box bleibt im STANDBY nach %d Versuchen", i+1)
+			return fmt.Errorf("box stays in STANDBY after %d attempts", i+1)
 		}
 	}
 }
@@ -130,7 +130,7 @@ func readSource(ctx context.Context, c *http.Client, url string) (string, error)
 	body := make([]byte, 1024)
 	n, _ := resp.Body.Read(body)
 	s := string(body[:n])
-	// Erstes source="X" Attribut
+	// First source="X" attribute
 	if i := strings.Index(s, `source="`); i >= 0 {
 		rest := s[i+8:]
 		if j := strings.IndexByte(rest, '"'); j >= 0 {
@@ -140,7 +140,7 @@ func readSource(ctx context.Context, c *http.Client, url string) (string, error)
 	return "", fmt.Errorf("source attribute not found")
 }
 
-// PresetKey simuliert einen physischen Preset Tastendruck.
+// PresetKey simulates a physical preset key press.
 //
 //	slot 1..6
 //	mode "p" = press&release, "ph" = press&hold
@@ -152,17 +152,17 @@ func PresetKey(ctx context.Context, host string, slot int, mode string) error {
 	return err
 }
 
-// AddPreset speichert ein Preset auf der Box damit die Hardware Tasten
-// einen `nowSelectionUpdated` Event mit dem ContentItem ausloesen koennen.
-// Wir setzen alle Presets als UPNP Source weil das die Box am ehesten
-// akzeptiert ohne ein laufender STS Worker.
+// AddPreset stores a preset on the box so the hardware keys can trigger
+// a `nowSelectionUpdated` event with the ContentItem. We set all presets
+// as a UPNP source because that is what the box is most likely to accept
+// without a running STS worker.
 //
-// CLI Syntax (aus BoseApp Strings):
+// CLI syntax (from BoseApp strings):
 //
 //	ws AddPreset <SOURCE> <TYPE> <LOCATION> <LABEL> <SOURCEACCOUNT> <PRESETID>
 func AddPreset(ctx context.Context, host string, slot int, name, streamURL string) error {
-	// LABEL muss in Quotes, sonst splittet die Box ihn beim Leerzeichen.
-	// LOCATION sollte keine Quotes haben.
+	// LABEL must be in quotes, otherwise the box splits it at the space.
+	// LOCATION should have no quotes.
 	cmd := fmt.Sprintf(`ws AddPreset UPNP audio %s "%s" UPnPUserName %d`,
 		streamURL, name, slot)
 	_, err := Send(ctx, host, cmd)
@@ -197,26 +197,25 @@ func AddPresetRaw(ctx context.Context, host string, slot int, source, typ, locat
 	return err
 }
 
-// RemovePreset loescht den Box Preset Slot.
+// RemovePreset deletes the box preset slot.
 func RemovePreset(ctx context.Context, host string, slot int) error {
 	_, err := Send(ctx, host, fmt.Sprintf("ws RemovePreset %d", slot))
 	return err
 }
 
-// PresetSpec ist eine Box Preset Spezifikation fuer SyncAllPresets.
+// PresetSpec is a box preset specification for SyncAllPresets.
 type PresetSpec struct {
 	Slot      int    // 1..6
-	Name      string // angezeigter Name (mit Quotes versehen wenn Leerzeichen)
-	StreamURL string // direkte Stream URL fuer UPnP
+	Name      string // displayed name (quoted if it contains a space)
+	StreamURL string // direct stream URL for UPnP
 }
 
-// SyncAllPresets schickt alle Presets als UPNP Source ContentItems an die
-// Box. Sollte nach Box Boot ausgefuehrt werden (Box braucht ~10s bis CLI
-// Server hochgefahren ist) und immer wenn der Stick Preset Store geupdated
-// wird.
+// SyncAllPresets sends all presets as UPNP source ContentItems to the
+// box. Should run after a box boot (the box needs ~10s until the CLI
+// server has come up) and whenever the stick preset store is updated.
 //
-// errs ist ein Map von Slot -> Fehler fuer einzelne Slots; fortgesetzt
-// nach Errors.
+// errs is a map of slot -> error for individual slots; continued after
+// errors.
 func SyncAllPresets(ctx context.Context, host string, presets []PresetSpec) map[int]error {
 	errs := map[int]error{}
 	for _, p := range presets {

--- a/internal/boxstate/boxstate.go
+++ b/internal/boxstate/boxstate.go
@@ -1,13 +1,13 @@
-// Package boxstate klassifiziert den Betriebszustand einer Bose-Box aus
-// ihren REST-Endpunkten (:8090). Es ersetzt die verstreuten Ad-hoc-Checks
-// (boxInSetupOOB, IsPaired, Setup-AP-Gates) durch einen einzigen,
-// testbaren Zustandsautomaten, den Agent, Desktop-App und Diagnose nutzen.
+// Package boxstate classifies the operating state of a Bose box from
+// its REST endpoints (:8090). It replaces the scattered ad-hoc checks
+// (boxInSetupOOB, IsPaired, setup-AP gates) with a single, testable
+// state machine that the agent, desktop app, and diagnostics use.
 //
-// Hintergrund (live taigan 2026-06-10): eine BCO-Box kann auf Chipset-Ebene
-// ins WLAN gejoint sein (echte LAN-IP) und trotzdem auf :8090 noch
-// SETUP_AP_OOB melden, bis der SoundTouch-Setup über das LAN abgeschlossen
-// wird. Der Zustand ergibt sich daher aus mehreren Fakten zusammen, nicht
-// aus einem einzelnen Endpunkt.
+// Background (live taigan 2026-06-10): a BCO box can be joined to the
+// Wi-Fi at the chipset level (real LAN IP) and still report SETUP_AP_OOB
+// on :8090, until the SoundTouch setup is completed over the LAN. The
+// state therefore follows from several facts together, not from a single
+// endpoint.
 package boxstate
 
 import (
@@ -17,22 +17,22 @@ import (
 	"github.com/JRpersonal/streborn/internal/boxapi"
 )
 
-// State ist der grob klassifizierte Box-Zustand.
+// State is the coarsely classified box state.
 type State int
 
 const (
-	// StateUnreachable: :8090 antwortet nicht.
+	// StateUnreachable: :8090 does not answer.
 	StateUnreachable State = iota
-	// StateOOBSetupAP: Box spannt ihren Bose-Setup-AP auf (eigene IP
-	// 192.168.1.1, /setup=SETUP_AP_OOB). Noch nicht im LAN. LED gelb.
+	// StateOOBSetupAP: box is spinning up its Bose setup AP (own IP
+	// 192.168.1.1, /setup=SETUP_AP_OOB). Not yet on the LAN. LED yellow.
 	StateOOBSetupAP
-	// StateOnlineNotConfigured: Box hat eine echte LAN-IP (assoziiert),
-	// aber die SoundTouch-Schicht ist noch nicht fertig konfiguriert
-	// (Setup noch OOB / Sprache nicht gesetzt / kein Account). Typisch
-	// direkt nach einem Chipset-Join. LED meist noch gelb.
+	// StateOnlineNotConfigured: box has a real LAN IP (associated),
+	// but the SoundTouch layer is not yet fully configured (setup
+	// still OOB / language not set / no account). Typical right after
+	// a chipset join. LED usually still yellow.
 	StateOnlineNotConfigured
-	// StateOnlineConfigured: im LAN und fertig konfiguriert
-	// (Setup verlassen, Account gesetzt). LED weiß.
+	// StateOnlineConfigured: on the LAN and fully configured
+	// (setup left, account set). LED white.
 	StateOnlineConfigured
 )
 
@@ -49,58 +49,58 @@ func (s State) String() string {
 	}
 }
 
-// IsOnline meldet, ob die Box im normalen LAN erreichbar ist (nicht im
-// eigenen Setup-AP).
+// IsOnline reports whether the box is reachable on the normal LAN (not in
+// its own setup AP).
 func (s State) IsOnline() bool {
 	return s == StateOnlineNotConfigured || s == StateOnlineConfigured
 }
 
-// IsConfigured meldet, ob der SoundTouch-Setup abgeschlossen ist.
+// IsConfigured reports whether the SoundTouch setup is complete.
 func (s State) IsConfigured() bool { return s == StateOnlineConfigured }
 
-// setupAPAddr ist die feste Gateway-IP, unter der eine Box im eigenen
-// Setup-AP erreichbar ist. Eine Box, die diese IP als eigene Adresse
-// meldet, IST der AP (im STA-Modus bekäme sie eine DHCP-Adresse, die im
-// üblichen Heimnetz nie exakt .1.1 ist, da das der Router ist).
+// setupAPAddr is the fixed gateway IP under which a box is reachable in
+// its own setup AP. A box that reports this IP as its own address IS the
+// AP (in STA mode it would get a DHCP address, which in a typical home
+// network is never exactly .1.1, since that is the router).
 const setupAPAddr = "192.168.1.1"
 
-// Facts bündelt die Rohfakten, aus denen der Zustand abgeleitet wird.
+// Facts bundles the raw facts the state is derived from.
 type Facts struct {
 	Reachable        bool
-	SetupState       string // z.B. SETUP_AP_OOB, SETUP_INACTIVE
-	SystemState      string // z.B. SETUP_LANG_SET, SETUP_LANG_NOT_SET
-	MargeAccountUUID string // leer = nicht gepaart
-	IP               string // gemeldete eigene IP (info/networkInfo)
-	SSID             string // gespeichertes WLAN-Profil (kann ohne Assoziation gesetzt sein)
+	SetupState       string // e.g. SETUP_AP_OOB, SETUP_INACTIVE
+	SystemState      string // e.g. SETUP_LANG_SET, SETUP_LANG_NOT_SET
+	MargeAccountUUID string // empty = not paired
+	IP               string // reported own IP (info/networkInfo)
+	SSID             string // stored Wi-Fi profile (can be set without association)
 	ModuleType       string // scm, sm2, ...
 	Variant          string // taigan, rhino, spotty, ...
 	Firmware         string
 	WifiProfileCount int
-	InterfaceState   string // Zustand des ersten Interfaces
+	InterfaceState   string // state of the first interface
 }
 
-// Classify leitet aus den Rohfakten den Zustand ab. Reine Funktion, ohne
-// Netzwerk, damit sie gegen Fixtures unit-getestet werden kann.
+// Classify derives the state from the raw facts. Pure function, no
+// network, so it can be unit-tested against fixtures.
 func Classify(f Facts) State {
 	if !f.Reachable {
 		return StateUnreachable
 	}
-	// Eigene IP == Setup-AP-Gateway -> die Box IST ihr eigener AP.
+	// Own IP == setup-AP gateway -> the box IS its own AP.
 	if f.IP == setupAPAddr {
 		return StateOOBSetupAP
 	}
 	onLAN := f.IP != "" && f.IP != "0.0.0.0"
 	if !onLAN {
-		// Erreichbar, aber keine brauchbare IP gemeldet: nur dann sicher
-		// OOB, wenn der Setup-State das bestätigt; sonst unbekannt ->
-		// als "im AP" behandeln (konservativ, blockt Preset-Push etc.).
+		// Reachable, but no usable IP reported: only definitely OOB when
+		// the setup state confirms it; otherwise unknown -> treat as "in
+		// the AP" (conservative, blocks preset push etc.).
 		if strings.EqualFold(f.SetupState, "SETUP_AP_OOB") {
 			return StateOOBSetupAP
 		}
 		return StateOOBSetupAP
 	}
-	// Echte LAN-IP vorhanden. Fertig konfiguriert nur, wenn der Setup
-	// verlassen wurde UND ein Account gesetzt ist.
+	// Real LAN IP present. Fully configured only when the setup was left
+	// AND an account is set.
 	leftSetup := !strings.EqualFold(f.SetupState, "SETUP_AP_OOB")
 	hasAccount := f.MargeAccountUUID != ""
 	if leftSetup && hasAccount {
@@ -109,20 +109,20 @@ func Classify(f Facts) State {
 	return StateOnlineNotConfigured
 }
 
-// Detector probt eine Box und klassifiziert ihren Zustand.
+// Detector probes a box and classifies its state.
 type Detector struct {
 	client *boxapi.Client
 }
 
-// New erzeugt einen Detector für den Box-Host (typisch eine LAN-IP oder
-// 192.168.1.1 im Setup-AP).
+// New creates a Detector for the box host (typically a LAN IP or
+// 192.168.1.1 in the setup AP).
 func New(host string) *Detector {
 	return &Detector{client: boxapi.New(host)}
 }
 
-// Detect probt /info, /networkInfo, /setup und /getActiveWirelessProfile
-// und liefert Zustand + Rohfakten. Wenn /info nicht erreichbar ist, gilt
-// die Box als unerreichbar; die übrigen Endpunkte sind best effort.
+// Detect probes /info, /networkInfo, /setup and /getActiveWirelessProfile
+// and returns state + raw facts. If /info is not reachable, the box is
+// considered unreachable; the remaining endpoints are best effort.
 func (d *Detector) Detect(ctx context.Context) (State, Facts, error) {
 	var f Facts
 	info, err := d.client.GetInfo(ctx)

--- a/internal/boxws/boxws.go
+++ b/internal/boxws/boxws.go
@@ -1,13 +1,13 @@
-// Package boxws verbindet sich mit dem Bose WebSocket Notification Stream
-// auf Port 8080 (Subprotocol "gabbo") und reagiert auf eingehende Events.
+// Package boxws connects to the Bose WebSocket notification stream on port
+// 8080 (subprotocol "gabbo") and reacts to incoming events.
 //
-// Wenn ein User eine physische Preset Taste auf der Box drueckt, sendet
-// die BoseApp ueber diesen WebSocket eine `<updates>` Nachricht mit
-// `presetSelectionUpdated` oder `nowPlayingUpdated`. Wir hooken den Event
-// und triggern unseren UPnP Player mit der zugehoerigen Stream URL.
+// When a user presses a physical preset button on the box, the BoseApp sends
+// an `<updates>` message over this WebSocket with `presetSelectionUpdated` or
+// `nowPlayingUpdated`. We hook the event and trigger our UPnP player with the
+// associated stream URL.
 //
-// Damit funktionieren die Hardware Preset Tasten obwohl Bose's eigene
-// Music Services in der FW deaktiviert sind.
+// This is what makes the hardware preset buttons work even though Bose's own
+// music services are disabled in the firmware.
 package boxws
 
 import (
@@ -24,68 +24,65 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// PresetEvent wird gefeuert wenn die Box meldet dass ein Preset Slot
-// ausgewaehlt wurde.
+// PresetEvent is fired when the box reports that a preset slot was
+// selected.
 type PresetEvent struct {
 	Slot int
 }
 
-// Handler bekommt eingehende Events aus dem Box WebSocket.
+// Handler receives incoming events from the box WebSocket.
 type Handler interface {
-	// OnPresetSelected wird gefeuert wenn die Box meldet dass ein Preset
-	// Slot aktiv ausgewaehlt wurde (physische Hardware Taste oder
-	// API Trigger). location und title kommen aus dem Box ContentItem
-	// und koennen ueber UPnP an die Box geschickt werden.
+	// OnPresetSelected is fired when the box reports that a preset slot was
+	// actively selected (physical hardware button or API trigger). location
+	// and title come from the box ContentItem and can be sent to the box over
+	// UPnP.
 	OnPresetSelected(ctx context.Context, slot int, location string, title string)
 
-	// OnRemoteSkip wird gefeuert wenn die Fernbedienung Naechster/Vorheriger
-	// Titel drueckt (die Box kann eine UPnP Quelle nicht selbst skippen und
-	// meldet QPLAY_SKIP_*_FAILED). forward=true -> next, false -> prev.
+	// OnRemoteSkip is fired when the remote presses next/previous track (the
+	// box cannot skip a UPnP source itself and reports QPLAY_SKIP_*_FAILED).
+	// forward=true -> next, false -> prev.
 	OnRemoteSkip(ctx context.Context, forward bool)
 
-	// OnUserStop wird gefeuert wenn die Box meldet dass die Wiedergabe
-	// gestoppt wurde (playStatus STOP_STATE in einem nowPlayingUpdated Event),
-	// also der Nutzer ueber Fernbedienung/Box bewusst gestoppt hat. Der Agent
-	// nutzt das um die Auto-Wiederaufnahme nicht gegen einen gewollten Stop
-	// laufen zu lassen.
+	// OnUserStop is fired when the box reports that playback was stopped
+	// (playStatus STOP_STATE in a nowPlayingUpdated event), i.e. the user
+	// deliberately stopped it via remote/box. The agent uses this to avoid
+	// running the auto-resume against a deliberate stop.
 	OnUserStop(ctx context.Context)
 
-	// OnThumbActivity wird gefeuert wenn die Box ein "nacktes"
-	// userActivityUpdate meldet: ein Tastendruck ohne begleitendes
-	// Volume-/NowPlaying-/Preset-Event. Die Fernbedienungs-Daumen liefern auf
-	// dieser Firmware nur dieses generische Event ohne Hoch/Runter-Kennung;
-	// ein nacktes userActivity ist die beste verfuegbare Naeherung fuer einen
-	// Daumendruck. Der Agent nutzt es als (einzelnen, nicht
-	// hoch/runter-unterscheidbaren) Trigger fuer einen konfigurierten Webhook.
-	// Entprellt und gegen Volume/Preset gefiltert in boxws; trotzdem
-	// heuristisch, daher live tunebar.
+	// OnThumbActivity is fired when the box reports a "bare"
+	// userActivityUpdate: a key press without an accompanying
+	// volume/nowPlaying/preset event. On this firmware the remote thumb keys
+	// only deliver this generic event with no up/down identity; a bare
+	// userActivity is the best available approximation for a thumb press. The
+	// agent uses it as a (single, non up/down-distinguishable) trigger for a
+	// configured webhook. Debounced and filtered against volume/preset in
+	// boxws; still heuristic, hence live tunable.
 	OnThumbActivity(ctx context.Context)
 
-	// OnPowerKey wird bei einem powerStateUpdated (Power-Taste / Standby-Wechsel)
-	// gefeuert. Fuer den optionalen "power"-Webhook (nur zusaetzlich: STR kann das
-	// firmware-seitige Ein/Ausschalten nicht unterdruecken). Beta.
+	// OnPowerKey is fired on a powerStateUpdated (power button / standby
+	// change). For the optional "power" webhook (additive only: STR cannot
+	// suppress the firmware-side power on/off). Beta.
 	OnPowerKey(ctx context.Context)
 
-	// OnSourceAux wird gefeuert wenn die aktive Quelle auf AUX wechselt. Fuer den
-	// optionalen "aux"-Webhook (nur zusaetzlich; die Firmware schaltet den Eingang
-	// ohnehin um). Heuristisch ueber den source-Wechsel erkannt, daher Beta.
+	// OnSourceAux is fired when the active source switches to AUX. For the
+	// optional "aux" webhook (additive only; the firmware switches the input
+	// anyway). Detected heuristically via the source change, hence beta.
 	OnSourceAux(ctx context.Context)
 
-	// OnZoneChanged wird gefeuert wenn die Box ihre Multiroom-Zone bzw. ihr
-	// Stereo-Paar aendert (zoneUpdated). Damit kennt STR auch Gruppen, die NICHT
-	// in STR gebildet wurden (z.B. ein in AfterTouch/Bose definiertes Stereopaar),
-	// statt den Frame als "unrecognized" zu verwerfen. z.Master == "" heisst die
-	// Zone wurde aufgeloest.
+	// OnZoneChanged is fired when the box changes its multiroom zone or its
+	// stereo pair (zoneUpdated). This lets STR also know about groups that
+	// were NOT formed in STR (e.g. a stereo pair defined in AfterTouch/Bose),
+	// instead of discarding the frame as "unrecognized". z.Master == "" means
+	// the zone was dissolved.
 	OnZoneChanged(ctx context.Context, z ZoneState)
 
-	// OnPowerWake wird gefeuert wenn die Box aus dem Standby kommt: entweder ueber
-	// ein powerStateUpdated (NICHT STANDBY) auf Firmware die das schickt, ODER, auf
-	// SoundTouch-Firmware die KEIN powerStateUpdated sendet (Portable/taigan, live
-	// 2026-06-13 bestaetigt), ueber den DO_NOT_RESUME-Restore der letzten Auswahl
-	// beim Aufwachen. Treiber fuer den optionalen "letzten Sender beim Einschalten
-	// fortsetzen"-Default. Ein Self-Wake (Stereopaar/Zone) sieht identisch aus und
-	// wird downstream ueber die Zonen-Mitgliedschaft abgefangen (webui.boxInZone),
-	// nicht hier.
+	// OnPowerWake is fired when the box comes out of standby: either via a
+	// powerStateUpdated (NOT STANDBY) on firmware that sends it, OR, on
+	// SoundTouch firmware that does NOT send a powerStateUpdated (Portable/
+	// taigan, confirmed live 2026-06-13), via the DO_NOT_RESUME restore of the
+	// last selection on wake. Driver for the optional "resume the last station
+	// on power-on" default. A self-wake (stereo pair/zone) looks identical and
+	// is caught downstream via the zone membership (webui.boxInZone), not here.
 	OnPowerWake(ctx context.Context)
 
 	// OnPresetsChanged fires when the box reports its own preset list
@@ -108,7 +105,7 @@ type BoxPreset struct {
 	Name          string `json:"name"`          // itemName
 }
 
-// Client haelt die Verbindung zur Box.
+// Client holds the connection to the box.
 type Client struct {
 	logger  *slog.Logger
 	url     string
@@ -129,8 +126,8 @@ type Client struct {
 	// generic <userActivityUpdate/>; we treat a "lone" one (no volume / now
 	// playing / preset event around it) as a thumb press and fire
 	// OnThumbActivity once, debounced. See noteExplainedActivity / noteUserActivity.
-	thumbMu       sync.Mutex
-	thumbPending  *time.Timer
+	thumbMu        sync.Mutex
+	thumbPending   *time.Timer
 	thumbExplained time.Time
 	thumbLastFire  time.Time
 }
@@ -229,19 +226,18 @@ func attrValue(s, attr string) string {
 	return ""
 }
 
-// New erzeugt einen Client. url Beispiel: "ws://127.0.0.1:8080/".
+// New creates a Client. url example: "ws://127.0.0.1:8080/".
 func New(logger *slog.Logger, url string, handler Handler) *Client {
 	return &Client{logger: logger, url: url, handler: handler}
 }
 
-// Run blockiert und reconnected automatisch wenn die Verbindung abbricht.
-// Stop via ctx Cancel.
+// Run blocks and reconnects automatically when the connection drops. Stop via
+// ctx cancel.
 //
-// Box sendet keine eigenen Keepalive Frames; STR pingt den Socket selbst
-// (wsKeepaliveInterval), damit eine lange Leerlaufphase die Verbindung nicht
-// mehr abreissen laesst. Ein Reconnect synct den Box-State ueber den
-// OnConnected-Hook wieder. Wenn lange nichts passiert, ist das normal - keine
-// WARN-Spam dafuer.
+// The box does not send its own keepalive frames; STR pings the socket itself
+// (wsKeepaliveInterval) so a long idle period no longer tears the connection
+// down. A reconnect resyncs the box state via the OnConnected hook. When
+// nothing happens for a long time that is normal - no WARN spam for it.
 func (c *Client) Run(ctx context.Context) {
 	backoff := time.Second
 	for {
@@ -253,12 +249,12 @@ func (c *Client) Run(ctx context.Context) {
 			return
 		}
 		if err != nil {
-			// Read timeout ist normal wenn Box nicht aktiv ist, reconnect
-			// laeuft sauber. Andere Errors hingegen interessant.
+			// A read timeout is normal when the box is not active; the
+			// reconnect runs cleanly. Other errors are interesting though.
 			if strings.Contains(err.Error(), "i/o timeout") {
 				c.logger.Debug("box websocket idle reconnect", "retry_in", backoff)
 			} else {
-				c.logger.Warn("box websocket Verbindung verloren", "err", err, "retry_in", backoff)
+				c.logger.Warn("box websocket connection lost", "err", err, "retry_in", backoff)
 			}
 		}
 		select {
@@ -356,9 +352,9 @@ func (c *Client) runOnce(ctx context.Context) error {
 	}
 }
 
-// handleMessage parsed eine eingehende XML Notification.
+// handleMessage parses an incoming XML notification.
 //
-// Bose's WebSocket Format fuer Hardware Preset Tasten (gemessen 15.05.2026):
+// Bose's WebSocket format for hardware preset buttons (measured 2026-05-15):
 //
 //	<updates deviceID="...">
 //	  <nowSelectionUpdated>
@@ -370,9 +366,9 @@ func (c *Client) runOnce(ctx context.Context) error {
 //	  </nowSelectionUpdated>
 //	</updates>
 //
-// Box folgt mit `<nowSelectionUpdated><preset id="0">` und INVALID_SOURCE
-// wenn sie den Source nicht aktivieren kann. Wir interessieren uns nur fuer
-// den ersten Event mit id >= 1.
+// The box follows up with `<nowSelectionUpdated><preset id="0">` and
+// INVALID_SOURCE when it cannot activate the source. We only care about the
+// first event with id >= 1.
 // wsContentItem is the <ContentItem> Bose nests inside a preset or nowPlaying.
 type wsContentItem struct {
 	Source        string `xml:"source,attr"`
@@ -709,12 +705,12 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 	var slot int
 	_, _ = fmt.Sscanf(pe.ID, "%d", &slot)
 	if slot < 1 || slot > 6 {
-		// id="0" + INVALID_SOURCE folgt auf den echten Press wenn Box den Source
-		// nicht selbst spielen kann. Ignorieren fuer die Wiedergabe, aber bei
-		// INVALID_SOURCE einmal loggen: das ist die Box-eigene fehlgeschlagene
-		// Self-Aktivierung, die das Display "Dienst nicht verfuegbar" zeigt
-		// (#22), bevor STR uebernimmt. Markers are matched within this preset
-		// element only (pe.Inner), so an unrelated frame's title cannot trip it.
+		// id="0" + INVALID_SOURCE follows the real press when the box cannot
+		// play the source itself. Ignore it for playback, but log it once on
+		// INVALID_SOURCE: this is the box's own failed self-activation that
+		// shows "service unavailable" on the display (#22) before STR takes
+		// over. Markers are matched within this preset element only (pe.Inner),
+		// so an unrelated frame's title cannot trip it.
 		if strings.Contains(pe.Inner, "INVALID_SOURCE") || strings.Contains(pe.Inner, "DISABLED") {
 			// A standby wake or a source teardown makes the box restore its last
 			// now-selection and, because it cannot natively play STR's UPNP
@@ -750,7 +746,7 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 		}
 		return
 	}
-	c.logger.Info("hardware preset gedrueckt",
+	c.logger.Info("hardware preset pressed",
 		"slot", slot,
 		"location", pe.ContentItem.Location,
 		"source", pe.ContentItem.Source,

--- a/internal/hosts/hosts.go
+++ b/internal/hosts/hosts.go
@@ -1,6 +1,6 @@
-// Package hosts manipuliert /etc/hosts beim Start und räumt beim Stop wieder auf.
-// Die Bose Software wird so umgelenkt, dass sie mit dem lokalen Binary
-// statt mit den echten Bose Servern kommuniziert.
+// Package hosts manipulates /etc/hosts at start and cleans it up again at stop.
+// The Bose software is redirected so it communicates with the local binary
+// instead of the real Bose servers.
 package hosts
 
 import (
@@ -17,18 +17,18 @@ const (
 	endMarker   = "# <<< streborn end <<<"
 )
 
-// Entry beschreibt eine Zeile, die in /etc/hosts eingefügt wird.
+// Entry describes a line that is inserted into /etc/hosts.
 type Entry struct {
 	IP   string
 	Host string
 }
 
-// DefaultEntries liefert die Standard Umleitungen.
+// DefaultEntries returns the default redirects.
 //
-// Der TuneIn Hostname mit dem Bose Partner Hash ist seit 15.05.2026 von Bose
-// abgeschaltet (NXDOMAIN). Wir leiten ihn auf 127.0.0.1 um damit unser
-// Marge Stub die TuneIn API emulieren kann und STSCertified BMXTuneInClient
-// glaubt die Bose TuneIn Cloud waere erreichbar.
+// The TuneIn hostname with the Bose partner hash has been shut down by Bose
+// since 2026-05-15 (NXDOMAIN). We redirect it to 127.0.0.1 so our marge stub
+// can emulate the TuneIn API and STSCertified BMXTuneInClient believes the
+// Bose TuneIn cloud is reachable.
 func DefaultEntries() []Entry {
 	return []Entry{
 		{IP: "127.0.0.1", Host: "streaming.bose.com"},
@@ -39,13 +39,13 @@ func DefaultEntries() []Entry {
 	}
 }
 
-// Manager verwaltet einen markierten Block in /etc/hosts.
+// Manager manages a marked block in /etc/hosts.
 type Manager struct {
 	path   string
 	logger *slog.Logger
 }
 
-// New erstellt einen Manager. Wenn path leer ist, wird /etc/hosts verwendet.
+// New creates a Manager. If path is empty, /etc/hosts is used.
 func New(path string, logger *slog.Logger) *Manager {
 	if path == "" {
 		path = defaultPath
@@ -53,12 +53,12 @@ func New(path string, logger *slog.Logger) *Manager {
 	return &Manager{path: path, logger: logger}
 }
 
-// Apply fügt den markierten Block mit den Entries in /etc/hosts ein
-// und ersetzt einen eventuell vorhandenen alten Block.
+// Apply inserts the marked block with the entries into /etc/hosts
+// and replaces any existing old block.
 func (m *Manager) Apply(entries []Entry) error {
 	current, err := os.ReadFile(m.path)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("hosts lesen: %w", err)
+		return fmt.Errorf("read hosts: %w", err)
 	}
 
 	stripped := removeBlock(current)
@@ -76,21 +76,21 @@ func (m *Manager) Apply(entries []Entry) error {
 	return nil
 }
 
-// Restore entfernt den markierten Block wieder aus /etc/hosts.
+// Restore removes the marked block from /etc/hosts again.
 func (m *Manager) Restore() error {
 	current, err := os.ReadFile(m.path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return fmt.Errorf("hosts lesen: %w", err)
+		return fmt.Errorf("read hosts: %w", err)
 	}
 	stripped := removeBlock(current)
 	if err := writeAtomic(m.path, stripped); err != nil {
-		return fmt.Errorf("hosts schreiben: %w", err)
+		return fmt.Errorf("write hosts: %w", err)
 	}
 	if m.logger != nil {
-		m.logger.Info("hosts Block entfernt", "path", m.path)
+		m.logger.Info("hosts block removed", "path", m.path)
 	}
 	return nil
 }
@@ -128,12 +128,12 @@ func removeBlock(in []byte) []byte {
 	return []byte(strings.Join(out, "\n"))
 }
 
-// writeAtomic schreibt content nach path. Versucht erst die klassische
-// "write to .tmp + rename" Strategie. Wenn das fehlschlaegt weil das
-// Verzeichnis read only ist (z.B. /etc auf einem ubifs Rootfs der nur eine
-// tmpfs Datei drueber gemountet hat), faellt es auf in-place Truncate write
-// zurueck. Damit klappt es auf der Bose Box wo /etc ro ist aber /etc/hosts
-// ein eigener tmpfs Mount ist.
+// writeAtomic writes content to path. It first tries the classic
+// "write to .tmp + rename" strategy. If that fails because the directory
+// is read only (e.g. /etc on a ubifs rootfs that only has a tmpfs file
+// mounted over it), it falls back to an in-place truncate write. That
+// way it works on the Bose box where /etc is ro but /etc/hosts is its
+// own tmpfs mount.
 func writeAtomic(path string, content []byte) error {
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, content, 0o644); err == nil {
@@ -141,7 +141,7 @@ func writeAtomic(path string, content []byte) error {
 			return nil
 		} else {
 			_ = os.Remove(tmp)
-			// Rename gescheitert, faellt durch zu in-place
+			// Rename failed, falls through to in-place
 		}
 	}
 	// In-place Truncate write. Close error is checked explicitly:

--- a/internal/marge/marge.go
+++ b/internal/marge/marge.go
@@ -1,16 +1,16 @@
-// Package marge emuliert den Bose Marge Server (streaming.bose.com).
-// Marge ist der interne Codename für den Bose Cloud Server, der
-// Presets, Account Daten und Multiroom Steuerung verwaltet.
+// Package marge emulates the Bose Marge server (streaming.bose.com).
+// Marge is the internal codename for the Bose cloud server that
+// manages presets, account data and multiroom control.
 //
-// Diese Implementierung läuft in zwei Modi gleichzeitig:
+// This implementation runs in two modes at the same time:
 //
-//  1. Spy: jede eingehende Anfrage wird mit Method, Pfad, Headers und Body
-//     in den Logs aufgezeichnet. Damit lernen wir was die Box wirklich
-//     anfragt sobald die DNS Umleitung steht.
+//  1. Spy: every incoming request is recorded in the logs with method, path,
+//     headers and body. This lets us learn what the box actually
+//     requests once the DNS redirection is in place.
 //
-//  2. Stub: für die wahrscheinlichsten Endpoints liefern wir sinnvolle
-//     Defaults zurück. Die Antworten sind so konstruiert dass die Box im
-//     Zweifel "alles ok, kein Account, keine Presets" interpretiert.
+//  2. Stub: for the most likely endpoints we return sensible
+//     defaults. The responses are constructed so that the box, when in
+//     doubt, interprets "all ok, no account, no presets".
 package marge
 
 import (
@@ -30,7 +30,7 @@ import (
 	"github.com/JRpersonal/streborn/internal/netutil"
 )
 
-// Server hält die Konfiguration und den HTTP Handler für die Marge Emulation.
+// Server holds the configuration and the HTTP handler for the Marge emulation.
 type Server struct {
 	logger   *slog.Logger
 	mu       sync.RWMutex
@@ -46,13 +46,13 @@ type Server struct {
 	// missing file = no reflection (the safe default).
 	reflectPath string
 
-	// requestLog speichert die letzten N Requests für Debug Zwecke
-	// (zugaenglich ueber /__spy/log auf demselben Listener).
+	// requestLog stores the last N requests for debug purposes
+	// (accessible via /__spy/log on the same listener).
 	requestLog    []SpyEntry
 	requestLogMax int
 }
 
-// SpyEntry ist ein einzelner gelogged HTTP Request.
+// SpyEntry is a single logged HTTP request.
 type SpyEntry struct {
 	When    time.Time
 	Method  string
@@ -61,25 +61,25 @@ type SpyEntry struct {
 	Body    string
 }
 
-// Option ist ein Functional Option Pattern für die Konfiguration.
+// Option is a functional option pattern for the configuration.
 type Option func(*Server)
 
-// WithDeviceID setzt die deviceID die in Antworten verwendet wird.
+// WithDeviceID sets the deviceID used in responses.
 func WithDeviceID(id string) Option {
 	return func(s *Server) { s.deviceID = id }
 }
 
-// WithSpyLogSize setzt wie viele Request Snapshots vorgehalten werden.
+// WithSpyLogSize sets how many request snapshots are retained.
 func WithSpyLogSize(n int) Option {
 	return func(s *Server) { s.requestLogMax = n }
 }
 
-// WithPresets initialisiert die Preset Liste.
+// WithPresets initializes the preset list.
 func WithPresets(p []Preset) Option {
 	return func(s *Server) { s.presets = p }
 }
 
-// WithSources initialisiert die Source Liste.
+// WithSources initializes the source list.
 func WithSources(items []SourceItem) Option {
 	return func(s *Server) { s.sources = items }
 }
@@ -106,7 +106,7 @@ func xmlEscapeText(in string) string {
 	return r.Replace(in)
 }
 
-// New erstellt einen neuen Marge Server.
+// New creates a new Marge server.
 func New(logger *slog.Logger, opts ...Option) *Server {
 	s := &Server{
 		logger:        logger,
@@ -118,26 +118,26 @@ func New(logger *slog.Logger, opts ...Option) *Server {
 	return s
 }
 
-// Handler liefert den HTTP Handler für die Marge Endpunkte.
+// Handler returns the HTTP handler for the Marge endpoints.
 //
-// Wir nutzen einen Catchall Handler der jede Anfrage durch den Spy
-// schickt, und dahinter ein Pattern Matching auf bekannte URL Schemata.
+// We use a catchall handler that sends every request through the spy,
+// and behind that a pattern matching on known URL schemes.
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 
-	// Diagnose Endpunkte. Praefix __ damit es nicht mit potentiellen
-	// echten Marge Pfaden kollidiert.
+	// Diagnostic endpoints. Prefix __ so it does not collide with potential
+	// real Marge paths.
 	mux.HandleFunc("/__spy/log", s.handleSpyLog)
 	mux.HandleFunc("/healthz", s.handleHealthz)
 
-	// Catchall, faengt alles andere.
+	// Catchall, catches everything else.
 	mux.HandleFunc("/", s.handleCatchall)
 
 	return s.spyMiddleware(mux)
 }
 
-// Run startet einen optionalen eigenständigen Listener (für Tests).
-// Im Produktivbetrieb wird Handler() in den zentralen Listener gemountet.
+// Run starts an optional standalone listener (for tests).
+// In production Handler() is mounted into the central listener.
 // Uses SO_REUSEADDR so test runs can rebind a freshly-released port
 // without a TIME_WAIT cooldown.
 func (s *Server) Run(ctx context.Context, addr string) error {
@@ -156,15 +156,15 @@ func (s *Server) Run(ctx context.Context, addr string) error {
 	}
 }
 
-// spyMiddleware loggt jeden eingehenden Request bevor er an den eigentlichen
-// Handler weitergereicht wird. Body wird gepuffert damit er sowohl gelogged
-// als auch vom Handler gelesen werden kann.
+// spyMiddleware logs every incoming request before it is passed on to the
+// actual handler. The body is buffered so it can be both logged
+// and read by the handler.
 func (s *Server) spyMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Body kopieren, damit downstream lesen kann.
+		// Copy the body so downstream can read it.
 		var bodyCopy []byte
 		if r.Body != nil {
-			buf, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1 MB Limit
+			buf, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1 MB limit
 			if err == nil {
 				bodyCopy = buf
 				r.Body = io.NopCloser(bytes.NewReader(buf))
@@ -180,9 +180,9 @@ func (s *Server) spyMiddleware(next http.Handler) http.Handler {
 		}
 		s.recordSpy(entry)
 
-		// Auf Debug damit die periodischen Bose Lisa Polls (alle paar min)
-		// nicht den Log fluten. Bei Fehlern wird im Handler INFO/WARN
-		// geloggt.
+		// At debug level so the periodic Bose Lisa polls (every few min)
+		// do not flood the log. On errors INFO/WARN is logged in the
+		// handler.
 		s.logger.Debug("marge request",
 			slog.String("method", entry.Method),
 			slog.String("path", entry.Path),
@@ -195,7 +195,7 @@ func (s *Server) spyMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// recordSpy speichert einen Eintrag im Ring Buffer.
+// recordSpy stores an entry in the ring buffer.
 func (s *Server) recordSpy(e SpyEntry) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -205,7 +205,7 @@ func (s *Server) recordSpy(e SpyEntry) {
 	}
 }
 
-// RecentRequests gibt eine Kopie der zuletzt gesehenen Requests zurueck.
+// RecentRequests returns a copy of the most recently seen requests.
 func (s *Server) RecentRequests() []SpyEntry {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -214,14 +214,14 @@ func (s *Server) RecentRequests() []SpyEntry {
 	return out
 }
 
-// handleHealthz ist der Standard Probe Endpunkt.
+// handleHealthz is the standard probe endpoint.
 func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("ok"))
 }
 
-// handleSpyLog gibt den Request Log als simpler Plaintext zurueck.
-// Nur fuer Debug Zwecke gedacht, nicht produktiv exponieren.
+// handleSpyLog returns the request log as plain text.
+// Intended for debug purposes only, do not expose in production.
 func (s *Server) handleSpyLog(w http.ResponseWriter, _ *http.Request) {
 	entries := s.RecentRequests()
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
@@ -239,19 +239,19 @@ func (s *Server) handleSpyLog(w http.ResponseWriter, _ *http.Request) {
 	}
 }
 
-// handleCatchall reagiert auf alles was nicht von einem konkreten Handler
-// bedient wird. Pattern Matching auf bekannte Pfad Schemata, sonst ein
-// generisches 200 OK mit XML.
+// handleCatchall responds to everything that is not served by a concrete
+// handler. Pattern matching on known path schemes, otherwise a
+// generic 200 OK with XML.
 func (s *Server) handleCatchall(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Path
 
-	// TuneIn Partner Subdomain wird in /etc/hosts auf 127.0.0.1 umgeleitet
-	// fuer den Fall dass STSCertified den Endpoint je rufen wuerde. Aktuell
-	// passiert das in dieser FW nicht (siehe internal/marge/tunein.go).
-	// Falls Box doch dort connectet, faellt der Request in den catchall
-	// default mit generischem 200 OK <ack/>.
+	// The TuneIn partner subdomain is redirected to 127.0.0.1 in /etc/hosts
+	// in case STSCertified ever calls the endpoint. Currently this
+	// does not happen in this FW (see internal/marge/tunein.go).
+	// If the box does connect there, the request falls into the catchall
+	// default with a generic 200 OK <ack/>.
 
-	// Reale Bose Cloud Endpoints aus mitgeschnittenem Traffic
+	// Real Bose cloud endpoints from captured traffic
 	switch {
 	case strings.HasPrefix(path, "/streaming/support/power_on"):
 		s.respondPowerOn(w, r)
@@ -262,9 +262,9 @@ func (s *Server) handleCatchall(w http.ResponseWriter, r *http.Request) {
 	case strings.HasPrefix(path, "/streaming/sourceproviders"):
 		s.respondSourceProviders(w, r)
 		return
-	// AddDevice Sync: /streaming/account/<accountId>/device/ POST
-	// Box ruft das nach POST /setMargeAccount auf der Box selbst.
-	// Antwort muss adddeviceresponse XML sein mit margetoken Element.
+	// AddDevice sync: /streaming/account/<accountId>/device/ POST
+	// The box calls this after POST /setMargeAccount on the box itself.
+	// The response must be adddeviceresponse XML with a margetoken element.
 	case strings.HasPrefix(path, "/streaming/account/") && strings.Contains(path, "/device") && r.Method == http.MethodPost:
 		s.respondAddDevice(w, r)
 		return
@@ -279,7 +279,7 @@ func (s *Server) handleCatchall(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Fallback Pattern Matching (legacy)
+	// Fallback pattern matching (legacy)
 	switch {
 	case strings.Contains(path, "preset"):
 		s.respondPresets(w)
@@ -294,16 +294,16 @@ func (s *Server) handleCatchall(w http.ResponseWriter, r *http.Request) {
 	case strings.Contains(path, "config"):
 		s.respondConfigStatus(w)
 	default:
-		// Generisches 200 OK damit die Box nicht in Retry Loops geht.
+		// Generic 200 OK so the box does not go into retry loops.
 		w.Header().Set("Content-Type", "application/xml; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><ack/>`))
 	}
 }
 
-// respondPowerOn antwortet auf POST /streaming/support/power_on.
-// Box sendet beim Boot diagnostic data, wir muessen mit einem "OK"
-// antworten damit die Box uns nicht als "Cloud down" markiert.
+// respondPowerOn responds to POST /streaming/support/power_on.
+// The box sends diagnostic data at boot; we must respond with an "OK"
+// so the box does not mark us as "Cloud down".
 func (s *Server) respondPowerOn(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/vnd.bose.streaming-v1.2+xml")
 	w.WriteHeader(http.StatusOK)
@@ -313,22 +313,22 @@ func (s *Server) respondPowerOn(w http.ResponseWriter, _ *http.Request) {
 </response>`))
 }
 
-// respondStreamingSupport ist Catchall fuer alle anderen /streaming/support/* Pfade.
+// respondStreamingSupport is the catchall for all other /streaming/support/* paths.
 func (s *Server) respondStreamingSupport(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/vnd.bose.streaming-v1.2+xml")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><response status="OK"/>`))
 }
 
-// respondBmxRegistry antwortet auf GET /bmx/registry/v1/services mit einer
-// Service Registry. STSCertified Code Pfad
-// `BMXController::GetServicesCB()` parsed diese Antwort und ENTFERNT jeden
-// Service der nicht in der Liste vorkommt
-// ("is no longer supported, so removing it"). Wir muessen also alle Music
-// Services aktiv listen damit STSCertified die Worker nicht abschaltet.
+// respondBmxRegistry responds to GET /bmx/registry/v1/services with a
+// service registry. The STSCertified code path
+// `BMXController::GetServicesCB()` parses this response and REMOVES every
+// service that does not appear in the list
+// ("is no longer supported, so removing it"). So we must actively list all
+// music services so STSCertified does not shut down the workers.
 //
-// askAgainAfter triggert das polling Intervall. Ohne den Wert stoppt
-// das polling sofort.
+// askAgainAfter triggers the polling interval. Without the value the
+// polling stops immediately.
 func (s *Server) respondBmxRegistry(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
@@ -348,29 +348,29 @@ func (s *Server) respondBmxRegistry(w http.ResponseWriter, _ *http.Request) {
 }`))
 }
 
-// respondBmxGeneric ist Catchall fuer andere /bmx/* Pfade.
+// respondBmxGeneric is the catchall for other /bmx/* paths.
 func (s *Server) respondBmxGeneric(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte(`{"status":"ok"}`))
 }
 
-// respondSourceProviders antwortet auf GET /streaming/sourceproviders mit
-// einer Liste von Music Service Providern. Aus dem BoseApp Binary wissen wir:
-// das Wire Format ist XML (nicht Protobuf), das Schema hat zwei Felder pro
-// Provider: id und name. Box liest das, registriert die Provider und macht
-// die zugehoerigen Sources READY.
+// respondSourceProviders responds to GET /streaming/sourceproviders with
+// a list of music service providers. From the BoseApp binary we know:
+// the wire format is XML (not Protobuf), the schema has two fields per
+// provider: id and name. The box reads this, registers the providers and makes
+// the associated sources READY.
 //
-// Wenn TUNEIN in der Liste ist, sollte INTERNET_RADIO als Source verfuegbar
-// werden und Preset Tasten mit Internet Radio Stations funktionieren.
+// If TUNEIN is in the list, INTERNET_RADIO should become available as a source
+// and preset buttons with internet radio stations should work.
 func (s *Server) respondSourceProviders(w http.ResponseWriter, _ *http.Request) {
-	// ProtoToMarkup Konvention:
+	// ProtoToMarkup convention:
 	//   message sourceProviders { repeated SourceProvider sourceprovider = 1; }
 	//   message SourceProvider {
 	//     optional string id = 1;             // → attribute id="..."
 	//     optional Common.String name = 2;    // → child <name>VALUE</name>
 	//   }
-	// Wrapper aussen genauso wie bei addDevice success:
+	// Wrapper on the outside, same as for addDevice success:
 	// <response status="OK"><sourceProviders>...</sourceProviders></response>
 	w.Header().Set("Content-Type", "application/vnd.bose.streaming-v1.2+xml")
 	w.WriteHeader(http.StatusOK)
@@ -385,32 +385,33 @@ func (s *Server) respondSourceProviders(w http.ResponseWriter, _ *http.Request) 
 		}
 		extra.WriteString(`<sourceprovider id="` + id + `"><name>` + xmlEscapeText(r.Name) + `</name></sourceprovider>`)
 	}
-	// ohne response wrapper, da AddDevice wrap201 nur fuer den initialen
-	// Pair Call relevant ist.
+	// without response wrapper, since AddDevice wrap201 is only relevant for the
+	// initial pair call.
 	_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8" ?>
 <sourceProviders><sourceprovider id="TUNEIN"><name>TuneIn Radio</name></sourceprovider><sourceprovider id="INTERNET_RADIO"><name>Internet Radio</name></sourceprovider><sourceprovider id="STORED_MUSIC"><name>Stored Music</name></sourceprovider>` + extra.String() + `</sourceProviders>`))
 }
 
-// respondAddDevice ist die Antwort auf den AddDevice Sync den die Box nach
-// POST /setMargeAccount triggert. Pfad: /streaming/account/<accountId>/device/
+// respondAddDevice is the response to the AddDevice sync that the box triggers
+// after POST /setMargeAccount. Path: /streaming/account/<accountId>/device/
 //
-// Aus Box-Spy beobachtet: Box schickt
-//   POST /streaming/account/<accountId>/device/
-//   Content-Type: application/vnd.bose.streaming-v1.2+xml
-//   Authorization: <userAuthToken aus PairDeviceWithAccount>
-//   Body: <device deviceid="..."><name>...</name><macaddress>...</macaddress></device>
+// Observed from box-spy: the box sends
 //
-// Box erwartet als Response ein adddeviceresponse XML mit margetoken Feld.
-// Wenn margetoken nicht leer ist, geht die State Machine in MargeStateAssociated.
-// addDeviceFormat steuert das XML Format der adddeviceresponse via Env Var.
-// Werte: "elem" (default), "attr", "wrap", "elem201", "attr201", "wrap201",
+//	POST /streaming/account/<accountId>/device/
+//	Content-Type: application/vnd.bose.streaming-v1.2+xml
+//	Authorization: <userAuthToken from PairDeviceWithAccount>
+//	Body: <device deviceid="..."><name>...</name><macaddress>...</macaddress></device>
+//
+// The box expects an adddeviceresponse XML with a margetoken field as response.
+// If margetoken is not empty, the state machine goes to MargeStateAssociated.
+// addDeviceFormat controls the XML format of the adddeviceresponse via env var.
+// Values: "elem" (default), "attr", "wrap", "elem201", "attr201", "wrap201",
 // "self".
 func addDeviceFormat() string {
 	v := os.Getenv("STICK_ADD_DEVICE_FORMAT")
 	if v == "" {
-		// wrap201 hat die Box im Sweep am 15.05.2026 dazu gebracht
-		// MargeStateAssociated zu erreichen (sie ruft danach
-		// /streaming/sourceproviders ab).
+		// wrap201 made the box reach MargeStateAssociated in the sweep on
+		// 2026-05-15 (it then fetches
+		// /streaming/sourceproviders).
 		return "wrap201"
 	}
 	return v
@@ -422,19 +423,19 @@ func (s *Server) respondAddDevice(w http.ResponseWriter, r *http.Request) {
 	if token == "" {
 		token = "11111111-1111-1111-1111-111111111111"
 	}
-	s.logger.Info("addDevice antwort gesendet",
+	s.logger.Info("addDevice response sent",
 		slog.String("comp", "marge"),
 		slog.String("clientPath", r.URL.Path),
 		slog.String("format", format),
 	)
-	// Bose ProtoToMarkup Konvention: TYPE_STRING Felder werden zu XML
-	// Attributes auf dem parent Element, message Felder werden zu Child
-	// Elements. Beispiel im Box Request:
-	//   <device deviceid="DEVICEID_PLACEHOLDER">          // string field als attribute
-	//     <name>...</name>                         // Common.String message als child
+	// Bose ProtoToMarkup convention: TYPE_STRING fields become XML
+	// attributes on the parent element, message fields become child
+	// elements. Example in the box request:
+	//   <device deviceid="DEVICEID_PLACEHOLDER">          // string field as attribute
+	//     <name>...</name>                         // Common.String message as child
 	//     <macaddress>...</macaddress>
 	//   </device>
-	// margetoken ist optional string, also Attribute.
+	// margetoken is an optional string, so an attribute.
 	w.Header().Set("Content-Type", "application/vnd.bose.streaming-v1.2+xml")
 
 	status := http.StatusOK
@@ -453,8 +454,8 @@ func (s *Server) respondAddDevice(w http.ResponseWriter, r *http.Request) {
 		body = fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8" ?>
 <response status="OK"><adddeviceresponse><margetoken>%s</margetoken></adddeviceresponse></response>`, token)
 	case strings.HasPrefix(format, "valueonly"):
-		// ProtoToMarkup value_only Option: outer tag enthaelt direkt
-		// den string value, kein inner margetoken element.
+		// ProtoToMarkup value_only option: the outer tag directly contains
+		// the string value, no inner margetoken element.
 		body = fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8" ?>
 <adddeviceresponse>%s</adddeviceresponse>`, token)
 	case strings.HasPrefix(format, "minimal"):
@@ -467,23 +468,23 @@ func (s *Server) respondAddDevice(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte(body))
 }
 
-// respondAccountFull antwortet auf /streaming/account/<id>/full mit minimaler
-// FullAccount XML. Box benutzt das nach AddDevice um die Account Settings,
-// Devices und Sources zu laden.
+// respondAccountFull responds to /streaming/account/<id>/full with minimal
+// FullAccount XML. The box uses this after AddDevice to load the account settings,
+// devices and sources.
 func (s *Server) respondAccountFull(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/vnd.bose.streaming-v1.2+xml")
 	w.WriteHeader(http.StatusOK)
 	// FullAccount.proto: account { mode, devices, sources, providerSettings, ... }
-	// Sources enthaelt MargeSource.source mit type=INTERNET_RADIO und
-	// sourceproviderid=INTERNET_RADIO. Damit sollte die Box die Source
-	// als verfuegbar registrieren.
-	// ProtoToMarkup Konvention:
+	// Sources contains MargeSource.source with type=INTERNET_RADIO and
+	// sourceproviderid=INTERNET_RADIO. This should make the box register the
+	// source as available.
+	// ProtoToMarkup convention:
 	//   string field → attribute
-	//   Common.String field → child element mit text content
+	//   Common.String field → child element with text content
 	//   message field → nested child element
-	// Root element heisst nicht "fullAccount" sondern matched die message
-	// name "account" oder der parent field name. Hier probieren wir
-	// <fullAccount> als root (matched filename Konvention).
+	// The root element is not called "fullAccount" but matches the message
+	// name "account" or the parent field name. Here we try
+	// <fullAccount> as root (matches the filename convention).
 	_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8" ?>
 <fullAccount>
   <mode><text>global</text></mode>
@@ -522,9 +523,9 @@ func (s *Server) reflectedSourcesXML() string {
 	return b.String()
 }
 
-// respondGroup antwortet auf /streaming/account/<id>/device/<deviceid>/group/.
-// Box prueft ob das Geraet schon in einer Multiroom Gruppe ist. Wir sagen
-// "nein, kein Group".
+// respondGroup responds to /streaming/account/<id>/device/<deviceid>/group/.
+// The box checks whether the device is already in a multiroom group. We say
+// "no, no group".
 func (s *Server) respondGroup(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/vnd.bose.streaming-v1.2+xml")
 	w.WriteHeader(http.StatusNotFound)
@@ -532,8 +533,8 @@ func (s *Server) respondGroup(w http.ResponseWriter, _ *http.Request) {
 <errors deviceID="DEVICEID_PLACEHOLDER"><error value="5550" name="GROUP_NO_GROUP_TO_REMOVE_ERROR" severity="Unknown">5550</error></errors>`))
 }
 
-// respondProviderSettings antwortet auf /streaming/account/<id>/provider_settings.
-// Music Service Provider Settings (Spotify Token, etc). Wir geben leer zurueck.
+// respondProviderSettings responds to /streaming/account/<id>/provider_settings.
+// Music service provider settings (Spotify token, etc). We return empty.
 func (s *Server) respondProviderSettings(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/vnd.bose.streaming-v1.2+xml")
 	w.WriteHeader(http.StatusOK)
@@ -541,8 +542,8 @@ func (s *Server) respondProviderSettings(w http.ResponseWriter, _ *http.Request)
 <providerSettings/>`))
 }
 
-// respondMargeAccountFull liefert ein "konfiguriertes" Marge Account.
-// Wenn die Box Account Info erfragt, sagen wir "ja du bist eingeloggt".
+// respondMargeAccountFull returns a "configured" Marge account.
+// When the box requests account info, we say "yes, you are logged in".
 func (s *Server) respondMargeAccountFull(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
@@ -627,7 +628,7 @@ func (s *Server) respondAccount(w http.ResponseWriter) {
 
 	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
 	if acc == nil {
-		// Bestaetigt der Box dass kein Account konfiguriert ist.
+		// Confirms to the box that no account is configured.
 		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><MargeAccount status="UNCONFIGURED"/>`))
 		return
 	}
@@ -652,14 +653,14 @@ func (s *Server) respondConfigStatus(w http.ResponseWriter) {
 	}
 }
 
-// SetAccount setzt den aktuellen Marge Account zur Laufzeit.
+// SetAccount sets the current Marge account at runtime.
 func (s *Server) SetAccount(acc *AccountInfo) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.account = acc
 }
 
-// SetPresets ueberschreibt die Preset Liste zur Laufzeit.
+// SetPresets overwrites the preset list at runtime.
 func (s *Server) SetPresets(p []Preset) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/marge/marge_test.go
+++ b/internal/marge/marge_test.go
@@ -33,20 +33,20 @@ func newTestServer() *Server {
 	)
 }
 
-func TestEmptyPresetsXMLWohlgeformt(t *testing.T) {
+func TestEmptyPresetsXMLWellFormed(t *testing.T) {
 	xmlWellFormed(t, EmptyPresetsXML)
 }
 
-func TestEmptyRecentsXMLWohlgeformt(t *testing.T) {
+func TestEmptyRecentsXMLWellFormed(t *testing.T) {
 	xmlWellFormed(t, EmptyRecentsXML)
 }
 
-func TestSoundTouchStatusXMLWohlgeformt(t *testing.T) {
+func TestSoundTouchStatusXMLWellFormed(t *testing.T) {
 	xmlWellFormed(t, SoundTouchConfiguredXML)
 	xmlWellFormed(t, SoundTouchNotConfiguredXML)
 }
 
-func TestPresetsHandlerLeer(t *testing.T) {
+func TestPresetsHandlerEmpty(t *testing.T) {
 	s := newTestServer()
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/preset/list", nil)
@@ -65,7 +65,7 @@ func TestPresetsHandlerMitInhalt(t *testing.T) {
 	s := newTestServer()
 	s.SetPresets([]Preset{
 		{ID: 1, Source: "SPOTIFY", Type: "uri", Location: "spotify:playlist:xyz",
-			SourceAccount: "user@example.com", ItemName: "Morgens",
+			SourceAccount: "user@example.com", ItemName: "Morning",
 			ContainerArt: "https://example.com/art.png",
 			CreatedOn:    1700000000, UpdatedOn: 1700000000},
 	})
@@ -74,7 +74,7 @@ func TestPresetsHandlerMitInhalt(t *testing.T) {
 	s.Handler().ServeHTTP(rec, req)
 	body := rec.Body.String()
 	xmlWellFormed(t, body)
-	if !strings.Contains(body, "Morgens") {
+	if !strings.Contains(body, "Morning") {
 		t.Fatalf("preset name not found: %s", body)
 	}
 	if !strings.Contains(body, "spotify:playlist:xyz") {
@@ -138,7 +138,7 @@ func TestReflectDeezerSource(t *testing.T) {
 	}
 }
 
-func TestSourcesHandlerOhneItems(t *testing.T) {
+func TestSourcesHandlerWithoutItems(t *testing.T) {
 	s := newTestServer()
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/sources", nil)
@@ -162,7 +162,7 @@ func TestAccountHandlerUnkonfiguriert(t *testing.T) {
 	}
 }
 
-func TestAccountHandlerKonfiguriert(t *testing.T) {
+func TestAccountHandlerConfigured(t *testing.T) {
 	s := newTestServer()
 	s.SetAccount(&AccountInfo{
 		AccountUUID:  "uuid-123",
@@ -183,7 +183,7 @@ func TestAccountHandlerKonfiguriert(t *testing.T) {
 func TestSpyLogfaengtRequestsAuf(t *testing.T) {
 	s := newTestServer()
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/some/unbekannter/pfad",
+	req := httptest.NewRequest(http.MethodPost, "/some/unknown/path",
 		strings.NewReader("<?xml version=\"1.0\"?><test/>"))
 	req.Header.Set("Content-Type", "application/xml")
 	s.Handler().ServeHTTP(rec, req)
@@ -195,7 +195,7 @@ func TestSpyLogfaengtRequestsAuf(t *testing.T) {
 	if entries[0].Method != "POST" {
 		t.Fatalf("method wrong: %s", entries[0].Method)
 	}
-	if entries[0].Path != "/some/unbekannter/pfad" {
+	if entries[0].Path != "/some/unknown/path" {
 		t.Fatalf("path wrong: %s", entries[0].Path)
 	}
 	if !strings.Contains(entries[0].Body, "<test") {
@@ -203,7 +203,7 @@ func TestSpyLogfaengtRequestsAuf(t *testing.T) {
 	}
 }
 
-func TestSpyLogEndpunkt(t *testing.T) {
+func TestSpyLogEndpoint(t *testing.T) {
 	s := newTestServer()
 	// First a request to log something
 	rec := httptest.NewRecorder()
@@ -223,7 +223,7 @@ func TestSpyLogEndpunkt(t *testing.T) {
 func TestCatchallGenericAck(t *testing.T) {
 	s := newTestServer()
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/voellig/unbekannt", nil)
+	req := httptest.NewRequest(http.MethodGet, "/completely/unknown", nil)
 	s.Handler().ServeHTTP(rec, req)
 	body := rec.Body.String()
 	xmlWellFormed(t, body)

--- a/internal/marge/marge_test.go
+++ b/internal/marge/marge_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-// xmlWellFormed prueft ob der String als XML parsebar ist.
+// xmlWellFormed checks whether the string is parseable as XML.
 func xmlWellFormed(t *testing.T, in string) {
 	t.Helper()
 	dec := xml.NewDecoder(strings.NewReader(in))
@@ -21,7 +21,7 @@ func xmlWellFormed(t *testing.T, in string) {
 			return
 		}
 		if err != nil {
-			t.Fatalf("xml nicht wohlgeformt: %v\n--\n%s\n--", err, in)
+			t.Fatalf("xml not well-formed: %v\n--\n%s\n--", err, in)
 		}
 	}
 }
@@ -57,7 +57,7 @@ func TestPresetsHandlerLeer(t *testing.T) {
 	body := rec.Body.String()
 	xmlWellFormed(t, body)
 	if !strings.Contains(body, "<presets") {
-		t.Fatalf("erwartete <presets im Body, bekam: %s", body)
+		t.Fatalf("expected <presets in body, got: %s", body)
 	}
 }
 
@@ -75,10 +75,10 @@ func TestPresetsHandlerMitInhalt(t *testing.T) {
 	body := rec.Body.String()
 	xmlWellFormed(t, body)
 	if !strings.Contains(body, "Morgens") {
-		t.Fatalf("Preset Name nicht gefunden: %s", body)
+		t.Fatalf("preset name not found: %s", body)
 	}
 	if !strings.Contains(body, "spotify:playlist:xyz") {
-		t.Fatalf("Preset Location nicht gefunden: %s", body)
+		t.Fatalf("preset location not found: %s", body)
 	}
 }
 
@@ -89,10 +89,10 @@ func TestServiceAvailabilityHandler(t *testing.T) {
 	s.Handler().ServeHTTP(rec, req)
 	body := rec.Body.String()
 	xmlWellFormed(t, body)
-	// Sicher gehen dass die wichtigsten Provider drin sind.
+	// Make sure the most important providers are present.
 	for _, want := range []string{"SPOTIFY", "DEEZER", "AMAZON", "AIRPLAY"} {
 		if !strings.Contains(body, want) {
-			t.Fatalf("provider %s fehlt: %s", want, body)
+			t.Fatalf("provider %s missing: %s", want, body)
 		}
 	}
 }
@@ -146,7 +146,7 @@ func TestSourcesHandlerOhneItems(t *testing.T) {
 	body := rec.Body.String()
 	xmlWellFormed(t, body)
 	if !strings.Contains(body, "DEVICEID_PLACEHOLDER") {
-		t.Fatalf("deviceID nicht im Body: %s", body)
+		t.Fatalf("deviceID not in body: %s", body)
 	}
 }
 
@@ -158,7 +158,7 @@ func TestAccountHandlerUnkonfiguriert(t *testing.T) {
 	body := rec.Body.String()
 	xmlWellFormed(t, body)
 	if !strings.Contains(body, "UNCONFIGURED") {
-		t.Fatalf("erwartete UNCONFIGURED Status: %s", body)
+		t.Fatalf("expected UNCONFIGURED status: %s", body)
 	}
 }
 
@@ -176,7 +176,7 @@ func TestAccountHandlerKonfiguriert(t *testing.T) {
 	body := rec.Body.String()
 	xmlWellFormed(t, body)
 	if !strings.Contains(body, "uuid-123") {
-		t.Fatalf("AccountUUID fehlt: %s", body)
+		t.Fatalf("AccountUUID missing: %s", body)
 	}
 }
 
@@ -190,33 +190,33 @@ func TestSpyLogfaengtRequestsAuf(t *testing.T) {
 
 	entries := s.RecentRequests()
 	if len(entries) != 1 {
-		t.Fatalf("erwartete 1 Spy Eintrag, bekam %d", len(entries))
+		t.Fatalf("expected 1 spy entry, got %d", len(entries))
 	}
 	if entries[0].Method != "POST" {
-		t.Fatalf("methode falsch: %s", entries[0].Method)
+		t.Fatalf("method wrong: %s", entries[0].Method)
 	}
 	if entries[0].Path != "/some/unbekannter/pfad" {
-		t.Fatalf("pfad falsch: %s", entries[0].Path)
+		t.Fatalf("path wrong: %s", entries[0].Path)
 	}
 	if !strings.Contains(entries[0].Body, "<test") {
-		t.Fatalf("body fehlt: %s", entries[0].Body)
+		t.Fatalf("body missing: %s", entries[0].Body)
 	}
 }
 
 func TestSpyLogEndpunkt(t *testing.T) {
 	s := newTestServer()
-	// Erst einen Request um was zu loggen
+	// First a request to log something
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/preset/foo", nil)
 	s.Handler().ServeHTTP(rec, req)
 
-	// Dann den Spy Log abrufen
+	// Then fetch the spy log
 	rec2 := httptest.NewRecorder()
 	req2 := httptest.NewRequest(http.MethodGet, "/__spy/log", nil)
 	s.Handler().ServeHTTP(rec2, req2)
 	body := rec2.Body.String()
 	if !strings.Contains(body, "GET /preset/foo") {
-		t.Fatalf("spy log enthaelt den Request nicht: %s", body)
+		t.Fatalf("spy log does not contain the request: %s", body)
 	}
 }
 
@@ -228,7 +228,7 @@ func TestCatchallGenericAck(t *testing.T) {
 	body := rec.Body.String()
 	xmlWellFormed(t, body)
 	if !strings.Contains(body, "<ack") {
-		t.Fatalf("generic ack fehlt: %s", body)
+		t.Fatalf("generic ack missing: %s", body)
 	}
 }
 

--- a/internal/marge/templates.go
+++ b/internal/marge/templates.go
@@ -1,24 +1,24 @@
 package marge
 
-// XML Templates und Konstanten für Marge Antworten.
+// XML templates and constants for Marge responses.
 //
-// Quelle: docs/probe-api-ST10.txt, gezogen aus der echten BoseApp HTTP API
-// auf 8090. Diese Antworten zeigen welchen State die Box aus Marge Daten
-// ableitet. Wir bauen unsere Antworten so dass die Box am Ende dieselbe
-// (oder eine reichere) Konfiguration ableiten kann.
+// Source: docs/probe-api-ST10.txt, pulled from the real BoseApp HTTP API
+// on 8090. These responses show which state the box derives from Marge data.
+// We build our responses so that the box can derive the same
+// (or a richer) configuration in the end.
 //
-// Achtung: Alle hier definierten Templates sind read only und enthalten
-// Platzhalter wie {{.DeviceID}}, die zur Laufzeit gefüllt werden.
+// Caution: all templates defined here are read only and contain
+// placeholders like {{.DeviceID}}, which are filled at runtime.
 
-// AccountConfigured beschreibt das Skelett einer Antwort die der Box
-// signalisiert "Du bist mit einem Bose Konto verbunden".
+// AccountConfigured describes the skeleton of a response that signals to the box
+// "You are connected to a Bose account".
 //
-// Wir wissen noch nicht welcher konkrete Endpunkt der Box diese Information
-// liefert. Vermutung anhand der BoseApp API:
-//   - /info zeigt margeAccountUUID
-//   - /soundTouchConfigurationStatus wechselt zu SOUNDTOUCH_CONFIGURED
+// We do not yet know which concrete endpoint of the box returns this
+// information. Guess based on the BoseApp API:
+//   - /info shows margeAccountUUID
+//   - /soundTouchConfigurationStatus switches to SOUNDTOUCH_CONFIGURED
 //
-// Sobald der Spy Mode die echten Anfragen offenlegt, wird das hier konkret.
+// Once spy mode reveals the real requests, this will become concrete here.
 const AccountConfiguredXMLTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <MargeAccount>
   <accountUUID>{{.AccountUUID}}</accountUUID>
@@ -28,14 +28,14 @@ const AccountConfiguredXMLTemplate = `<?xml version="1.0" encoding="UTF-8"?>
   <created>{{.CreatedAt}}</created>
 </MargeAccount>`
 
-// EmptyPresetsXML ist die Antwort wenn der Account noch keine Presets hat.
-// Match mit /presets Antwort der Box im Werkszustand.
+// EmptyPresetsXML is the response when the account has no presets yet.
+// Matches the /presets response of the box in factory state.
 const EmptyPresetsXML = `<?xml version="1.0" encoding="UTF-8"?>
 <presets/>`
 
-// PresetsXMLTemplate ist die Antwort wenn der Account Presets hat.
-// Jeder Preset enthält ein ContentItem das wiederum source, sourceAccount
-// und mit Source spezifischen Feldern versehen ist.
+// PresetsXMLTemplate is the response when the account has presets.
+// Each preset contains a ContentItem which in turn carries source, sourceAccount
+// and source-specific fields.
 const PresetsXMLTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <presets>{{range .Presets}}
   <preset id="{{.ID}}" createdOn="{{.CreatedOn}}" updatedOn="{{.UpdatedOn}}">
@@ -46,13 +46,13 @@ const PresetsXMLTemplate = `<?xml version="1.0" encoding="UTF-8"?>
   </preset>{{end}}
 </presets>`
 
-// EmptyRecentsXML wenn keine Recents vorhanden.
+// EmptyRecentsXML when no recents are present.
 const EmptyRecentsXML = `<?xml version="1.0" encoding="UTF-8"?>
 <recents/>`
 
-// ServiceAvailabilityXMLTemplate listet welche Streaming Provider verfuegbar
-// sind. Beobachtung aus der Box: PANDORA hat geo restriction reason,
-// AMAZON/DEEZER/SPOTIFY/AIRPLAY/LOCAL_MUSIC sind verfuegbar.
+// ServiceAvailabilityXMLTemplate lists which streaming providers are available.
+// Observation from the box: PANDORA has a geo restriction reason,
+// AMAZON/DEEZER/SPOTIFY/AIRPLAY/LOCAL_MUSIC are available.
 const ServiceAvailabilityXMLTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <serviceAvailability>
   <services>{{range .Services}}
@@ -60,23 +60,23 @@ const ServiceAvailabilityXMLTemplate = `<?xml version="1.0" encoding="UTF-8"?>
   </services>
 </serviceAvailability>`
 
-// SourcesXMLTemplate ist das Format das die Box ueber /sources ausspielt.
-// Wir liefern die gleiche Struktur wenn Marge die Source Liste pushed.
+// SourcesXMLTemplate is the format the box emits via /sources.
+// We return the same structure when Marge pushes the source list.
 const SourcesXMLTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <sources deviceID="{{.DeviceID}}">{{range .Items}}
   <sourceItem source="{{.Source}}"{{if .Account}} sourceAccount="{{.Account}}"{{end}} status="{{.Status}}" isLocal="{{.IsLocal}}" multiroomallowed="{{.MultiroomAllowed}}">{{.DisplayName}}</sourceItem>{{end}}
 </sources>`
 
-// SoundTouchConfiguredXML signalisiert eine erfolgreich konfigurierte Box.
+// SoundTouchConfiguredXML signals a successfully configured box.
 const SoundTouchConfiguredXML = `<?xml version="1.0" encoding="UTF-8"?>
 <SoundTouchConfigurationStatus status="SOUNDTOUCH_CONFIGURED"/>`
 
-// SoundTouchNotConfiguredXML ist der Default Zustand.
+// SoundTouchNotConfiguredXML is the default state.
 const SoundTouchNotConfiguredXML = `<?xml version="1.0" encoding="UTF-8"?>
 <SoundTouchConfigurationStatus status="SOUNDTOUCH_NOT_CONFIGURED"/>`
 
-// DefaultServices ist die Liste der Streaming Provider die wir als verfuegbar
-// melden. Geo Restriction Reasons sind aus der echten ST10 Probe uebernommen.
+// DefaultServices is the list of streaming providers we report as available.
+// Geo restriction reasons are taken from the real ST10 probe.
 var DefaultServices = []ServiceAvailability{
 	{Type: "PANDORA", Available: false, Reason: "PANDORA_GEO_RESTRICTION_ERROR"},
 	{Type: "AIRPLAY", Available: true},
@@ -92,14 +92,14 @@ var DefaultServices = []ServiceAvailability{
 	{Type: "UPNP", Available: false},
 }
 
-// ServiceAvailability ist ein einzelner Streaming Provider Eintrag.
+// ServiceAvailability is a single streaming provider entry.
 type ServiceAvailability struct {
 	Type      string
 	Available bool
 	Reason    string
 }
 
-// Preset bildet einen einzelnen Preset Eintrag ab.
+// Preset represents a single preset entry.
 type Preset struct {
 	ID            int
 	CreatedOn     int64
@@ -112,7 +112,7 @@ type Preset struct {
 	ContainerArt  string
 }
 
-// SourceItem bildet eine Streaming Source ab.
+// SourceItem represents a streaming source.
 type SourceItem struct {
 	Source           string
 	Account          string
@@ -122,7 +122,7 @@ type SourceItem struct {
 	DisplayName      string
 }
 
-// AccountInfo enthält die Daten des Marge Accounts.
+// AccountInfo contains the data of the Marge account.
 type AccountInfo struct {
 	AccountUUID  string
 	AccountEmail string

--- a/internal/marge/tunein.go
+++ b/internal/marge/tunein.go
@@ -1,25 +1,25 @@
-// TuneIn API Stub. Vorgehalten als Infrastruktur fuer einen moeglichen
-// kuenftigen Pfad ueber Bose's TuneIn Worker, derzeit NICHT aktiv im Code
-// Pfad da STSCertified den TuneIn Worker in der finalen FW Version nicht
-// startet (siehe docs/findings-pair-flow.md "Service Discovery Update").
+// TuneIn API stub. Kept as infrastructure for a possible
+// future path via Bose's TuneIn worker, currently NOT active in the code
+// path since STSCertified does not start the TuneIn worker in the final FW version
+// (see docs/findings-pair-flow.md "Service Discovery Update").
 //
-// Wenn Bose den Service jemals reaktiviert oder eine aeltere FW Version
-// auf der Box flasht, koennten wir hier einen TuneIn-kompatiblen OPML/JSON
-// Endpoint anbieten, mit Backend Radio-Browser.info. Der Hostname
-// 7f5055e9ff15f2a5035a488b81ec10f4.api.radiotime.com wird bereits via
-// /etc/hosts auf 127.0.0.1 umgeleitet (internal/hosts.DefaultEntries).
+// If Bose ever reactivates the service or flashes an older FW version
+// onto the box, we could offer a TuneIn-compatible OPML/JSON
+// endpoint here, backed by Radio-Browser.info. The hostname
+// 7f5055e9ff15f2a5035a488b81ec10f4.api.radiotime.com is already redirected via
+// /etc/hosts to 127.0.0.1 (internal/hosts.DefaultEntries).
 //
-// Bekannte Pfade die der BMXTuneInClient ruft (aus STSCertified Binary
-// Strings):
+// Known paths that the BMXTuneInClient calls (from STSCertified binary
+// strings):
 //
 //	/profiles/<id>/nowPlaying?partnerId=Bose&serial=<deviceSerial>
 //	/now-playing/...
-//	/Browse.ashx?id=s<station>      (Standard TuneIn OPML)
+//	/Browse.ashx?id=s<station>      (standard TuneIn OPML)
 //	/Tune.ashx?id=s<station>
 //	/Describe.ashx?id=s<station>
 //
-// Wenn das jemals reaktiviert wird, hier einen Handler bauen der
-// Radio-Browser API Stationen in das TuneIn OPML Format konvertiert.
+// If this is ever reactivated, build a handler here that
+// converts Radio-Browser API stations into the TuneIn OPML format.
 package marge
 
 import (
@@ -27,9 +27,9 @@ import (
 	"strings"
 )
 
-// isTuneInRequest detected ob der Request an den Bose TuneIn Partner
-// Subdomain geht. Wird derzeit im catchall nicht mehr aufgerufen weil
-// die Box den Endpoint nicht anspricht.
+// isTuneInRequest detects whether the request goes to the Bose TuneIn partner
+// subdomain. Currently no longer called in the catchall because
+// the box does not contact the endpoint.
 func isTuneInRequest(r *http.Request) bool {
 	host := r.Host
 	if h, _, ok := strings.Cut(host, ":"); ok {

--- a/internal/presets/presets.go
+++ b/internal/presets/presets.go
@@ -1,17 +1,17 @@
-// Package presets liest und schreibt die Preset Konfiguration auf dem USB Stick.
+// Package presets reads and writes the preset configuration on the USB stick.
 //
-// Das Persistenz Format akzeptiert zwei Varianten:
+// The persistence format accepts two variants:
 //
-//  1. Array direkt:           [{...}, {...}]
-//  2. Object mit "presets":   {"presets": [{...}, ...]}
+//  1. Array directly:         [{...}, {...}]
+//  2. Object with "presets":  {"presets": [{...}, ...]}
 //
-// Feld Namen sind robust gegen die verschiedenen Wizard Versionen:
+// Field names are robust against the different wizard versions:
 //
-//	"slot" oder "id"               -> Slot
+//	"slot" or "id"                 -> Slot
 //	"name"                          -> Name
-//	"stream_url" oder "url"        -> StreamURL
+//	"stream_url" or "url"          -> StreamURL
 //	"type"                          -> Type ("radio", "spotify", ...)
-//	"art"                           -> Art (Coverbild URL, optional)
+//	"art"                           -> Art (cover image URL, optional)
 package presets
 
 import (
@@ -21,7 +21,7 @@ import (
 	"sync"
 )
 
-// Preset beschreibt einen einzelnen Preset Slot.
+// Preset describes a single preset slot.
 type Preset struct {
 	Slot      int    `json:"slot"`
 	Name      string `json:"name"`
@@ -53,7 +53,7 @@ type Preset struct {
 	Homepage string `json:"homepage,omitempty"`
 }
 
-// rawPreset ist der Disk Format Helper. Akzeptiert mehrere Alias Felder.
+// rawPreset is the disk format helper. Accepts multiple alias fields.
 type rawPreset struct {
 	Slot      int    `json:"slot"`
 	ID        int    `json:"id"`
@@ -69,25 +69,25 @@ type rawPreset struct {
 	Homepage  string `json:"homepage"`
 }
 
-// rawWrapper unterstuetzt das Object Format {"presets": [...]}.
+// rawWrapper supports the object format {"presets": [...]}.
 type rawWrapper struct {
 	Presets []rawPreset `json:"presets"`
 }
 
-// Store hält alle Presets im Speicher und synchronisiert sie mit der Datei.
+// Store holds all presets in memory and synchronizes them with the file.
 type Store struct {
 	path string
 	mu   sync.RWMutex
 	data []Preset
 }
 
-// New erzeugt einen leeren Store ohne Persistenz Pfad.
+// New creates an empty Store without a persistence path.
 func New() *Store { return &Store{} }
 
-// Load liest die presets.json vom angegebenen Pfad.
-// Existiert die Datei nicht oder ist leer, wird ein leerer Store zurueck.
-// Bei Parse Fehler wird ebenfalls ein leerer Store geliefert plus der Fehler
-// damit der Aufrufer entscheidet ob er crasht oder weitermacht.
+// Load reads the presets.json from the given path.
+// If the file does not exist or is empty, an empty Store is returned.
+// On parse error an empty Store is also returned plus the error so the
+// caller decides whether it crashes or continues.
 func Load(path string) (*Store, error) {
 	s := &Store{path: path}
 	b, err := os.ReadFile(path)
@@ -95,30 +95,30 @@ func Load(path string) (*Store, error) {
 		if os.IsNotExist(err) {
 			return s, nil
 		}
-		return s, fmt.Errorf("presets lesen: %w", err)
+		return s, fmt.Errorf("read presets: %w", err)
 	}
 	if len(b) == 0 {
 		return s, nil
 	}
 
-	// Erst versuche das Array Format
+	// First try the array format
 	var arr []rawPreset
 	if err := json.Unmarshal(b, &arr); err == nil {
 		s.data = normalize(arr)
 		return s, nil
 	}
 
-	// Dann das Object Format mit "presets" Wrapper
+	// Then the object format with "presets" wrapper
 	var wrap rawWrapper
 	if err := json.Unmarshal(b, &wrap); err == nil && wrap.Presets != nil {
 		s.data = normalize(wrap.Presets)
 		return s, nil
 	}
 
-	return s, fmt.Errorf("presets parsen: unbekanntes Format in %s", path)
+	return s, fmt.Errorf("parse presets: unknown format in %s", path)
 }
 
-// normalize wandelt rawPreset in Preset um, mit Alias Aufloesung.
+// normalize converts rawPreset into Preset, with alias resolution.
 func normalize(in []rawPreset) []Preset {
 	out := make([]Preset, 0, len(in))
 	for _, p := range in {
@@ -150,7 +150,7 @@ func normalize(in []rawPreset) []Preset {
 	return out
 }
 
-// All liefert eine Kopie aller Presets.
+// All returns a copy of all presets.
 func (s *Store) All() []Preset {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -159,7 +159,7 @@ func (s *Store) All() []Preset {
 	return out
 }
 
-// Get liefert den Preset für den angegebenen Slot.
+// Get returns the preset for the given slot.
 func (s *Store) Get(slot int) (Preset, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -171,8 +171,8 @@ func (s *Store) Get(slot int) (Preset, bool) {
 	return Preset{}, false
 }
 
-// SetSlot fuegt ein Preset hinzu oder ersetzt das vorhandene fuer den
-// gleichen Slot. Persistiert sofort.
+// SetSlot adds a preset or replaces the existing one for the same slot.
+// Persists immediately.
 func (s *Store) SetSlot(p Preset) error {
 	s.mu.Lock()
 	replaced := false
@@ -190,7 +190,7 @@ func (s *Store) SetSlot(p Preset) error {
 	return s.Save()
 }
 
-// RemoveSlot entfernt das Preset fuer den angegebenen Slot.
+// RemoveSlot removes the preset for the given slot.
 func (s *Store) RemoveSlot(slot int) error {
 	s.mu.Lock()
 	out := make([]Preset, 0, len(s.data))
@@ -204,24 +204,24 @@ func (s *Store) RemoveSlot(slot int) error {
 	return s.Save()
 }
 
-// Save schreibt die Presets im Object Format ({"presets":[...]}) zurueck.
-// Das ist auch das Format das der Wizard schreibt, damit beides kompatibel ist.
+// Save writes the presets back in the object format ({"presets":[...]}).
+// That is also the format the wizard writes, so both are compatible.
 func (s *Store) Save() error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.path == "" {
-		return fmt.Errorf("Store hat keinen Pfad")
+		return fmt.Errorf("Store has no path")
 	}
 	wrapper := struct {
 		Presets []Preset `json:"presets"`
 	}{Presets: s.data}
 	b, err := json.MarshalIndent(wrapper, "", "  ")
 	if err != nil {
-		return fmt.Errorf("presets serialisieren: %w", err)
+		return fmt.Errorf("serialize presets: %w", err)
 	}
 	tmp := s.path + ".tmp"
 	if err := os.WriteFile(tmp, b, 0o644); err != nil {
-		return fmt.Errorf("presets schreiben: %w", err)
+		return fmt.Errorf("write presets: %w", err)
 	}
 	return os.Rename(tmp, s.path)
 }

--- a/internal/shepherd/shepherd.go
+++ b/internal/shepherd/shepherd.go
@@ -1,19 +1,19 @@
-// Package shepherd integriert den STR Agent in den Bose
-// shepherdd Watchdog auf der SoundTouch Box.
+// Package shepherd integrates the STR agent into the Bose
+// shepherdd watchdog on the SoundTouch box.
 //
-// Auf der Box gibt es das Init Skript /etc/init.d/SoundTouch das shepherdd
-// startet. Es liest Config Files aus /var/run/shepherd. Wenn statt dessen
-// /mnt/nv/shepherd als Verzeichnis existiert, wird dieser Pfad genutzt und
-// die Config Files dort werden uebernommen (Override Modus).
+// On the box there is the init script /etc/init.d/SoundTouch that starts
+// shepherdd. It reads config files from /var/run/shepherd. If instead
+// /mnt/nv/shepherd exists as a directory, this path is used and
+// the config files there are picked up (override mode).
 //
-// Dieses Paket pflegt /mnt/nv/shepherd: legt die Standard Symlinks an
-// (core, noncore, product, rhino, hsp) und schreibt unsere eigene
-// Shepherd-streborn.xml. Damit wird unser Agent von shepherdd
-// supervisiert und automatisch neu gestartet wenn er crasht.
+// This package maintains /mnt/nv/shepherd: it creates the standard
+// symlinks (core, noncore, product, rhino, hsp) and writes our own
+// Shepherd-streborn.xml. This way our agent is supervised by shepherdd
+// and automatically restarted if it crashes.
 //
-// Phase 1 (rc.local direct start) und Phase 2 (shepherdd Integration)
-// duerfen NICHT gleichzeitig aktiv sein. install.sh und ggf. dieses Paket
-// muessen das beim Aktivieren sicherstellen.
+// Phase 1 (rc.local direct start) and Phase 2 (shepherdd integration)
+// must NOT be active at the same time. install.sh and possibly this
+// package must ensure that when activating.
 package shepherd
 
 import (
@@ -25,21 +25,21 @@ import (
 	"strings"
 )
 
-// DefaultShepherdDir ist der Override Pfad, den /etc/init.d/SoundTouch erkennt.
+// DefaultShepherdDir is the override path that /etc/init.d/SoundTouch recognizes.
 const DefaultShepherdDir = "/mnt/nv/shepherd"
 
-// DefaultBoseConfigDir ist das Verzeichnis der Bose Standard Configs.
+// DefaultBoseConfigDir is the directory of the Bose standard configs.
 const DefaultBoseConfigDir = "/opt/Bose/etc"
 
-// DefaultStickBin ist der vermutete Pfad zum Agent Binary auf dem USB Stick.
+// DefaultStickBin is the presumed path to the agent binary on the USB stick.
 const DefaultStickBin = "/media/sda1/streborn-armv7l"
 
-// DefaultPresetsPath ist der vermutete Pfad zur presets.json.
+// DefaultPresetsPath is the presumed path to presets.json.
 const DefaultPresetsPath = "/media/sda1/presets.json"
 
-// StandardSymlinks sind die fuenf Bose Configs die wir per Symlink referenzieren
-// muessen damit shepherdd alle Standard Daemons findet. Reihenfolge identisch
-// zum Original Init Skript.
+// StandardSymlinks are the five Bose configs that we must reference via
+// symlink so shepherdd finds all standard daemons. Order identical to
+// the original init script.
 var StandardSymlinks = []string{
 	"Shepherd-core.xml",
 	"Shepherd-noncore.xml",
@@ -48,10 +48,10 @@ var StandardSymlinks = []string{
 	"Shepherd-hsp.xml",
 }
 
-// OwnConfigName ist der Dateiname unserer eigenen Shepherd Config.
+// OwnConfigName is the file name of our own shepherd config.
 const OwnConfigName = "Shepherd-streborn.xml"
 
-// Config beschreibt wie unsere Shepherd Integration aufgesetzt wird.
+// Config describes how our shepherd integration is set up.
 type Config struct {
 	// ShepherdDir, default DefaultShepherdDir.
 	ShepherdDir string
@@ -61,13 +61,13 @@ type Config struct {
 	AgentBinary string
 	// PresetsPath, default DefaultPresetsPath.
 	PresetsPath string
-	// AgentArgs sind die kompletten CLI Argumente die der Agent bekommt.
-	// Wenn nil, wird DefaultAgentArgs verwendet.
+	// AgentArgs are the complete CLI arguments the agent receives.
+	// If nil, DefaultAgentArgs is used.
 	AgentArgs []string
 }
 
-// DefaultAgentArgs sind die Flags die wir dem Agent mitgeben.
-// Identisch zu run.sh damit Phase 1 und Phase 2 austauschbar sind.
+// DefaultAgentArgs are the flags we pass to the agent.
+// Identical to run.sh so phase 1 and phase 2 are interchangeable.
 func DefaultAgentArgs(presetsPath string) []string {
 	return []string{
 		"--presets", presetsPath,
@@ -80,13 +80,13 @@ func DefaultAgentArgs(presetsPath string) []string {
 	}
 }
 
-// Manager kapselt die Operationen Setup, Status, Teardown.
+// Manager encapsulates the operations setup, status, teardown.
 type Manager struct {
 	cfg    Config
 	logger *slog.Logger
 }
 
-// New erstellt einen Manager mit Default Pfaden wenn die Config Felder leer sind.
+// New creates a Manager with default paths if the config fields are empty.
 func New(cfg Config, logger *slog.Logger) *Manager {
 	if cfg.ShepherdDir == "" {
 		cfg.ShepherdDir = DefaultShepherdDir
@@ -109,7 +109,7 @@ func New(cfg Config, logger *slog.Logger) *Manager {
 	return &Manager{cfg: cfg, logger: logger}
 }
 
-// Status beschreibt den aktuellen Zustand der Shepherd Integration.
+// Status describes the current state of the shepherd integration.
 type Status struct {
 	DirExists       bool
 	MissingSymlinks []string
@@ -117,12 +117,12 @@ type Status struct {
 	BrokenSymlinks  []string
 }
 
-// IsHealthy gibt true zurueck wenn die Integration komplett und konsistent ist.
+// IsHealthy returns true if the integration is complete and consistent.
 func (s Status) IsHealthy() bool {
 	return s.DirExists && len(s.MissingSymlinks) == 0 && s.HasOwnConfig && len(s.BrokenSymlinks) == 0
 }
 
-// Check liest den aktuellen Zustand von /mnt/nv/shepherd ohne ihn zu veraendern.
+// Check reads the current state of /mnt/nv/shepherd without changing it.
 func (m *Manager) Check() (Status, error) {
 	var st Status
 
@@ -135,7 +135,7 @@ func (m *Manager) Check() (Status, error) {
 		return st, fmt.Errorf("stat %s: %w", m.cfg.ShepherdDir, err)
 	}
 	if !fi.IsDir() {
-		return st, fmt.Errorf("%s ist keine Directory", m.cfg.ShepherdDir)
+		return st, fmt.Errorf("%s is not a directory", m.cfg.ShepherdDir)
 	}
 	st.DirExists = true
 
@@ -146,20 +146,20 @@ func (m *Manager) Check() (Status, error) {
 			st.MissingSymlinks = append(st.MissingSymlinks, name)
 			continue
 		}
-		// Pruefen ob es ein Symlink ist
+		// Check whether it is a symlink
 		if fi.Mode()&os.ModeSymlink == 0 {
-			// Existiert aber kein Symlink, akzeptieren wir auch (Bose koennte
-			// das selbst eingerichtet haben). Aber wir loggen es als hint.
-			m.logger.Debug("Eintrag ist kein Symlink", "name", name)
+			// Exists but is not a symlink; we accept that too (Bose could
+			// have set it up itself). But we log it as a hint.
+			m.logger.Debug("entry is not a symlink", "name", name)
 			continue
 		}
-		// Target lesen und pruefen ob es existiert
+		// Read the target and check whether it exists
 		target, err := os.Readlink(path)
 		if err != nil {
 			st.BrokenSymlinks = append(st.BrokenSymlinks, name)
 			continue
 		}
-		// Wenn target relativ, gegen ShepherdDir aufloesen
+		// If target is relative, resolve it against ShepherdDir
 		if !filepath.IsAbs(target) {
 			target = filepath.Join(m.cfg.ShepherdDir, target)
 		}
@@ -176,69 +176,69 @@ func (m *Manager) Check() (Status, error) {
 	return st, nil
 }
 
-// Install richtet /mnt/nv/shepherd ein. Idempotent: wenn alles schon passt,
-// wird nichts angefasst.
+// Install sets up /mnt/nv/shepherd. Idempotent: if everything already
+// matches, nothing is touched.
 func (m *Manager) Install() error {
 	if err := os.MkdirAll(m.cfg.ShepherdDir, 0o755); err != nil {
 		return fmt.Errorf("mkdir %s: %w", m.cfg.ShepherdDir, err)
 	}
 
-	// Standard Symlinks anlegen
+	// Create the standard symlinks
 	for _, name := range StandardSymlinks {
 		src := filepath.Join(m.cfg.BoseConfigDir, name)
 		dst := filepath.Join(m.cfg.ShepherdDir, name)
 
 		if _, err := os.Stat(src); err != nil {
-			// Wenn die Bose Config fehlt, Symlink ueberspringen aber nicht
-			// abbrechen. shepherdd ignoriert fehlende Files.
-			m.logger.Warn("Bose Config fehlt, Symlink uebersprungen",
+			// If the Bose config is missing, skip the symlink but do not
+			// abort. shepherdd ignores missing files.
+			m.logger.Warn("Bose config missing, symlink skipped",
 				"src", src, "err", err)
 			continue
 		}
 
-		// Existiert das Ziel schon und zeigt auf src? Dann nichts tun.
+		// Does the target already exist and point to src? Then do nothing.
 		if existing, err := os.Readlink(dst); err == nil && existing == src {
-			m.logger.Debug("Symlink bereits korrekt", "dst", dst)
+			m.logger.Debug("symlink already correct", "dst", dst)
 			continue
 		}
 
-		// Falls dst existiert (Symlink oder Datei), erst entfernen
+		// If dst exists (symlink or file), remove it first
 		_ = os.Remove(dst)
 
 		if err := os.Symlink(src, dst); err != nil {
 			return fmt.Errorf("symlink %s -> %s: %w", dst, src, err)
 		}
-		m.logger.Info("Symlink erstellt", "dst", dst, "src", src)
+		m.logger.Info("symlink created", "dst", dst, "src", src)
 	}
 
-	// Eigene Config schreiben
+	// Write our own config
 	xml := RenderConfig(m.cfg.AgentBinary, m.cfg.AgentArgs)
 	ownPath := filepath.Join(m.cfg.ShepherdDir, OwnConfigName)
 	tmpPath := ownPath + ".new"
 	if err := os.WriteFile(tmpPath, []byte(xml), 0o644); err != nil {
-		return fmt.Errorf("schreibe %s: %w", tmpPath, err)
+		return fmt.Errorf("write %s: %w", tmpPath, err)
 	}
 	if err := os.Rename(tmpPath, ownPath); err != nil {
 		return fmt.Errorf("rename %s -> %s: %w", tmpPath, ownPath, err)
 	}
-	m.logger.Info("Eigene Config geschrieben", "path", ownPath)
+	m.logger.Info("own config written", "path", ownPath)
 
 	return nil
 }
 
-// Uninstall entfernt /mnt/nv/shepherd komplett. Beim naechsten Reboot faellt
-// das Init Skript auf den Default Pfad /var/run/shepherd zurueck, unser
-// Agent startet dann nicht mehr automatisch.
+// Uninstall removes /mnt/nv/shepherd completely. On the next reboot the
+// init script falls back to the default path /var/run/shepherd, and our
+// agent no longer starts automatically.
 func (m *Manager) Uninstall() error {
 	if err := os.RemoveAll(m.cfg.ShepherdDir); err != nil {
-		return fmt.Errorf("entferne %s: %w", m.cfg.ShepherdDir, err)
+		return fmt.Errorf("remove %s: %w", m.cfg.ShepherdDir, err)
 	}
-	m.logger.Info("Shepherd Integration entfernt", "dir", m.cfg.ShepherdDir)
+	m.logger.Info("shepherd integration removed", "dir", m.cfg.ShepherdDir)
 	return nil
 }
 
-// RenderConfig produziert die XML Repraesentation unserer Shepherd Config.
-// Wir bauen es als String weil das XML simpel und uebersichtlich ist.
+// RenderConfig produces the XML representation of our shepherd config.
+// We build it as a string because the XML is simple and easy to read.
 func RenderConfig(binary string, args []string) string {
 	var sb strings.Builder
 	sb.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")
@@ -252,7 +252,7 @@ func RenderConfig(binary string, args []string) string {
 	return sb.String()
 }
 
-// escapeXML escaped die fuenf Standard XML Entitaeten.
+// escapeXML escapes the five standard XML entities.
 func escapeXML(s string) string {
 	r := strings.NewReplacer(
 		"&", "&amp;",

--- a/internal/shepherd/shepherd_test.go
+++ b/internal/shepherd/shepherd_test.go
@@ -68,7 +68,7 @@ func newTestManager(t *testing.T) (*Manager, string) {
 	return New(cfg, newTestLogger()), tmp
 }
 
-func TestRenderConfigWohlgeformt(t *testing.T) {
+func TestRenderConfigWellFormed(t *testing.T) {
 	xmlStr := RenderConfig("/media/sda1/streborn-armv7l",
 		[]string{"--listen-marge", ":8080", "--presets", "/media/sda1/presets.json"})
 
@@ -110,7 +110,7 @@ func TestRenderConfigEscapesXMLSpecials(t *testing.T) {
 	}
 }
 
-func TestCheckLeeresVerzeichnisFehlt(t *testing.T) {
+func TestCheckEmptyDirectoryMissing(t *testing.T) {
 	m, _ := newTestManager(t)
 	st, err := m.Check()
 	if err != nil {

--- a/internal/shepherd/shepherd_test.go
+++ b/internal/shepherd/shepherd_test.go
@@ -15,16 +15,16 @@ func newTestLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
-// skipIfNoSymlinkPrivilege uebergeht Tests die echte Symlinks brauchen.
-// Auf Windows ohne Developer Mode oder Admin Rechte schlaegt os.Symlink fehl.
-// Diese Tests werden auf CI (Linux) und auf der echten Box ohnehin gefahren,
-// daher ist Skip auf Windows ok.
+// skipIfNoSymlinkPrivilege skips tests that need real symlinks.
+// On Windows without Developer Mode or admin rights, os.Symlink fails.
+// These tests run on CI (Linux) and on the real box anyway,
+// so skipping on Windows is fine.
 func skipIfNoSymlinkPrivilege(t *testing.T) {
 	t.Helper()
 	if runtime.GOOS != "windows" {
 		return
 	}
-	// Probehalber einen Test Symlink anlegen
+	// Try creating a test symlink as a probe
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src")
 	dst := filepath.Join(dir, "dst")
@@ -32,11 +32,11 @@ func skipIfNoSymlinkPrivilege(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.Symlink(src, dst); err != nil {
-		t.Skipf("symlinks nicht verfuegbar auf dieser Plattform: %v", err)
+		t.Skipf("symlinks not available on this platform: %v", err)
 	}
 }
 
-// makeBoseConfigs legt simulierte Bose Standard Configs in einem Tempdir an.
+// makeBoseConfigs creates simulated Bose standard configs in a tempdir.
 func makeBoseConfigs(t *testing.T, dir string) {
 	t.Helper()
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -79,24 +79,24 @@ func TestRenderConfigWohlgeformt(t *testing.T) {
 			break
 		}
 		if err != nil {
-			t.Fatalf("XML nicht wohlgeformt: %v\n%s", err, xmlStr)
+			t.Fatalf("XML not well-formed: %v\n%s", err, xmlStr)
 		}
 	}
 	if !strings.Contains(xmlStr, `name="streborn"`) {
-		t.Errorf("daemon name fehlt: %s", xmlStr)
+		t.Errorf("daemon name missing: %s", xmlStr)
 	}
 	if !strings.Contains(xmlStr, `exe="/media/sda1/streborn-armv7l"`) {
-		t.Errorf("exe Pfad fehlt: %s", xmlStr)
+		t.Errorf("exe path missing: %s", xmlStr)
 	}
 	if !strings.Contains(xmlStr, `<arg>:8080</arg>`) {
-		t.Errorf("arg Port fehlt: %s", xmlStr)
+		t.Errorf("arg port missing: %s", xmlStr)
 	}
 }
 
 func TestRenderConfigEscapesXMLSpecials(t *testing.T) {
-	xmlStr := RenderConfig("/bin/test", []string{`--name=<böse>`})
+	xmlStr := RenderConfig("/bin/test", []string{`--name=<bad>`})
 	if !strings.Contains(xmlStr, "&lt;b") || !strings.Contains(xmlStr, "&gt;") {
-		t.Errorf("XML Entities nicht escaped: %s", xmlStr)
+		t.Errorf("XML entities not escaped: %s", xmlStr)
 	}
 	dec := xml.NewDecoder(strings.NewReader(xmlStr))
 	for {
@@ -105,7 +105,7 @@ func TestRenderConfigEscapesXMLSpecials(t *testing.T) {
 			break
 		}
 		if err != nil {
-			t.Fatalf("XML nicht wohlgeformt nach Escape: %v\n%s", err, xmlStr)
+			t.Fatalf("XML not well-formed after escape: %v\n%s", err, xmlStr)
 		}
 	}
 }
@@ -117,13 +117,13 @@ func TestCheckLeeresVerzeichnisFehlt(t *testing.T) {
 		t.Fatal(err)
 	}
 	if st.DirExists {
-		t.Error("DirExists sollte false sein")
+		t.Error("DirExists should be false")
 	}
 	if len(st.MissingSymlinks) != len(StandardSymlinks) {
-		t.Errorf("erwartete %d missing, bekam %d", len(StandardSymlinks), len(st.MissingSymlinks))
+		t.Errorf("expected %d missing, got %d", len(StandardSymlinks), len(st.MissingSymlinks))
 	}
 	if st.IsHealthy() {
-		t.Error("nicht healthy bei leerem Verzeichnis erwartet")
+		t.Error("expected not healthy for an empty directory")
 	}
 }
 
@@ -138,26 +138,26 @@ func TestInstallUndCheck(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !st.IsHealthy() {
-		t.Errorf("nach Install sollte healthy sein, ist %+v", st)
+		t.Errorf("after Install should be healthy, is %+v", st)
 	}
 	if !st.DirExists {
 		t.Error("DirExists nach Install")
 	}
 	if len(st.MissingSymlinks) != 0 {
-		t.Errorf("keine MissingSymlinks nach Install erwartet, bekam %v", st.MissingSymlinks)
+		t.Errorf("expected no MissingSymlinks after Install, got %v", st.MissingSymlinks)
 	}
 	if !st.HasOwnConfig {
 		t.Error("HasOwnConfig nach Install")
 	}
 
-	// Eigene Config Datei muss existieren und korrekt aussehen
+	// Our own config file must exist and look correct
 	ownPath := filepath.Join(m.cfg.ShepherdDir, OwnConfigName)
 	data, err := os.ReadFile(ownPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(string(data), `name="streborn"`) {
-		t.Errorf("daemon name fehlt in %s", ownPath)
+		t.Errorf("daemon name missing in %s", ownPath)
 	}
 }
 
@@ -167,13 +167,13 @@ func TestInstallIdempotent(t *testing.T) {
 	if err := m.Install(); err != nil {
 		t.Fatal(err)
 	}
-	// Modtime der Symlinks merken
+	// Remember the modtime of the symlinks
 	beforeStat, err := os.Lstat(filepath.Join(m.cfg.ShepherdDir, "Shepherd-core.xml"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Nochmal Install, sollte keine Aenderung am Symlink machen
+	// Install again, should make no change to the symlink
 	if err := m.Install(); err != nil {
 		t.Fatal(err)
 	}
@@ -182,33 +182,33 @@ func TestInstallIdempotent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Modtime sollte gleich sein (Symlink nicht angefasst)
+	// Modtime should be the same (symlink not touched)
 	if !beforeStat.ModTime().Equal(afterStat.ModTime()) {
-		t.Error("Symlink wurde erneut angefasst trotz korrektem Stand")
+		t.Error("symlink was touched again despite being in the correct state")
 	}
 }
 
 func TestInstallFehlendeBoseConfigsUebersprungen(t *testing.T) {
 	skipIfNoSymlinkPrivilege(t)
 	m, _ := newTestManager(t)
-	// Eine Bose Config absichtlich loeschen
+	// Intentionally delete one Bose config
 	os.Remove(filepath.Join(m.cfg.BoseConfigDir, "Shepherd-hsp.xml"))
 
 	if err := m.Install(); err != nil {
-		t.Fatalf("Install sollte trotz fehlender Bose Config klappen: %v", err)
+		t.Fatalf("Install should succeed despite the missing Bose config: %v", err)
 	}
 
-	// hsp Symlink darf nicht existieren
+	// The hsp symlink must not exist
 	if _, err := os.Lstat(filepath.Join(m.cfg.ShepherdDir, "Shepherd-hsp.xml")); err == nil {
-		t.Error("Symlink Shepherd-hsp.xml sollte nicht existieren")
+		t.Error("symlink Shepherd-hsp.xml should not exist")
 	}
-	// Andere Symlinks aber schon
+	// But the other symlinks should
 	if _, err := os.Lstat(filepath.Join(m.cfg.ShepherdDir, "Shepherd-core.xml")); err != nil {
-		t.Error("Symlink Shepherd-core.xml sollte existieren")
+		t.Error("symlink Shepherd-core.xml should exist")
 	}
-	// Eigene Config muss da sein
+	// Our own config must be present
 	if _, err := os.Stat(filepath.Join(m.cfg.ShepherdDir, OwnConfigName)); err != nil {
-		t.Error("eigene Config sollte existieren")
+		t.Error("own config should exist")
 	}
 }
 
@@ -222,7 +222,7 @@ func TestUninstall(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(m.cfg.ShepherdDir); !os.IsNotExist(err) {
-		t.Errorf("ShepherdDir sollte weg sein, err=%v", err)
+		t.Errorf("ShepherdDir should be gone, err=%v", err)
 	}
 }
 
@@ -232,8 +232,8 @@ func TestCheckBrokenSymlink(t *testing.T) {
 	if err := m.Install(); err != nil {
 		t.Fatal(err)
 	}
-	// Eine der Bose Configs entfernen NACH dem Install. Damit wird der
-	// Symlink broken.
+	// Remove one of the Bose configs AFTER the install. This makes the
+	// symlink broken.
 	os.Remove(filepath.Join(m.cfg.BoseConfigDir, "Shepherd-rhino.xml"))
 
 	st, err := m.Check()
@@ -241,39 +241,39 @@ func TestCheckBrokenSymlink(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(st.BrokenSymlinks) != 1 || st.BrokenSymlinks[0] != "Shepherd-rhino.xml" {
-		t.Errorf("erwartete genau Shepherd-rhino.xml als broken, bekam %v", st.BrokenSymlinks)
+		t.Errorf("expected exactly Shepherd-rhino.xml as broken, got %v", st.BrokenSymlinks)
 	}
 	if st.IsHealthy() {
-		t.Error("nicht healthy bei broken symlink")
+		t.Error("not healthy with a broken symlink")
 	}
 }
 
 func TestDefaultAgentArgs(t *testing.T) {
 	args := DefaultAgentArgs("/media/sda1/presets.json")
-	// Muss mindestens diese Flags enthalten
+	// Must contain at least these flags
 	required := []string{"--presets", "--listen-webui", "--listen-marge",
 		"--listen-bmx", "--hosts", "--log-level"}
 	have := strings.Join(args, " ")
 	for _, r := range required {
 		if !strings.Contains(have, r) {
-			t.Errorf("Flag %s fehlt in %v", r, args)
+			t.Errorf("flag %s missing in %v", r, args)
 		}
 	}
 }
 
 func TestStatusIsHealthy(t *testing.T) {
 	tests := []struct {
-		name  string
-		st    Status
-		want  bool
+		name string
+		st   Status
+		want bool
 	}{
-		{"alles leer", Status{}, false},
-		{"nur dir", Status{DirExists: true}, false},
-		{"dir + config aber kein Symlinks fehlen",
+		{"all empty", Status{}, false},
+		{"only dir", Status{DirExists: true}, false},
+		{"dir + config but no symlinks missing",
 			Status{DirExists: true, HasOwnConfig: true}, true},
-		{"missing Symlink", Status{DirExists: true, HasOwnConfig: true,
+		{"missing symlink", Status{DirExists: true, HasOwnConfig: true,
 			MissingSymlinks: []string{"x"}}, false},
-		{"broken Symlink", Status{DirExists: true, HasOwnConfig: true,
+		{"broken symlink", Status{DirExists: true, HasOwnConfig: true,
 			BrokenSymlinks: []string{"x"}}, false},
 	}
 	for _, tc := range tests {

--- a/internal/streamproxy/streamproxy.go
+++ b/internal/streamproxy/streamproxy.go
@@ -1,19 +1,19 @@
-// Package streamproxy verpackt fremde Radio Streams in eine stabile
-// URL die Bose's UPnP Player nicht mehr loslassen kann.
+// Package streamproxy wraps third-party radio streams in a stable URL that
+// Bose's UPnP player can no longer let go of.
 //
-// Hintergrund: viele moderne Radiosender (1LIVE, SWR3, Rock Antenne via
-// streamonkey) antworten mit HTTP 302 Redirect auf eine CDN URL mit
-// signed Token. Bose's UPnP Player folgt dem Redirect zwar, behaelt aber
-// die per-Token-URL. Wenn der Token nach einigen Stunden ablaeuft, killt
-// die CDN die Verbindung — Bose merkt das als "Stream tot" und geht in
-// INVALID_SOURCE. User Eindruck: "Sender hoert nach einer Weile auf zu
-// spielen".
+// Background: many modern radio stations (1LIVE, SWR3, Rock Antenne via
+// streamonkey) answer with an HTTP 302 redirect to a CDN URL carrying a
+// signed token. Bose's UPnP player does follow the redirect, but holds on
+// to the per-token URL. When the token expires after a few hours, the CDN
+// kills the connection — Bose registers that as "stream dead" and goes into
+// INVALID_SOURCE. The user's impression: "the station stops playing after a
+// while".
 //
-// Mit diesem Proxy sieht Bose immer dieselbe URL
-// `http://127.0.0.1:8888/stream/<slot>`. Der Stick Agent loest intern
-// den Redirect zur CDN auf und streamt die Bytes durch. Wenn die CDN
-// die Verbindung killt (Token expiry), connectet der Proxy SOFORT
-// neu — Bose's TCP Verbindung bleibt offen, Bose merkt keinen Drop.
+// With this proxy Bose always sees the same URL
+// `http://127.0.0.1:8888/stream/<slot>`. The stick agent internally resolves
+// the redirect to the CDN and streams the bytes through. When the CDN kills
+// the connection (token expiry), the proxy reconnects IMMEDIATELY — Bose's
+// TCP connection stays open, so Bose never notices a drop.
 package streamproxy
 
 import (
@@ -202,7 +202,7 @@ func (s *Server) CurrentTitle() string {
 }
 
 // setTitle records a freshly parsed StreamTitle for url and fires onTitle when
-// it changed to a new non-empty value. Empty titles (StreamTitle='') clear the
+// it changed to a new non-empty value. Empty titles (StreamTitle=”) clear the
 // current title but never fire the push, so a station that briefly sends an
 // empty title does not blank the box display with a spurious update.
 func (s *Server) setTitle(url, title string) {
@@ -243,13 +243,12 @@ func New(store *presets.Store, logger *slog.Logger) *Server {
 	return &Server{
 		store:  store,
 		logger: logger,
-		// Eigener Client damit wir Redirect Verhalten kontrollieren.
-		// Default ist Follow bis 10 — passt fuer Streamonkey & Co.
-		// Kein Timeout: Streams sind endlos, wir lesen bis EOF.
-		// Der DialContext-Guard blockt SSRF-Ziele (loopback/link-local/
-		// metadata) nach der DNS-Aufloesung — eine boesartige
-		// radio-browser-URL kann die Box so nicht auf ihre eigenen
-		// Loopback-Dienste oder Cloud-Metadata zeigen lassen.
+		// Our own client so we control redirect behaviour. The default is
+		// follow up to 10 — fine for Streamonkey & co. No timeout: streams
+		// are endless, we read until EOF. The DialContext guard blocks SSRF
+		// targets (loopback/link-local/metadata) after DNS resolution — a
+		// malicious radio-browser URL therefore cannot point the box at its
+		// own loopback services or cloud metadata.
 		client: &http.Client{
 			Transport: &http.Transport{
 				Proxy:                 http.ProxyFromEnvironment,
@@ -573,8 +572,8 @@ func (s *Server) clearFailure(url string) {
 	s.errMu.Unlock()
 }
 
-// Handler registriert /stream/<slot> sowie /stream/raw fuer ad-hoc URLs
-// (z.B. aus der Radio Suche) auf den uebergebenen Mux.
+// Register registers /stream/<slot> as well as /stream/raw for ad-hoc URLs
+// (e.g. from the radio search) on the supplied mux.
 func (s *Server) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/stream/raw", s.handleRaw)
 	mux.HandleFunc("/stream/", s.handle)
@@ -652,9 +651,9 @@ func (s *Server) handleBitrate(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, `{"bitrate":%d}`, s.CurrentBitrate())
 }
 
-// handleRaw streamt eine beliebige URL durch — vom Radio Suche
-// Play Pfad genutzt damit Bose's UPnP auch HTTPS Streams via uns
-// bekommen kann. URL kommt als ?u=<base64url> Parameter.
+// handleRaw streams an arbitrary URL through — used by the radio search
+// play path so Bose's UPnP can receive HTTPS streams via us as well. The
+// URL arrives as a ?u=<base64url> parameter.
 func (s *Server) handleRaw(w http.ResponseWriter, r *http.Request) {
 	enc := r.URL.Query().Get("u")
 	if enc == "" {
@@ -663,7 +662,7 @@ func (s *Server) handleRaw(w http.ResponseWriter, r *http.Request) {
 	}
 	decoded, err := base64.RawURLEncoding.DecodeString(enc)
 	if err != nil {
-		// Fallback: vielleicht plain URL-encoded
+		// Fallback: maybe plain URL-encoded
 		decoded = []byte(enc)
 	}
 	url := unwrapSelfProxy(string(decoded))
@@ -768,18 +767,17 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Wir machen genau einen GET zum CDN, kopieren bytes auf Bose.
-	// Wenn CDN EOF liefert (Token expiry), reconnecten wir intern und
-	// streamen weiter — Bose's Verbindung bleibt offen. Wir haben einen
-	// generoesen Retry Budget aber bei Client Disconnect (context cancel)
-	// hoeren wir sofort auf — sonst rauschen wir in einer Endlosschleife
-	// gegen den CDN.
+	// We do exactly one GET to the CDN and copy bytes to Bose. When the CDN
+	// returns EOF (token expiry), we reconnect internally and keep streaming —
+	// Bose's connection stays open. We have a generous retry budget, but on a
+	// client disconnect (context cancel) we stop immediately — otherwise we
+	// would charge into an endless loop against the CDN.
 	start := time.Now()
 	s.resetAudioGap()
 	headersSent := false
 	var lastErr error
 	for attempt := 0; attempt < 60; attempt++ {
-		// Wenn Bose die Verbindung beendet hat, sofort raus.
+		// If Bose has closed the connection, bail out immediately.
 		if r.Context().Err() != nil {
 			s.logger.Info("stream proxy end: client gone", "slot", slot, "elapsed", time.Since(start).Round(time.Second).String())
 			return
@@ -790,15 +788,15 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 					"attempt", attempt, "gapMs", gap.Milliseconds(), "lastErr", errStr(lastErr))
 			}
 			s.logger.Info("stream proxy reconnect", "slot", slot, "attempt", attempt, "lastErr", errStr(lastErr))
-			// Kurz warten damit wir CDN nicht mit Reconnects ueberlasten
+			// Wait briefly so we do not overload the CDN with reconnects
 			select {
 			case <-time.After(500 * time.Millisecond):
 			case <-r.Context().Done():
 				return
 			}
 		}
-		// Aktuelle URL holen — User koennte das Preset zwischenzeitlich
-		// geaendert haben.
+		// Fetch the current URL — the user might have changed the preset in
+		// the meantime.
 		cur, ok := s.store.Get(slot)
 		if !ok || cur.StreamURL == "" {
 			return
@@ -806,9 +804,9 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		boseAlive, err := s.streamOne(r.Context(), w, r, unwrapSelfProxy(cur.StreamURL), !headersSent)
 		lastErr = err
 		if !boseAlive {
-			// Bose hat die Verbindung beendet (Standby, Sender Wechsel).
-			// Normales Ende, klar getrennt vom Give-up-Fall unten, damit
-			// im Log Box-Stop vs Outbound-Problem unterscheidbar ist.
+			// Bose closed the connection (standby, station switch). A normal
+			// end, kept clearly distinct from the give-up case below, so the
+			// log can tell a box stop from an outbound problem.
 			s.logger.Info("stream proxy end: bose disconnected", "slot", slot, "elapsed", time.Since(start).Round(time.Second).String(), "lastErr", errStr(err))
 			if s.onDisconnect != nil {
 				s.onDisconnect(err)
@@ -821,18 +819,18 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		}
 		headersSent = true
 	}
-	// 60 Reconnects erschoepft: die Box wollte weiter Bytes, aber der
-	// Upstream scheiterte wiederholt. Ein Netzwerkfehler in lastErr deutet
-	// auf den Outbound-Pfad der Box (z.B. flakiges Kabel) statt auf die Box.
+	// 60 reconnects exhausted: the box still wanted bytes, but upstream
+	// kept failing. A network error in lastErr points at the box's outbound
+	// path (e.g. a flaky cable) rather than the box itself.
 	s.logger.Warn("stream proxy gave up reconnecting", "slot", slot, "attempts", 60, "elapsed", time.Since(start).Round(time.Second).String(), "lastErr", errStr(lastErr))
 }
 
-// streamOne macht einen Roundtrip zum upstream + kopiert Body zu w.
-// Returnt boseAlive=true wenn die Verbindung zu Bose noch offen ist
-// (Reconnect sinnvoll), false wenn Bose disconnected hat. Der zweite
-// Rueckgabewert ist der letzte Upstream-Fehler dieses Versuchs (nil bei
-// sauberem EOF oder normalem Bose-Disconnect); der Aufrufer loggt ihn am
-// Stream-Ende, damit Box-Stop von Outbound-Problemen unterscheidbar ist.
+// streamOne does one round trip to the upstream and copies the body to w.
+// It returns boseAlive=true when the connection to Bose is still open (a
+// reconnect makes sense), false when Bose has disconnected. The second
+// return value is the last upstream error of this attempt (nil on a clean
+// EOF or a normal Bose disconnect); the caller logs it at stream end so a
+// box stop can be told apart from outbound problems.
 func (s *Server) streamOne(ctx context.Context, w http.ResponseWriter, r *http.Request, url string, sendHeaders bool) (bool, error) {
 	if err := safeHTTPURL(url); err != nil {
 		s.logger.Warn("stream proxy refusing url", "url", url, "err", err)
@@ -855,7 +853,7 @@ func (s *Server) streamOne(ctx context.Context, w http.ResponseWriter, r *http.R
 
 	resp, err := s.client.Do(req)
 	if err != nil {
-		// Wenn Bose die Verbindung beendet hat, kein Retry sinnvoll.
+		// If Bose has closed the connection, a retry makes no sense.
 		if errors.Is(err, context.Canceled) || ctx.Err() != nil {
 			return false, nil
 		}
@@ -872,7 +870,7 @@ func (s *Server) streamOne(ctx context.Context, w http.ResponseWriter, r *http.R
 			http.Error(w, "upstream unreachable", http.StatusBadGateway)
 			return false, err
 		}
-		// Headers schon gesendet — Reconnect probieren
+		// Headers already sent — try a reconnect
 		return true, err
 	}
 	defer resp.Body.Close()
@@ -941,7 +939,7 @@ func (s *Server) streamOne(ctx context.Context, w http.ResponseWriter, r *http.R
 
 	if sendHeaders {
 		for k, vv := range resp.Header {
-			// Hop by hop Headers nicht weitergeben
+			// Do not pass hop-by-hop headers through
 			switch strings.ToLower(k) {
 			case "connection", "transfer-encoding":
 				continue
@@ -961,7 +959,7 @@ func (s *Server) streamOne(ctx context.Context, w http.ResponseWriter, r *http.R
 		w.WriteHeader(resp.StatusCode)
 	}
 
-	// Flush kontinuierlich damit Bose's Player nicht auf Buffer wartet
+	// Flush continuously so Bose's player does not wait on a buffer
 	flusher, _ := w.(http.Flusher)
 	// Throughput fallback for stations that send no icy-br and have not
 	// been measured before. The box fills its decode buffer fast at the
@@ -1003,7 +1001,7 @@ func (s *Server) streamOne(ctx context.Context, w http.ResponseWriter, r *http.R
 		n, readErr := src.Read(buf)
 		if n > 0 {
 			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
-				// Bose hat Verbindung geschlossen
+				// Bose closed the connection
 				return false, nil
 			}
 			if flusher != nil {
@@ -1032,7 +1030,7 @@ func (s *Server) streamOne(ctx context.Context, w http.ResponseWriter, r *http.R
 			}
 		}
 		if readErr != nil {
-			// Bose hat zu — KEIN Retry, sonst Endlos Schleife
+			// Bose has closed — NO retry, otherwise an endless loop
 			if errors.Is(readErr, context.Canceled) || ctx.Err() != nil {
 				return false, nil
 			}

--- a/internal/sysinfo/sysinfo.go
+++ b/internal/sysinfo/sysinfo.go
@@ -1,6 +1,6 @@
-// Package sysinfo liest System Informationen aus dem laufenden Linux Kernel,
-// insbesondere die Netzwerk Interfaces. Auf der ST10 brauchen wir die MAC
-// der wlan0 Interface als deviceID die wir in den Marge Antworten ausgeben.
+// Package sysinfo reads system information from the running Linux kernel,
+// in particular the network interfaces. On the ST10 we need the MAC of the
+// wlan0 interface as the deviceID we report in the Marge responses.
 package sysinfo
 
 import (
@@ -10,17 +10,17 @@ import (
 	"strings"
 )
 
-// DefaultInterfaces sind die Interfaces in Reihenfolge die wir fuer die
-// DeviceID priorisieren. wlan0 ist auf der ST10 die primary WLAN
-// Schnittstelle, eth0 ein Fallback wenn jemand die Box per Ethernet
-// angesprochen hat (es gibt ST Soundbars mit eth0).
+// DefaultInterfaces are the interfaces, in order, that we prioritize for
+// the DeviceID. wlan0 is the primary Wi-Fi interface on the ST10, eth0 a
+// fallback if someone reached the box over Ethernet (there are ST
+// soundbars with eth0).
 var DefaultInterfaces = []string{"wlan0", "eth0", "wlan1"}
 
-// DeviceID liefert die MAC der ersten Interface aus prefer als 12 Hex
-// String ohne Doppelpunkte. Wenn keine der Interfaces eine MAC liefert,
-// gibt es einen Fehler.
+// DeviceID returns the MAC of the first interface from prefer as a 12-char
+// hex string without colons. If none of the interfaces yield a MAC, it
+// returns an error.
 //
-// Beispiel: aus "a0:f6:fd:02:ff:d8" wird "DEVICEID_PLACEHOLDER".
+// Example: "a0:f6:fd:02:ff:d8" becomes "DEVICEID_PLACEHOLDER".
 func DeviceID(prefer []string) (string, error) {
 	if prefer == nil {
 		prefer = DefaultInterfaces
@@ -35,7 +35,7 @@ func DeviceID(prefer []string) (string, error) {
 		}
 		return strings.ToUpper(strings.ReplaceAll(mac, ":", "")), nil
 	}
-	// Fallback: alle Interfaces durchgehen und die erste non zero MAC nehmen
+	// Fallback: walk all interfaces and take the first non-zero MAC
 	ifaces, err := net.Interfaces()
 	if err != nil {
 		return "", fmt.Errorf("read interfaces: %w", err)
@@ -44,7 +44,7 @@ func DeviceID(prefer []string) (string, error) {
 		if len(iface.HardwareAddr) == 0 {
 			continue
 		}
-		// Loopback ueberspringen
+		// Skip loopback
 		if iface.Flags&net.FlagLoopback != 0 {
 			continue
 		}
@@ -54,11 +54,11 @@ func DeviceID(prefer []string) (string, error) {
 		}
 		return strings.ToUpper(strings.ReplaceAll(mac, ":", "")), nil
 	}
-	return "", errors.New("keine MAC Adresse gefunden")
+	return "", errors.New("no MAC address found")
 }
 
-// MACOf liefert die MAC der genannten Interface als Lowercase mit Doppelpunkten.
-// Leerer String wenn die Interface zwar existiert aber keine MAC hat (selten).
+// MACOf returns the MAC of the named interface as lowercase with colons.
+// Empty string if the interface exists but has no MAC (rare).
 func MACOf(name string) (string, error) {
 	iface, err := net.InterfaceByName(name)
 	if err != nil {
@@ -70,7 +70,7 @@ func MACOf(name string) (string, error) {
 	return iface.HardwareAddr.String(), nil
 }
 
-// IPOf liefert die erste globale IPv4 der Interface oder leeren String.
+// IPOf returns the first global IPv4 of the interface, or an empty string.
 func IPOf(name string) (string, error) {
 	iface, err := net.InterfaceByName(name)
 	if err != nil {

--- a/internal/sysinfo/sysinfo_test.go
+++ b/internal/sysinfo/sysinfo_test.go
@@ -7,12 +7,12 @@ import (
 )
 
 func TestDeviceIDFallback(t *testing.T) {
-	// Suche nach einer realen Interface die wir im Test verifizieren koennen.
-	// Wir koennen kein wlan0 erwarten (z.B. CI Linux), aber irgendeine Interface
-	// mit echter MAC ist normalerweise da (eth0 auf Linux, vEthernet auf Win).
+	// Look for a real interface we can verify in the test. We cannot expect
+	// wlan0 (e.g. CI Linux), but some interface with a real MAC is normally
+	// present (eth0 on Linux, vEthernet on Windows).
 	ifaces, err := net.Interfaces()
 	if err != nil {
-		t.Skipf("kann Interfaces nicht lesen: %v", err)
+		t.Skipf("cannot read interfaces: %v", err)
 	}
 
 	haveAnyMAC := false
@@ -26,46 +26,46 @@ func TestDeviceIDFallback(t *testing.T) {
 		}
 	}
 	if !haveAnyMAC {
-		t.Skip("keine Interface mit MAC vorhanden")
+		t.Skip("no interface with a MAC present")
 	}
 
-	// Wir geben absichtlich nicht existierende Interface Praeferenzen, damit
-	// der Fallback Pfad genommen wird.
-	id, err := DeviceID([]string{"intf-existiert-nicht"})
+	// We deliberately pass non-existent interface preferences so the
+	// fallback path is taken.
+	id, err := DeviceID([]string{"intf-does-not-exist"})
 	if err != nil {
-		t.Fatalf("DeviceID Fallback fehlgeschlagen: %v", err)
+		t.Fatalf("DeviceID fallback failed: %v", err)
 	}
 	if len(id) != 12 {
-		t.Errorf("DeviceID Laenge falsch, got %d (%s)", len(id), id)
+		t.Errorf("DeviceID length wrong, got %d (%s)", len(id), id)
 	}
-	// Muss Uppercase Hex sein
+	// Must be uppercase hex
 	for _, r := range id {
 		if (r < '0' || r > '9') && (r < 'A' || r > 'F') {
-			t.Errorf("DeviceID enthaelt non hex: %s", id)
+			t.Errorf("DeviceID contains non-hex: %s", id)
 			break
 		}
 	}
 	if strings.Contains(id, ":") {
-		t.Errorf("DeviceID enthaelt Doppelpunkte: %s", id)
+		t.Errorf("DeviceID contains colons: %s", id)
 	}
 }
 
 func TestDeviceIDOhneTreffer(t *testing.T) {
-	// Wenn wir zwingen koennten dass nichts gefunden wird... das geht nicht
-	// portabel ohne Mock. Wir testen daher nur den happy path oben.
-	t.Skip("Negativ Test braucht Mocking, ausgelassen")
+	// If we could force a no-match... that is not portable without a mock,
+	// so we only test the happy path above.
+	t.Skip("negative test needs mocking, skipped")
 }
 
 func TestMACOfFehler(t *testing.T) {
 	_, err := MACOf("nichtexistierende-interface-xyz")
 	if err == nil {
-		t.Error("erwartete Fehler bei nicht existierender Interface")
+		t.Error("expected an error for a non-existent interface")
 	}
 }
 
 func TestIPOfFehler(t *testing.T) {
 	_, err := IPOf("nichtexistierende-interface-xyz")
 	if err == nil {
-		t.Error("erwartete Fehler bei nicht existierender Interface")
+		t.Error("expected an error for a non-existent interface")
 	}
 }

--- a/internal/sysinfo/sysinfo_test.go
+++ b/internal/sysinfo/sysinfo_test.go
@@ -50,20 +50,20 @@ func TestDeviceIDFallback(t *testing.T) {
 	}
 }
 
-func TestDeviceIDOhneTreffer(t *testing.T) {
+func TestDeviceIDNoMatch(t *testing.T) {
 	// If we could force a no-match... that is not portable without a mock,
 	// so we only test the happy path above.
 	t.Skip("negative test needs mocking, skipped")
 }
 
-func TestMACOfFehler(t *testing.T) {
+func TestMACOfError(t *testing.T) {
 	_, err := MACOf("nichtexistierende-interface-xyz")
 	if err == nil {
 		t.Error("expected an error for a non-existent interface")
 	}
 }
 
-func TestIPOfFehler(t *testing.T) {
+func TestIPOfError(t *testing.T) {
 	_, err := IPOf("nichtexistierende-interface-xyz")
 	if err == nil {
 		t.Error("expected an error for a non-existent interface")

--- a/internal/tlsgen/tlsgen.go
+++ b/internal/tlsgen/tlsgen.go
@@ -1,19 +1,19 @@
-// Package tlsgen erstellt und verwaltet die selbst signierten Zertifikate
-// fuer die TLS Termination der Bose Cloud Domains.
+// Package tlsgen creates and manages the self-signed certificates
+// for the TLS termination of the Bose cloud domains.
 //
-// Konzept:
+// Concept:
 //
-//  1. Beim ersten Start wird eine Root CA generiert und in /mnt/nv/...
-//     persistiert (siehe DefaultCADir).
-//  2. Mit dieser Root CA wird ein Server Cert signiert das die Bose Cloud
-//     Domains als SubjectAltNames enthaelt (streaming.bose.com,
+//  1. On the first start a root CA is generated and persisted in
+//     /mnt/nv/... (see DefaultCADir).
+//  2. With this root CA a server cert is signed that contains the Bose
+//     cloud domains as SubjectAltNames (streaming.bose.com,
 //     content.api.bose.io, events.api.bosecm.com, worldwide.bose.com).
-//  3. Bei weiteren Starts werden die Files geladen statt neu generiert.
+//  3. On subsequent starts the files are loaded instead of regenerated.
 //
-// Damit die Bose Box unsere Certs akzeptiert, muss die Root CA als
-// vertrauenswuerdig im System Trust Store eingetragen sein. Das macht
-// das setup-tls.sh Skript via bind mount auf /etc/ssl/certs/ca-certificates.crt
-// und /etc/pki/tls/certs/ca-bundle.crt.
+// For the Bose box to accept our certs, the root CA must be entered as
+// trusted in the system trust store. The setup-tls.sh script does that
+// via a bind mount onto /etc/ssl/certs/ca-certificates.crt
+// and /etc/pki/tls/certs/ca-bundle.crt.
 package tlsgen
 
 import (
@@ -33,11 +33,11 @@ import (
 	"time"
 )
 
-// DefaultCADir ist der Persistenz Pfad auf der Box.
+// DefaultCADir is the persistence path on the box.
 const DefaultCADir = "/mnt/nv/streborn/ca"
 
-// DefaultDomains sind die SANs die das Server Cert abdeckt. Identisch zu
-// internal/hosts.DefaultEntries damit alles passt.
+// DefaultDomains are the SANs the server cert covers. Identical to
+// internal/hosts.DefaultEntries so everything matches.
 var DefaultDomains = []string{
 	"streaming.bose.com",
 	"content.api.bose.io",
@@ -73,7 +73,7 @@ var (
 	notAfterFixed  = time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
 )
 
-// Bundle haelt die geladenen Zertifikate und Keys zusammen.
+// Bundle holds the loaded certificates and keys together.
 type Bundle struct {
 	RootCAPEM     []byte
 	RootKeyPEM    []byte
@@ -81,21 +81,21 @@ type Bundle struct {
 	ServerKeyPEM  []byte
 }
 
-// TLSCert wandelt das Server Cert plus Key in ein tls.Certificate fuer
-// die direkte Verwendung im http.Server.
+// TLSCert converts the server cert plus key into a tls.Certificate for
+// direct use in the http.Server.
 func (b *Bundle) TLSCert() (tls.Certificate, error) {
 	return tls.X509KeyPair(b.ServerCertPEM, b.ServerKeyPEM)
 }
 
-// Manager kapselt das Laden und ggf. Generieren der Cert Files.
+// Manager encapsulates loading and, if needed, generating the cert files.
 type Manager struct {
 	dir     string
 	domains []string
 	logger  *slog.Logger
 }
 
-// New erstellt einen Manager. Wenn dir leer ist wird DefaultCADir genommen.
-// Wenn domains leer ist DefaultDomains.
+// New creates a Manager. If dir is empty, DefaultCADir is used.
+// If domains is empty, DefaultDomains is used.
 func New(dir string, domains []string, logger *slog.Logger) *Manager {
 	if dir == "" {
 		dir = DefaultCADir
@@ -109,8 +109,8 @@ func New(dir string, domains []string, logger *slog.Logger) *Manager {
 	return &Manager{dir: dir, domains: domains, logger: logger}
 }
 
-// EnsureBundle laedt die Bundle aus dem Verzeichnis oder generiert ein neues
-// wenn nichts da ist. Idempotent.
+// EnsureBundle loads the bundle from the directory or generates a new one
+// if nothing is there. Idempotent.
 //
 // Also re-generates an existing bundle if its server cert was signed
 // with the old "now + 9y" scheme and now has NotAfter in the past or
@@ -182,8 +182,8 @@ func (m *Manager) bundleNeedsRegen(b *Bundle) bool {
 	return cert.NotAfter.Before(threshold)
 }
 
-// load liest alle vier Files aus dem Verzeichnis. ErrNotExist wenn auch nur
-// eine Datei fehlt.
+// load reads all four files from the directory. ErrNotExist if even a
+// single file is missing.
 func (m *Manager) load() (*Bundle, error) {
 	bundle := &Bundle{}
 	files := []struct {
@@ -205,7 +205,7 @@ func (m *Manager) load() (*Bundle, error) {
 	return bundle, nil
 }
 
-// save schreibt das Bundle auf die Platte mit restriktiven Permissions.
+// save writes the bundle to disk with restrictive permissions.
 func (m *Manager) save(b *Bundle) error {
 	if err := os.MkdirAll(m.dir, 0o700); err != nil {
 		return err
@@ -233,9 +233,9 @@ func (m *Manager) save(b *Bundle) error {
 	return nil
 }
 
-// generate erzeugt ein komplett neues Bundle.
+// generate produces a completely new bundle.
 func (m *Manager) generate() (*Bundle, error) {
-	// Root CA Schluessel
+	// Root CA key
 	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("root key: %w", err)
@@ -263,7 +263,7 @@ func (m *Manager) generate() (*Bundle, error) {
 		return nil, fmt.Errorf("sign root CA: %w", err)
 	}
 
-	// Server Schluessel
+	// Server key
 	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("server key: %w", err)
@@ -284,7 +284,7 @@ func (m *Manager) generate() (*Bundle, error) {
 		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		DNSNames:    m.domains,
 	}
-	// Mit Root CA signieren
+	// Sign with the root CA
 	rootCert, err := x509.ParseCertificate(rootDER)
 	if err != nil {
 		return nil, fmt.Errorf("parse root cert: %w", err)
@@ -294,7 +294,7 @@ func (m *Manager) generate() (*Bundle, error) {
 		return nil, fmt.Errorf("sign server cert: %w", err)
 	}
 
-	// PEM kodieren
+	// PEM encode
 	bundle := &Bundle{
 		RootCAPEM:     pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootDER}),
 		ServerCertPEM: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverDER}),

--- a/internal/tlsgen/tlsgen_test.go
+++ b/internal/tlsgen/tlsgen_test.go
@@ -32,22 +32,22 @@ func TestEnsureBundleGeneriertNeu(t *testing.T) {
 	}
 	if len(bundle.RootCAPEM) == 0 || len(bundle.RootKeyPEM) == 0 ||
 		len(bundle.ServerCertPEM) == 0 || len(bundle.ServerKeyPEM) == 0 {
-		t.Fatal("Bundle hat leere Felder")
+		t.Fatal("bundle has empty fields")
 	}
 	for _, name := range []string{rootCAFile, rootKeyFile, serverCertFile, serverKeyFile} {
 		path := filepath.Join(m.dir, name)
 		fi, err := os.Stat(path)
 		if err != nil {
-			t.Errorf("Datei nicht gefunden: %s, err=%v", path, err)
+			t.Errorf("file not found: %s, err=%v", path, err)
 			continue
 		}
-		// Key Files muessen restriktiv sein (0600).
-		// Auf Windows werden die Permissions nicht so umgesetzt, daher
-		// dort den Check ueberspringen.
+		// Key files must be restrictive (0600).
+		// On Windows the permissions are not applied this way, so
+		// skip the check there.
 		if name == rootKeyFile || name == serverKeyFile {
 			mode := fi.Mode().Perm()
 			if mode != 0o600 && mode != 0o666 {
-				t.Logf("WARN %s Permissions %v (Windows toleriert)", name, mode)
+				t.Logf("WARN %s permissions %v (tolerated on Windows)", name, mode)
 			}
 		}
 	}
@@ -70,10 +70,10 @@ func TestEnsureBundleIdempotent(t *testing.T) {
 		t.Error("second EnsureBundle on fresh bundle should not report regenerated")
 	}
 	if string(first.RootCAPEM) != string(second.RootCAPEM) {
-		t.Error("RootCA wurde neu generiert beim zweiten Aufruf")
+		t.Error("RootCA was regenerated on the second call")
 	}
 	if string(first.ServerCertPEM) != string(second.ServerCertPEM) {
-		t.Error("Server Cert wurde neu generiert beim zweiten Aufruf")
+		t.Error("server cert was regenerated on the second call")
 	}
 }
 
@@ -88,10 +88,10 @@ func TestBundleTLSCert(t *testing.T) {
 		t.Fatalf("TLSCert: %v", err)
 	}
 	if cert.Certificate == nil {
-		t.Error("kein Certificate in tls.Certificate")
+		t.Error("no Certificate in tls.Certificate")
 	}
 	if cert.PrivateKey == nil {
-		t.Error("kein PrivateKey in tls.Certificate")
+		t.Error("no PrivateKey in tls.Certificate")
 	}
 }
 
@@ -104,7 +104,7 @@ func TestServerCertVertrauenswuerdigKette(t *testing.T) {
 
 	pool := x509.NewCertPool()
 	if !pool.AppendCertsFromPEM(bundle.RootCAPEM) {
-		t.Fatal("RootCA nicht parsebar")
+		t.Fatal("RootCA not parsable")
 	}
 	serverCert, err := parseFirstCert(bundle.ServerCertPEM)
 	if err != nil {
@@ -114,7 +114,7 @@ func TestServerCertVertrauenswuerdigKette(t *testing.T) {
 	for _, dns := range []string{"streaming.bose.com", "content.api.bose.io"} {
 		opts := x509.VerifyOptions{Roots: pool, DNSName: dns}
 		if _, err := serverCert.Verify(opts); err != nil {
-			t.Errorf("Verify fuer %s fehlgeschlagen: %v", dns, err)
+			t.Errorf("Verify for %s failed: %v", dns, err)
 		}
 	}
 }
@@ -130,11 +130,11 @@ func TestServerCertGueltigkeit(t *testing.T) {
 		t.Fatal(err)
 	}
 	if cert.NotBefore.After(time.Now()) {
-		t.Errorf("NotBefore in der Zukunft: %v", cert.NotBefore)
+		t.Errorf("NotBefore in the future: %v", cert.NotBefore)
 	}
-	// Mindestens 8 Jahre gueltig
+	// Valid for at least 8 years
 	if cert.NotAfter.Before(time.Now().Add(8 * 365 * 24 * time.Hour)) {
-		t.Errorf("NotAfter zu kurz: %v", cert.NotAfter)
+		t.Errorf("NotAfter too short: %v", cert.NotAfter)
 	}
 }
 
@@ -149,7 +149,7 @@ func TestRootCAIstCA(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !root.IsCA {
-		t.Error("Root Cert hat IsCA=false")
+		t.Error("root cert has IsCA=false")
 	}
 	if root.KeyUsage&x509.KeyUsageCertSign == 0 {
 		t.Error("root cert cannot sign")
@@ -171,7 +171,7 @@ func TestServerCertHatSANs(t *testing.T) {
 		have[n] = true
 	}
 	if !have["streaming.bose.com"] || !have["content.api.bose.io"] {
-		t.Errorf("SAN fehlt: %v", cert.DNSNames)
+		t.Errorf("SAN missing: %v", cert.DNSNames)
 	}
 }
 
@@ -365,13 +365,13 @@ func TestRefreshTrustStoreSkipsMissingTargets(t *testing.T) {
 	}
 }
 
-// parseFirstCert dekodiert das erste CERTIFICATE Block aus pemData.
+// parseFirstCert decodes the first CERTIFICATE block from pemData.
 func parseFirstCert(pemData []byte) (*x509.Certificate, error) {
 	rest := pemData
 	for {
 		block, r := pem.Decode(rest)
 		if block == nil {
-			return nil, errors.New("kein CERTIFICATE Block im PEM")
+			return nil, errors.New("no CERTIFICATE block in PEM")
 		}
 		if block.Type == "CERTIFICATE" {
 			return x509.ParseCertificate(block.Bytes)

--- a/internal/tlsgen/tlsgen_test.go
+++ b/internal/tlsgen/tlsgen_test.go
@@ -24,7 +24,7 @@ func newTestManager(t *testing.T) *Manager {
 	return New(dir, []string{"streaming.bose.com", "content.api.bose.io"}, logger)
 }
 
-func TestEnsureBundleGeneriertNeu(t *testing.T) {
+func TestEnsureBundleGeneratesNew(t *testing.T) {
 	m := newTestManager(t)
 	bundle, _, err := m.EnsureBundle()
 	if err != nil {
@@ -119,7 +119,7 @@ func TestServerCertVertrauenswuerdigKette(t *testing.T) {
 	}
 }
 
-func TestServerCertGueltigkeit(t *testing.T) {
+func TestServerCertValidity(t *testing.T) {
 	m := newTestManager(t)
 	bundle, _, err := m.EnsureBundle()
 	if err != nil {

--- a/internal/tlsgen/truststore.go
+++ b/internal/tlsgen/truststore.go
@@ -7,43 +7,41 @@ import (
 	"os"
 )
 
-// DefaultTrustStorePaths sind die System Trust Store Files die wir auf
-// der Box ueber bind mount mit unserer Root CA erweitern. Beide werden
-// von unterschiedlichen Bose Komponenten gelesen (libcurl vs. openssl),
-// daher beide patchen.
+// DefaultTrustStorePaths are the system trust store files that we
+// extend on the box with our root CA via bind mount. Both are read
+// by different Bose components (libcurl vs. openssl), so we patch both.
 var DefaultTrustStorePaths = []string{
 	"/etc/pki/tls/certs/ca-bundle.crt",
 	"/etc/ssl/certs/ca-certificates.crt",
 }
 
-// trustStoreMarkerBegin / End umklammern unseren Append Block, damit
-// RefreshTrustStore beim Re-Apply den vorherigen Block erkennen und
-// ueberspringen kann (Idempotenz). Marker bewusst auffaellig formuliert
-// damit Operator beim Debuggen mit `cat` direkt sieht was passiert ist.
+// trustStoreMarkerBegin / End bracket our append block so that
+// RefreshTrustStore can detect and skip the previous block on re-apply
+// (idempotency). The markers are deliberately conspicuous so an
+// operator debugging with `cat` immediately sees what happened.
 const (
 	trustStoreMarkerBegin = "# >>> STR Root CA (refresh) >>>"
 	trustStoreMarkerEnd   = "# <<< STR Root CA (refresh) <<<"
 )
 
-// RefreshTrustStore haengt die uebergebene Root CA an die bind-gemounteten
-// Trust Store Overlays an. Wird aufgerufen wenn EnsureBundle eine alte
-// CA durch eine frisch generierte ersetzt hat — sonst zeigt der Trust
-// Store noch die alte CA und Bose verwirft unsere Server Cert mit
+// RefreshTrustStore appends the given root CA to the bind-mounted
+// trust store overlays. It is called when EnsureBundle has replaced an
+// old CA with a freshly generated one — otherwise the trust store
+// still shows the old CA and Bose rejects our server cert with
 // `tls: unknown certificate authority` (#60 .180 and #80 .144).
 //
-// Wir schreiben mit O_APPEND damit der Inode erhalten bleibt und der
-// bestehende bind mount den neuen Inhalt sofort sieht — kein umount,
-// kein remount, keine Race mit Bose Prozessen die das File bereits
-// geoeffnet haben.
+// We write with O_APPEND so the inode is preserved and the existing
+// bind mount sees the new content immediately — no umount, no remount,
+// no race with Bose processes that already have the file open.
 //
-// Idempotent: enthaelt das Overlay bereits den exakten PEM Block den
-// wir anhaengen wuerden, ueberspringen wir das Ziel. Damit kostet ein
-// erneuter Aufruf (z.B. nach noch einem Cold Boot) nichts.
+// Idempotent: if the overlay already contains the exact PEM block we
+// would append, we skip the target. So a repeated call (e.g. after yet
+// another cold boot) costs nothing.
 //
-// Best-effort: ein Ziel das nicht existiert oder nicht beschreibbar
-// ist wird als WARN geloggt aber blockiert die anderen Ziele nicht.
-// Im Dev / Test Build (kein /etc auf der Host Platte beschreibbar)
-// loggt das Funktionsergebnis sauber ohne den Agent zu killen.
+// Best-effort: a target that does not exist or is not writable is
+// logged as WARN but does not block the other targets. In the
+// dev / test build (no /etc writable on the host disk) the function
+// result is logged cleanly without killing the agent.
 func RefreshTrustStore(rootCAPEM []byte, logger *slog.Logger) error {
 	return refreshTrustStorePaths(rootCAPEM, DefaultTrustStorePaths, logger)
 }
@@ -73,8 +71,8 @@ func refreshTrustStorePaths(rootCAPEM []byte, paths []string, logger *slog.Logge
 	return nil
 }
 
-// appendRootIfNew haengt rootCAPEM mit Marker Block an target an, es sei
-// denn target enthaelt bereits exakt dieses PEM zwischen den Markern.
+// appendRootIfNew appends rootCAPEM with a marker block to target,
+// unless target already contains exactly this PEM between the markers.
 func appendRootIfNew(target string, rootCAPEM []byte) error {
 	current, err := os.ReadFile(target)
 	if err != nil {
@@ -95,24 +93,24 @@ func appendRootIfNew(target string, rootCAPEM []byte) error {
 	return nil
 }
 
-// containsRootBlock prueft ob current bereits einen Marker Block mit
-// exakt dem uebergebenen PEM enthaelt. Vergleich ueber bytes.Contains
-// statt PEM-Parsing, weil ein Marker Match plus exakter PEM Substring
-// fuer Idempotenz reicht (wir schreiben den Block immer in der gleichen
-// kanonischen Form).
+// containsRootBlock checks whether current already contains a marker
+// block with exactly the given PEM. Comparison via bytes.Contains
+// instead of PEM parsing, because a marker match plus an exact PEM
+// substring is enough for idempotency (we always write the block in
+// the same canonical form).
 func containsRootBlock(current, rootCAPEM []byte) bool {
 	needle := buildAppendBlock(rootCAPEM)
 	return bytes.Contains(current, needle)
 }
 
-// buildAppendBlock formatiert den Append Block kanonisch:
+// buildAppendBlock formats the append block canonically:
 //
 //	\n# >>> STR Root CA (refresh) >>>\n
 //	<PEM>
 //	# <<< STR Root CA (refresh) <<<\n
 //
-// Das fuehrende \n verhindert dass der Marker an die letzte Zeile des
-// bestehenden Bundles geklebt wird (manche Bundles enden ohne Newline).
+// The leading \n prevents the marker from being glued to the last line
+// of the existing bundle (some bundles end without a newline).
 func buildAppendBlock(rootCAPEM []byte) []byte {
 	var b bytes.Buffer
 	b.WriteByte('\n')

--- a/internal/upnp/upnp.go
+++ b/internal/upnp/upnp.go
@@ -1,6 +1,6 @@
-// Package upnp ist ein minimaler UPnP AVTransport Control Point.
-// Er reicht um einen Stream URL an einen DLNA Media Renderer (z.B. die
-// Bose SoundTouch) zu schicken und Play/Pause/Stop zu steuern.
+// Package upnp is a minimal UPnP AVTransport control point.
+// It is enough to send a stream URL to a DLNA media renderer (e.g. the
+// Bose SoundTouch) and to control play/pause/stop.
 package upnp
 
 import (
@@ -15,18 +15,18 @@ import (
 	"github.com/JRpersonal/streborn/internal/netutil"
 )
 
-// Renderer haelt die Adresse eines AVTransport Endpoints.
+// Renderer holds the address of an AVTransport endpoint.
 type Renderer struct {
-	// ControlURL ist die volle URL des AVTransport Control Endpoints,
-	// z.B. http://192.0.2.66:8091/AVTransport/Control
+	// ControlURL is the full URL of the AVTransport control endpoint,
+	// e.g. http://192.0.2.66:8091/AVTransport/Control
 	ControlURL string
 
-	// Client wird fuer alle SOAP Requests verwendet. Wenn nil, http.DefaultClient.
+	// Client is used for all SOAP requests. If nil, http.DefaultClient.
 	Client *http.Client
 }
 
-// NewBoseRenderer liefert einen Renderer fuer die typische Bose SoundTouch
-// UPnP Konfiguration auf Port 8091.
+// NewBoseRenderer returns a Renderer for the typical Bose SoundTouch
+// UPnP configuration on port 8091.
 func NewBoseRenderer(host string) *Renderer {
 	return &Renderer{
 		ControlURL: fmt.Sprintf("http://%s:8091/AVTransport/Control", host),
@@ -34,14 +34,14 @@ func NewBoseRenderer(host string) *Renderer {
 	}
 }
 
-// SetURI laedt eine neue Stream URL in den Renderer.
-// metaTitle wird im DIDL-Lite Metadata als Track Name eingebettet, iconURL
-// wird als upnp:albumArtURI mitgegeben damit die SoundTouch Box das
-// Sender Logo in ihrer Now Playing Anzeige zeigt.
+// SetURI loads a new stream URL into the renderer.
+// metaTitle is embedded in the DIDL-Lite metadata as the track name, iconURL
+// is passed as upnp:albumArtURI so the SoundTouch box shows the station logo
+// in its now-playing display.
 //
-// iconURL kann eine pipe-separierte Kette von Fallback URLs sein (so
-// persistieren wir das im preset.art). Die Box bekommt nur den ersten
-// Eintrag — der Rest ist Frontend Fallback Material.
+// iconURL can be a pipe-separated chain of fallback URLs (that is how we
+// persist it in preset.art). The box only gets the first entry — the rest is
+// frontend fallback material.
 func (r *Renderer) SetURI(ctx context.Context, streamURL, metaTitle, iconURL string) error {
 	if idx := strings.Index(iconURL, "|"); idx >= 0 {
 		iconURL = iconURL[:idx]
@@ -52,27 +52,27 @@ func (r *Renderer) SetURI(ctx context.Context, streamURL, metaTitle, iconURL str
 	return r.soapCall(ctx, "SetAVTransportURI", body)
 }
 
-// Play startet die Wiedergabe.
+// Play starts playback.
 func (r *Renderer) Play(ctx context.Context) error {
 	body := `<?xml version="1.0"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:Play xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><Speed>1</Speed></u:Play></s:Body></s:Envelope>`
 	return r.soapCall(ctx, "Play", body)
 }
 
-// Pause haelt die Wiedergabe an.
+// Pause halts playback.
 func (r *Renderer) Pause(ctx context.Context) error {
 	body := `<?xml version="1.0"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:Pause xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID></u:Pause></s:Body></s:Envelope>`
 	return r.soapCall(ctx, "Pause", body)
 }
 
-// Stop beendet die Wiedergabe.
+// Stop ends playback.
 func (r *Renderer) Stop(ctx context.Context) error {
 	body := `<?xml version="1.0"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:Stop xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID></u:Stop></s:Body></s:Envelope>`
 	return r.soapCall(ctx, "Stop", body)
 }
 
-// PlayURL ist eine Convenience Methode: setzt URI und drueckt Play.
-// iconURL ist optional; wenn gesetzt wird es als albumArtURI an die Box
-// gegeben damit sie das Sender Logo anzeigt.
+// PlayURL is a convenience method: sets the URI and presses Play.
+// iconURL is optional; when set it is passed to the box as albumArtURI so
+// it shows the station logo.
 func (r *Renderer) PlayURL(ctx context.Context, streamURL, title, iconURL string) error {
 	resolved, _ := ResolveStreamURL(ctx, streamURL)
 	if resolved != "" && resolved != streamURL {
@@ -112,27 +112,27 @@ func (r *Renderer) PlayURLMime(ctx context.Context, streamURL, title, iconURL, m
 	return nil
 }
 
-// ResolveStreamURL bereitet eine Sender URL fuer die Box vor:
+// ResolveStreamURL prepares a station URL for the box:
 //
-//  1. Bei Playlist Endungen (.pls / .m3u) wird die enthaltene Stream
-//     URL extrahiert (Box kann Playlist Dateien nicht abspielen).
-//  2. Bei HTTPS URLs wird versucht die HTTP Variante zu nutzen wenn
-//     sie antwortet. Bose UPnP Renderer hat oft Probleme mit HTTPS
-//     Streams (Cert Chain, TLS Version) und liefert dann SOAP 402.
-//  3. Sonst die Original URL.
+//  1. For playlist extensions (.pls / .m3u) the contained stream URL is
+//     extracted (the box cannot play playlist files).
+//  2. For HTTPS URLs it tries to use the HTTP variant if it answers. The
+//     Bose UPnP renderer often has trouble with HTTPS streams (cert
+//     chain, TLS version) and then returns SOAP 402.
+//  3. Otherwise the original URL.
 func ResolveStreamURL(ctx context.Context, u string) (string, error) {
 	if u == "" {
 		return "", nil
 	}
 	lower := strings.ToLower(u)
-	// 1) Playlist Endungen aufloesen
+	// 1) Resolve playlist extensions
 	if strings.Contains(lower, ".pls") || strings.Contains(lower, ".m3u") {
 		if resolved := extractStreamFromPlaylist(ctx, u); resolved != "" {
 			u = resolved
 			lower = strings.ToLower(u)
 		}
 	}
-	// 2) HTTPS → HTTP Fallback wenn der Host auch ueber HTTP antwortet
+	// 2) HTTPS -> HTTP fallback if the host also answers over HTTP
 	if strings.HasPrefix(lower, "https://") {
 		httpVar := "http://" + u[len("https://"):]
 		if isStreamReachable(ctx, httpVar) {
@@ -142,8 +142,8 @@ func ResolveStreamURL(ctx context.Context, u string) (string, error) {
 	return u, nil
 }
 
-// extractStreamFromPlaylist laedt eine .pls / .m3u Datei und gibt die
-// erste Stream URL zurueck. Leer wenn nichts gefunden / Fehler.
+// extractStreamFromPlaylist loads a .pls / .m3u file and returns the
+// first stream URL. Empty if nothing is found / on error.
 func extractStreamFromPlaylist(ctx context.Context, u string) string {
 	if err := netutil.SafeHTTPURL(u); err != nil {
 		return ""
@@ -180,8 +180,8 @@ func extractStreamFromPlaylist(ctx context.Context, u string) string {
 	return ""
 }
 
-// isStreamReachable prueft mit GET Range 0-0 ob der Server antwortet.
-// HEAD wird von vielen Streaming Servern nicht unterstuetzt.
+// isStreamReachable checks with GET Range 0-0 whether the server answers.
+// HEAD is not supported by many streaming servers.
 func isStreamReachable(ctx context.Context, u string) bool {
 	if err := netutil.SafeHTTPURL(u); err != nil {
 		return false
@@ -205,7 +205,7 @@ func isStreamReachable(ctx context.Context, u string) bool {
 
 func (r *Renderer) soapCall(ctx context.Context, action, body string) error {
 	if r.ControlURL == "" {
-		return errors.New("ControlURL nicht gesetzt")
+		return errors.New("ControlURL not set")
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.ControlURL, strings.NewReader(body))
 	if err != nil {
@@ -230,10 +230,10 @@ func (r *Renderer) soapCall(ctx context.Context, action, body string) error {
 	return nil
 }
 
-// buildDIDL erzeugt das CurrentURIMetaData XML fuer einen Audio Stream.
-// DLNA Renderer wollen oft DIDL-Lite mit upnp:class und res protocolInfo um
-// den Stream Codec zu erkennen. Wenn iconURL gesetzt ist wird es als
-// upnp:albumArtURI eingebettet damit die Box ein Sender Logo zeigt.
+// buildDIDL builds the CurrentURIMetaData XML for an audio stream.
+// DLNA renderers often want DIDL-Lite with upnp:class and res protocolInfo
+// to detect the stream codec. If iconURL is set it is embedded as
+// upnp:albumArtURI so the box shows a station logo.
 func buildDIDL(streamURL, title, iconURL string) string {
 	return buildDIDLMime(streamURL, title, iconURL, "audio/mpeg")
 }
@@ -256,13 +256,13 @@ func buildDIDLMime(streamURL, title, iconURL, mime string) string {
 	return `<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"><item id="0" parentID="-1" restricted="1"><dc:title>` + xmlEscapeAttr(title) + `</dc:title><upnp:class>object.item.audioItem.musicTrack</upnp:class>` + art + `<res protocolInfo="http-get:*:` + mime + `:*">` + xmlEscapeAttr(streamURL) + `</res></item></DIDL-Lite>`
 }
 
-// xmlEscape escaped Sonderzeichen fuer XML Element Content.
+// xmlEscape escapes special characters for XML element content.
 func xmlEscape(s string) string {
 	r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;")
 	return r.Replace(s)
 }
 
-// xmlEscapeAttr ist identisch zu xmlEscape plus Quotes.
+// xmlEscapeAttr is identical to xmlEscape plus quotes.
 func xmlEscapeAttr(s string) string {
 	r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;", `'`, "&apos;")
 	return r.Replace(s)

--- a/internal/webui/const.go
+++ b/internal/webui/const.go
@@ -4,9 +4,9 @@ import "time"
 
 const shutdownTimeout = 5 * time.Second
 
-// indexHTML ist die minimale HTML Seite die der Stick auf "/" ausgibt.
-// Sie ist fuer Direkt Browser Zugriff (Handy ohne Desktop App). Die echte
-// UI kommt spaeter via Wails Desktop App ueber die gleiche REST API.
+// indexHTML is the minimal HTML page the stick serves on "/".
+// It is for direct browser access (a phone without the desktop app). The
+// real UI comes later via the Wails desktop app over the same REST API.
 const indexHTML = `<!doctype html>
 <html lang="de">
 <head>
@@ -34,7 +34,7 @@ h1 { font-size: 22px; margin: 0 0 16px 0; color: #e88; }
 </head>
 <body>
 <h1>STR</h1>
-<div class="status" id="status">Status laedt...</div>
+<div class="status" id="status">Status loading...</div>
 <div class="controls">
 <button onclick="api('/api/pause', 'POST')">Pause</button>
 <button onclick="api('/api/stop', 'POST')">Stop</button>
@@ -66,7 +66,7 @@ async function loadPresets() {
     if (p) {
       div.innerHTML = '<div class="num">#' + i + '</div><div class="name">' + escapeHtml(p.name || 'Preset ' + i) + '</div><div class="url">' + escapeHtml(p.stream_url || '') + '</div>';
     } else {
-      div.innerHTML = '<div class="num">#' + i + '</div><div class="name">— leer —</div>';
+      div.innerHTML = '<div class="num">#' + i + '</div><div class="name">— empty —</div>';
     }
     grid.appendChild(div);
   }

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -505,6 +505,7 @@ func (s *Server) Run(ctx context.Context) error {
 	mux.HandleFunc("/api/play", s.handlePlay)
 	mux.HandleFunc("/api/play/", s.handlePlaySlot)
 	mux.HandleFunc("/api/pause", s.handlePause)
+	mux.HandleFunc("/api/resume", s.handleResume)
 	mux.HandleFunc("/api/stop", s.handleStop)
 	mux.HandleFunc("/api/status", s.handleStatus)
 	mux.HandleFunc("/api/recent", s.handleRecent)
@@ -1801,6 +1802,15 @@ func (s *Server) NoteUserStop() {
 	s.lastUserStopMu.Unlock()
 }
 
+// ClearUserStop cancels a recorded user-stop so a manual resume re-enables the
+// guarded auto-re-push immediately instead of staying suppressed for the
+// userStopWindow.
+func (s *Server) ClearUserStop() {
+	s.lastUserStopMu.Lock()
+	s.lastUserStop = time.Time{}
+	s.lastUserStopMu.Unlock()
+}
+
 // userStoppedRecently reports whether a deliberate stop happened within
 // userStopWindow.
 func (s *Server) userStoppedRecently() bool {
@@ -2127,6 +2137,49 @@ func (s *Server) handlePause(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "paused"})
+}
+
+// handleResume resumes playback from a UPnP PAUSED state with a plain
+// AVTransport Play (what the Bose remote's own play/pause does), so a paused
+// network-library track continues from its position instead of restarting.
+// /api/play always re-pushes SetAVTransportURI, which restarts a finite track,
+// and Pause/Stop were the only transport controls STR exposed, so a paused NAS
+// track could not be resumed from the app (#202). If the box is no longer
+// paused (it left PAUSED after a standby/timeout, surfacing as a "wrong state"
+// fault), fall back to re-pushing the last stream.
+func (s *Server) handleResume(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	s.boxCmdMu.Lock()
+	defer s.boxCmdMu.Unlock()
+	if s.renderer == nil {
+		http.Error(w, "renderer not configured", http.StatusServiceUnavailable)
+		return
+	}
+	// A user-initiated resume cancels the deliberate-stop intent so the guarded
+	// auto-re-push is allowed again for the rest of the session.
+	s.ClearUserStop()
+	if err := s.renderer.Play(r.Context()); err != nil {
+		if isWrongTransportState(err) {
+			// The box is no longer in PAUSED. Re-push the last stream so the user
+			// still gets audio (from the start for a finite track).
+			s.lastPlayMu.Lock()
+			lp := s.lastPlay
+			s.lastPlayMu.Unlock()
+			if lp != nil {
+				if perr := s.renderer.PlayURLMime(r.Context(), lp.boxURL, lp.title, lp.art, lp.mime); perr == nil {
+					writeJSON(w, http.StatusOK, map[string]string{"status": "playing"})
+					return
+				}
+			}
+			writeJSON(w, http.StatusOK, map[string]string{"status": "not_playing"})
+			return
+		}
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "playing"})
 }
 
 // isWrongTransportState reports whether a UPnP AVTransport error was the

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -1,6 +1,6 @@
-// Package webui stellt das Config Web Interface auf Port 8888 bereit.
-// Enthaelt die HTML UI plus eine REST API die spaeter auch von der Wails
-// Desktop App genutzt wird.
+// Package webui provides the config web interface on port 8888.
+// Contains the HTML UI plus a REST API that is later also used by the
+// Wails desktop app.
 package webui
 
 import (
@@ -57,8 +57,8 @@ type Server struct {
 	renderer    *upnp.Renderer
 	autoPair    *autopair.Manager
 	regionMu    sync.RWMutex
-	region      string // ISO 3166-1 alpha-2 vom Setup Wizard, leer wenn unbekannt
-	regionFile  string // Pfad fuer persistente Speicherung
+	region      string // ISO 3166-1 alpha-2 from the setup wizard, empty if unknown
+	regionFile  string // path for persistent storage
 	streamProxy *streamproxy.Server
 	// webhooks holds the user-configured HTTP requests (thumbs trigger). nil
 	// when not wired; endpoints then report unavailable.
@@ -284,10 +284,10 @@ func (s *Server) SetWifiSignalFn(fn func() string) { s.wifiSignalFn = fn }
 // this after the announcer is up.
 func (s *Server) SetBoxNameFn(fn func() (name, model string)) { s.boxNameFn = fn }
 
-// Option ist ein functional option fuer New.
+// Option is a functional option for New.
 type Option func(*Server)
 
-// WithPresets verbindet den Store fuer Preset CRUD.
+// WithPresets wires the store for preset CRUD.
 func WithPresets(p *presets.Store) Option {
 	return func(s *Server) { s.presets = p }
 }
@@ -298,7 +298,7 @@ func WithZones(z *zones.Store) Option {
 	return func(s *Server) { s.zones = z }
 }
 
-// WithBoxHost setzt die Bose Box IP/Hostname fuer UPnP Calls.
+// WithBoxHost sets the Bose box IP/hostname for UPnP calls.
 func WithBoxHost(host string) Option {
 	return func(s *Server) {
 		s.boxHost = host
@@ -318,21 +318,21 @@ func WithReflectSourcesPath(path string) Option {
 	return func(s *Server) { s.reflectPath = path }
 }
 
-// WithAutoPair gibt dem Server Zugriff auf den AutoPair Manager damit
-// Play Calls auch nach Standby Aufwecken die Box wieder pairen koennen.
+// WithAutoPair gives the server access to the AutoPair manager so that
+// play calls can re-pair the box again after waking it from standby.
 func WithAutoPair(m *autopair.Manager) Option {
 	return func(s *Server) { s.autoPair = m }
 }
 
-// WithRegion uebergibt den vom Setup Wizard gewaehlten Country Code.
-// Wird ueber /api/region exposed damit die Desktop App ihre Defaults
-// fuer Radio Suche und Sprache daraus ableiten kann.
+// WithRegion passes the country code chosen by the setup wizard.
+// Exposed via /api/region so the desktop app can derive its defaults
+// for radio search and language from it.
 func WithRegion(cc string) Option {
 	return func(s *Server) { s.region = strings.ToUpper(cc) }
 }
 
-// WithRegionFile setzt den persistenten Pfad fuer Aenderungen von
-// /api/region (PUT). Ohne diesen Pfad sind Aenderungen nur in memory.
+// WithRegionFile sets the persistent path for changes from
+// /api/region (PUT). Without this path changes are only in memory.
 func WithRegionFile(path string) Option {
 	return func(s *Server) { s.regionFile = path }
 }
@@ -351,10 +351,10 @@ func WithDisplayTrackFile(path string) Option {
 	return func(s *Server) { s.displayTrackPath = path }
 }
 
-// WithStreamProxy haengt den Stream Proxy ein. Wenn gesetzt wird der
-// /stream/ Endpoint registriert. Bose ContentItems werden dann mit
-// http://127.0.0.1:8888/stream/<slot> verlinkt statt mit der echten
-// CDN URL — Streams ueberleben Token Expiry.
+// WithStreamProxy wires in the stream proxy. When set, the /stream/
+// endpoint is registered. Bose ContentItems are then linked with
+// http://127.0.0.1:8888/stream/<slot> instead of the real CDN URL —
+// streams survive token expiry.
 func WithStreamProxy(p *streamproxy.Server) Option {
 	return func(s *Server) { s.streamProxy = p }
 }
@@ -455,14 +455,14 @@ func WithRecent(r *recent.Store) Option {
 	return func(s *Server) { s.recent = r }
 }
 
-// ensureBoxReady weckt die Box aus dem Standby (mit retry+poll bis
-// wirklich wach) und stellt sicher dass der Marge Account aktiv ist.
-// Wird vor jedem Play Call aufgerufen.
+// ensureBoxReady wakes the box from standby (with retry+poll until
+// really awake) and ensures the marge account is active.
+// Called before every play call.
 func (s *Server) ensureBoxReady(ctx context.Context) {
 	if s.boxHost != "" {
 		wakeCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
 		if err := boxcli.WakeAndWait(wakeCtx, s.boxHost, 6*time.Second, s.logger); err != nil {
-			s.logger.Warn("Box konnte nicht aus STANDBY geholt werden", "err", err)
+			s.logger.Warn("Box could not be woken from STANDBY", "err", err)
 		}
 		cancel()
 	}
@@ -473,7 +473,7 @@ func (s *Server) ensureBoxReady(ctx context.Context) {
 	}
 }
 
-// New erstellt einen neuen Webui Server.
+// New creates a new webui server.
 func New(addr string, logger *slog.Logger, opts ...Option) *Server {
 	s := &Server{addr: addr, logger: logger}
 	for _, o := range opts {
@@ -482,7 +482,7 @@ func New(addr string, logger *slog.Logger, opts ...Option) *Server {
 	return s
 }
 
-// Run startet den Server und blockiert bis ctx abgebrochen wird.
+// Run starts the server and blocks until ctx is cancelled.
 //
 // Every step that can fail or block emits a phase-marker log at WARN
 // level so that even on a `--log-level warn` deployment (or with the
@@ -539,8 +539,8 @@ func (s *Server) Run(ctx context.Context) error {
 	mux.HandleFunc("/api/debug/state", s.handleDebugState)
 	mux.HandleFunc("/api/debug/probe", s.handleDebugProbe)
 
-	// Stream Proxy: stabile URLs fuer Radio Streams mit Token Expiry.
-	// Siehe internal/streamproxy fuer Details.
+	// Stream proxy: stable URLs for radio streams with token expiry.
+	// See internal/streamproxy for details.
 	if s.streamProxy != nil {
 		s.streamProxy.Register(mux)
 	}
@@ -592,7 +592,7 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 }
 
-// corsMiddleware erlaubt Cross-Origin Calls von der Desktop App.
+// corsMiddleware allows cross-origin calls from the desktop app.
 func corsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
@@ -764,9 +764,9 @@ func (s *Server) handlePresetSlot(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		// Sync zur Box damit Hardware Tasten den richtigen Slot kennen.
-		// Bose bekommt die Stream Proxy URL, nicht den echten CDN.
-		// So ueberlebt der Stream Token Expiry.
+		// Sync to the box so hardware buttons know the correct slot.
+		// Bose gets the stream proxy URL, not the real CDN.
+		// This way the stream survives token expiry.
 		if s.boxHost != "" {
 			boxCtx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 			// Spotify presets store the live Ogg stream as the box-side location
@@ -894,8 +894,8 @@ func legacySpotifyURI(streamURL string) string {
 type playRequest struct {
 	URL   string `json:"url"`
 	Title string `json:"title"`
-	Icon  string `json:"icon"` // albumArtURI fuer Box Display
-	UUID  string `json:"uuid"` // optional, fuer Click Tracking
+	Icon  string `json:"icon"` // albumArtURI for box display
+	UUID  string `json:"uuid"` // optional, for click tracking
 	// Mime is the source codec MIME (audio/flac, audio/mp4, ...) for a network
 	// library track, so the box decodes it correctly. Empty for radio -> the
 	// renderer defaults to audio/mpeg.
@@ -1227,8 +1227,8 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	// Stream Proxy URL nutzen damit auch nach Token Expiry weitergespielt
-	// wird (Bose sieht die stabile loopback URL).
+	// Use the stream proxy URL so playback continues even after token
+	// expiry (Bose sees the stable loopback URL).
 	playURL := boxurl.StreamSlot(slot)
 	if err := s.renderer.PlayURL(r.Context(), playURL, p.Name, p.Art); err != nil {
 		writeJSON(w, http.StatusBadGateway, map[string]any{
@@ -2169,8 +2169,8 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "stopped"})
 }
 
-// handleAgentVersion liefert die laufende Stick Agent Version. Wird von
-// der Desktop App genutzt um zu erkennen ob ein Update faellig ist.
+// handleAgentVersion returns the running stick agent version. Used by
+// the desktop app to detect whether an update is due.
 func (s *Server) handleAgentVersion(w http.ResponseWriter, _ *http.Request) {
 	out := map[string]string{
 		"version": agentVersion(),
@@ -2190,12 +2190,12 @@ func (s *Server) handleAgentVersion(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, out)
 }
 
-// handleAgentUpdate nimmt ein neues Stick Agent Binary entgegen, schreibt
-// es atomar nach /mnt/nv/streborn/bin/streborn-armv7l und
-// startet den Agent neu. Body muss das rohe ARM Binary sein.
+// handleAgentUpdate receives a new stick agent binary, writes it
+// atomically to /mnt/nv/streborn/bin/streborn-armv7l and restarts the
+// agent. Body must be the raw ARM binary.
 //
-// Nach Erfolg gibt der Stick noch 200 OK zurueck und beendet sich. Der
-// rc.local Bootstrap startet den neuen Agent.
+// On success the stick still returns 200 OK and then exits. The
+// rc.local bootstrap starts the new agent.
 func (s *Server) handleAgentUpdate(w http.ResponseWriter, r *http.Request) {
 	if !requireMethod(w, r, http.MethodPost) {
 		return
@@ -2286,8 +2286,8 @@ func (s *Server) handleAgentUpdate(w http.ResponseWriter, r *http.Request) {
 	}()
 }
 
-// isLocalLAN true wenn der Request von einer privaten LAN IP kommt
-// (RFC1918) oder localhost. Update aus dem Internet wird blockiert.
+// isLocalLAN true if the request comes from a private LAN IP
+// (RFC1918) or localhost. Updates from the internet are blocked.
 func isLocalLAN(remoteAddr string) bool {
 	host, _, err := net.SplitHostPort(remoteAddr)
 	if err != nil {
@@ -2303,9 +2303,9 @@ func isLocalLAN(remoteAddr string) bool {
 	return ip.IsPrivate() || ip.IsLoopback()
 }
 
-// guessErrorReason konvertiert den technischen UPnP / Netzwerk Fehler
-// in einen menschen-lesbaren Hinweis. Die SOAP Antworten der Box sind
-// stark in XML eingewickelt und nicht direkt verstaendlich.
+// guessErrorReason converts the technical UPnP / network error into a
+// human-readable hint. The box's SOAP responses are heavily wrapped in
+// XML and not directly understandable.
 func guessErrorReason(err error) string {
 	if err == nil {
 		return ""
@@ -2327,8 +2327,8 @@ func guessErrorReason(err error) string {
 
 // ---- Box Settings (Bose API Proxy) ----
 
-// handleBoxSettings liefert info + volume + bass + network + sources
-// kombiniert als JSON.
+// handleBoxSettings returns info + volume + bass + network + sources
+// combined as JSON.
 func (s *Server) handleBoxSettings(w http.ResponseWriter, r *http.Request) {
 	if s.boxHost == "" {
 		http.Error(w, "box host not configured", http.StatusServiceUnavailable)
@@ -2431,7 +2431,7 @@ func ssidAfter(s, anchor string) string {
 	return ""
 }
 
-// handleBoxName PUT setzt den Box Namen. Body {"name":"..."}.
+// handleBoxName PUT sets the box name. Body {"name":"..."}.
 func (s *Server) handleBoxName(w http.ResponseWriter, r *http.Request) {
 	if !requireMethod(w, r, http.MethodPut) {
 		return
@@ -2443,7 +2443,7 @@ func (s *Server) handleBoxName(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if strings.TrimSpace(req.Name) == "" {
-		http.Error(w, "name leer", http.StatusBadRequest)
+		http.Error(w, "name empty", http.StatusBadRequest)
 		return
 	}
 	c := boxapi.New(s.boxHost)
@@ -2453,16 +2453,15 @@ func (s *Server) handleBoxName(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
-	// Bose setzt bei /name POST nebenher die margeURL auf default zurueck —
-	// AutoPair triggern damit der Pair State unmittelbar wieder hergestellt
-	// wird.
+	// On /name POST Bose also resets the margeURL back to default —
+	// trigger AutoPair so the pair state is immediately re-established.
 	if s.autoPair != nil {
 		go s.autoPair.TriggerNow(context.Background())
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok", "name": req.Name})
 }
 
-// handleBoxVolume PUT setzt Lautstaerke. Body {"value":N}.
+// handleBoxVolume PUT sets the volume. Body {"value":N}.
 func (s *Server) handleBoxVolume(w http.ResponseWriter, r *http.Request) {
 	if !requireMethod(w, r, http.MethodPut) {
 		return
@@ -2485,11 +2484,11 @@ func (s *Server) handleBoxVolume(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]int{"value": req.Value})
 }
 
-// handleBoxSource PUT schaltet die Box auf eine andere Quelle: AUX,
-// BLUETOOTH oder STANDBY. Body {"source":"AUX"}.
+// handleBoxSource PUT switches the box to another source: AUX,
+// BLUETOOTH or STANDBY. Body {"source":"AUX"}.
 //
-// Bose /select erwartet ein ContentItem XML. Wir bauen das je nach
-// Source. STANDBY hat ein eigenes ContentItem ohne sourceAccount.
+// Bose /select expects a ContentItem XML. We build it depending on the
+// source. STANDBY has its own ContentItem without sourceAccount.
 func (s *Server) handleBoxSource(w http.ResponseWriter, r *http.Request) {
 	if !requireMethod(w, r, http.MethodPut) {
 		return
@@ -2507,9 +2506,9 @@ func (s *Server) handleBoxSource(w http.ResponseWriter, r *http.Request) {
 	}
 	client := &http.Client{Timeout: 6 * time.Second}
 
-	// Sonderfall STANDBY: kein ContentItem Source bei Bose. /key POWER
-	// triggert nur LED Animation, /standby ist der echte Endpoint —
-	// und Bose erwartet **GET**, kein POST (POST liefert 400).
+	// Special case STANDBY: no ContentItem source at Bose. /key POWER
+	// only triggers the LED animation, /standby is the real endpoint —
+	// and Bose expects **GET**, not POST (POST returns 400).
 	if src == "STANDBY" {
 		u := fmt.Sprintf("http://%s:8090/standby", s.boxHost)
 		resp, err := client.Get(u)
@@ -2567,7 +2566,7 @@ func (s *Server) handleBoxSource(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"source": src})
 }
 
-// handleBoxBass PUT setzt Bass Wert. Body {"value":N}.
+// handleBoxBass PUT sets the bass value. Body {"value":N}.
 func (s *Server) handleBoxBass(w http.ResponseWriter, r *http.Request) {
 	if !requireMethod(w, r, http.MethodPut) {
 		return
@@ -3104,9 +3103,9 @@ func (s *Server) handleZoneDissolve(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 
-// handleBoxGroup liest die aktuelle Stereo-Pair-Group der Box.
-// Read-only. Antwort ist {"id":"...","name":"...","members":[...]}.
-// Bei einer Box ohne Pair ist id leer und members leer.
+// handleBoxGroup reads the box's current stereo pair group.
+// Read-only. Response is {"id":"...","name":"...","members":[...]}.
+// For a box without a pair, id is empty and members is empty.
 func (s *Server) handleBoxGroup(w http.ResponseWriter, r *http.Request) {
 	if !requireMethod(w, r, http.MethodGet) {
 		return
@@ -3201,9 +3200,9 @@ func (s *Server) handleStickStatus(w http.ResponseWriter, _ *http.Request) {
 	if mounted && version != "" {
 		out["version"] = version
 	}
-	// SSH Status — schauen ob Port 22 aktuell listened. Wenn ja
-	// kann jemand im LAN auf die Box zugreifen, App zeigt Warn Banner.
-	// Wir probieren einen TCP Connect auf localhost mit 200 ms timeout.
+	// SSH status — check whether port 22 is currently listening. If so
+	// someone on the LAN can access the box, the app shows a warning banner.
+	// We try a TCP connect to localhost with a 200 ms timeout.
 	if conn, dialErr := net.DialTimeout("tcp", "127.0.0.1:22", 200*time.Millisecond); dialErr == nil {
 		_ = conn.Close()
 		out["sshOpen"] = true
@@ -3211,12 +3210,11 @@ func (s *Server) handleStickStatus(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, out)
 }
 
-// handleDebugState liefert wichtige Box State Dateien als JSON damit
-// wir ohne SSH von aussen debuggen koennen wenn der Stick eingebaut ist.
+// handleDebugState returns important box state files as JSON so we can
+// debug from outside without SSH when the stick is installed.
 //
-// Wird nur fuer interaktive Diagnose genutzt — die App selbst ruft das
-// nicht regelmaessig. Limit pro Datei: 8 KB damit die Antwort kompakt
-// bleibt.
+// Used only for interactive diagnosis — the app itself does not call
+// this regularly. Limit per file: 8 KB so the response stays compact.
 func (s *Server) handleDebugState(w http.ResponseWriter, r *http.Request) {
 	if !isLocalLAN(r.RemoteAddr) {
 		http.Error(w, "debug only from LAN", http.StatusForbidden)
@@ -3366,17 +3364,16 @@ func boxPresetURL(slot int, isSpotify bool) string {
 	return boxurl.Preset(slot, isSpotify)
 }
 
-// handleBoxSyncPresets ueberschreibt die Box eigene Preset Liste mit
-// allen aktuellen Stick Presets via Bose CLI. Damit funktionieren die
-// Hardware Tasten 1-6 wieder wenn der initial Sync beim Boot aus
-// irgendwelchen Gruenden nicht durchgelaufen ist (z.B. Box war noch
-// nicht erreichbar).
+// handleBoxSyncPresets overwrites the box's own preset list with all
+// current stick presets via the Bose CLI. This makes hardware buttons
+// 1-6 work again when the initial sync at boot did not run for some
+// reason (e.g. the box was not yet reachable).
 func (s *Server) handleBoxSyncPresets(w http.ResponseWriter, r *http.Request) {
 	if !requireMethod(w, r, http.MethodPost) {
 		return
 	}
 	if s.presets == nil || s.boxHost == "" {
-		http.Error(w, "presets store oder box host nicht konfiguriert", http.StatusServiceUnavailable)
+		http.Error(w, "presets store or box host not configured", http.StatusServiceUnavailable)
 		return
 	}
 	var specs []boxcli.PresetSpec
@@ -3409,10 +3406,10 @@ func (s *Server) handleBoxSyncPresets(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// handleBoxReboot startet die Box neu via shell `reboot`. Wird genutzt
-// damit conf Files vom Stick (wlan / region / name) beim run.sh Boot
-// Pfad applied werden — wir vermeiden so ein dauerhaft laufendes USB
-// Watcher Polling.
+// handleBoxReboot restarts the box via shell `reboot`. Used so that
+// conf files from the stick (wlan / region / name) are applied on the
+// run.sh boot path — this avoids a permanently running USB watcher
+// polling loop.
 func (s *Server) handleBoxReboot(w http.ResponseWriter, r *http.Request) {
 	if !requireMethod(w, r, http.MethodPost) {
 		return
@@ -3421,9 +3418,9 @@ func (s *Server) handleBoxReboot(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "reboot only allowed from LAN", http.StatusForbidden)
 		return
 	}
-	s.logger.Info("Box Reboot vom User angefordert")
+	s.logger.Info("Box reboot requested by user")
 	writeJSON(w, http.StatusOK, map[string]string{"status": "rebooting"})
-	// 1s spaeter ausfuehren damit unsere HTTP Response noch raus geht.
+	// Execute 1s later so our HTTP response still gets out.
 	go func() {
 		time.Sleep(1 * time.Second)
 		_ = exec.Command("reboot").Run()
@@ -3799,7 +3796,7 @@ func (s *Server) handleBoxPresetRecall(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "slot": body.Slot})
 }
 
-// handleBoxWLAN setzt die WLAN Konfiguration der Box zur Laufzeit.
+// handleBoxWLAN sets the box's WLAN configuration at runtime.
 // Body: {"ssid":"...", "password":"..."}
 //
 // Robust across the two Wi-Fi stacks SoundTouch ships (see run.sh's WLAN
@@ -4013,8 +4010,8 @@ func rebootBox() {
 	_ = exec.Command("sh", "-c", "(sleep 1; sync; /sbin/reboot) </dev/null >/dev/null 2>&1 &").Start()
 }
 
-// buildWPAConfig erzeugt eine minimale wpa_supplicant.conf. Bei leerem
-// Passwort wird key_mgmt=NONE gesetzt (offenes WLAN).
+// buildWPAConfig generates a minimal wpa_supplicant.conf. With an empty
+// password key_mgmt=NONE is set (open WLAN).
 func buildWPAConfig(ssid, psk string) string {
 	var b strings.Builder
 	b.WriteString("ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=root\n")
@@ -4045,9 +4042,9 @@ func escapeWPAValue(s string) string {
 	return r.Replace(s)
 }
 
-// countryToLanguage liefert den Default Sprach Code fuer das radio-browser
-// "language" Filter Feld aus einem ISO 3166-1 Country Code. Fallback ist
-// "english" wenn unbekannt — die Welt versteht das.
+// countryToLanguage returns the default language code for the radio-browser
+// "language" filter field from an ISO 3166-1 country code. Fallback is
+// "english" if unknown — the world understands that.
 var countryToLanguage = map[string]string{
 	"DE": "german", "AT": "german", "CH": "german", "LI": "german",
 	"GB": "english", "US": "english", "IE": "english", "AU": "english",
@@ -4080,8 +4077,8 @@ func languageForCountry(cc string) string {
 	return "english"
 }
 
-// handleRegion liefert die vom Setup Wizard gespeicherte Region samt
-// abgeleiteter Default Sprache, oder setzt sie neu via PUT.
+// handleRegion returns the region saved by the setup wizard together
+// with the derived default language, or sets it anew via PUT.
 func (s *Server) handleRegion(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
@@ -4101,7 +4098,7 @@ func (s *Server) handleRegion(w http.ResponseWriter, r *http.Request) {
 		}
 		cc := strings.ToUpper(strings.TrimSpace(req.Country))
 		if len(cc) != 2 {
-			http.Error(w, "country muss ISO 3166-1 alpha-2 sein", http.StatusBadRequest)
+			http.Error(w, "country must be ISO 3166-1 alpha-2", http.StatusBadRequest)
 			return
 		}
 		s.regionMu.Lock()
@@ -4122,22 +4119,22 @@ func (s *Server) handleRegion(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// agentVersion und agentBuild werden via Setter aus main.go versorgt.
+// agentVersion and agentBuild are supplied via setters from main.go.
 var (
 	agentVersion = func() string { return "1.0.0" }
 	agentBuild   = func() string { return "dev" }
 )
 
-// SetAgentVersion erlaubt main.go beim Start die Semver Version zu setzen.
+// SetAgentVersion allows main.go to set the semver version at startup.
 func SetAgentVersion(v string) { agentVersion = func() string { return v } }
 
-// SetAgentBuild setzt den Build Stamp (Datum/Commit) als zusaetzliche Info.
+// SetAgentBuild sets the build stamp (date/commit) as additional info.
 func SetAgentBuild(b string) { agentBuild = func() string { return b } }
 
-// handleStatus proxied das now_playing XML der Box, mit einem kurzen
-// Micro-Cache (statusCacheTTL) davor. Mehrere oder zu schnell pollende
-// Clients teilen sich so denselben Box-Roundtrip, statt die fragile
-// BoseApp (:8090) auf jeder Abfrage neu zu treffen.
+// handleStatus proxies the box's now_playing XML, with a short
+// micro-cache (statusCacheTTL) in front. Multiple or too-rapidly polling
+// clients thus share the same box roundtrip instead of hitting the
+// fragile BoseApp (:8090) anew on every request.
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	if s.boxHost == "" {
 		http.Error(w, "box host not configured", http.StatusServiceUnavailable)

--- a/internal/zones/zones.go
+++ b/internal/zones/zones.go
@@ -75,7 +75,7 @@ func Load(path string) (*Store, error) {
 		if os.IsNotExist(err) {
 			return s, nil
 		}
-		return s, fmt.Errorf("zones lesen: %w", err)
+		return s, fmt.Errorf("read zones: %w", err)
 	}
 	if len(b) == 0 {
 		return s, nil

--- a/radiobrowser/radiobrowser.go
+++ b/radiobrowser/radiobrowser.go
@@ -1,12 +1,12 @@
-// Package radiobrowser ist ein duenner Client fuer https://radio-browser.info,
-// eine community Internet Radio Station Datenbank ohne API Key.
+// Package radiobrowser is a thin client for https://radio-browser.info,
+// a community internet radio station database without an API key.
 //
-// API Doku: https://api.radio-browser.info/
+// API docs: https://api.radio-browser.info/
 //
-// Wir nutzen mehrere Mirror Server mit automatischem Failover. Die Liste
-// ist hardcoded da die offizielle Server Discovery selbst einen Mirror
-// braucht — Henne-Ei. Mirrors sind alphabetisch nach Latenz aus DE/EU
-// Sicht sortiert.
+// We use several mirror servers with automatic failover. The list is
+// hardcoded because the official server discovery itself needs a mirror
+// — chicken-and-egg. Mirrors are sorted by latency from a DE/EU
+// perspective.
 package radiobrowser
 
 import (
@@ -48,11 +48,11 @@ var Mirrors = []string{
 	"https://91.98.4.78/json",
 }
 
-// Station beschreibt einen einzelnen Sender wie er von der API kommt.
+// Station describes a single station as it comes from the API.
 //
-// LastCheckOK ist 1 wenn radio-browser den Sender beim letzten Check
-// erreicht hat. ClickTrend ist der Aenderungstrend ueber 24h.
-// Favicon ist eine URL zu einem Logo, kann fehlen.
+// LastCheckOK is 1 if radio-browser reached the station on the last
+// check. ClickTrend is the change trend over 24h. Favicon is a URL to a
+// logo, may be missing.
 type Station struct {
 	StationUUID string `json:"stationuuid"`
 	Name        string `json:"name"`
@@ -78,13 +78,13 @@ type Station struct {
 	LastCheckOK int `json:"lastcheckok"`
 }
 
-// Tag ist ein Genre Tag mit Anzahl der Stations.
+// Tag is a genre tag with the number of stations.
 type Tag struct {
 	Name         string `json:"name"`
 	StationCount int    `json:"stationcount"`
 }
 
-// Language listet eine Sprache plus Sender Anzahl.
+// Language lists a language plus station count.
 type Language struct {
 	Name         string `json:"name"`
 	Iso639       string `json:"iso_639"`
@@ -100,7 +100,7 @@ type Language struct {
 // while still dialling the IP, so the fallback actually works.
 const ipMirrorServerName = "de1.api.radio-browser.info"
 
-// Client kapselt http.Client plus Mirror Rotation.
+// Client wraps http.Client plus mirror rotation.
 type Client struct {
 	HTTP    *http.Client // standard client for hostname mirrors
 	ipHTTP  *http.Client // client for IP-literal mirrors (TLS ServerName pinned)
@@ -109,7 +109,7 @@ type Client struct {
 	mirrors []string
 }
 
-// New erzeugt einen Client mit defaults und allen Mirrors.
+// New creates a Client with defaults and all mirrors.
 func New() *Client {
 	mirrors := make([]string, len(Mirrors))
 	copy(mirrors, Mirrors)
@@ -130,7 +130,7 @@ func New() *Client {
 	}
 }
 
-// SearchOpts buendelt alle Such Parameter.
+// SearchOpts bundles all search parameters.
 //
 // TagList is a list of substrings, each of which must match SOME tag
 // of a station (AND across the list, substring per element). Set this
@@ -147,7 +147,7 @@ type SearchOpts struct {
 	OnlyOK   bool
 }
 
-// Search sucht Stations nach den uebergebenen Optionen.
+// Search searches stations according to the given options.
 func (c *Client) Search(ctx context.Context, opts SearchOpts) ([]Station, error) {
 	if opts.Limit <= 0 {
 		opts.Limit = 30
@@ -181,9 +181,9 @@ func (c *Client) Search(ctx context.Context, opts SearchOpts) ([]Station, error)
 	if opts.OnlyOK {
 		q.Set("lastcheckok", "true")
 	}
-	// reverse=true bedeutet descending: bei votes/clickcount/clicktrend
-	// will man die hoechsten zuerst. Bei "name" wuerde reverse aus A->Z
-	// ein Z->A machen, also dort weglassen.
+	// reverse=true means descending: for votes/clickcount/clicktrend you
+	// want the highest first. For "name" reverse would turn A->Z into
+	// Z->A, so leave it out there.
 	if order != "name" {
 		q.Set("reverse", "true")
 	}
@@ -357,7 +357,7 @@ func tokenize(s string) []string {
 	return out
 }
 
-// TopVote liefert die meistgevoteten Sender, gefiltert nach country.
+// TopVote returns the most-voted stations, filtered by country.
 func (c *Client) TopVote(ctx context.Context, cc string, limit int, onlyOK bool) ([]Station, error) {
 	return c.Search(ctx, SearchOpts{
 		Country: cc,
@@ -367,13 +367,13 @@ func (c *Client) TopVote(ctx context.Context, cc string, limit int, onlyOK bool)
 	})
 }
 
-// ByCountry liefert alle Sender eines Landes (gut fuer Stoebern).
+// ByCountry returns all stations of a country (good for browsing).
 func (c *Client) ByCountry(ctx context.Context, cc string, limit int) ([]Station, error) {
 	return c.Search(ctx, SearchOpts{Country: cc, Limit: limit, Order: "votes"})
 }
 
-// TopTags liefert die populaersten Tags fuer Genre Chips. Limit hier ist
-// nicht ein API Parameter sondern eine clientseitige Begrenzung.
+// TopTags returns the most popular tags for genre chips. Limit here is
+// not an API parameter but a client-side cap.
 func (c *Client) TopTags(ctx context.Context, limit int) ([]Tag, error) {
 	q := url.Values{}
 	q.Set("order", "stationcount")
@@ -387,7 +387,7 @@ func (c *Client) TopTags(ctx context.Context, limit int) ([]Tag, error) {
 	return out, err
 }
 
-// Languages liefert die Sprach Liste (mit Anzahl der Stations).
+// Languages returns the language list (with the number of stations).
 func (c *Client) Languages(ctx context.Context, limit int) ([]Language, error) {
 	q := url.Values{}
 	q.Set("order", "stationcount")
@@ -401,11 +401,11 @@ func (c *Client) Languages(ctx context.Context, limit int) ([]Language, error) {
 	return out, err
 }
 
-// LanguagesByCountry holt alle Stations fuer einen Country Code und
-// aggregiert by language Feld. radio-browser.info hat keinen direkten
-// "languages by country" Endpoint, daher der Workaround. Pro Land sind
-// das ca. 1k bis 5k Stations — ein JSON Payload von 1 MB max, im
-// Server lokal aggregierbar in unter 100 ms.
+// LanguagesByCountry fetches all stations for a country code and
+// aggregates by the language field. radio-browser.info has no direct
+// "languages by country" endpoint, hence the workaround. Per country
+// that is about 1k to 5k stations — a JSON payload of 1 MB max,
+// aggregatable locally in the server in under 100 ms.
 func (c *Client) LanguagesByCountry(ctx context.Context, country string) ([]Language, error) {
 	stations, err := c.Search(ctx, SearchOpts{
 		Country: country,
@@ -418,9 +418,9 @@ func (c *Client) LanguagesByCountry(ctx context.Context, country string) ([]Lang
 	}
 	counts := make(map[string]int, 64)
 	for _, st := range stations {
-		// language Feld kann mehrere kommagetrennte Sprachen enthalten
-		// ("german,english"). Wir zaehlen jede einzeln damit Stationen
-		// die mehrere Sprachen tragen in jeder Sprache mitgezaehlt werden.
+		// the language field may contain several comma-separated languages
+		// ("german,english"). We count each one individually so stations
+		// carrying multiple languages are counted in each language.
 		for _, raw := range strings.Split(st.Language, ",") {
 			lang := strings.TrimSpace(strings.ToLower(raw))
 			if lang == "" {
@@ -433,7 +433,7 @@ func (c *Client) LanguagesByCountry(ctx context.Context, country string) ([]Lang
 	for name, n := range counts {
 		out = append(out, Language{Name: name, StationCount: n})
 	}
-	// Sort by stationcount desc damit das Frontend nicht selbst sortieren muss
+	// Sort by stationcount desc so the frontend does not have to sort itself
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].StationCount != out[j].StationCount {
 			return out[i].StationCount > out[j].StationCount
@@ -443,15 +443,15 @@ func (c *Client) LanguagesByCountry(ctx context.Context, country string) ([]Lang
 	return out, nil
 }
 
-// Vote schickt einen Daumen hoch fuer den Sender. Best Effort: Fehler
-// wird zurueckgegeben aber kann ignoriert werden.
+// Vote sends a thumbs up for the station. Best effort: the error is
+// returned but can be ignored.
 func (c *Client) Vote(ctx context.Context, uuid string) error {
 	var out map[string]any
 	return c.fetchJSON(ctx, "/vote/"+url.PathEscape(uuid), &out)
 }
 
-// Click traegt einen Click fuer den Sender ein. Damit zaehlt unsere App
-// in die Beliebtheits Statistik mit ein.
+// Click records a click for the station. This way our app counts toward
+// the popularity statistics.
 func (c *Client) Click(ctx context.Context, uuid string) error {
 	var out map[string]any
 	return c.fetchJSON(ctx, "/url/"+url.PathEscape(uuid), &out)
@@ -464,9 +464,9 @@ func (c *Client) Click(ctx context.Context, uuid string) error {
 // failover was effectively dead.
 const perMirrorTimeout = 6 * time.Second
 
-// fetchJSON probiert alle Mirrors der Reihe nach. Erster erfolgreicher
-// gewinnt. Bei Erfolg merken wir uns den Mirror als "primary" damit der
-// naechste Call denselben Server bevorzugt.
+// fetchJSON tries all mirrors in order. First success wins. On success
+// we remember the mirror as "primary" so the next call prefers the same
+// server.
 //
 // Each attempt runs under its own derived context with a 3 s timeout
 // instead of sharing the outer handler ctx. That way a single slow
@@ -489,7 +489,7 @@ func (c *Client) fetchJSON(ctx context.Context, path string, out any) error {
 		}
 		err := c.tryMirror(ctx, base, path, out)
 		if err == nil {
-			// Erfolg: Mirror nach vorne sortieren wenn nicht schon erster
+			// Success: move the mirror to the front if not already first
 			if i > 0 {
 				c.mu.Lock()
 				c.mirrors[0], c.mirrors[i] = c.mirrors[i], c.mirrors[0]
@@ -500,7 +500,7 @@ func (c *Client) fetchJSON(ctx context.Context, path string, out any) error {
 		lastErr = err
 	}
 	if lastErr == nil {
-		lastErr = fmt.Errorf("kein mirror erreichbar")
+		lastErr = fmt.Errorf("no mirror reachable")
 	}
 	return lastErr
 }

--- a/setup/run.sh
+++ b/setup/run.sh
@@ -39,25 +39,25 @@ log() {
     echo "$(date): $*" >> "$LOG"
 }
 
-# NUR wenn Sync Flag gesetzt ist: Stick -> NAND kopieren.
-# Standard: NAND ist Source of Truth.
+# ONLY if the sync flag is set: copy stick -> NAND.
+# Default: NAND is the source of truth.
 sync_from_stick_if_requested() {
     if [ ! -f "$SYNC_FLAG" ]; then
         return 0
     fi
     if [ ! -r "$STICK_BIN" ]; then
-        log "Sync angefordert aber Stick Binary nicht lesbar, ignoriere"
+        log "Sync requested but stick binary not readable, ignoring"
         rm -f "$SYNC_FLAG"
         return 1
     fi
     if cp "$STICK_BIN" "$CACHED_BIN.new" 2>/dev/null; then
         chmod +x "$CACHED_BIN.new"
         mv "$CACHED_BIN.new" "$CACHED_BIN"
-        log "Stick Binary in NAND Cache gesynct"
+        log "Synced stick binary into the NAND cache"
         rm -f "$SYNC_FLAG"
         return 0
     fi
-    log "Sync gescheitert (Stick I/O Error?), behalte NAND Cache"
+    log "Sync failed (stick I/O error?), keeping the NAND cache"
     rm -f "$CACHED_BIN.new"
     rm -f "$SYNC_FLAG"
     return 1
@@ -65,22 +65,22 @@ sync_from_stick_if_requested() {
 
 sync_from_stick_if_requested
 
-# Binary Auswahl: NAND Cache zuerst, Stick als Fallback.
+# Binary selection: NAND cache first, stick as fallback.
 if [ -x "$CACHED_BIN" ]; then
     BIN="$CACHED_BIN"
 elif [ -x "$STICK_BIN" ]; then
     BIN="$STICK_BIN"
-    log "Kein NAND Cache, nutze Stick Binary direkt"
+    log "No NAND cache, using the stick binary directly"
 else
-    log "FEHLER: weder NAND Cache noch Stick Binary verfuegbar"
+    log "ERROR: neither NAND cache nor stick binary available"
     exit 1
 fi
 
-# === Schon laufender Agent? Dann Stop. ===
+# === Agent already running? Then stop it. ===
 if [ -f "$PIDFILE" ]; then
     OLDPID=$(cat "$PIDFILE" 2>/dev/null || echo 0)
     if [ -n "$OLDPID" ] && kill -0 "$OLDPID" 2>/dev/null; then
-        log "Alter Agent laeuft noch (PID $OLDPID), stoppe ihn"
+        log "Old agent still running (PID $OLDPID), stopping it"
         kill -TERM "$OLDPID" 2>/dev/null
         sleep 2
         kill -KILL "$OLDPID" 2>/dev/null
@@ -88,13 +88,13 @@ if [ -f "$PIDFILE" ]; then
     rm -f "$PIDFILE"
 fi
 
-# === Optional Update anwenden ===
+# === Apply optional update ===
 if [ -x "$STICK/update.sh" ]; then
-    log "Pruefe Update via $STICK/update.sh"
+    log "Checking for an update via $STICK/update.sh"
     "$STICK/update.sh" 2>&1 | tee -a "$LOG" || true
 fi
 
-# === Hosts Block via bind mount schreibbar machen (rootfs ro) ===
+# === Make the hosts block writable via a bind mount (rootfs ro) ===
 mount | grep -q '/etc/hosts' || {
     cp /etc/hosts /tmp/hosts.original 2>/dev/null
     cp /etc/hosts /tmp/hosts.live 2>/dev/null
@@ -103,15 +103,15 @@ mount | grep -q '/etc/hosts' || {
 
 # === iptables NAT optional ===
 if command -v iptables >/dev/null 2>&1; then
-    log "iptables NAT verfuegbar"
+    log "iptables NAT available"
 else
-    log "iptables NAT nicht verfuegbar, Marge laeuft direkt auf 443"
+    log "iptables NAT not available, Marge runs directly on 443"
 fi
 
-log "bind mount auf /etc/hosts aktiv"
-log "Starte Agent Version $(${BIN} --version 2>/dev/null || echo v0.0.0)"
+log "bind mount on /etc/hosts active"
+log "Starting agent version $(${BIN} --version 2>/dev/null || echo v0.0.0)"
 
-# === Agent starten ===
+# === Start the agent ===
 nohup "$BIN" \
     --presets "$STICK/presets.json" \
     --listen-webui :8888 \
@@ -126,9 +126,9 @@ nohup "$BIN" \
 
 NEW_PID=$!
 echo "$NEW_PID" > "$PIDFILE"
-log "Agent gestartet mit PID $NEW_PID"
+log "Agent started with PID $NEW_PID"
 
-# === Root CA in System Trust Store mounten ===
+# === Mount the Root CA into the system trust store ===
 ROOT_CA="$PERSIST/ca/root.crt"
 WAIT=0
 while [ ! -r "$ROOT_CA" ] && [ "$WAIT" -lt 20 ]; do
@@ -137,7 +137,7 @@ while [ ! -r "$ROOT_CA" ] && [ "$WAIT" -lt 20 ]; do
 done
 
 if [ -r "$ROOT_CA" ]; then
-    log "Root CA vorhanden nach ${WAIT}s, setze bind mount"
+    log "Root CA present after ${WAIT}s, setting up the bind mount"
 
     for target in /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt; do
         if [ ! -f "$target" ]; then continue; fi
@@ -148,8 +148,8 @@ if [ -r "$ROOT_CA" ]; then
         if mount | grep -q "$target"; then
             umount "$target" 2>/dev/null
         fi
-        mount --bind "$bundle" "$target" 2>/dev/null && echo "bind mount aktiv: $bundle -> $target"
+        mount --bind "$bundle" "$target" 2>/dev/null && echo "bind mount active: $bundle -> $target"
     done
 fi
 
-log "Bootstrap abgeschlossen"
+log "Bootstrap complete"

--- a/sticksetup/sticksetup.go
+++ b/sticksetup/sticksetup.go
@@ -1,8 +1,8 @@
-// Package sticksetup enthaelt die Windows/Mac Logik fuer das Bestuecken
-// eines frischen SD Sticks: Drive Discovery, File Copy, optional Eject.
-// Wird von der Desktop App genutzt; ist nicht Teil des Stick Agent.
+// Package sticksetup contains the Windows/Mac logic for provisioning a
+// fresh SD stick: drive discovery, file copy, optional eject. Used by
+// the desktop app; not part of the stick agent.
 //
-// Top-level Package (nicht internal/) damit Wails App importieren kann.
+// Top-level package (not internal/) so the Wails app can import it.
 package sticksetup
 
 import (
@@ -24,21 +24,21 @@ import (
 // then it falls back to the default logger. Mirrors dlna.Logger.
 var Logger = slog.Default()
 
-// Drive beschreibt ein potenzielles Ziellaufwerk fuer den Stick Setup.
+// Drive describes a potential target drive for the stick setup.
 type Drive struct {
-	Path        string `json:"path"`        // z.B. "D:\" oder "/Volumes/UNTITLED"
-	Label       string `json:"label"`       // Volume Label oder ""
-	TotalBytes  int64  `json:"totalBytes"`  // Groesse in Bytes
-	FreeBytes   int64  `json:"freeBytes"`   // verfuegbar in Bytes
+	Path        string `json:"path"`        // e.g. "D:\" or "/Volumes/UNTITLED"
+	Label       string `json:"label"`       // volume label or ""
+	TotalBytes  int64  `json:"totalBytes"`  // size in bytes
+	FreeBytes   int64  `json:"freeBytes"`   // available in bytes
 	Filesystem  string `json:"filesystem"`  // FAT32 / exFAT / NTFS
-	Removable   bool   `json:"removable"`   // Wechseldatentraeger
-	HasStick    bool   `json:"hasStick"`    // wurde schon mal als STR bestueckt?
-	Description string `json:"description"` // Anzeige Hint fuer den User
+	Removable   bool   `json:"removable"`   // removable medium
+	HasStick    bool   `json:"hasStick"`    // already provisioned as STR before?
+	Description string `json:"description"` // display hint for the user
 }
 
-// ListDrives findet alle entfernbaren Volumes die als Stick Ziel taugen.
-// Auf Windows: alle Drive Letters die nicht Fixed sind. Auf Mac/Linux:
-// alle Mounts unter /Volumes bzw /media die fat32 sind.
+// ListDrives finds all removable volumes that qualify as a stick target.
+// On Windows: all drive letters that are not fixed. On Mac/Linux: all
+// mounts under /Volumes or /media that are fat32.
 func ListDrives() ([]Drive, error) {
 	start := time.Now()
 	var drives []Drive
@@ -145,23 +145,23 @@ func stickWritable(path string) bool {
 	return true
 }
 
-// WLANConfig beschreibt eine WLAN Konfiguration die auf den Stick
-// geschrieben wird. Box's run.sh erkennt die Datei und provisioniert
-// wpa_supplicant beim ersten Boot.
+// WLANConfig describes a WLAN configuration written to the stick. The
+// box's run.sh detects the file and provisions wpa_supplicant on the
+// first boot.
 type WLANConfig struct {
 	SSID     string `json:"ssid"`
 	Password string `json:"password"`
 }
 
-// WriteStickFiles bestueckt das angegebene Ziel mit den eingebetteten
-// usb-stick Templates plus optional dem Stick Agent Binary.
+// WriteStickFiles provisions the given target with the embedded usb-stick
+// templates plus, optionally, the stick agent binary.
 //
-// binaryBytes ist das Stick Agent Binary (ARM build). Wenn nil, wird
-// nichts geschrieben — sinnvoll fuer "nur Templates aktualisieren" Flow.
-// Setzt die Files mit dem korrekten Mode fuer FAT32 (Mode wird auf FAT32
-// ignoriert, ist aber sauber).
+// binaryBytes is the stick agent binary (ARM build). If nil, nothing is
+// written — useful for the "update templates only" flow. Sets the files
+// with the correct mode for FAT32 (mode is ignored on FAT32, but it is
+// clean).
 //
-// Returns Liste der geschriebenen Files.
+// Returns the list of written files.
 func WriteStickFiles(targetPath string, binaryBytes, goLibrespotBytes []byte, stickVersion string) ([]string, error) {
 	if targetPath == "" {
 		return nil, fmt.Errorf("targetPath is empty")
@@ -176,7 +176,7 @@ func WriteStickFiles(targetPath string, binaryBytes, goLibrespotBytes []byte, st
 
 	written := []string{}
 
-	// Embed Files
+	// Embed files
 	stickFS := usbstick.Files()
 	err = fs.WalkDir(stickFS, ".", func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -185,7 +185,7 @@ func WriteStickFiles(targetPath string, binaryBytes, goLibrespotBytes []byte, st
 		if d.IsDir() {
 			return nil
 		}
-		// files.go ist Go Code, nicht fuer den Stick gedacht.
+		// files.go is Go code, not meant for the stick.
 		if strings.HasSuffix(path, ".go") {
 			return nil
 		}
@@ -204,7 +204,7 @@ func WriteStickFiles(targetPath string, binaryBytes, goLibrespotBytes []byte, st
 		return written, err
 	}
 
-	// Binary schreiben falls vorhanden
+	// Write the binary if present
 	if len(binaryBytes) > 0 {
 		dstName := "streborn-armv7l"
 		dstPath := filepath.Join(targetPath, dstName)
@@ -228,16 +228,16 @@ func WriteStickFiles(targetPath string, binaryBytes, goLibrespotBytes []byte, st
 		written = append(written, glrName)
 	}
 
-	// remote_services Marker fuer Dauer-SSH — IMMER neu schreiben damit
-	// auch alte Sticks einen aktuellen Zeitstempel bekommen und der
-	// User sofort sieht dass das Setup wirklich gelaufen ist.
+	// remote_services marker for persistent SSH — ALWAYS rewrite so that
+	// even old sticks get a current timestamp and the user immediately
+	// sees that the setup really ran.
 	markerPath := filepath.Join(targetPath, "remote_services")
 	_ = writeFile(markerPath, []byte(""))
 	written = append(written, "remote_services")
 
-	// version.txt mit echter App Version (z.B. "1.0.0"). Wird IMMER neu
-	// geschrieben damit nach einem Update Stick der Vergleich app == stick
-	// passt und kein falsches "Update verfuegbar" Banner mehr erscheint.
+	// version.txt with the real app version (e.g. "1.0.0"). ALWAYS
+	// rewritten so that after an update stick the comparison app == stick
+	// holds and no false "update available" banner appears anymore.
 	versionPath := filepath.Join(targetPath, "version.txt")
 	v := strings.TrimSpace(stickVersion)
 	if v == "" {
@@ -290,8 +290,8 @@ func StickFileSet(binaryBytes, goLibrespotBytes []byte, stickVersion string) (ma
 	return files, nil
 }
 
-// IsBoseStick prueft ob auf dem Stick schon STR Files liegen
-// (also der Stick bereits bestueckt wurde).
+// IsBoseStick checks whether STR files are already on the stick (i.e.
+// the stick has already been provisioned).
 func IsBoseStick(path string) bool {
 	marker := filepath.Join(path, "run.sh")
 	if _, err := os.Stat(marker); err == nil {
@@ -300,8 +300,8 @@ func IsBoseStick(path string) bool {
 	return false
 }
 
-// StickVersion liest die version.txt vom Stick. Leer wenn die Datei
-// nicht da oder leer ist.
+// StickVersion reads version.txt from the stick. Empty if the file is
+// not there or empty.
 func StickVersion(path string) string {
 	b, err := os.ReadFile(filepath.Join(path, "version.txt"))
 	if err != nil {
@@ -310,10 +310,10 @@ func StickVersion(path string) string {
 	return strings.TrimSpace(string(b))
 }
 
-// StickConfigs liefert die noch nicht angewendeten Setup Konfigs vom
-// Stick. Wenn der User den Stick noch nicht in die Box gesteckt hat,
-// liegen wlan.conf / region.conf / name.conf darauf — die App nutzt
-// die Werte zum Vorbefuellen der Wizard Felder.
+// StickConfigs returns the not-yet-applied setup configs from the stick.
+// If the user has not yet inserted the stick into the box, wlan.conf /
+// region.conf / name.conf are on it — the app uses the values to prefill
+// the wizard fields.
 type StickConfigs struct {
 	WLANSSID string `json:"wlanSSID"`
 	WLANPass string `json:"wlanPass"`
@@ -322,8 +322,8 @@ type StickConfigs struct {
 	Locale   string `json:"locale"`
 }
 
-// ReadStickConfigs liest die conf Files vom Stick. Felder die nicht
-// existieren oder leer sind bleiben leer im Ergebnis.
+// ReadStickConfigs reads the conf files from the stick. Fields that do
+// not exist or are empty stay empty in the result.
 func ReadStickConfigs(path string) StickConfigs {
 	out := StickConfigs{}
 	if b, err := os.ReadFile(filepath.Join(path, "wlan.conf")); err == nil {
@@ -354,9 +354,9 @@ func ReadStickConfigs(path string) StickConfigs {
 	return out
 }
 
-// WriteWLANConfig schreibt eine wlan.conf JSON Datei auf den Stick.
-// Box's run.sh erkennt das beim ersten Boot und provisioniert
-// wpa_supplicant entsprechend.
+// WriteWLANConfig writes a wlan.conf JSON file to the stick. The box's
+// run.sh detects it on the first boot and provisions wpa_supplicant
+// accordingly.
 func WriteWLANConfig(targetPath string, cfg WLANConfig) error {
 	if cfg.SSID == "" {
 		return fmt.Errorf("SSID must not be empty")
@@ -369,16 +369,17 @@ func WriteWLANConfig(targetPath string, cfg WLANConfig) error {
 	return writeFile(dst, data)
 }
 
-// RegionConfig haelt den vom User beim Setup gewaehlten Country Code
-// (ISO 3166-1 alpha-2). Wird vom Stick beim Start gelesen und u.a. als
-// Default fuer die Radio Suche Land und die Sprach Auswahl benutzt.
+// RegionConfig holds the country code (ISO 3166-1 alpha-2) the user
+// chose during setup. Read by the stick at startup and used, among other
+// things, as the default for the radio search country and the language
+// selection.
 type RegionConfig struct {
 	Country string `json:"country"`
 }
 
-// WriteRegionConfig schreibt region.conf JSON auf den Stick. Stick's
-// run.sh persistiert es beim Bootstrap nach NAND und loescht die Datei
-// vom Stick.
+// WriteRegionConfig writes region.conf JSON to the stick. The stick's
+// run.sh persists it to NAND during bootstrap and deletes the file from
+// the stick.
 func WriteRegionConfig(targetPath string, cfg RegionConfig) error {
 	if cfg.Country == "" {
 		return fmt.Errorf("country must not be empty")
@@ -391,14 +392,14 @@ func WriteRegionConfig(targetPath string, cfg RegionConfig) error {
 	return writeFile(dst, data)
 }
 
-// NameConfig haelt den vom User beim Setup gewaehlten Box Namen (z.B.
-// "Wohnzimmer"). Wird beim ersten Boot vom Stick auf die Box via Bose
-// REST API angewendet. Stick haengt die UID der Box noch automatisch an.
+// NameConfig holds the box name the user chose during setup (e.g.
+// "Living Room"). Applied to the box from the stick on the first boot via
+// the Bose REST API. The stick automatically appends the box's UID.
 type NameConfig struct {
 	Name string `json:"name"`
 }
 
-// WriteNameConfig schreibt eine name.conf JSON Datei auf den Stick.
+// WriteNameConfig writes a name.conf JSON file to the stick.
 func WriteNameConfig(targetPath string, cfg NameConfig) error {
 	if cfg.Name == "" {
 		return fmt.Errorf("name must not be empty")
@@ -411,29 +412,28 @@ func WriteNameConfig(targetPath string, cfg NameConfig) error {
 	return writeFile(dst, data)
 }
 
-// LangConfig haelt die Signale aus dem Setup-Wizard (aktives App-UI
-// Locale, z.B. "de"/"en", und das vom User gewaehlte Land als ISO
-// 3166-1 alpha-2) plus den daraus abgeleiteten Bose sysLanguage
-// Integer. Der Stick liest das beim ersten Boot und nutzt SysLanguage
-// fuer das OOB Language Gate UND als Display-Sprache der Box, statt eine
-// fest verdrahtete Sprache zu erzwingen. Siehe project_bose_language_enum:
-// Englisch=3 ist der weltweite Default.
+// LangConfig holds the signals from the setup wizard (active app UI
+// locale, e.g. "de"/"en", and the country the user chose as ISO
+// 3166-1 alpha-2) plus the Bose sysLanguage integer derived from them.
+// The stick reads this on the first boot and uses SysLanguage for the
+// OOB language gate AND as the box's display language, instead of
+// forcing a hard-wired language. See project_bose_language_enum:
+// English=3 is the worldwide default.
 type LangConfig struct {
 	Locale      string `json:"locale"`
 	Country     string `json:"country"`
 	SysLanguage int    `json:"sysLanguage"`
 }
 
-// SysLanguageForLocale bildet einen BCP-47 Locale (oder nur das
-// Primaer-Subtag) auf den Bose sysLanguage Integer ab. Single source
-// of truth fuer alle Stellen die eine Sprache an die Box schicken
-// (Stick lang.conf + Setup-AP Push). Unbekannte Locales fallen auf
-// Englisch (3) zurueck, den neutralen weltweiten Default. 0 (unset)
-// und 14 (undefiniert) werden nie zurueckgegeben. Voller Enum in
+// SysLanguageForLocale maps a BCP-47 locale (or just the primary subtag)
+// to the Bose sysLanguage integer. Single source of truth for everywhere
+// that sends a language to the box (stick lang.conf + setup-AP push).
+// Unknown locales fall back to English (3), the neutral worldwide
+// default. 0 (unset) and 14 (undefined) are never returned. Full enum in
 // project_bose_language_enum.
 func SysLanguageForLocale(locale string) int {
 	s := strings.ToLower(strings.TrimSpace(locale))
-	// Chinesisch braucht das Region-Subtag fuer simplified vs traditional.
+	// Chinese needs the region subtag for simplified vs traditional.
 	switch {
 	case strings.HasPrefix(s, "zh-tw"), strings.HasPrefix(s, "zh-hk"),
 		strings.HasPrefix(s, "zh-mo"), strings.HasPrefix(s, "zh-hant"):
@@ -441,7 +441,7 @@ func SysLanguageForLocale(locale string) int {
 	case strings.HasPrefix(s, "zh"):
 		return 10 // Simplified Chinese
 	}
-	// Primaer-Subtag (vor '-' oder '_').
+	// Primary subtag (before '-' or '_').
 	primary := s
 	for i := 0; i < len(s); i++ {
 		if s[i] == '-' || s[i] == '_' {
@@ -602,11 +602,11 @@ func localePrimary(locale string) string {
 	return s
 }
 
-// WriteLangConfig schreibt lang.conf JSON auf den Stick. locale +
-// country sind die Wizard-Signale (fuer den Record), sysLanguage ist der
-// vom User im Sprach-Dropdown bestaetigte Wert. Ein ungueltiger Wert
-// (<=0, 14, oder >25) wird auf SuggestBoxLanguage zurueckgesetzt, damit
-// run.sh den Integer ohne eigene Mapping-Tabelle direkt lesen kann.
+// WriteLangConfig writes lang.conf JSON to the stick. locale + country
+// are the wizard signals (for the record), sysLanguage is the value the
+// user confirmed in the language dropdown. An invalid value (<=0, 14, or
+// >25) is reset to SuggestBoxLanguage so run.sh can read the integer
+// directly without its own mapping table.
 func WriteLangConfig(targetPath string, locale, country string, sysLanguage int) error {
 	loc := strings.TrimSpace(locale)
 	if loc == "" {
@@ -625,24 +625,24 @@ func WriteLangConfig(targetPath string, locale, country string, sysLanguage int)
 	return writeFile(dst, data)
 }
 
-// Eject wirft das Volume aus. Plattformspezifisch implementiert.
+// Eject ejects the volume. Implemented per platform.
 func Eject(path string) error {
 	return ejectImpl(path)
 }
 
-// FormatFAT32 formatiert den Stick neu als FAT32. ACHTUNG: alle Daten
-// gehen verloren. Wird vom Setup Wizard vor dem Beschreiben angeboten
-// damit der User nicht ausserhalb der App formatieren muss (Windows
-// Dialog zeigt FAT32 fuer Sticks ab 32 GB nicht an).
+// FormatFAT32 reformats the stick as FAT32. WARNING: all data is lost.
+// Offered by the setup wizard before writing so the user does not have to
+// format outside the app (the Windows dialog does not show FAT32 for
+// sticks of 32 GB and up).
 func FormatFAT32(path, label string) error {
 	return formatFAT32Impl(path, label)
 }
 
-// writeFile schreibt eine Datei atomar mit fsync. Wichtig: f.Sync()
-// erzwingt FlushFileBuffers vor Close, sonst koennte Windows die Daten
-// im Lazy Write Cache halten und beim Stick Ziehen ohne sauberen Eject
-// gehen sie verloren — genau das hat dazu gefuehrt dass conf Files vom
-// Setup nicht auf der Box ankamen.
+// writeFile writes a file atomically with fsync. Important: f.Sync()
+// forces FlushFileBuffers before Close, otherwise Windows could keep the
+// data in the lazy write cache and it would be lost when the stick is
+// pulled without a clean eject — exactly what caused conf files from the
+// setup not to reach the box.
 //
 // Close errors on the error path are intentionally discarded with
 // `_ = f.Close()`: we are about to os.Remove the tmp file anyway,

--- a/sticksetup/sticksetup_unix.go
+++ b/sticksetup/sticksetup_unix.go
@@ -12,7 +12,7 @@ import (
 	"syscall"
 )
 
-func listDrivesWindows() ([]Drive, error) { return nil, fmt.Errorf("nicht auf Windows") }
+func listDrivesWindows() ([]Drive, error) { return nil, fmt.Errorf("not on Windows") }
 
 func listDrivesMac() ([]Drive, error) {
 	root := "/Volumes"
@@ -20,7 +20,7 @@ func listDrivesMac() ([]Drive, error) {
 }
 
 func listDrivesLinux() ([]Drive, error) {
-	// Versuche typische Mount Punkte
+	// Try typical mount points
 	candidates := []string{"/media", "/mnt", "/run/media"}
 	var all []Drive
 	for _, c := range candidates {
@@ -41,7 +41,7 @@ func scanMounts(root string) ([]Drive, error) {
 			continue
 		}
 		path := filepath.Join(root, e.Name())
-		// Sub Verzeichnis bei /media/<user>/<volume>
+		// Subdirectory at /media/<user>/<volume>
 		if runtime.GOOS == "linux" {
 			subs, err := os.ReadDir(path)
 			if err == nil {
@@ -79,18 +79,20 @@ func makeDrive(path string) Drive {
 	}
 }
 
-// detectFs ist Best Effort — Stat liefert filesystem type nur auf Linux.
+// detectFs is best-effort — Stat returns the filesystem type only on Linux.
 func detectFs(path string) string {
-	return "FAT32" // Assumption fuer Stick targets
+	return "FAT32" // assumption for stick targets
 }
 
-// formatFAT32Impl stub fuer Mac/Linux — aktuell nicht implementiert.
-// User auf diesen Plattformen formatiert vorerst selbst.
+// formatFAT32Impl stub for Mac/Linux — not implemented yet.
+// Users on these platforms format the stick themselves for now.
 //
 // macOS note (issue #58): `diskutil eraseDisk` requires a whole-disk
 // node (`/dev/diskN`), not a mounted volume path (`/Volumes/BOSE`).
 // Passing the volume produced
-//   "A volume was specified instead of a whole disk: /Volumes/BOSE"
+//
+//	"A volume was specified instead of a whole disk: /Volumes/BOSE"
+//
 // We therefore resolve the volume to its ParentWholeDisk via
 // `diskutil info -plist <path>` before calling eraseDisk.
 func formatFAT32Impl(path, label string) error {
@@ -152,7 +154,7 @@ func macParentWholeDisk(volumePath string) (string, error) {
 	return disk, nil
 }
 
-// ejectImpl auf Mac/Linux via OS Commands.
+// ejectImpl on Mac/Linux via OS commands.
 func ejectImpl(path string) error {
 	switch runtime.GOOS {
 	case "darwin":
@@ -162,7 +164,7 @@ func ejectImpl(path string) error {
 		}
 		return nil
 	default:
-		// Linux: einfach umount, das ist meistens was der User will
+		// Linux: just umount, that is mostly what the user wants
 		cmd := exec.Command("umount", path)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("umount: %v: %s", err, string(out))

--- a/sticksetup/sticksetup_windows.go
+++ b/sticksetup/sticksetup_windows.go
@@ -26,7 +26,7 @@ func listDrivesWindows() ([]Drive, error) {
 
 	mask, _, _ := getLogicalDrives.Call()
 	if mask == 0 {
-		return nil, fmt.Errorf("GetLogicalDrives lieferte 0")
+		return nil, fmt.Errorf("GetLogicalDrives returned 0")
 	}
 
 	var out []Drive
@@ -74,10 +74,10 @@ func listDrivesWindows() ([]Drive, error) {
 		label := syscall.UTF16ToString(volumeName)
 		fs := syscall.UTF16ToString(fsName)
 
-		// Box liest nur FAT32. Auf NTFS / exFAT / sonstigem Filesystem
-		// gilt der Stick NICHT als Bose Stick auch wenn run.sh & Co
-		// drauf liegen — sonst zeigt die App faelschlich "Stick
-		// erkannt, Version 1.0.0" und schreibt sinnlose Files.
+		// The box only reads FAT32. On NTFS / exFAT / any other filesystem
+		// the stick does NOT count as a Bose stick even if run.sh & co are
+		// on it — otherwise the app would wrongly show "stick detected,
+		// version 1.0.0" and write pointless files.
 		hasStick := false
 		if strings.EqualFold(fs, "FAT32") {
 			hasStick = IsBoseStick(root)
@@ -107,22 +107,22 @@ func descForDrive(path, label, fs string, total int64) string {
 	return fmt.Sprintf("%s %s (%.1f GB, %s)", path, label, gb, fs)
 }
 
-// listDrivesMac und listDrivesLinux sind auf Windows nicht implementiert
-// aber wir brauchen die Symbole damit das gemeinsame sticksetup.go Switch
-// statement kompiliert.
-func listDrivesMac() ([]Drive, error)   { return nil, fmt.Errorf("nicht auf Mac") }
-func listDrivesLinux() ([]Drive, error) { return nil, fmt.Errorf("nicht auf Linux") }
+// listDrivesMac and listDrivesLinux are not implemented on Windows, but
+// we need the symbols so the shared sticksetup.go switch statement
+// compiles.
+func listDrivesMac() ([]Drive, error)   { return nil, fmt.Errorf("not on Mac") }
+func listDrivesLinux() ([]Drive, error) { return nil, fmt.Errorf("not on Linux") }
 
-// formatFAT32Impl formatiert das Volume neu als FAT32 via embeddedem
-// winformat.exe Helper, der FmIfs.dll FormatEx direkt aufruft. Das hat
-// kein 32 GB Limit (anders als Format-Volume Cmdlet) und liefert einen
-// sauberen Exit Code zurueck.
+// formatFAT32Impl reformats the volume as FAT32 via the embedded
+// winformat.exe helper, which calls FmIfs.dll FormatEx directly. That has
+// no 32 GB limit (unlike the Format-Volume cmdlet) and returns a clean
+// exit code.
 //
-// Ablauf:
-//  1. winformat.exe aus dem Embed in TEMP extrahieren
-//  2. Mit Start-Process -Verb RunAs starten — User sieht EINEN UAC Prompt
-//  3. Helper laeuft elevated, ruft FmIfs.FormatEx, schreibt Exit Code
-//  4. Wir lesen stderr fuer eine sinnvolle Fehlermeldung
+// Flow:
+//  1. Extract winformat.exe from the embed into TEMP
+//  2. Launch it with Start-Process -Verb RunAs — the user sees ONE UAC prompt
+//  3. The helper runs elevated, calls FmIfs.FormatEx, writes the exit code
+//  4. We read stderr for a meaningful error message
 func formatFAT32Impl(path, label string) error {
 	letter := strings.TrimSuffix(path, ":\\")
 	letter = strings.TrimSuffix(letter, ":/")
@@ -139,8 +139,8 @@ func formatFAT32Impl(path, label string) error {
 			"please re-download the installer from the GitHub release page)")
 	}
 
-	// Helper in TEMP extrahieren. Eindeutiger Name pro Aufruf damit
-	// alte Instanzen das File nicht sperren.
+	// Extract the helper into TEMP. Unique name per call so old
+	// instances do not lock the file.
 	tmpDir := os.TempDir()
 	stamp := time.Now().UnixNano()
 	helperPath := filepath.Join(tmpDir, fmt.Sprintf("st-winformat-%d.exe", stamp))
@@ -151,11 +151,11 @@ func formatFAT32Impl(path, label string) error {
 	defer os.Remove(helperPath)
 	defer os.Remove(statusPath)
 
-	// Start-Process -Verb RunAs zeigt den UAC Prompt und wartet auf
-	// Exit. WICHTIG: -RedirectStandardError ist mit -Verb NICHT
-	// erlaubt (PowerShell wirft ParameterBindingException), daher
-	// schreibt der Helper das Ergebnis selbst in die Status Datei.
-	// $LASTEXITCODE liefern wir an die App zurueck.
+	// Start-Process -Verb RunAs shows the UAC prompt and waits for exit.
+	// IMPORTANT: -RedirectStandardError is NOT allowed with -Verb
+	// (PowerShell throws ParameterBindingException), so the helper writes
+	// the result into the status file itself. We return $LASTEXITCODE to
+	// the app.
 	ps := fmt.Sprintf(
 		`$ErrorActionPreference='Stop'; try { $p = Start-Process -FilePath '%s' -ArgumentList '%s','%s','%s' -Verb RunAs -Wait -PassThru -WindowStyle Hidden; exit $p.ExitCode } catch { Write-Error $_.Exception.Message; exit 99 }`,
 		strings.ReplaceAll(helperPath, `'`, `''`),
@@ -167,7 +167,7 @@ func formatFAT32Impl(path, label string) error {
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: 0x08000000}
 	out, runErr := cmd.CombinedOutput()
 
-	// Status Datei lesen — das ist die Quelle der Wahrheit.
+	// Read the status file — this is the source of truth.
 	statusData, _ := os.ReadFile(statusPath)
 	status := strings.TrimSpace(string(statusData))
 
@@ -175,7 +175,7 @@ func formatFAT32Impl(path, label string) error {
 		return nil
 	}
 
-	// Kein OK Status → entweder UAC abgelehnt oder Helper hat Fehler gemeldet.
+	// No OK status → either UAC was declined or the helper reported an error.
 	if runErr != nil {
 		msg := strings.TrimSpace(string(out))
 		// Exit Code 1223 = ERROR_CANCELLED (UAC declined by user).
@@ -200,25 +200,26 @@ func formatFAT32Impl(path, label string) error {
 	return fmt.Errorf("format failed: helper never executed (UAC declined or antivirus blocked it?)")
 }
 
-// ejectImpl wirft das Volume sauber aus via Win32 API direkt.
-// Vorgehen ist der Microsoft Standard fuer "Safely Remove Hardware":
-//   1. CreateFile(\\.\X:) — Handle aufs Volume
-//   2. FSCTL_LOCK_VOLUME — exklusiver Lock damit niemand mehr schreibt
-//   3. FSCTL_DISMOUNT_VOLUME — Filesystem-Mount entfernen
-//   4. IOCTL_STORAGE_MEDIA_REMOVAL — Hardware Removal-Schutz aus
-//   5. IOCTL_STORAGE_EJECT_MEDIA — den USB Driver anweisen das Geraet
-//      freizugeben (kein Disconnect Sound beim Ziehen mehr)
+// ejectImpl ejects the volume cleanly via the Win32 API directly.
+// The procedure is the Microsoft standard for "Safely Remove Hardware":
+//  1. CreateFile(\\.\X:) — handle to the volume
+//  2. FSCTL_LOCK_VOLUME — exclusive lock so nobody writes anymore
+//  3. FSCTL_DISMOUNT_VOLUME — remove the filesystem mount
+//  4. IOCTL_STORAGE_MEDIA_REMOVAL — turn off the hardware removal guard
+//  5. IOCTL_STORAGE_EJECT_MEDIA — tell the USB driver to release the
+//     device (no more disconnect sound when pulling it)
 //
-// Das ist deutlich robuster als Shell.Application Eject Verb, das oft
-// nur den Drive Letter entfernt aber USB Driver aktiv laesst.
+// This is considerably more robust than the Shell.Application Eject verb,
+// which often only removes the drive letter but leaves the USB driver
+// active.
 func ejectImpl(path string) error {
 	letter := strings.TrimSuffix(path, ":\\")
 	letter = strings.TrimSuffix(letter, ":/")
 	if len(letter) == 0 {
-		return fmt.Errorf("kein Drive Letter in %q", path)
+		return fmt.Errorf("no drive letter in %q", path)
 	}
 
-	// Schreibe Caches flushen lassen
+	// Let write caches flush
 	time.Sleep(1 * time.Second)
 
 	drivePath := `\\.\` + letter + ":"
@@ -259,7 +260,7 @@ func ejectImpl(path string) error {
 	defer closeHandle.Call(h)
 
 	var bytesReturned uint32
-	// Lock — retry weil andere Prozesse (Indexer) ggf. noch zugreifen
+	// Lock — retry because other processes (the indexer) may still be accessing it
 	var lockErr error
 	for i := 0; i < 10; i++ {
 		r, _, e := deviceIoControl.Call(h, fsctlLockVolume, 0, 0, 0, 0, uintptr(unsafe.Pointer(&bytesReturned)), 0)
@@ -274,16 +275,16 @@ func ejectImpl(path string) error {
 		return fmt.Errorf("lock volume: %v", lockErr)
 	}
 
-	// Dismount Filesystem
+	// Dismount the filesystem
 	if r, _, e := deviceIoControl.Call(h, fsctlDismountVolume, 0, 0, 0, 0, uintptr(unsafe.Pointer(&bytesReturned)), 0); r == 0 {
 		return fmt.Errorf("dismount: %v", e)
 	}
 
-	// Media Removal aktivieren (PREVENT_MEDIA_REMOVAL = 0 = false)
+	// Enable media removal (PREVENT_MEDIA_REMOVAL = 0 = false)
 	var preventRemoval byte = 0
 	deviceIoControl.Call(h, ioctlStorageMediaRemov, uintptr(unsafe.Pointer(&preventRemoval)), 1, 0, 0, uintptr(unsafe.Pointer(&bytesReturned)), 0)
 
-	// Eject — der eigentliche "Safe to Remove" Hardware Trigger
+	// Eject — the actual "Safe to Remove" hardware trigger
 	if r, _, e := deviceIoControl.Call(h, ioctlStorageEjectMedia, 0, 0, 0, 0, uintptr(unsafe.Pointer(&bytesReturned)), 0); r == 0 {
 		return fmt.Errorf("eject media: %v", e)
 	}

--- a/usb-stick/autostart.sh
+++ b/usb-stick/autostart.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # autostart.sh: DEPRECATED.
 #
-# Diese Datei stammt aus der Planungsphase. Die produktive Bootstrap
-# Kette ist jetzt:
+# This file dates from the planning phase. The production bootstrap
+# chain is now:
 #
 #   /mnt/nv/rc.local  (via shelby_local beim Boot)
 #       -> /media/sda1/run.sh
@@ -11,8 +11,8 @@
 # Installation:
 #   sh /media/sda1/install.sh
 #
-# Diese autostart.sh ist nur noch ein Fallback Eintrittspunkt der run.sh
-# aufruft. Kann ohne Verlust entfernt werden sobald die Migration
-# abgeschlossen ist.
+# This autostart.sh is now only a fallback entry point that calls
+# run.sh. It can be removed without loss once the migration is
+# complete.
 
 exec "$(dirname "$0")/run.sh" "$@"

--- a/usb-stick/files.go
+++ b/usb-stick/files.go
@@ -1,6 +1,6 @@
-// Package usbstick embedded die SD Stick Template Dateien via go:embed.
-// Die Desktop App nutzt das um einen frischen Stick zu bestuecken ohne
-// dass der User das Repo separat haben muss.
+// Package usbstick embeds the SD stick template files via go:embed.
+// The desktop app uses it to populate a fresh stick without the user
+// needing the repo separately.
 package usbstick
 
 import (
@@ -11,11 +11,11 @@ import (
 //go:embed *.sh *.local *.json *.txt *.so
 var raw embed.FS
 
-// Files liefert alle eingebetteten Stick Template Files als io/fs.FS.
-// Iteration via fs.WalkDir.
+// Files returns all embedded stick template files as an io/fs.FS.
+// Iterate via fs.WalkDir.
 func Files() fs.FS { return raw }
 
-// List liefert die Namen aller eingebetteten Files (ohne Pfad).
+// List returns the names of all embedded files (without path).
 func List() ([]string, error) {
 	entries, err := raw.ReadDir(".")
 	if err != nil {
@@ -30,10 +30,10 @@ func List() ([]string, error) {
 	return out, nil
 }
 
-// Read liefert die rohen Bytes einer eingebetteten Datei.
+// Read returns the raw bytes of an embedded file.
 func Read(name string) ([]byte, error) {
 	return raw.ReadFile(name)
 }
 
-// Compile-time check dass Files das fs.FS Interface erfuellt.
+// Compile-time check that Files satisfies the fs.FS interface.
 var _ fs.FS = Files()

--- a/usb-stick/install.sh
+++ b/usb-stick/install.sh
@@ -1,21 +1,20 @@
 #!/bin/sh
-# install.sh: Einmal manuell auf der Box ausfuehren, um den Autostart
-# zu aktivieren.
+# install.sh: run once manually on the box to enable the autostart.
 #
-# Phase 1 (rc.local direkt):
-#   sh /media/sda1/install.sh             # Phase 1 aktivieren
-#   sh /media/sda1/install.sh remove      # Phase 1 deaktivieren
-#   sh /media/sda1/install.sh status      # Status anzeigen
+# Phase 1 (rc.local directly):
+#   sh /media/sda1/install.sh             # enable phase 1
+#   sh /media/sda1/install.sh remove      # disable phase 1
+#   sh /media/sda1/install.sh status      # show status
 #
-# Phase 2 (Integration in shepherdd):
-#   sh /media/sda1/install.sh shepherd install   # Phase 2 aktivieren
-#   sh /media/sda1/install.sh shepherd remove    # Phase 2 deaktivieren
-#   sh /media/sda1/install.sh shepherd status    # Shepherd Status
+# Phase 2 (integration into shepherdd):
+#   sh /media/sda1/install.sh shepherd install   # enable phase 2
+#   sh /media/sda1/install.sh shepherd remove    # disable phase 2
+#   sh /media/sda1/install.sh shepherd status    # shepherd status
 #
-# Phase 1 und Phase 2 sind exklusiv. Aktivieren von Phase 2 deaktiviert
-# automatisch Phase 1, und umgekehrt.
+# Phase 1 and phase 2 are mutually exclusive. Enabling phase 2 disables
+# phase 1 automatically, and vice versa.
 #
-# Achtung: Erfordert root. Auf der ST10 sind wir das ohnehin.
+# Note: requires root. On the ST10 we are root anyway.
 
 set -u
 
@@ -37,28 +36,28 @@ BIN="$STICK/streborn-armv7l"
 # a later stick read failure at boot cannot leave the box with no agent to run.
 CACHED_BIN="/mnt/nv/streborn/bin/streborn-armv7l"
 
-# Sicherstellen dass NAND Persist Verzeichnis existiert.
+# Make sure the NAND persist directory exists.
 mkdir -p /mnt/nv/streborn/bin 2>/dev/null
 
 phase1_install() {
     if [ ! -f "$RC_SRC" ]; then
-        echo "FEHLER: $RC_SRC nicht gefunden" >&2
+        echo "ERROR: $RC_SRC not found" >&2
         exit 1
     fi
-    # Phase 2 vorher entfernen wenn aktiv
+    # Remove phase 2 first if active
     if [ -d /mnt/nv/shepherd ]; then
-        echo "Phase 2 ist aktiv, entferne sie zuerst"
+        echo "Phase 2 is active, removing it first"
         phase2_remove
     fi
-    echo "Kopiere $RC_SRC nach $RC_DST"
-    cp "$RC_SRC" "$RC_DST" || { echo "FEHLER beim Kopieren" >&2; exit 1; }
+    echo "Copying $RC_SRC to $RC_DST"
+    cp "$RC_SRC" "$RC_DST" || { echo "ERROR while copying" >&2; exit 1; }
     chmod +x "$RC_DST"
 
-    # run.sh in NAND als run-override.sh deployen. Damit ist NAND die
-    # Source of Truth fuer den Boot - SD card I/O Probleme oder veraltete
-    # run.sh auf der SD machen kein Problem mehr.
+    # Deploy run.sh into NAND as run-override.sh. This makes NAND the
+    # source of truth for the boot - SD card I/O problems or a stale
+    # run.sh on the SD card are no longer a problem.
     if [ -f "$RUN_SRC" ]; then
-        echo "Kopiere $RUN_SRC nach $RUN_OVERRIDE"
+        echo "Copying $RUN_SRC to $RUN_OVERRIDE"
         cp "$RUN_SRC" "$RUN_OVERRIDE"
         chmod +x "$RUN_OVERRIDE"
     fi
@@ -75,86 +74,86 @@ phase1_install() {
     # marker the desktop app classifies as a stick problem (and offers the SSH
     # NAND-copy repair), instead of an opaque post-reboot "agent not up".
     if [ -s "$BIN" ]; then
-        echo "Kopiere Agent Binary nach $CACHED_BIN"
+        echo "Copying agent binary to $CACHED_BIN"
         if cp "$BIN" "$CACHED_BIN.new" 2>&1; then
             # chmod is part of the condition: a non-executable cache makes
             # run.sh's [ -x "$CACHED_BIN" ] test fail at boot, which would
             # surface as the misleading "neither NAND cache nor stick binary
             # available" even though the file is there. Fail loudly instead.
             if chmod +x "$CACHED_BIN.new" && mv "$CACHED_BIN.new" "$CACHED_BIN" 2>&1; then
-                echo "Agent Binary auf NAND gecached ($(wc -c < "$CACHED_BIN") Bytes)"
+                echo "Agent binary cached on NAND ($(wc -c < "$CACHED_BIN") bytes)"
             else
                 rm -f "$CACHED_BIN.new"
-                echo "FEHLER: Agent Binary chmod/mv nach NAND fehlgeschlagen" >&2
+                echo "ERROR: agent binary chmod/mv to NAND failed" >&2
                 exit 1
             fi
         else
             rm -f "$CACHED_BIN.new"
-            echo "FEHLER: Agent Binary konnte nicht vom Stick nach NAND kopiert werden (stick I/O error?)" >&2
+            echo "ERROR: agent binary could not be copied from the stick to NAND (stick I/O error?)" >&2
             exit 1
         fi
     fi
 
-    # presets.json von SD nach NAND migrieren beim ersten Install.
-    # SD card wirft oft I/O Error beim Schreiben (FAT32), deshalb haelt
-    # der Agent die presets.json auf NAND.
+    # Migrate presets.json from SD to NAND on the first install.
+    # The SD card often throws an I/O error on write (FAT32), so the
+    # agent keeps presets.json on NAND.
     if [ -f "$PRESETS_SRC" ] && [ ! -f "$PRESETS_DST" ]; then
-        echo "Migriere presets.json nach NAND"
+        echo "Migrating presets.json to NAND"
         cp "$PRESETS_SRC" "$PRESETS_DST"
     fi
 
     ls -la "$RC_DST" "$RUN_OVERRIDE" 2>/dev/null
-    echo "Phase 1 aktiv. Beim naechsten Boot wird $RC_DST ausgefuehrt."
-    echo "NAND Override aktiv: Agent laeuft via $RUN_OVERRIDE"
+    echo "Phase 1 active. On the next boot $RC_DST will run."
+    echo "NAND override active: agent runs via $RUN_OVERRIDE"
 }
 
 phase1_remove() {
     if [ -e "$RC_DST" ]; then
         rm -f "$RC_DST"
-        echo "Phase 1 entfernt: $RC_DST"
+        echo "Phase 1 removed: $RC_DST"
     else
-        echo "Phase 1 war nicht aktiv"
+        echo "Phase 1 was not active"
     fi
     if [ -e "$RUN_OVERRIDE" ]; then
         rm -f "$RUN_OVERRIDE"
-        echo "NAND Override entfernt: $RUN_OVERRIDE"
+        echo "NAND override removed: $RUN_OVERRIDE"
     fi
 }
 
 phase1_status() {
     if [ -x "$RC_DST" ]; then
-        echo "Phase 1 (rc.local direct): aktiv"
+        echo "Phase 1 (rc.local direct): active"
         ls -la "$RC_DST"
     else
-        echo "Phase 1 (rc.local direct): inaktiv"
+        echo "Phase 1 (rc.local direct): inactive"
     fi
     if [ -x "$RUN_OVERRIDE" ]; then
-        echo "NAND Override: aktiv"
+        echo "NAND override: active"
         ls -la "$RUN_OVERRIDE"
     else
-        echo "NAND Override: nicht installiert"
+        echo "NAND override: not installed"
     fi
     if [ -f "$PRESETS_DST" ]; then
         cnt=$(grep -c '"slot"' "$PRESETS_DST" 2>/dev/null || echo 0)
-        echo "Presets auf NAND: $cnt Eintraege"
+        echo "Presets on NAND: $cnt entries"
     fi
 }
 
 phase2_install() {
     if [ ! -x "$BIN" ]; then
-        echo "FEHLER: Agent Binary nicht ausfuehrbar: $BIN" >&2
+        echo "ERROR: agent binary not executable: $BIN" >&2
         exit 1
     fi
-    # Phase 1 vorher entfernen wenn aktiv
+    # Remove phase 1 first if active
     if [ -x "$RC_DST" ]; then
-        echo "Phase 1 ist aktiv, entferne sie zuerst"
+        echo "Phase 1 is active, removing it first"
         phase1_remove
     fi
-    echo "Aktiviere Phase 2: shepherd install ueber $BIN"
-    "$BIN" shepherd install || { echo "FEHLER" >&2; exit 1; }
+    echo "Enabling phase 2: shepherd install via $BIN"
+    "$BIN" shepherd install || { echo "ERROR" >&2; exit 1; }
     echo
-    echo "Phase 2 aktiv. Beim naechsten Boot startet shepherdd unseren Agent."
-    echo "Empfehlung: jetzt 'reboot' oder 'kill -HUP \$(pgrep shepherdd)' damit es sofort wirkt."
+    echo "Phase 2 active. On the next boot shepherdd starts our agent."
+    echo "Recommendation: run 'reboot' now or 'kill -HUP \$(pgrep shepherdd)' so it takes effect immediately."
 }
 
 phase2_remove() {
@@ -162,7 +161,7 @@ phase2_remove() {
         "$BIN" shepherd remove || true
     else
         rm -rf /mnt/nv/shepherd
-        echo "Phase 2 entfernt (per rm, Binary war nicht da)"
+        echo "Phase 2 removed (via rm, binary was not present)"
     fi
 }
 
@@ -171,10 +170,10 @@ phase2_status() {
         "$BIN" shepherd status
     else
         if [ -d /mnt/nv/shepherd ]; then
-            echo "Phase 2: Verzeichnis vorhanden, Binary aber nicht ausfuehrbar"
+            echo "Phase 2: directory present, but binary not executable"
             ls -la /mnt/nv/shepherd
         else
-            echo "Phase 2 (shepherd integration): inaktiv"
+            echo "Phase 2 (shepherd integration): inactive"
         fi
     fi
 }
@@ -189,13 +188,13 @@ case "${1:-install}" in
       remove|uninstall) phase2_remove ;;
       status)         phase2_status ;;
       *)
-        echo "Verwendung: $0 shepherd {install|remove|status}" >&2
+        echo "Usage: $0 shepherd {install|remove|status}" >&2
         exit 1
         ;;
     esac
     ;;
   *)
-    echo "Verwendung: $0 [install|remove|status|shepherd <install|remove|status>]" >&2
+    echo "Usage: $0 [install|remove|status|shepherd <install|remove|status>]" >&2
     exit 1
     ;;
 esac

--- a/usb-stick/iptables-setup.sh
+++ b/usb-stick/iptables-setup.sh
@@ -1,31 +1,31 @@
 #!/bin/sh
-# iptables-setup.sh: setzt PREROUTING Regeln damit Bose Box Traffic auf
-# 80 und 443 zu unseren lokalen Agent Ports geht.
+# iptables-setup.sh: sets PREROUTING rules so Bose box traffic on
+# 80 and 443 goes to our local agent ports.
 #
-# Wird vom run.sh nach Agent Start aufgerufen, beim Stop wieder entfernt.
+# Called by run.sh after the agent starts, removed again on stop.
 #
-# Aufruf:
-#   sh iptables-setup.sh install   # Regeln setzen
-#   sh iptables-setup.sh remove    # Regeln entfernen
-#   sh iptables-setup.sh status    # Aktive Regeln zeigen
+# Usage:
+#   sh iptables-setup.sh install   # set the rules
+#   sh iptables-setup.sh remove    # remove the rules
+#   sh iptables-setup.sh status    # show active rules
 #
-# Die Regeln tragen einen unique Marker im Kommentar, damit sie sicher
-# wieder entfernt werden koennen ohne andere Regeln zu treffen.
+# The rules carry a unique marker in the comment so they can be
+# removed safely without affecting other rules.
 
 set -u
 
 MARKER="streborn-redirect"
 
-# Zielports im Agent. Muessen mit run.sh und der Agent Konfig matchen.
-# 9080 statt 8080 weil 8080 von Bose's eigenem WebServer belegt ist.
+# Target ports in the agent. Must match run.sh and the agent config.
+# 9080 instead of 8080 because 8080 is taken by Bose's own web server.
 MARGE_HTTP_PORT=9080
 MARGE_HTTPS_PORT=8443
 BMX_PORT=8081
 WEBUI_PORT=8888
 
-# Quellports die wir umleiten wollen.
-# 80 ist normalerweise PtsServer, wir leiten es zu Marge HTTP um.
-# 443 ist HTTPS fuer die Bose Cloud Domains, geht zu Marge HTTPS.
+# Source ports we want to redirect.
+# 80 is normally PtsServer, we redirect it to Marge HTTP.
+# 443 is HTTPS for the Bose cloud domains, goes to Marge HTTPS.
 HTTP_PORT=80
 HTTPS_PORT=443
 
@@ -44,50 +44,50 @@ HTTPS_PORT=443
 INPUT_ACCEPT_PORTS="$WEBUI_PORT $MARGE_HTTP_PORT $BMX_PORT $MARGE_HTTPS_PORT"
 
 install_rules() {
-    # Erst aufraeumen falls alte Regeln noch da
+    # Clean up first in case old rules are still there
     remove_rules quiet
 
-    echo "Installiere iptables PREROUTING Regeln"
+    echo "Installing iptables PREROUTING rules"
 
-    # Module versuchen zu laden falls noetig (REDIRECT, DNAT, conntrack)
+    # Try to load modules if needed (REDIRECT, DNAT, conntrack)
     for mod in xt_REDIRECT iptable_nat nf_nat_redirect xt_DNAT iptable_nat nf_nat; do
         modprobe "$mod" 2>/dev/null
     done
 
-    # Bose Box hat kein REDIRECT Target. Wir nutzen DNAT auf 127.0.0.1 stattdessen.
-    # Damit DNAT auf localhost klappt muss erst /proc/sys/net/ipv4/conf/all/route_localnet=1
+    # The Bose box has no REDIRECT target. We use DNAT to 127.0.0.1 instead.
+    # For DNAT to localhost to work, /proc/sys/net/ipv4/conf/all/route_localnet=1 must be set first
     echo 1 > /proc/sys/net/ipv4/conf/all/route_localnet 2>/dev/null
     echo 1 > /proc/sys/net/ipv4/conf/lo/route_localnet 2>/dev/null
 
-    # 443 (HTTPS) auf Marge HTTPS umleiten via DNAT
+    # Redirect 443 (HTTPS) to Marge HTTPS via DNAT
     iptables -t nat -A PREROUTING -p tcp --dport "$HTTPS_PORT" \
         -m comment --comment "$MARKER" \
         -j DNAT --to-destination "127.0.0.1:$MARGE_HTTPS_PORT" \
-        || echo "WARN: konnte 443 PREROUTING nicht setzen"
+        || echo "WARN: could not set 443 PREROUTING"
 
-    # 80 (HTTP) auf Marge HTTP umleiten via DNAT
+    # Redirect 80 (HTTP) to Marge HTTP via DNAT
     iptables -t nat -A PREROUTING -p tcp --dport "$HTTP_PORT" \
         -m comment --comment "$MARKER" \
         -j DNAT --to-destination "127.0.0.1:$MARGE_HTTP_PORT" \
-        || echo "WARN: konnte 80 PREROUTING nicht setzen"
+        || echo "WARN: could not set 80 PREROUTING"
 
-    # OUTPUT chain damit auch lokal generierter Traffic (z.B. wenn die Box
-    # gegen localhost den Cloud Hostnamen aufloest) umgeleitet wird.
+    # OUTPUT chain so that locally generated traffic (e.g. when the box
+    # resolves the cloud hostname against localhost) is also redirected.
     iptables -t nat -A OUTPUT -p tcp --dport "$HTTPS_PORT" \
         -d 127.0.0.1 -m comment --comment "$MARKER" \
         -j DNAT --to-destination "127.0.0.1:$MARGE_HTTPS_PORT" \
-        || echo "WARN: konnte OUTPUT 443 nicht setzen"
+        || echo "WARN: could not set OUTPUT 443"
 
     iptables -t nat -A OUTPUT -p tcp --dport "$HTTP_PORT" \
         -d 127.0.0.1 -m comment --comment "$MARKER" \
         -j DNAT --to-destination "127.0.0.1:$MARGE_HTTP_PORT" \
-        || echo "WARN: konnte OUTPUT 80 nicht setzen"
+        || echo "WARN: could not set OUTPUT 80"
 
-    # MASQUERADE auf OUTPUT damit Antwort Pakete von 127.0.0.1:8080 zurueck
-    # an den richtigen Absender geroutet werden
+    # MASQUERADE on OUTPUT so reply packets from 127.0.0.1:8080 are routed
+    # back to the correct sender
     iptables -t nat -A POSTROUTING -o lo -m comment --comment "$MARKER" \
         -j MASQUERADE \
-        || echo "WARN: konnte MASQUERADE nicht setzen"
+        || echo "WARN: could not set MASQUERADE"
 
     # INPUT chain: punch holes for our agent ports so Series-I boxes
     # (SMSC/SCM, no wlan0) do not REJECT the inbound SYNs at the
@@ -101,24 +101,24 @@ install_rules() {
             -m comment --comment "$MARKER" \
             -j ACCEPT 2>/dev/null \
             && echo "INPUT ACCEPT for tcp/$port installed" \
-            || echo "WARN: konnte INPUT ACCEPT fuer tcp/$port nicht setzen"
+            || echo "WARN: could not set INPUT ACCEPT for tcp/$port"
     done
 
-    echo "Fertig. Status:"
+    echo "Done. Status:"
     show_status
 }
 
 remove_rules() {
     quiet="${1:-}"
-    # NAT Tabelle nach unserem Marker durchsuchen und loeschen
+    # Search the NAT table for our marker and delete it
     while iptables -t nat -S 2>/dev/null | grep -q "$MARKER"; do
         rule="$(iptables -t nat -S 2>/dev/null | grep "$MARKER" | head -1)"
-        # rule beginnt mit "-A CHAIN ...", wir machen daraus "-D CHAIN ..."
+        # rule starts with "-A CHAIN ...", we turn it into "-D CHAIN ..."
         del_rule="$(echo "$rule" | sed 's/^-A /-D /')"
         # shellcheck disable=SC2086
         iptables -t nat $del_rule 2>/dev/null || break
     done
-    # Filter Tabelle (INPUT) ebenfalls aufraeumen, gleiche Marker-Logik.
+    # Clean up the filter table (INPUT) as well, same marker logic.
     while iptables -S 2>/dev/null | grep -q "$MARKER"; do
         rule="$(iptables -S 2>/dev/null | grep "$MARKER" | head -1)"
         del_rule="$(echo "$rule" | sed 's/^-A /-D /')"
@@ -126,20 +126,20 @@ remove_rules() {
         iptables $del_rule 2>/dev/null || break
     done
     if [ "$quiet" != "quiet" ]; then
-        echo "iptables Regeln mit Marker '$MARKER' entfernt"
+        echo "iptables rules with marker '$MARKER' removed"
     fi
 }
 
 show_status() {
     echo "----- NAT PREROUTING -----"
     iptables -t nat -L PREROUTING -n -v --line-numbers 2>/dev/null \
-        | grep -E "(Chain|$MARKER|num   pkts)" || echo "keine Regeln"
+        | grep -E "(Chain|$MARKER|num   pkts)" || echo "no rules"
     echo "----- NAT OUTPUT -----"
     iptables -t nat -L OUTPUT -n -v --line-numbers 2>/dev/null \
-        | grep -E "(Chain|$MARKER|num   pkts)" || echo "keine Regeln"
+        | grep -E "(Chain|$MARKER|num   pkts)" || echo "no rules"
     echo "----- FILTER INPUT (full) -----"
     iptables -L INPUT -n -v --line-numbers 2>/dev/null \
-        || echo "kein filter table verfuegbar"
+        || echo "no filter table available"
 }
 
 case "${1:-install}" in
@@ -147,7 +147,7 @@ case "${1:-install}" in
     remove|uninstall)  remove_rules ;;
     status)   show_status ;;
     *)
-        echo "Verwendung: $0 {install|remove|status}" >&2
+        echo "Usage: $0 {install|remove|status}" >&2
         exit 1
         ;;
 esac

--- a/usb-stick/provision-wlan.sh
+++ b/usb-stick/provision-wlan.sh
@@ -13,7 +13,7 @@
 # the BoseApp HTTP API. The Desktop App does NOT produce that
 # format. If you need to run this manually, write wlan.conf as:
 #   ssid=MyHomeWifi
-#   security=wpa2     (oder wpa, wpa_or_wpa2, wep, open)
+#   security=wpa2     (or wpa, wpa_or_wpa2, wep, open)
 #   passphrase=secret-password
 # Then: sh /media/sda1/provision-wlan.sh
 # Logs: /mnt/nv/streborn/wlan-provision.log
@@ -29,16 +29,16 @@ log() {
 }
 
 if [ ! -r "$CONF" ]; then
-    log "wlan.conf nicht lesbar, beende"
+    log "wlan.conf not readable, exiting"
     exit 0
 fi
 
-# Konfiguration einlesen (key=value Format, Kommentare mit # erlaubt)
+# Read the configuration (key=value format, comments with # allowed)
 ssid=""
 security=""
 passphrase=""
 while IFS='=' read -r key value; do
-    # Kommentare und leere Zeilen ignorieren
+    # Ignore comments and empty lines
     case "$key" in
         "" | \#* | " "*) continue ;;
     esac
@@ -50,23 +50,23 @@ while IFS='=' read -r key value; do
 done < "$CONF"
 
 if [ -z "$ssid" ] || [ -z "$passphrase" ]; then
-    log "FEHLER ssid oder passphrase fehlt in wlan.conf"
+    log "ERROR ssid or passphrase missing in wlan.conf"
     exit 1
 fi
 if [ -z "$security" ]; then
     security="wpa_or_wpa2"
 fi
 
-log "Provisioning Profile fuer SSID '$ssid' security $security"
+log "Provisioning profile for SSID '$ssid' security $security"
 
-# Pruefen ob die Box schon im WLAN ist. Wenn ja, machen wir nichts.
+# Check whether the box is already on Wi-Fi. If so, do nothing.
 i=0
 while [ $i -lt 30 ]; do
     if wget -qO- -T 2 "$BOSE_API/networkInfo" 2>/dev/null | grep -q "NETWORK_WIFI_CONNECTED"; then
-        log "Box ist schon im WLAN, kein Provisioning noetig"
+        log "Box is already on Wi-Fi, no provisioning needed"
         exit 0
     fi
-    # BoseApp noch nicht erreichbar?
+    # BoseApp not reachable yet?
     if ! wget -qO- -T 2 "$BOSE_API/info" >/dev/null 2>&1; then
         sleep 2
         i=$((i+1))
@@ -76,13 +76,13 @@ while [ $i -lt 30 ]; do
 done
 
 if [ $i -ge 30 ]; then
-    log "BoseApp nicht erreichbar nach 60s, gebe auf"
+    log "BoseApp not reachable after 60s, giving up"
     exit 1
 fi
 
-log "BoseApp reagiert, sende addWirelessProfile"
+log "BoseApp responds, sending addWirelessProfile"
 
-# Mehrere Body Formate ausprobieren. Wir loggen welcher klappt.
+# Try several body formats. We log which one works.
 BODIES="
 <addWirelessProfile><ssid>${ssid}</ssid><security>${security}</security><passphrase>${passphrase}</passphrase></addWirelessProfile>
 <profile ssid=\"${ssid}\" security=\"${security}\" passphrase=\"${passphrase}\"/>
@@ -95,16 +95,16 @@ IFS='
 '
 for body in $BODIES; do
     [ -z "$body" ] && continue
-    log "Versuche Body: $body"
+    log "Trying body: $body"
     resp=$(echo "$body" | wget -qO- -T 5 --header="Content-Type: application/xml" \
         --post-data="$body" "$BOSE_API/addWirelessProfile" 2>&1)
     log "Response: $resp"
     case "$resp" in
         *Error* | *error* | *FAIL*)
-            log "Format fail, naechstes probieren"
+            log "Format fail, trying the next one"
             ;;
         *)
-            log "Format akzeptiert"
+            log "Format accepted"
             success=true
             break
             ;;
@@ -113,20 +113,20 @@ done
 IFS="$IFS_OLD"
 
 if ! $success; then
-    log "Kein Body Format hat geklappt"
+    log "No body format worked"
     exit 1
 fi
 
-log "Warte bis Box im WLAN ist"
+log "Waiting until the box is on Wi-Fi"
 i=0
 while [ $i -lt 30 ]; do
     if wget -qO- -T 2 "$BOSE_API/networkInfo" 2>/dev/null | grep -q "NETWORK_WIFI_CONNECTED"; then
-        log "Erfolg, Box ist im WLAN"
+        log "Success, box is on Wi-Fi"
         exit 0
     fi
     sleep 2
     i=$((i+1))
 done
 
-log "WLAN nicht aktiv nach 60s, eventuell falsche Credentials oder anderes Problem"
+log "Wi-Fi not active after 60s, possibly wrong credentials or another problem"
 exit 1

--- a/usb-stick/run.sh
+++ b/usb-stick/run.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
-# run.sh v2: NAND Cache ist Source of Truth.
+# run.sh v2: the NAND cache is the source of truth.
 #
-# Geaendert gegenueber v1 (15.05.2026):
-#   - Stick Binary auf SD card wird NICHT automatisch auf NAND kopiert.
-#     Damit verschwinden manuell deployte NAND Updates nicht beim Reboot.
-#   - Stick Binary wird nur noch als FALLBACK genutzt, wenn NAND leer ist.
-#   - Manuelles Stick->NAND Sync: touch /mnt/nv/streborn/sync-from-stick
-#     Dann wird beim naechsten Boot vom Stick gesynct.
+# Changed compared to v1 (2026-05-15):
+#   - The stick binary on the SD card is NOT automatically copied to NAND.
+#     This keeps manually deployed NAND updates from disappearing on reboot.
+#   - The stick binary is only used as a FALLBACK when NAND is empty.
+#   - Manual stick->NAND sync: touch /mnt/nv/streborn/sync-from-stick
+#     Then it syncs from the stick on the next boot.
 #
-# Auf der Box installieren: scp setup/run.sh stbox:/media/sda1/run.sh
+# Install on the box: scp setup/run.sh stbox:/media/sda1/run.sh
 #
 # ===========================================================================
 # TABLE OF CONTENTS (~3460 lines, single file on purpose: Bose runs this from
@@ -55,16 +55,15 @@ if [ ! -e "$STICK/run.sh" ] && [ ! -e "$STICK/streborn-armv7l" ]; then
     done
 fi
 PERSIST="/mnt/nv/streborn"
-# Aktiver Log liegt in tmpfs (/tmp) damit der NAND Flash im Dauerbetrieb
-# nicht abgenutzt wird. Bei jedem Start retten wir den vorherigen Log
-# nach NAND als previous.log (ueberlebt einen Box Reboot).
+# The active log lives in tmpfs (/tmp) so the NAND flash is not worn out
+# in continuous operation. On every start we save the previous log to
+# NAND as previous.log (survives a box reboot).
 LOG="/tmp/streborn-agent.log"
 PREV_LOG="$PERSIST/previous.log"
 PIDFILE="$PERSIST/agent.pid"
 
-# Vorherige Session in NAND retten bevor wir den tmpfs Log
-# ueberschreiben — damit haben wir nach jedem Crash / Reboot noch den
-# letzten Log zur Hand.
+# Save the previous session to NAND before we overwrite the tmpfs log,
+# so after every crash / reboot we still have the last log at hand.
 if [ -f "$LOG" ] && [ -s "$LOG" ]; then
     cp "$LOG" "$PREV_LOG" 2>/dev/null
 fi
@@ -1140,18 +1139,18 @@ shim_late_swap() {
 }
 (shim_late_swap) &
 
-# Binary Auswahl: NAND Cache zuerst, Stick als Fallback.
+# Binary selection: NAND cache first, stick as fallback.
 if [ -x "$CACHED_BIN" ]; then
     BIN="$CACHED_BIN"
 elif [ -x "$STICK_BIN" ]; then
     BIN="$STICK_BIN"
-    log "Kein NAND Cache, nutze Stick Binary direkt"
+    log "no NAND cache, using the stick binary directly"
 else
     log "ERROR: neither NAND cache nor stick binary available"
     exit 1
 fi
 
-# === Schon laufender Agent? Dann Stop. ===
+# === Agent already running? Then stop it. ===
 if [ -f "$PIDFILE" ]; then
     OLDPID=$(cat "$PIDFILE" 2>/dev/null || echo 0)
     if [ -n "$OLDPID" ] && kill -0 "$OLDPID" 2>/dev/null; then
@@ -1163,29 +1162,29 @@ if [ -f "$PIDFILE" ]; then
     rm -f "$PIDFILE"
 fi
 
-# === Optional Update anwenden ===
+# === Apply optional update ===
 if [ -x "$STICK/update.sh" ]; then
     log "checking for update via $STICK/update.sh"
     "$STICK/update.sh" 2>&1 | tee -a "$LOG" || true
 fi
 
-# === WLAN Provisioning aus wlan.conf vom Stick (multi-approach) ===
+# === Wi-Fi provisioning from wlan.conf on the stick (multi-approach) ===
 #
-# Eine factory-reset Bose schreibt /etc/wpa_supplicant.conf beim
-# Boot aus ihrer eigenen NetManager DB. Wenn dort kein Profil hinter
-# legt ist, schmeisst sie unsere Direct-Write Variante beim naechsten
-# Boot wieder raus. Deshalb fahren wir BEIDE Wege parallel:
+# A factory-reset Bose writes /etc/wpa_supplicant.conf on boot from
+# its own NetManager DB. If no profile is stored there, it throws out
+# our direct-write variant again on the next boot. So we run BOTH
+# paths in parallel:
 #
-#   A) Direct write nach /etc/wpa_supplicant.conf + wpa_supplicant
-#      Restart. Greift sofort, Box ist binnen Sekunden im WLAN.
-#   B) addWirelessProfile API call gegen 127.0.0.1:8090. Persistiert
-#      das Profil in NetManagers eigener DB, ueberlebt damit den
-#      naechsten Reboot ohne dass wir wlan.conf wieder lesen muessen.
+#   A) Direct write to /etc/wpa_supplicant.conf + wpa_supplicant
+#      restart. Takes effect immediately, the box is on Wi-Fi within seconds.
+#   B) addWirelessProfile API call against 127.0.0.1:8090. Persists
+#      the profile in NetManager's own DB, so it survives the next
+#      reboot without us having to read wlan.conf again.
 #
-# Was zuerst erfolgreich ist gewinnt. Jeder Schritt wird in
-# /media/sda1/setup.log mit Timestamp geschrieben damit ein User
-# das Stick einfach abziehen und Diagnose-Log via App hochladen kann
-# (Bose's Factory Reset wischt NAND, der Stick bleibt unberuehrt).
+# Whichever succeeds first wins. Every step is written to
+# /media/sda1/setup.log with a timestamp so a user can simply pull
+# the stick and upload the diagnostic log via the app (Bose's factory
+# reset wipes NAND, the stick stays untouched).
 # NAND-persisted credentials cache: once one of the WLAN provisioning
 # approaches actually succeeded on a previous boot, we wrote the
 # SSID+pass into $PERSIST/wlan-creds so subsequent boots can replay
@@ -2697,10 +2696,10 @@ log "starting agent version $(${BIN} --version 2>/dev/null || echo v0.0.0)"
 # early sync logs). Re-running the sync here would just double the
 # work.
 
-# === Agent starten ===
-# Presets liegen auf NAND (read/write). SD card ist FAT32 und wirft oft
-# I/O Error bei Schreibversuchen, deshalb wird die Liste auf NAND gehalten.
-# Erste Migration vom Stick falls NAND noch leer.
+# === Start the agent ===
+# Presets live on NAND (read/write). The SD card is FAT32 and often throws
+# an I/O error on writes, so the list is kept on NAND.
+# First migration from the stick if NAND is still empty.
 PRESETS_NAND="$PERSIST/presets.json"
 if [ ! -f "$PRESETS_NAND" ] && [ -r "$STICK/presets.json" ]; then
     cp "$STICK/presets.json" "$PRESETS_NAND" 2>/dev/null
@@ -3226,9 +3225,9 @@ done
     fi
 ) &
 
-# SoftwareUpdate-Hijack-Logik: returnt 0 wenn der lokale Listener-PID
-# auf :17008 wirklich von einem SoftwareUpdate-Prozess kommt UND
-# dieser Prozess unsere LD_PRELOAD-Env-Var bereits gesetzt hat. The
+# SoftwareUpdate hijack logic: returns 0 when the local listener PID
+# on :17008 really comes from a SoftwareUpdate process AND that
+# process has already set our LD_PRELOAD env var. The
 # log line emitted on every call lets a remote bundle answer "did
 # the shim ever fully take hold" without staring at process-tree
 # dumps for matching string fragments — particularly useful on
@@ -3371,23 +3370,21 @@ fi
 
 # === Aggressive Boot-Race Watchdog (Phase A: t=0..120s) ===
 #
-# Hintergrund: Auf langsameren ST20-Varianten haben Reporter
-# beobachtet, dass die Box nach dem Stick-Boot zwar rebootet, aber
-# Port 8888 nie öffnet. Ursache ist nicht reproduzierbar — Verdacht
-# fällt auf Bose's Service-Manager (shepherdd / SCM), der waehrend
-# der ersten ~90s nach dem Boot eigene Aufraeumarbeiten faehrt und
-# unter Last unseren nohup-Prozess mit verreisst, oder auf OOM-
-# Kills (RAM-Druck im Boot). Der bestehende 90s-Watchdog unten
-# fängt das ein, aber erst NACH dem ersten Zyklus — dadurch ist
-# der Agent auf einer langsamen Box fuer bis zu 90s tot, der User
-# sieht "Install failed" und gibt auf.
+# Background: on slower ST20 variants reporters have observed that
+# the box does reboot after the stick boot, but port 8888 never
+# opens. The cause is not reproducible — suspicion falls on Bose's
+# service manager (shepherdd / SCM), which during the first ~90s
+# after boot runs its own cleanup work and under load drags our
+# nohup process down with it, or on OOM kills (RAM pressure at
+# boot). The existing 90s watchdog below catches that, but only
+# AFTER the first cycle — so on a slow box the agent is dead for up
+# to 90s, the user sees "Install failed" and gives up.
 #
-# Diese Phase-A-Schleife prueft ALLE 5s die ersten 120s ob (a) der
-# Agent-PID noch lebt UND (b) :8888 tatsaechlich gebunden ist.
-# Wenn entweder ausfaellt, sofort neustarten. Kosten pro Check:
-# 1 kill -0, 1 nc/ss-Lookup. Bei stabilem Agent feuert kein cp,
-# kein Flash-Write. Nach 120s übergibt es an den langsamen
-# 90s-Watchdog (Phase B).
+# This phase-A loop checks EVERY 5s for the first 120s whether (a)
+# the agent PID is still alive AND (b) :8888 is actually bound.
+# If either fails, restart immediately. Cost per check: 1 kill -0,
+# 1 nc/ss lookup. With a stable agent no cp fires, no flash write.
+# After 120s it hands over to the slow 90s watchdog (phase B).
 agent_port_bound() {
     # ss is the cheapest probe but BusyBox often ships without it.
     if command -v ss >/dev/null 2>&1; then
@@ -3530,11 +3527,11 @@ agent_port_bound() {
     while true; do
         sleep 90
         if [ ! -f "$PIDFILE" ]; then
-            break  # PID File weg, run.sh wird neu durchlaufen
+            break  # PID file gone, run.sh runs again
         fi
         CUR_PID=$(cat "$PIDFILE" 2>/dev/null || echo 0)
         if [ -n "$CUR_PID" ] && [ "$CUR_PID" -gt 0 ] && kill -0 "$CUR_PID" 2>/dev/null; then
-            continue  # Agent laeuft noch
+            continue  # agent still running
         fi
         log "watchdog: agent (PID $CUR_PID) died, restarting"
         # Belt-and-suspenders: even though the agent has SO_REUSEADDR,
@@ -3566,25 +3563,25 @@ if [ -r "$ROOT_CA" ]; then
         if mount | grep -q "$target"; then
             umount "$target" 2>/dev/null
         fi
-        mount --bind "$bundle" "$target" 2>/dev/null && echo "bind mount aktiv: $bundle -> $target"
+        mount --bind "$bundle" "$target" 2>/dev/null && echo "bind mount active: $bundle -> $target"
     done
 fi
 
 log "bootstrap complete"
 
-# === USB Stick aushaengen ===
-# Bootstrap ist durch — alle Configs (wlan/region/name/presets/binary)
-# sind nach NAND uebernommen. Den Stick brauchen wir zur Laufzeit
-# nicht mehr. Wir haengen ihn aktiv aus damit der User den Stick im
-# Betrieb ziehen kann ohne dirty FS (Windows muss dann keine FAT
-# Reparatur mehr machen).
+# === Unmount the USB stick ===
+# Bootstrap is done — all configs (wlan/region/name/presets/binary)
+# have been copied to NAND. We no longer need the stick at runtime.
+# We actively unmount it so the user can pull the stick during
+# operation without a dirty FS (then Windows does not need to repair
+# the FAT).
 #
-# SSH wird absichtlich NICHT gestoppt — pre-1.0 lassen wir den Kanal
-# offen damit die Desktop App ihren Diagnostic Bundle Pull auch bei
-# kaputtem Agent durchziehen kann (siehe ensure_sshd_running am
-# Anfang von run.sh). Die fruehere Logik hat sshd hier explizit
-# beendet sobald der Agent auf :8888 erreichbar war, was bei jedem
-# spaeteren Crash den Pfad zu den Logs verschloss.
+# SSH is deliberately NOT stopped — pre-1.0 we leave the channel
+# open so the desktop app can pull its diagnostic bundle even with
+# a broken agent (see ensure_sshd_running at the start of run.sh).
+# The earlier logic explicitly stopped sshd here as soon as the
+# agent was reachable on :8888, which closed the path to the logs
+# on every later crash.
 #
 # Debug opt-out: if /media/sda1/keep-open exists, skip the entire
 # cleanup so the stick stays mounted. Used during interactive
@@ -3596,12 +3593,12 @@ if [ -e "$STICK/keep-open" ]; then
     setup_log "keep-open marker on stick — skipping umount for live debug"
 else
 #
-# Detached Hintergrund Block damit run.sh sofort returnen kann
-# (shelby_local will dass rc.local schnell durchlaeuft). Lange
-# Wartezeit + aktive Pruefung dass kein Prozess mehr den Stick
-# offen hat, bevor wir tatsaechlich umount machen — sonst riskieren
-# wir den Agent zu verwirren weil seine Goroutines (syncRunOverride,
-# initialBoxPresetSync) noch lesen.
+# Detached background block so run.sh can return immediately
+# (shelby_local wants rc.local to finish quickly). Long wait +
+# active check that no process still has the stick open before we
+# actually unmount — otherwise we risk confusing the agent because
+# its goroutines (syncRunOverride, initialBoxPresetSync) are still
+# reading.
 (
     # Pre-cleanup wait. Pre-1.0 we run it long, on purpose: the box
     # is on the user's LAN and the SSH cost is real, but right now
@@ -3622,14 +3619,14 @@ else
     sleep 300
 
     if ! mountpoint -q "$STICK" 2>/dev/null && ! mount | grep -q " $STICK "; then
-        exit 0  # schon ausgehaengt, nichts zu tun
+        exit 0  # already unmounted, nothing to do
     fi
 
-    # Aktive Pruefung: wer haelt noch ein File auf dem Stick offen?
-    # Wir scannen /proc/*/fd/* nach Links die auf $STICK zeigen. Wenn
-    # noch jemand drauf zugreift, warten wir nochmal — bis zu 90 s
-    # zusaetzlich. Danach erzwingen wir den umount nicht, sondern
-    # fallen auf Read Only Remount zurueck (Flash Wear Schutz).
+    # Active check: who still holds a file open on the stick? We scan
+    # /proc/*/fd/* for links pointing at $STICK. If someone is still
+    # accessing it, we wait again — up to 90 s more. After that we do
+    # not force the umount, but fall back to a read-only remount (flash
+    # wear protection).
     STICK_DEV=$(mount | grep " $STICK " | awk '{print \$1}')
     WAIT_BUSY=0
     while [ "$WAIT_BUSY" -lt 90 ]; do
@@ -3674,15 +3671,15 @@ else
         # pull box-side logs after a failed install without the user
         # typing anything.
         mount -o remount,ro "$STICK" 2>/dev/null \
-            && log "USB Stick read-only remounted"
+            && log "USB stick read-only remounted"
         exit 0
     fi
     if umount "$STICK" 2>/dev/null; then
-        log "USB Stick ausgehaengt — kann sicher gezogen werden"
+        log "USB stick unmounted — safe to remove"
     else
-        log "umount fehlgeschlagen (Prozess haelt Stick), versuche read only remount"
+        log "umount failed (a process holds the stick), trying read-only remount"
         if mount -o remount,ro "$STICK" 2>/dev/null; then
-            log "USB Stick read only remounted"
+            log "USB stick read-only remounted"
         fi
     fi
 ) &

--- a/usb-stick/setup-tls.sh
+++ b/usb-stick/setup-tls.sh
@@ -1,17 +1,17 @@
 #!/bin/sh
-# setup-tls.sh: installiert die STR Root CA in die System
-# Trust Stores via bind mount.
+# setup-tls.sh: installs the STR Root CA into the system
+# trust stores via a bind mount.
 #
-# Hintergrund: BoseApp/IoT linken dynamisch gegen libssl/libcrypto/libcurl.
-# Die Bundles unter /etc/pki/tls/certs/ca-bundle.crt und
-# /etc/ssl/certs/ca-certificates.crt werden geleen. rootfs ist read only,
-# also kopieren wir die Originals nach /tmp, haengen unsere Root CA dran
-# und mounten via bind drueber.
+# Background: BoseApp/IoT link dynamically against libssl/libcrypto/libcurl.
+# The bundles at /etc/pki/tls/certs/ca-bundle.crt and
+# /etc/ssl/certs/ca-certificates.crt are what they read. The rootfs is read only,
+# so we copy the originals to /tmp, append our Root CA to them
+# and mount over them via a bind mount.
 #
-# Aufruf:
-#   sh setup-tls.sh install   # bind mount setzen
-#   sh setup-tls.sh remove    # bind mount entfernen
-#   sh setup-tls.sh status    # Status anzeigen
+# Usage:
+#   sh setup-tls.sh install   # set up the bind mount
+#   sh setup-tls.sh remove    # remove the bind mount
+#   sh setup-tls.sh status    # show status
 
 set -u
 
@@ -29,11 +29,11 @@ install_one() {
     target="$1"
     overlay="$2"
     if [ ! -e "$target" ]; then
-        echo "WARN: $target existiert nicht, ueberspringe"
+        echo "WARN: $target does not exist, skipping"
         return
     fi
     if is_mounted "$target"; then
-        echo "$target bereits gemountet, entferne erst"
+        echo "$target already mounted, removing it first"
         umount "$target" 2>/dev/null
     fi
     cp "$target" "$overlay"
@@ -44,9 +44,9 @@ install_one() {
         echo "# <<< STR Root CA <<<"
     } >> "$overlay"
     if mount --bind "$overlay" "$target"; then
-        echo "bind mount aktiv: $overlay -> $target"
+        echo "bind mount active: $overlay -> $target"
     else
-        echo "FEHLER: bind mount auf $target schlug fehl" >&2
+        echo "ERROR: bind mount on $target failed" >&2
     fi
 }
 
@@ -54,20 +54,20 @@ remove_one() {
     target="$1"
     if is_mounted "$target"; then
         if umount "$target"; then
-            echo "bind mount entfernt: $target"
+            echo "bind mount removed: $target"
         else
-            echo "FEHLER: umount $target schlug fehl" >&2
+            echo "ERROR: umount $target failed" >&2
         fi
     else
-        echo "kein bind mount auf $target"
+        echo "no bind mount on $target"
     fi
 }
 
 case "${1:-install}" in
     install)
         if [ ! -r "$ROOT_CA" ]; then
-            echo "FEHLER: Root CA nicht lesbar unter $ROOT_CA" >&2
-            echo "Hat der Agent schon mal gelaufen? Er erzeugt die CA beim ersten Start." >&2
+            echo "ERROR: Root CA not readable at $ROOT_CA" >&2
+            echo "Has the agent ever run? It generates the CA on first start." >&2
             exit 1
         fi
         install_one "$BUNDLE1" "$OVERLAY1"
@@ -80,26 +80,26 @@ case "${1:-install}" in
     status)
         echo "Root CA:"
         if [ -r "$ROOT_CA" ]; then
-            echo "  vorhanden: $ROOT_CA"
+            echo "  present: $ROOT_CA"
             openssl x509 -in "$ROOT_CA" -noout -subject 2>/dev/null
         else
-            echo "  fehlt: $ROOT_CA"
+            echo "  missing: $ROOT_CA"
         fi
         echo "Bundle 1: $BUNDLE1"
         if is_mounted "$BUNDLE1"; then
-            echo "  bind mount aktiv"
+            echo "  bind mount active"
         else
-            echo "  bind mount NICHT aktiv"
+            echo "  bind mount NOT active"
         fi
         echo "Bundle 2: $BUNDLE2"
         if is_mounted "$BUNDLE2"; then
-            echo "  bind mount aktiv"
+            echo "  bind mount active"
         else
-            echo "  bind mount NICHT aktiv"
+            echo "  bind mount NOT active"
         fi
         ;;
     *)
-        echo "Verwendung: $0 {install|remove|status}" >&2
+        echo "Usage: $0 {install|remove|status}" >&2
         exit 1
         ;;
 esac

--- a/usb-stick/update.sh
+++ b/usb-stick/update.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
-# update.sh: prueft GitHub Releases und tauscht das Binary aus.
+# update.sh: checks GitHub releases and swaps out the binary.
 #
-# Achtung: Bose BusyBox auf der ST10 hat kein curl, nur wget. Daher hier
-# wget Pfade. wget 1.19.4 unterstuetzt --tries nicht, mit -T fuer Timeout
-# arbeiten. Releases werden via api.github.com geholt, aber api.github.com
-# liefert JSON. Wir greppen daraus den Tag Namen mit sed.
+# Note: the Bose BusyBox on the ST10 has no curl, only wget. Hence the
+# wget paths here. wget 1.19.4 does not support --tries, so work with -T
+# for the timeout. Releases are fetched via api.github.com, but
+# api.github.com returns JSON. We grep the tag name out of it with sed.
 
 set -u
 
@@ -16,7 +16,7 @@ BIN="${STICK_DIR}/${ARCH_ASSET}"
 
 CURRENT="$(cat "${VERSION_FILE}" 2>/dev/null || echo none)"
 
-# api.github.com mit wget, T 10 fuer 10 Sekunden Timeout
+# api.github.com via wget, T 10 for a 10 second timeout
 TMP="/tmp/streborn-release.json"
 if ! wget -qO "$TMP" -T 10 "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null; then
     echo "$(date) update: GitHub API unreachable" >&2

--- a/wifiprofiles/hide_unix.go
+++ b/wifiprofiles/hide_unix.go
@@ -4,5 +4,5 @@ package wifiprofiles
 
 import "os/exec"
 
-// hideWindow ist auf Mac/Linux kein-op, da dort keine Console aufpoppt.
+// hideWindow is a no-op on Mac/Linux, since no console pops up there.
 func hideWindow(cmd *exec.Cmd) {}

--- a/wifiprofiles/hide_windows.go
+++ b/wifiprofiles/hide_windows.go
@@ -7,8 +7,8 @@ import (
 	"syscall"
 )
 
-// hideWindow setzt das CREATE_NO_WINDOW Flag damit Console Tools nicht
-// kurz ein cmd Fenster aufflackern lassen.
+// hideWindow sets the CREATE_NO_WINDOW flag so console tools do not
+// briefly flash up a cmd window.
 func hideWindow(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		HideWindow:    true,

--- a/wifiprofiles/wifiprofiles.go
+++ b/wifiprofiles/wifiprofiles.go
@@ -1,17 +1,17 @@
-// Package wifiprofiles liest WLAN Profile vom Host Betriebssystem aus
-// damit die Desktop App eine Liste bekannter SSIDs anzeigen kann. Wird
-// im Stick Setup verwendet damit der User die SSID nicht abtippen muss.
+// Package wifiprofiles reads WLAN profiles from the host operating
+// system so the desktop app can show a list of known SSIDs. Used in the
+// stick setup so the user does not have to type the SSID by hand.
 //
-// Plattformen:
+// Platforms:
 //
 //	Windows  netsh wlan show profiles
-//	Mac      networksetup -listpreferredwirelessnetworks (auf erstem WLAN Adapter)
+//	Mac      networksetup -listpreferredwirelessnetworks (on the first WLAN adapter)
 //	Linux    nmcli connection show
 //
-// Passwoerter werden NICHT automatisch ausgelesen weil das je nach
-// Plattform User Consent benoetigt. Es gibt ein optionales TryPassword
-// das es versuchen darf — wird vom Frontend nur auf expliziten Klick
-// "Passwort vorfuellen" aufgerufen.
+// Passwords are NOT read out automatically because that requires user
+// consent depending on the platform. There is an optional TryPassword
+// that may attempt it — the frontend only calls it on an explicit
+// "prefill password" click.
 package wifiprofiles
 
 import (
@@ -22,23 +22,23 @@ import (
 	"strings"
 )
 
-// run startet ein OS Command und verbirgt auf Windows das Console Fenster
-// das sonst kurz aufflackert. Funktioniert auch auf Mac/Linux ohne extra
-// Setup.
+// run starts an OS command and hides the console window on Windows that
+// would otherwise flash up briefly. Works on Mac/Linux too without extra
+// setup.
 func run(name string, args ...string) ([]byte, error) {
 	cmd := exec.Command(name, args...)
 	hideWindow(cmd)
 	return cmd.CombinedOutput()
 }
 
-// Profile beschreibt einen bekannten WLAN Eintrag.
+// Profile describes a known WLAN entry.
 type Profile struct {
-	SSID     string `json:"ssid"`
-	HasPass  bool   `json:"hasPass"` // true wenn Passwort vermutlich gespeichert (bei Windows aus netsh erkennbar)
-	Source   string `json:"source"`  // "netsh" / "networksetup" / "nmcli"
+	SSID    string `json:"ssid"`
+	HasPass bool   `json:"hasPass"` // true if a password is likely stored (detectable from netsh on Windows)
+	Source  string `json:"source"`  // "netsh" / "networksetup" / "nmcli"
 }
 
-// List liefert alle gespeicherten WLAN Profile auf dem Host.
+// List returns all stored WLAN profiles on the host.
 func List() ([]Profile, error) {
 	switch runtime.GOOS {
 	case "windows":
@@ -50,11 +50,11 @@ func List() ([]Profile, error) {
 	}
 }
 
-// TryPassword versucht das gespeicherte Passwort fuer eine SSID
-// auszulesen. Auf Windows: `netsh wlan show profile name=X key=clear`,
-// fordert Admin Rechte oder zumindest User Session permissions. Auf Mac
-// muss der Keychain Zugriff geben. Returns ("", nil) wenn nichts
-// gefunden, error bei OS Fehler.
+// TryPassword attempts to read out the stored password for an SSID. On
+// Windows: `netsh wlan show profile name=X key=clear`, which requires
+// admin rights or at least user session permissions. On Mac the keychain
+// must grant access. Returns ("", nil) if nothing is found, error on an
+// OS failure.
 func TryPassword(ssid string) (string, error) {
 	switch runtime.GOOS {
 	case "windows":
@@ -66,8 +66,8 @@ func TryPassword(ssid string) (string, error) {
 	}
 }
 
-// CurrentSSID liefert das aktuell verbundene WLAN auf dem Host. Leer
-// wenn der Host nicht im WLAN ist oder die Abfrage fehlschlaegt.
+// CurrentSSID returns the currently connected WLAN on the host. Empty
+// if the host is not on a WLAN or the query fails.
 func CurrentSSID() string {
 	switch runtime.GOOS {
 	case "windows":
@@ -84,8 +84,8 @@ func currentSSIDWindows() string {
 	if err != nil {
 		return ""
 	}
-	// "SSID                   : MeinWifi"
-	// "BSSID                  : aa:bb:..." → muss ausgeschlossen werden
+	// "SSID                   : MyWifi"
+	// "BSSID                  : aa:bb:..." → must be excluded
 	scanner := bufio.NewScanner(strings.NewReader(string(out)))
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
@@ -151,19 +151,18 @@ func listWindows() ([]Profile, error) {
 	if err != nil {
 		return nil, fmt.Errorf("netsh: %v", err)
 	}
-	// Toleranter Parser: jede Zeile mit `:` wo der LEFT Key nicht
-	// offensichtlich ein Adapter Header ist und der Rest nicht leer.
-	// Funktioniert auf DE, EN und sehr wahrscheinlich auch weiteren
-	// Localizations weil wir nicht auf das Wort "Benutzerprofil" angewiesen
-	// sind sondern auf das Pattern "<irgendwas> : <SSID>".
+	// Tolerant parser: any line with `:` where the LEFT key is not
+	// obviously an adapter header and the rest is not empty. Works on DE,
+	// EN and very likely further localizations because we do not rely on
+	// the word "Benutzerprofil" but on the pattern "<anything> : <SSID>".
 	var profiles []Profile
 	scanner := bufio.NewScanner(strings.NewReader(string(out)))
 	for scanner.Scan() {
 		raw := scanner.Text()
-		// Items sind eingerueckt mit Leerzeichen. Ohne Einrueckung sind
-		// Header Zeilen ("Profile in WLAN-Adapter \"Wi-Fi\":") oder
-		// Sektionsueberschriften. Das ist plattformunabhaengig und sehr
-		// robust gegen Locale Variationen.
+		// Items are indented with spaces. Without indentation they are
+		// header lines ("Profile in WLAN-Adapter \"Wi-Fi\":") or section
+		// headings. This is platform-independent and very robust against
+		// locale variations.
 		if len(raw) == 0 || (raw[0] != ' ' && raw[0] != '\t') {
 			continue
 		}
@@ -178,7 +177,7 @@ func listWindows() ([]Profile, error) {
 			continue
 		}
 		keyLower := strings.ToLower(key)
-		// Adapter / Interface Header ausschliessen (defensive)
+		// Exclude adapter / interface headers (defensive)
 		if strings.Contains(keyLower, "schnittstell") ||
 			strings.Contains(keyLower, "interface") ||
 			strings.Contains(keyLower, "wlan-adapter") {
@@ -203,9 +202,9 @@ func tryPasswordWindows(ssid string) (string, error) {
 		}
 		key := strings.TrimSpace(parts[0])
 		val := strings.TrimSpace(parts[1])
-		// Spezifischer Match auf das ECHTE Passwort Feld. "Schluesselinhalt"
-		// (de neu), "Schlüsselinhalt" (de mit Umlaut), "Key Content" (en).
-		// NICHT matchen: "Verschluesselung", "Schluessel index" etc.
+		// Specific match on the REAL password field. "Schluesselinhalt"
+		// (de new), "Schlüsselinhalt" (de with umlaut), "Key Content" (en).
+		// Do NOT match: "Verschluesselung", "Schluessel index" etc.
 		klower := strings.ToLower(key)
 		isPassword := klower == "schluesselinhalt" ||
 			klower == "schlüsselinhalt" ||
@@ -225,7 +224,7 @@ func tryPasswordWindows(ssid string) (string, error) {
 // ----- Mac -----
 
 func listMac() ([]Profile, error) {
-	// Finde erstes Wireless Device
+	// Find the first wireless device
 	cmd := exec.Command("networksetup", "-listallhardwareports")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -246,7 +245,7 @@ func listMac() ([]Profile, error) {
 		}
 	}
 	if device == "" {
-		return nil, fmt.Errorf("kein Wi-Fi Adapter gefunden")
+		return nil, fmt.Errorf("no Wi-Fi adapter found")
 	}
 	cmd2 := exec.Command("networksetup", "-listpreferredwirelessnetworks", device)
 	out2, err := cmd2.CombinedOutput()
@@ -267,7 +266,7 @@ func listMac() ([]Profile, error) {
 
 func tryPasswordMac(ssid string) (string, error) {
 	cmd := exec.Command("security", "find-generic-password", "-ga", ssid)
-	// security gibt das Passwort auf stderr (!) und gibt einen 'password:' line.
+	// security prints the password on stderr (!) and emits a 'password:' line.
 	out, _ := cmd.CombinedOutput()
 	for _, line := range strings.Split(string(out), "\n") {
 		line = strings.TrimSpace(line)
@@ -304,7 +303,7 @@ func listLinux() ([]Profile, error) {
 }
 
 func tryPasswordLinux(ssid string) (string, error) {
-	// Braucht root oder NetworkManager Permission. Best Effort.
+	// Needs root or NetworkManager permission. Best effort.
 	cmd := exec.Command("nmcli", "-s", "-g", "802-11-wireless-security.psk", "connection", "show", ssid)
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
## Summary

This branch came out of triaging recent GitHub issues and diagnostic logs. It contains user-facing fixes plus a repo-wide English-only cleanup.

### User-facing fixes (these appear in the release notes)
- **fix(settings): show AirPlay and Bluetooth as available, not inactive (#200).** AirPlay 2 / Bluetooth are local speaker-firmware features that keep working without the Bose cloud, but the box's `/sources` `READY` flag is unreliable for them post-cloud, so a working AirPlay reported a non-`READY` status and was labelled "Inactive". They now show as "available". Confirmed by the reporter's diagnostic (AirPlay actively playing while `/sources` still reported non-`READY`). Playback was never affected — only the badge.
- **fix(player): resume paused NAS/DLNA playback from its position (#202).** The transport controls only exposed Pause and Stop; resuming re-pushed `SetAVTransportURI` and restarted a finite track, so a paused NAS/DLNA track could not be resumed from the app (only the Bose remote could). Adds a plain AVTransport-Play resume (`/api/resume` + `App.Resume`) and turns the Pause button into a Play/Pause toggle; new `controls.play` string in all 11 locales.
- **fix(diagnostics): record stick-prepare steps so failed installs are diagnosable (#195).** A stick-boot install (the ST10 path) never goes through the SSH installer that logs, so a failed self-install showed only discovery noise. `FormatStick` / `WriteStickFiles` now log (incl. embedded agent size + prepared version).
- **fix(install): show the on-box install log in English (#195).** `install.sh`'s output (shown in "Show install log") was in German. Translated; the desktop app's error detection already matched both `ERROR` and the old `FEHLER`.

### English-only cleanup (docs/test — intentionally kept out of the release notes)
- All box-side shell scripts: `install.sh`, `run.sh`, `provision-wlan.sh`, `setup-tls.sh`, `iptables-setup.sh`, `autostart.sh`, `update.sh`, `setup/run.sh`.
- The entire Go codebase — `internal/`, `cmd/`, `desktop-app/`, and the top-level packages (`discovery`, `radiobrowser`, `sticksetup`, `wifiprofiles`, `usb-stick`): German comments + developer-facing log/error/flag-help strings, plus German test-function names and fixtures.
- **Deliberately kept** (correct): the German `netsh` field-name match-strings in `wifiprofiles` and the `app.go` reference to the i18n display string `"Bereit für STR"`. The English run.sh failure markers the desktop app greps for are untouched.

### Verification
- Agent cross-compiles for the ARM target (`GOOS=linux GOARCH=arm GOARM=7`); `desktop-app` builds; `go test ./...` green.
- `gofmt` clean; shell scripts pass `sh -n`; frontend JS parses; all 11 i18n bundles parse and carry the new keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kuctzo5Z8pM2KpPmN4ez9x