### PR TITLE
fix(agent): switch the speaker on reliably with the power button after a long standby

### DIFF
--- a/internal/boxcli/boxcli.go
+++ b/internal/boxcli/boxcli.go
@@ -45,17 +45,37 @@ func Send(ctx context.Context, host, cmd string) (string, error) {
 	return sb.String(), nil
 }
 
-// PowerOn wakes the box from standby. Idempotent: if the box is already
-// on, it returns OK and does nothing.
+// PowerOn toggles the box's power. NOTE: `sys power` is a TOGGLE, not an
+// idempotent power-on — the same command also returns the box to standby (see
+// the announce standby-restore in internal/webui/announce.go). Callers must
+// therefore confirm the box is actually in standby before calling this, or they
+// risk turning a running box off. WakeAndWait does that gating; prefer it over
+// calling PowerOn directly.
 func PowerOn(ctx context.Context, host string) error {
 	_, err := Send(ctx, host, "sys power")
 	return err
 }
 
-// WakeAndWait makes sure the box is out of standby. Sends `sys power`
-// and polls `/now_playing` until source != STANDBY or timeout. The box
-// sometimes reacts with a delay or ignores sys power entirely when it is
-// in deep standby; in that case it is sent multiple times.
+// selfWakeGrace is how long WakeAndWait first watches for the box to leave
+// standby on its OWN before it sends a `sys power` toggle. Because `sys power`
+// is a power TOGGLE (see PowerOn), toggling a box that is already coming out of
+// standby — for example because the user just pressed the physical power button
+// or a hardware preset, which is exactly the press that produced the gabbo wake
+// frame STR is reacting to — would CANCEL that wake, and the box looks dead to
+// the button. That is the overnight-standby "won't switch on / needs several
+// presses" report (ST30 Klaus, ST20 #197, preset first-press #183), made easy to
+// hit once the keepalive (#183) started delivering the wake frame instantly,
+// mid-transition. Watching for a self-wake first means STR only toggles a box
+// that stays firmly, stably asleep — a genuine STR-initiated wake such as an app
+// play on an idle box with no user press.
+const selfWakeGrace = 2500 * time.Millisecond
+
+// WakeAndWait makes sure the box is out of standby. It first watches briefly for
+// the box to wake on its own (a user button press already waking it); only if it
+// stays in standby does it send the `sys power` toggle, polling `/now_playing`
+// until source != STANDBY or timeout. The box sometimes reacts with a delay or
+// ignores sys power entirely when it is in deep standby; in that case it is sent
+// multiple times.
 //
 // logger may be nil; when present, per-iteration phase markers are emitted
 // so a diagnostic bundle shows the standby-exit timeline (#60).
