### PR TITLE
ci(release): free macOS runner disk space before the DMG build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -690,6 +690,21 @@ jobs:
           cp glr-download/go-librespot-armv7l desktop-app/agentbin/go-librespot-armv7l
           ls -la desktop-app/agentbin/
 
+      - name: Free disk space
+        # GitHub macOS runners ship large iOS/tvOS/watchOS simulator runtimes
+        # (10+ GB) that a Wails build and DMG packaging never need. The release
+        # failed twice on fresh runners with "hdiutil: create failed - No space
+        # left on device" while staging the universal-binary app into the DMG,
+        # once the app grew. Reclaiming the simulator space gives the build and
+        # hdiutil the scratch room they need. Best-effort: never fail on a miss.
+        run: |
+          df -h /
+          xcrun simctl delete all || true
+          sudo rm -rf ~/Library/Developer/CoreSimulator/Caches/* || true
+          sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/* || true
+          sudo rm -rf /Library/Developer/CoreSimulator/Volumes/* || true
+          df -h /
+
       - name: Build macOS desktop app (universal)
         working-directory: desktop-app
         env:


### PR DESCRIPTION
Fixes the v0.8.12 release failure: `hdiutil: create failed - No space left on device` in build-desktop-macos. Frees the unused simulator runtimes before the universal build so the DMG has scratch space. No app code change.