@@ -80,6 +100,32 @@ func WakeAndWait(ctx context.Context, host string, maxWait time.Duration, logger
 
 	logPhase("wake phase: start", "host", host, "max_wait", maxWait.String())
 
+	// Phase 1: self-wake grace. The wake STR is reacting to was almost always
+	// caused by the user pressing a button, which is itself bringing the box out
+	// of standby. Give it that moment to surface so we do NOT toggle it back off.
+	graceDeadline := time.Now().Add(selfWakeGrace)
+	if graceDeadline.After(deadline) {
+		graceDeadline = deadline
+	}
+	for {
+		state, err := readSource(ctx, client, infoURL)
+		if err == nil && state != "STANDBY" {
+			logPhase("wake phase: box left standby on its own, not toggling (user wake)", "source", state)
+			return nil
+		}
+		if !time.Now().Before(graceDeadline) {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			logPhase("wake phase: ctx cancelled (grace)", "err", ctx.Err().Error())
+			return ctx.Err()
+		case <-time.After(300 * time.Millisecond):
+		}
+	}
+
+	// Phase 2: still firmly asleep after the grace -> no user wake in progress,
+	// so this is a genuine STR-initiated wake. Toggle it on.
 	for i := 0; ; i++ {
 		// Check first: is the box maybe already awake?
 		state, err := readSource(ctx, client, infoURL)

--- a/internal/boxcli/boxcli_test.go
+++ b/internal/boxcli/boxcli_test.go
@@ -1,0 +1,115 @@
+package boxcli
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeBox stands in for the speaker on its two fixed local ports: the BoseApp
+// REST API on :8090 (/now_playing) and the TAP CLI on :17000 (sys power). The
+// ports are hardcoded in boxcli, so the test binds them on the loopback host;
+// if they are unavailable it skips rather than failing CI.
+//
+// /now_playing reports STANDBY while the box is asleep, and reports a normal
+// source once it has either woken on its own (selfWoke) or received a `sys
+// power` toggle (powerCmd > 0) — mirroring the toggle semantics of the real CLI.
+type fakeBox struct {
+	httpLn   net.Listener
+	cliLn    net.Listener
+	selfWoke atomic.Bool  // the box left standby on its own (user button press)
+	powerCmd atomic.Int32 // number of `sys power` commands received
+}
+
+func (b *fakeBox) awake() bool { return b.selfWoke.Load() || b.powerCmd.Load() > 0 }
+
+func startFakeBox(t *testing.T) *fakeBox {
+	t.Helper()
+	httpLn, err := net.Listen("tcp", "127.0.0.1:8090")
+	if err != nil {
+		t.Skipf("cannot bind 127.0.0.1:8090 (in use?): %v", err)
+	}
+	cliLn, err := net.Listen("tcp", "127.0.0.1:17000")
+	if err != nil {
+		_ = httpLn.Close()
+		t.Skipf("cannot bind 127.0.0.1:17000 (in use?): %v", err)
+	}
+	b := &fakeBox{httpLn: httpLn, cliLn: cliLn}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/now_playing", func(w http.ResponseWriter, _ *http.Request) {
+		src := "STANDBY"
+		if b.awake() {
+			src = "UPNP"
+		}
+		_, _ = w.Write([]byte(`<nowPlaying source="` + src + `"></nowPlaying>`))
+	})
+	srv := &http.Server{Handler: mux}
+	go func() { _ = srv.Serve(httpLn) }()
+
+	go func() {
+		for {
+			conn, err := cliLn.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				if line, _ := bufio.NewReader(c).ReadString('\n'); line != "" {
+					b.powerCmd.Add(1)
+				}
+			}(conn)
+		}
+	}()
+
+	t.Cleanup(func() {
+		_ = srv.Close()
+		_ = cliLn.Close()
+	})
+	return b
+}
+
+// TestWakeAndWaitDoesNotToggleSelfWake is the regression guard for the
+// overnight-standby "power button does nothing / box switches off again" reports
+// (ST30 Klaus, ST20 #197, #183): when the box leaves standby on its own (the
+// user pressed the physical button), WakeAndWait must NOT send a `sys power`
+// toggle, because that would cancel the user's wake.
+func TestWakeAndWaitDoesNotToggleSelfWake(t *testing.T) {
+	b := startFakeBox(t)
+
+	// Simulate the box waking itself ~600ms in, well within the self-wake grace.
+	go func() {
+		time.Sleep(600 * time.Millisecond)
+		b.selfWoke.Store(true)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+	if err := WakeAndWait(ctx, "127.0.0.1", 6*time.Second, nil); err != nil {
+		t.Fatalf("WakeAndWait returned error on a self-waking box: %v", err)
+	}
+	if n := b.powerCmd.Load(); n != 0 {
+		t.Fatalf("WakeAndWait sent %d `sys power` toggle(s) to a self-waking box; want 0 (toggling cancels the user's wake)", n)
+	}
+}
+
+// TestWakeAndWaitTogglesWhenAsleep confirms a genuinely asleep box (no user
+// wake) still gets a `sys power` toggle after the grace, so STR-initiated wakes
+// (e.g. an app play on an idle box) keep working. The fake box leaves standby
+// only once it receives that toggle.
+func TestWakeAndWaitTogglesWhenAsleep(t *testing.T) {
+	b := startFakeBox(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := WakeAndWait(ctx, "127.0.0.1", 8*time.Second, nil); err != nil {
+		t.Fatalf("WakeAndWait returned error on an asleep box: %v", err)
+	}
+	if n := b.powerCmd.Load(); n < 1 {
+		t.Fatalf("WakeAndWait sent %d `sys power` toggle(s) to an asleep box; want >=1", n)
+	}
+}


### PR DESCRIPTION
## Symptom
After a long (e.g. overnight) standby, pressing the power button could fail to switch the speaker on, or switch it back off, so it took several presses. Reported for the ST30 (Klaus); matches **#197** (ST20 "needs to be powered off multiple times") and **#183** (first preset press after overnight standby shows "not available").

## Root cause
`sys power` on the box's TAP CLI is a power **TOGGLE**, not an idempotent power-on — the same command is used in `internal/webui/announce.go` to send the box **back** to standby after an announcement. (The `PowerOn` doc comment wrongly claimed it was idempotent.)

`boxcli.WakeAndWait` fired this toggle whenever it read `STANDBY`. Since the keepalive change (`805ba62`, #183) keeps the gabbo `:8080` link open through standby, STR now receives the box's wake frame **instantly** — while the box is still mid-transition out of standby **from the user's own button press**. STR then read a transient `STANDBY` and toggled `sys power`, cancelling the user's wake. Before the keepalive, STR only learned of the wake after a reconnect (seconds later), by which time the box was already awake and `WakeAndWait` did nothing — which is why this only surfaced now.

## Fix
The wake STR reacts to is almost always caused by the user pressing a button, which is itself bringing the box out of standby. `WakeAndWait` now first watches briefly (`selfWakeGrace`, 2.5s) for the box to leave standby on its own and only sends the `sys power` toggle if it stays firmly asleep — i.e. a genuine STR-initiated wake (an app play on an idle box). This makes it impossible for STR to cancel a user-initiated wake. Also corrects the misleading "idempotent" note on `PowerOn`.

The change is conservative: worst case it behaves as before (a slow box that does not self-wake within the grace still gets the toggle); it only shrinks the collision window.

## Tests
Adds `internal/boxcli/boxcli_test.go` covering both paths:
- self-wake → **no** `sys power` toggle (the regression guard)
- genuinely asleep → toggle still sent

Pass with `-race`. `go vet`, the `GOOS=linux GOARCH=arm GOARM=7` cross-build, and the `boxws`/`webui` suites are green.

## Verification note
This is a hardware-behaviour fix that should still be confirmed on a real ST30 (ideally with a diagnostic bundle from Klaus capturing a power-on after an overnight standby).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PybyZt74gKms4AyLzobrK

---
_Generated by [Claude Code](https://claude.ai/code/session_014PybyZt74gKms4AyLzobrK)_