### PR TITLE
Folder-queue fixes, Recently-played speaker picker, ST20 standby, diagnostic privacy (v0.8.15)

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -433,6 +433,10 @@ func run() error {
 		// reappears awake-but-idle on a gabbo reconnect, re-push the last stream.
 		// Reuses the power-on resume guards (opt-out, zone, user-stop).
 		onBoxReconnect: webuiSrv.RecoverAfterReconnect,
+		// Clear the transport when the box powers off STR's UPnP source, so ST20
+		// (scm) firmware that bounces UPNP<->STANDBY does not turn itself back on
+		// (#197). Zone-guarded and debounced in the webui.
+		onEnterStandby: webuiSrv.HandleEnterStandby,
 		// Surface the box's own presets (incl. foreign sources like Deezer) to the
 		// webui so the app can show/preserve them (Option C). Map boxws -> webui at
 		// the composition root to keep the two packages decoupled.
@@ -903,6 +907,11 @@ type presetWsHandler struct {
 	// press (#183). This recovers that stuck wake. Wired to
 	// webui.RecoverAfterReconnect, which reuses the power-on resume guards. nil-safe.
 	onBoxReconnect func()
+	// onEnterStandby fires when STR's UPnP source drops to STANDBY (a power-off
+	// seen over gabbo). It clears the box transport so ST20 (scm) firmware that
+	// oscillates UPNP<->STANDBY does not switch the speaker back on (#197). Wired to
+	// webui.HandleEnterStandby, which is zone-guarded and debounced. nil-safe.
+	onEnterStandby func()
 	// noteBoxPresets records the box's OWN preset list (gabbo presetsUpdated),
 	// including foreign sources like Deezer that STR did not set, into the webui
 	// so the app can show and preserve them (Option C). Wired to
@@ -1150,6 +1159,16 @@ func (h *presetWsHandler) OnPowerWake(_ context.Context) {
 func (h *presetWsHandler) OnConnected(_ context.Context) {
 	if h.onBoxReconnect != nil {
 		h.onBoxReconnect()
+	}
+}
+
+// OnEnterStandby fires when the box's UPnP (STR) source drops to STANDBY on a
+// power-off. It clears the transport so ST20 (scm) firmware that oscillates
+// UPNP<->STANDBY does not switch the speaker back on (#197). boxws calls this via
+// an optional interface, so only handlers that wire it (this one) react.
+func (h *presetWsHandler) OnEnterStandby(_ context.Context) {
+	if h.onEnterStandby != nil {
+		h.onEnterStandby()
 	}
 }
 

--- a/desktop-app/frontend/src/state.js
+++ b/desktop-app/frontend/src/state.js
@@ -8,6 +8,12 @@ export const state = {
   view: 'box',
   boxes: [],
   currentBox: null,
+  // Recently-played view scope (#221): an explicit speaker pick instead of
+  // implicitly following the Music-tab box. recentAllBoxes merges every STR
+  // speaker; otherwise recentBoxKey (deviceID or host:port) selects one, falling
+  // back to currentBox until the user picks from the dropdown.
+  recentAllBoxes: false,
+  recentBoxKey: null,
   settingsBox: null,   // The box whose settings are currently being edited
   presets: [],
   boxPresets: [],      // the box's OWN presets (incl. foreign sources like Deezer)

--- a/desktop-app/frontend/src/style.css
+++ b/desktop-app/frontend/src/style.css
@@ -1336,6 +1336,9 @@ body {
 .recent-scope { display: flex; gap: 6px; }
 .recent-scope .chip { background: var(--brand-bg); color: var(--brand-text-mid); border: 1px solid var(--brand-border); border-radius: 14px; padding: 4px 12px; font-size: 12px; cursor: pointer; }
 .recent-scope .chip.active { background: var(--brand); color: #04222e; border-color: var(--brand); font-weight: 600; }
+/* Speaker picker (#221): replaces the old "this speaker / all" chips. */
+.recent-box-select { background: var(--brand-bg); color: var(--brand-text-mid); border: 1px solid var(--brand-border); border-radius: 14px; padding: 4px 28px 4px 12px; font-size: 12px; cursor: pointer; max-width: 220px; }
+.recent-box-select:hover { border-color: var(--brand); }
 .recent-list { display: flex; flex-direction: column; gap: 12px; }
 .recent-empty, .recent-loading { color: var(--brand-text-mid); padding: 24px 4px; text-align: center; }
 .recent-card { background: #1b1b1b; border: 1px solid var(--brand-border); border-radius: 10px; overflow: hidden; }

--- a/desktop-app/frontend/src/views/library.js
+++ b/desktop-app/frontend/src/views/library.js
@@ -245,11 +245,25 @@ async function libraryPlayFolder() {
     showError(t('library.errorNoURL'));
     return;
   }
+  // Recently-played card (#220): name the card after the open folder (last
+  // breadcrumb), key it on the server UDN + container id so repeated plays of the
+  // same folder group together, and seed its cover from the first track's art.
+  const stack = libState.stack || [];
+  const last = stack.length > 0 ? stack[stack.length - 1] : null;
+  const srv = libState.servers.find((s) => s.udn === libState.currentUDN);
+  const card = {
+    key: `queue:${libState.currentUDN || ''}:${(last && last.id) || ''}`,
+    name: (last && last.title)
+      || (srv && (srv.friendlyName || srv.address))
+      || t('controls.playFolder'),
+    art: items[0].art || '',
+  };
   const payload = {
     items,
     start: 0,
     shuffle: !!libState.shuffle,
     repeat: libState.repeat || 'off',
+    card,
   };
   try {
     await StartQueue(state.currentBox.host, state.currentBox.port, JSON.stringify(payload));

--- a/desktop-app/frontend/src/views/recent.js
+++ b/desktop-app/frontend/src/views/recent.js
@@ -38,6 +38,27 @@ function recentStrBoxes() {
   return (state.boxes || []).filter((b) => b && b.kind !== 'stock' && b.host);
 }
 
+// recentBoxKey is the stable identity used both for the dropdown option values
+// and the per-entry _boxKey tag, so a picked speaker matches its history.
+function recentBoxKey(b) {
+  return b.deviceID || (b.host + ':' + b.port);
+}
+
+// recentSelectedBoxes resolves the view scope (#221) to the speakers to read:
+// every STR speaker when "All speakers" is chosen, the explicitly picked one
+// otherwise, falling back to the app-wide current box (then the first speaker)
+// so the view is never empty before the user touches the dropdown.
+function recentSelectedBoxes() {
+  const all = recentStrBoxes();
+  if (state.recentAllBoxes) return all;
+  if (state.recentBoxKey) {
+    const found = all.find((b) => recentBoxKey(b) === state.recentBoxKey);
+    if (found) return [found];
+  }
+  if (state.currentBox) return [state.currentBox];
+  return all.length ? [all[0]] : [];
+}
+
 // cardStation projects a recent card into the radio-station shape the search-row
 // helpers (playStation/openPick/toggleFav/isFav, stationLogoCandidates) expect,
 // so a radio card reuses them verbatim. CardKey is the stable favourite identity.
@@ -105,11 +126,9 @@ function groupRecentCards(entries) {
 // preset (= the box holds that account's token) can offer a play button that
 // recalls the slot. One presets fetch per box on view-open: app-side, no box poll.
 async function loadRecentCards() {
-  const boxes = state.recentAllBoxes
-    ? recentStrBoxes()
-    : (state.currentBox ? [state.currentBox] : []);
+  const boxes = recentSelectedBoxes();
   const results = await Promise.all(boxes.map(async (b) => {
-    const boxKey = b.deviceID || (b.host + ':' + b.port);
+    const boxKey = recentBoxKey(b);
     // friendlyName first: the backend always fills Name with a "str-<IP>" fallback,
     // so b.name is never empty. This matches the box switcher and the rest of the app.
     const boxName = getBoxLabel(b);
@@ -350,14 +369,24 @@ export async function renderRecent() {
   const root = $('view-recent');
   if (!root) return;
   stopRecentAutoRefresh(); // re-entry / scope toggle: never stack timers
-  const multi = recentStrBoxes().length > 1;
-  const showAll = multi && !!state.recentAllBoxes;
+  const boxesList = recentStrBoxes();
+  const multi = boxesList.length > 1;
+  // Speaker picker (#221): a dropdown so it is explicit WHICH speaker's history
+  // is shown (the old "This speaker" chip implicitly followed the Music tab), plus
+  // an "All speakers" merge. The currently scoped speaker is preselected.
+  const selectedBoxes = recentSelectedBoxes();
+  const selectedKey = (!state.recentAllBoxes && selectedBoxes.length === 1)
+    ? recentBoxKey(selectedBoxes[0]) : '';
   let html = `<div class="recent-head"><h2 class="recent-title">${escapeHtml(t('recent.title'))}</h2>`;
   if (multi) {
-    html += `<div class="recent-scope">`
-      + `<button class="chip${showAll ? '' : ' active'}" id="recentThisBox">${escapeHtml(t('recent.thisBox'))}</button>`
-      + `<button class="chip${showAll ? ' active' : ''}" id="recentAllBoxes">${escapeHtml(t('recent.allBoxes'))}</button>`
-      + `</div>`;
+    const opts = `<option value="__all__"${state.recentAllBoxes ? ' selected' : ''}>${escapeHtml(t('recent.allBoxes'))}</option>`
+      + boxesList.map((b) => {
+        const k = recentBoxKey(b);
+        const sel = (!state.recentAllBoxes && k === selectedKey) ? ' selected' : '';
+        return `<option value="${escapeAttr(k)}"${sel}>${escapeHtml(getBoxLabel(b))}</option>`;
+      }).join('');
+    html += `<div class="recent-scope"><select class="recent-box-select" id="recentBoxSelect" `
+      + `title="${escapeAttr(t('recent.thisBox'))}">${opts}</select></div>`;
   }
   // Clear the whole list (Brice). Clears every box in the current scope.
   html += `<button class="btn btn-mini recent-clear" id="recentClear" title="${escapeAttr(t('recent.clearAll'))}">${escapeHtml(t('recent.clearAll'))}</button>`;
@@ -365,15 +394,22 @@ export async function renderRecent() {
     + `<div class="recent-list" id="recentList"><div class="muted recent-loading">${escapeHtml(t('recent.loading'))}</div></div>`;
   root.innerHTML = html;
 
-  const tb = $('recentThisBox'), ab = $('recentAllBoxes');
-  if (tb) tb.onclick = () => { state.recentAllBoxes = false; renderRecent(); };
-  if (ab) ab.onclick = () => { state.recentAllBoxes = true; renderRecent(); };
+  const sel = $('recentBoxSelect');
+  if (sel) sel.onchange = () => {
+    if (sel.value === '__all__') {
+      state.recentAllBoxes = true;
+    } else {
+      state.recentAllBoxes = false;
+      state.recentBoxKey = sel.value;
+    }
+    renderRecent();
+  };
 
   const clr = $('recentClear');
   if (clr) clr.onclick = async () => {
     const ok = await confirmWarn(t('recent.clearConfirmTitle'), t('recent.clearConfirmBody'));
     if (!ok) return;
-    const boxes = state.recentAllBoxes ? recentStrBoxes() : (state.currentBox ? [state.currentBox] : []);
+    const boxes = recentSelectedBoxes();
     clr.disabled = true;
     for (const b of boxes) { try { await ClearRecent(b.host, b.port); } catch { /* skip unreachable box */ } }
     await refreshRecentList();

--- a/desktop-app/logexport.go
+++ b/desktop-app/logexport.go
@@ -480,19 +480,61 @@ var macRegex = regexp.MustCompile(`(?i)\b([0-9A-F]{2}[:-]){5}[0-9A-F]{2}\b`)
 var deviceIDRegex = regexp.MustCompile(`(?i)\b[0-9A-F]{12}\b`)
 var ssidHintRegex = regexp.MustCompile(`(?i)(ssid|ssid_name|wpa-psk\s+\S+|psk=)[^\s]*`)
 
-func sanitizeLog(b []byte) []byte {
-	s := string(b)
+// nameTagRegex catches the speaker's user-chosen friendly name as it appears in
+// gabbo frame bodies captured in the box debug state / agent log
+// (<nameUpdated>Living Room</nameUpdated>) and in any <name>...</name> a box
+// log echoes. A friendly name is a personal identifier (CLAUDE.md), so it must
+// be hashed even though it is free-form text with no fixed value shape.
+var nameTagRegex = regexp.MustCompile(`<(name|nameUpdated)>([^<]+)</(?:name|nameUpdated)>`)
+
+// friendlyNameJSONRegex catches the friendly name as a JSON value, e.g. the
+// /api/agent/version payload ("friendlyName":"Bose Wit") and any status JSON
+// that carries it. Keyed on the field name so radio/preset display names (also
+// "name") are not over-scrubbed.
+var friendlyNameJSONRegex = regexp.MustCompile(`(?i)("friendlyName"\s*:\s*")([^"]*)(")`)
+
+// scrubPII is the single sanitization pass shared by every text blob that can
+// leave the host (the app log, box-side logs pulled over SSH, the /api/debug
+// state, /api/status). Keeping one function means a field added to the bundle
+// cannot accidentally skip a scrub the other paths already do — the exact hole
+// that leaked real device IDs and friendly names through anonymizeText while
+// sanitizeLog scrubbed them (see #187/#197 diagnostic bundles).
+func scrubPII(s string) string {
 	s = ipv4Regex.ReplaceAllStringFunc(s, func(ip string) string { return maskIP(ip) })
 	s = macRegex.ReplaceAllStringFunc(s, func(m string) string { return "MAC#" + hashShort(m) })
 	s = deviceIDRegex.ReplaceAllStringFunc(s, func(m string) string { return "DEV#" + hashShort(m) })
+	s = nameTagRegex.ReplaceAllStringFunc(s, func(m string) string {
+		sub := nameTagRegex.FindStringSubmatch(m)
+		return "<" + sub[1] + ">NAME#" + hashShort(sub[2]) + "</" + sub[1] + ">"
+	})
+	s = friendlyNameJSONRegex.ReplaceAllStringFunc(s, func(m string) string {
+		sub := friendlyNameJSONRegex.FindStringSubmatch(m)
+		return sub[1] + "NAME#" + hashShort(sub[2]) + sub[3]
+	})
 	s = ssidHintRegex.ReplaceAllString(s, "<SSID-REDACTED>")
-	return []byte(s)
+	return s
+}
+
+func sanitizeLog(b []byte) []byte {
+	return []byte(scrubPII(string(b)))
 }
 
 func anonymizeSnapshot(s boxSnapshot) boxSnapshot {
 	s.Host = maskIP(s.Host)
 	s.BoseInfo = anonymizeBoseInfoXML(s.BoseInfo)
 	s.STRStatus = anonymizeText(s.STRStatus)
+	// /api/agent/version carries the user-chosen friendlyName ("Bose Wit"), which
+	// was previously copied into the bundle verbatim. Round-trip the parsed map
+	// through scrubPII so friendlyName (and any device ID it grows) is hashed like
+	// everything else. Model/version/build are left intact.
+	if len(s.STRAgentVer) > 0 {
+		if b, err := json.Marshal(s.STRAgentVer); err == nil {
+			var m map[string]any
+			if json.Unmarshal([]byte(scrubPII(string(b))), &m) == nil {
+				s.STRAgentVer = m
+			}
+		}
+	}
 	if s.DebugState != nil {
 		s.DebugState = anonymizeDebugState(s.DebugState)
 	}
@@ -517,15 +559,12 @@ func anonymizeSnapshot(s boxSnapshot) boxSnapshot {
 	return s
 }
 
-// anonymizeText scrubs IPs, MACs, and SSID hints from a text blob
-// using the same rules as sanitizeLog above. Used for box-side
-// logs we pull over SSH so the user can safely attach them to a
-// public GitHub issue.
+// anonymizeText scrubs IPs, MACs, device IDs, friendly names, and SSID hints
+// from a text blob using the same shared pass (scrubPII) as the app log. Used
+// for box-side logs we pull over SSH and the /api/debug state so the user can
+// safely attach them to a public GitHub issue.
 func anonymizeText(s string) string {
-	s = ipv4Regex.ReplaceAllStringFunc(s, func(ip string) string { return maskIP(ip) })
-	s = macRegex.ReplaceAllStringFunc(s, func(m string) string { return "MAC#" + hashShort(m) })
-	s = ssidHintRegex.ReplaceAllString(s, "<SSID-REDACTED>")
-	return s
+	return scrubPII(s)
 }
 
 // anonymizeDebugState walks the /api/debug/state map and scrubs

--- a/desktop-app/logexport_test.go
+++ b/desktop-app/logexport_test.go
@@ -94,3 +94,38 @@ func TestAnonymizeText(t *testing.T) {
 		}
 	}
 }
+
+// TestAnonymizeText_ScrubsDeviceIDAndFriendlyName guards the leak found in the
+// #187/#197 diagnostic bundles: the gabbo frames captured in the agent log /
+// debug state carried the raw device ID and the user-chosen friendly name
+// because anonymizeText only scrubbed IP/MAC/SSID. Both must now be hashed.
+func TestAnonymizeText_ScrubsDeviceIDAndFriendlyName(t *testing.T) {
+	raw := `<updates deviceID="B0D5CC04E5BF"><nameUpdated>ST-10-Firma 7ADB</nameUpdated></updates>` +
+		` nowPlaying deviceID="68C90B85A0A9"`
+	got := anonymizeText(raw)
+	for _, leaked := range []string{"B0D5CC04E5BF", "68C90B85A0A9", "ST-10-Firma 7ADB"} {
+		if strings.Contains(got, leaked) {
+			t.Errorf("anonymizeText leaked %q:\n%s", leaked, got)
+		}
+	}
+	if !strings.Contains(got, "DEV#") || !strings.Contains(got, "<nameUpdated>NAME#") {
+		t.Errorf("expected DEV#/NAME# markers:\n%s", got)
+	}
+}
+
+// TestAnonymizeSnapshot_ScrubsAgentFriendlyName guards the second leak: the
+// /api/agent/version friendlyName ("Bose Wit") was copied into box-<n>.json
+// verbatim because anonymizeSnapshot never touched STRAgentVer.
+func TestAnonymizeSnapshot_ScrubsAgentFriendlyName(t *testing.T) {
+	in := boxSnapshot{
+		Host:        "192.168.1.50",
+		STRAgentVer: map[string]any{"friendlyName": "Bose Wit", "model": "SoundTouch 20", "version": "v0.8.14"},
+	}
+	got := anonymizeSnapshot(in)
+	if fn, _ := got.STRAgentVer["friendlyName"].(string); strings.Contains(fn, "Bose Wit") || !strings.HasPrefix(fn, "NAME#") {
+		t.Errorf("friendlyName not hashed: %v", got.STRAgentVer["friendlyName"])
+	}
+	if got.STRAgentVer["model"] != "SoundTouch 20" {
+		t.Errorf("model must be left intact, got %v", got.STRAgentVer["model"])
+	}
+}

--- a/internal/boxws/boxws.go
+++ b/internal/boxws/boxws.go
@@ -559,6 +559,18 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 				if src == "AUX" {
 					c.handler.OnSourceAux(ctx)
 				}
+				// #197: some ST20 (scm) firmware oscillates UPNP->STANDBY->UPNP on a
+				// power-off, re-selecting STR's UPnP source so the speaker switches
+				// itself back on. When STR's own source (UPNP) drops to STANDBY, give
+				// the handler a chance to clear the transport so the box has nothing to
+				// bounce back to. Optional interface so handlers that do not need it
+				// (tests) are unaffected. Gated to prev==UPNP so it only fires for
+				// STR-driven playback, never an AUX/Spotify power-off.
+				if src == "STANDBY" && prev == "UPNP" {
+					if h, ok := c.handler.(interface{ OnEnterStandby(context.Context) }); ok {
+						h.OnEnterStandby(ctx)
+					}
+				}
 			}
 		}
 	}

--- a/internal/boxws/boxws_test.go
+++ b/internal/boxws/boxws_test.go
@@ -12,16 +12,17 @@ import (
 // recHandler records which gabbo events the parser dispatched so tests can
 // assert that marker words in user-supplied text no longer mis-fire.
 type recHandler struct {
-	presets    []int
-	userStops  int
-	powerKeys  int
-	powerWakes int
-	sourceAux  int
-	skips      []bool
-	zones      []ZoneState
-	boxPresets [][]BoxPreset
-	mu         sync.Mutex
-	thumbs     int // guarded by mu (fired from the debounce timer goroutine)
+	presets      []int
+	userStops    int
+	powerKeys    int
+	powerWakes   int
+	sourceAux    int
+	enterStandby int
+	skips        []bool
+	zones        []ZoneState
+	boxPresets   [][]BoxPreset
+	mu           sync.Mutex
+	thumbs       int // guarded by mu (fired from the debounce timer goroutine)
 }
 
 func (h *recHandler) thumbCount() int { h.mu.Lock(); defer h.mu.Unlock(); return h.thumbs }
@@ -38,12 +39,39 @@ func (h *recHandler) OnPowerKey(context.Context)                   { h.powerKeys
 func (h *recHandler) OnSourceAux(context.Context)                  { h.sourceAux++ }
 func (h *recHandler) OnZoneChanged(_ context.Context, z ZoneState) { h.zones = append(h.zones, z) }
 func (h *recHandler) OnPowerWake(context.Context)                  { h.powerWakes++ }
+func (h *recHandler) OnEnterStandby(context.Context)               { h.enterStandby++ }
 func (h *recHandler) OnPresetsChanged(_ context.Context, p []BoxPreset) {
 	h.boxPresets = append(h.boxPresets, p)
 }
 
 func newTestClient(h Handler) *Client {
 	return New(slog.New(slog.NewTextHandler(io.Discard, nil)), "ws://127.0.0.1:8080/", h)
+}
+
+// TestHandleMessage_EnterStandbyOnlyFromUPNP covers the #197 hook: STR clears the
+// transport when its own UPnP source drops to STANDBY, but not on a power-off from
+// another source (AUX/Spotify), so it never fights an unrelated standby.
+func TestHandleMessage_EnterStandbyOnlyFromUPNP(t *testing.T) {
+	standbyFrame := `<updates deviceID="x"><nowPlayingUpdated><nowPlaying source="STANDBY">` +
+		`<ContentItem source="STANDBY"/></nowPlaying></nowPlayingUpdated></updates>`
+
+	// UPNP -> STANDBY fires the hook once.
+	h := &recHandler{}
+	c := newTestClient(h)
+	c.handleMessage(context.Background(), []byte(`<updates><nowPlayingUpdated><nowPlaying source="UPNP"><playStatus>PLAY_STATE</playStatus></nowPlaying></nowPlayingUpdated></updates>`))
+	c.handleMessage(context.Background(), []byte(standbyFrame))
+	if h.enterStandby != 1 {
+		t.Fatalf("UPNP->STANDBY must fire OnEnterStandby once, got %d", h.enterStandby)
+	}
+
+	// AUX -> STANDBY must NOT fire it (STR did not drive that source).
+	h2 := &recHandler{}
+	c2 := newTestClient(h2)
+	c2.handleMessage(context.Background(), []byte(`<updates><nowPlayingUpdated><nowPlaying source="AUX"/></nowPlayingUpdated></updates>`))
+	c2.handleMessage(context.Background(), []byte(standbyFrame))
+	if h2.enterStandby != 0 {
+		t.Fatalf("AUX->STANDBY must not fire OnEnterStandby, got %d", h2.enterStandby)
+	}
 }
 
 func TestHandleMessage_StopStateInTitleDoesNotFireUserStop(t *testing.T) {

--- a/internal/webui/queue_test.go
+++ b/internal/webui/queue_test.go
@@ -155,6 +155,21 @@ func TestQueueSetShuffleKeepsCurrent(t *testing.T) {
 	}
 }
 
+// TestNowPlayingStandby covers the #219 power-off-during-queue guard: a box that
+// went to standby must be detected so the watcher stops the queue instead of
+// advancing (which would wake the box and play the next track). A track literally
+// named "STANDBY" while actually playing must NOT be mistaken for it.
+func TestNowPlayingStandby(t *testing.T) {
+	standby := `<?xml version="1.0"?><nowPlaying deviceID="x" source="STANDBY"><ContentItem source="STANDBY" isPresetable="false" /></nowPlaying>`
+	if !nowPlayingStandby(standby) {
+		t.Fatal("a source=STANDBY nowPlaying must be detected as standby")
+	}
+	playing := `<?xml version="1.0"?><nowPlaying source="UPNP"><ContentItem source="UPNP" location="http://a"><itemName>STANDBY (band)</itemName></ContentItem><playStatus>PLAY_STATE</playStatus></nowPlaying>`
+	if nowPlayingStandby(playing) {
+		t.Fatal("a playing UPNP track named STANDBY must NOT count as standby")
+	}
+}
+
 func TestQueueSnapshot(t *testing.T) {
 	q := newPlayQueue()
 	q.load(mkItems(3), 1, false, repeatAll)

--- a/internal/webui/queueplay.go
+++ b/internal/webui/queueplay.go
@@ -277,7 +277,16 @@ func (s *Server) runQueueWatcher(ctx context.Context) {
 			gen, lastPos, obsTotal, sawPlay = curGen, 0, 0, false
 		}
 
-		ps, pos, total := s.pollNowPlaying()
+		ps, pos, total, standby := s.pollNowPlaying()
+		if standby {
+			// The box was powered off mid-queue (top switch, remote, or the app's
+			// Standby button -> now_playing source=STANDBY). A standby is never a
+			// track end: stop the queue so STR does not advance and re-push the next
+			// track, which would wake the box back up and resume playing (#219).
+			s.logger.Info("queue watcher: box entered standby, stopping queue (not advancing)")
+			s.stopQueue()
+			return
+		}
 		if total > obsTotal {
 			obsTotal = total // remember it even after the box later reports 0
 		}
@@ -345,22 +354,38 @@ func nearEnd(progress, end time.Duration) bool {
 var (
 	reNowPlayStatus = regexp.MustCompile(`<playStatus>([^<]+)</playStatus>`)
 	reNowPlayTime   = regexp.MustCompile(`<time total="(\d+)"\s*>(\d+)</time>`)
+	// reNowPlaySource reads the <nowPlaying source="..."> attribute (not a track
+	// title), so a station/track literally named "STANDBY" cannot be mistaken for
+	// the box being off.
+	reNowPlaySource = regexp.MustCompile(`<nowPlaying[^>]*\bsource="([^"]*)"`)
 )
 
-// pollNowPlaying reads the box's now_playing once and returns the play status
-// and the current/total position. Zero values on any error.
-func (s *Server) pollNowPlaying() (status string, pos, total time.Duration) {
+// nowPlayingStandby reports whether the box's now_playing says it is in standby
+// (powered off). The box reports source="STANDBY" (some firmwares
+// "NETWORK_STANDBY") on the nowPlaying root when it is off.
+func nowPlayingStandby(body string) bool {
+	if m := reNowPlaySource.FindStringSubmatch(body); m != nil {
+		return strings.Contains(m[1], "STANDBY")
+	}
+	return false
+}
+
+// pollNowPlaying reads the box's now_playing once and returns the play status,
+// the current/total position, and whether the box is in standby. Zero values on
+// any error.
+func (s *Server) pollNowPlaying() (status string, pos, total time.Duration, standby bool) {
 	if s.boxHost == "" {
-		return "", 0, 0
+		return "", 0, 0, false
 	}
 	cl := &http.Client{Timeout: 3 * time.Second}
 	resp, err := cl.Get("http://" + s.boxHost + ":8090/now_playing")
 	if err != nil {
-		return "", 0, 0
+		return "", 0, 0, false
 	}
 	b, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
 	resp.Body.Close()
 	body := string(b)
+	standby = nowPlayingStandby(body)
 	if m := reNowPlayStatus.FindStringSubmatch(body); m != nil {
 		status = m[1]
 	} else {
@@ -383,7 +408,7 @@ func (s *Server) pollNowPlaying() (status string, pos, total time.Duration) {
 			pos = time.Duration(c) * time.Second
 		}
 	}
-	return status, pos, total
+	return status, pos, total, standby
 }
 
 // --- HTTP handlers -------------------------------------------------------

--- a/internal/webui/queueplay.go
+++ b/internal/webui/queueplay.go
@@ -3,6 +3,7 @@ package webui
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"regexp"
@@ -52,7 +53,10 @@ func (s *Server) RecallSlot(ctx context.Context, slot int) (handled bool) {
 	}
 	s.ensureBoxReady(ctx)
 	s.logger.Info("preset slot recall (hardware): queue", "slot", slot, "tracks", len(items), "shuffle", p.Shuffle)
-	if err := s.startQueue(ctx, items, 0, p.Shuffle, repeatOff); err != nil {
+	// Record the saved folder as a Recently-played card (#220), keyed on the slot
+	// so repeated recalls of the same preset group together.
+	card := recentCardCtx{key: fmt.Sprintf("queue:slot:%d", slot), name: p.Name, art: p.Art}
+	if err := s.startQueue(ctx, items, 0, p.Shuffle, repeatOff, card); err != nil {
 		s.logger.Warn("hardware queue recall failed", "slot", slot, "err", err)
 	}
 	return true
@@ -90,6 +94,9 @@ func (s *Server) pushStream(ctx context.Context, url, title, art, mime string) e
 		return err
 	}
 	s.setLastPlay(playURL, title, art, mime)
+	// Recently-played (#220): hang this queue track under the active folder card.
+	// No-op outside a queue (pushStream is queue-only) or before a card is set.
+	s.recentNoteQueueTrack(title)
 	return nil
 }
 
@@ -100,16 +107,17 @@ func (s *Server) queueCtx() context.Context {
 	return context.Background()
 }
 
-// startQueue replaces the queue with items and starts playing from start.
-func (s *Server) startQueue(ctx context.Context, items []queueItem, start int, shuffle bool, rep repeatMode) error {
+// startQueue replaces the queue with items and starts playing from start. card
+// carries the Recently-played folder identity (#220); a zero card skips recording.
+func (s *Server) startQueue(ctx context.Context, items []queueItem, start int, shuffle bool, rep repeatMode, card recentCardCtx) error {
 	s.boxCmdMu.Lock()
 	defer s.boxCmdMu.Unlock()
-	return s.startQueueLocked(ctx, items, start, shuffle, rep)
+	return s.startQueueLocked(ctx, items, start, shuffle, rep, card)
 }
 
 // startQueueLocked is startQueue for callers that already hold boxCmdMu (e.g. a
 // preset slot recall, which takes the lock for the whole handler).
-func (s *Server) startQueueLocked(ctx context.Context, items []queueItem, start int, shuffle bool, rep repeatMode) error {
+func (s *Server) startQueueLocked(ctx context.Context, items []queueItem, start int, shuffle bool, rep repeatMode, card recentCardCtx) error {
 	if s.renderer == nil {
 		return errors.New("renderer not configured")
 	}
@@ -123,6 +131,20 @@ func (s *Server) startQueueLocked(ctx context.Context, items []queueItem, start 
 		return errors.New("empty queue")
 	}
 	s.ClearUserStop()
+	// Record the folder as a Recently-played card before the first push, so that
+	// push (and every auto-advance after it) is hung under it. The replay target
+	// and cover fall back to the first track when the caller left them empty.
+	if card.key != "" {
+		if card.url == "" {
+			card.url = it.URL
+		}
+		if card.art == "" {
+			card.art = it.Art
+		}
+		s.recentNoteQueueCard(card.key, card.name, card.art, card.url)
+	} else {
+		s.recentClearQueueCard()
+	}
 	if err := s.pushStream(ctx, it.URL, it.Title, it.Art, it.Mime); err != nil {
 		return err
 	}
@@ -167,6 +189,7 @@ func (s *Server) cancelWatcher() {
 func (s *Server) stopQueue() {
 	s.queue.clear()
 	s.cancelWatcher()
+	s.recentClearQueueCard()
 }
 
 // advanceAndPlay moves to the next track (natural end vs manual skip differ on
@@ -231,9 +254,10 @@ func (s *Server) runQueueWatcher(ctx context.Context) {
 	ticker := time.NewTicker(queuePollInterval)
 	defer ticker.Stop()
 	var (
-		gen     int
-		lastPos time.Duration
-		sawPlay bool
+		gen      int
+		lastPos  time.Duration
+		obsTotal time.Duration // largest total the box reported for this track
+		sawPlay  bool
 	)
 	for {
 		select {
@@ -250,13 +274,19 @@ func (s *Server) runQueueWatcher(ctx context.Context) {
 		dur := s.queueTrackDur
 		s.queueMu.Unlock()
 		if curGen != gen {
-			gen, lastPos, sawPlay = curGen, 0, false
+			gen, lastPos, obsTotal, sawPlay = curGen, 0, 0, false
 		}
 
 		ps, pos, total := s.pollNowPlaying()
+		if total > obsTotal {
+			obsTotal = total // remember it even after the box later reports 0
+		}
+		// Track length: the queue item's duration, or the box's reported total
+		// when the item carried none (a DLNA server, e.g. Synology, that did not
+		// expose duration in its metadata leaves dur==0). #219
 		end := dur
-		if total > 0 {
-			end = total
+		if obsTotal > end {
+			end = obsTotal
 		}
 
 		switch ps {
@@ -265,7 +295,10 @@ func (s *Server) runQueueWatcher(ctx context.Context) {
 			if pos > 0 {
 				lastPos = pos
 			}
-			continue
+			// Do NOT continue: fall through to the wall-clock net. Some renderers
+			// (seen on the ST20 with direct-played NAS files) finish a finite file
+			// but stay in PLAY_STATE with the position frozen at the end instead of
+			// reporting STOP_STATE, so end detection cannot rely on the state alone.
 		case "PAUSE_STATE":
 			continue // paused: never advance, and freeze the wall-clock timer
 		case "STOP_STATE":
@@ -283,13 +316,21 @@ func (s *Server) runQueueWatcher(ctx context.Context) {
 				return
 			}
 			continue
+		default:
+			// No usable status this tick (poll error or an idle box).
+			if !sawPlay && time.Since(start) >= queueStallTimeout {
+				s.advanceAndPlay(true) // a track that never started: skip it
+				continue
+			}
 		}
 
-		// No usable status this tick (poll error or an idle box). Safety nets:
-		if !sawPlay && time.Since(start) >= queueStallTimeout {
-			s.advanceAndPlay(true) // a track that never started: skip it
-		} else if sawPlay && dur > 0 && time.Since(start) >= dur+queueTimerMargin {
-			s.advanceAndPlay(true) // missed the STOP frame: the track length elapsed
+		// Wall-clock safety net, reached on PLAY_STATE and on an unknown status:
+		// once playback was seen and the track length is known, advance a margin
+		// past it. This covers both a missed STOP frame and a box that freezes at
+		// PLAY_STATE on a finite file's EOF (#219), neither of which the STOP path
+		// above can catch.
+		if sawPlay && end > 0 && time.Since(start) >= end+queueTimerMargin {
+			s.advanceAndPlay(true)
 		}
 	}
 }
@@ -355,11 +396,21 @@ type queueStartItem struct {
 	DurationSec int    `json:"duration_sec"`
 }
 
+// queueCard is the optional Recently-played folder identity the desktop app
+// sends with a folder play (#220). When absent the queue still plays; it just is
+// not recorded as a card.
+type queueCard struct {
+	Key  string `json:"key"`
+	Name string `json:"name"`
+	Art  string `json:"art"`
+}
+
 type queueStartRequest struct {
 	Items   []queueStartItem `json:"items"`
 	Start   int              `json:"start"`
 	Shuffle bool             `json:"shuffle"`
 	Repeat  string           `json:"repeat"`
+	Card    queueCard        `json:"card"`
 }
 
 func toQueueItems(in []queueStartItem) []queueItem {
@@ -398,7 +449,8 @@ func (s *Server) handleQueue(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "no playable items", http.StatusBadRequest)
 			return
 		}
-		if err := s.startQueue(r.Context(), items, req.Start, req.Shuffle, parseRepeat(req.Repeat)); err != nil {
+		card := recentCardCtx{key: req.Card.Key, name: req.Card.Name, art: req.Card.Art}
+		if err := s.startQueue(r.Context(), items, req.Start, req.Shuffle, parseRepeat(req.Repeat), card); err != nil {
 			writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
 			return
 		}

--- a/internal/webui/recent_queue_test.go
+++ b/internal/webui/recent_queue_test.go
@@ -1,0 +1,54 @@
+package webui
+
+import (
+	"testing"
+
+	"github.com/JRpersonal/streborn/internal/recent"
+)
+
+// TestRecentQueueCardRecordsFolderAndTracks covers #220: a DLNA folder played as
+// an auto-advancing queue is recorded as one "library" (upnp) Recently-played
+// card, with each track the queue pushes hung under it, and later tracks stop
+// attaching once the queue is cleared.
+func TestRecentQueueCardRecordsFolderAndTracks(t *testing.T) {
+	s := &Server{recent: recent.New()}
+
+	// startQueue notes the folder card, then the first push records the first
+	// track (which folds into the card placeholder), then auto-advance records more.
+	s.recentNoteQueueCard("queue:srv:42", "Jazz", "art.png", "http://nas/1.mp3")
+	s.recentNoteQueueTrack("Song A")
+	s.recentNoteQueueTrack("Song B")
+
+	all := s.recent.All()
+	if len(all) != 2 {
+		t.Fatalf("want 2 entries (card folded into first track, then second track), got %d: %+v", len(all), all)
+	}
+	for _, e := range all {
+		if e.Source != "upnp" || e.CardKey != "queue:srv:42" || e.CardName != "Jazz" {
+			t.Fatalf("entry not attributed to the folder card: %+v", e)
+		}
+	}
+	if all[0].Track != "Song A" || all[1].Track != "Song B" {
+		t.Fatalf("tracks not recorded in order: %+v", all)
+	}
+	if all[0].CardURL != "http://nas/1.mp3" {
+		t.Fatalf("replay target lost: %+v", all[0])
+	}
+
+	// After the queue stops (single play / stop / runs out), later tracks must not
+	// attach to the now-dead folder card.
+	s.recentClearQueueCard()
+	s.recentNoteQueueTrack("Song C")
+	if got := len(s.recent.All()); got != 2 {
+		t.Fatalf("track recorded after the queue card was cleared: want 2 entries, got %d", got)
+	}
+}
+
+// TestRecentQueueCardNilStore makes sure the helpers are no-ops without a wired
+// recent store (dev builds), never panicking.
+func TestRecentQueueCardNilStore(t *testing.T) {
+	s := &Server{}
+	s.recentNoteQueueCard("k", "n", "a", "u")
+	s.recentNoteQueueTrack("t")
+	s.recentClearQueueCard()
+}

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -176,6 +176,14 @@ type Server struct {
 	lastUserStopMu sync.Mutex
 	lastUserStop   time.Time
 
+	// lastStandbyStop debounces the #197 standby-bounce mitigation: some ST20
+	// (scm) firmware oscillates UPNP->STANDBY->UPNP on a power-off, re-selecting
+	// STR's UPnP source so the box turns itself back on. HandleEnterStandby clears
+	// the transport once per standbyStopDebounce so the rapid flip does not issue a
+	// burst of Stops.
+	standbyStopMu   sync.Mutex
+	lastStandbyStop time.Time
+
 	// resumeOnPowerOnPath persists the per-box opt-out for "resume the last
 	// station when the speaker is switched on" (default on; file absent or "1").
 	// Empty falls back to defaultResumeOnPowerOnPath.
@@ -1963,6 +1971,56 @@ func (s *Server) userStoppedRecently() bool {
 	s.lastUserStopMu.Lock()
 	defer s.lastUserStopMu.Unlock()
 	return !s.lastUserStop.IsZero() && time.Since(s.lastUserStop) < userStopWindow
+}
+
+// standbyStopDebounce coalesces the rapid UPNP<->STANDBY oscillation a power-off
+// produces on some ST20 (scm) firmware into a single transport Stop.
+const standbyStopDebounce = 4 * time.Second
+
+// standbyBounceFixEnabled gates the #197 mitigation. Default on; set
+// STR_STANDBY_STOP=0 on the box to disable it if it ever regresses, without an
+// OTA (run.sh exports the agent's environment).
+func standbyBounceFixEnabled() bool {
+	return os.Getenv("STR_STANDBY_STOP") != "0"
+}
+
+// HandleEnterStandby reacts to the box's own UPnP source dropping to STANDBY
+// (a power-off), seen over gabbo. On some ST20 (scm) firmware the box then
+// oscillates STANDBY->UPNP and switches itself back on because STR's UPnP
+// transport still has a URI loaded and is treated as the active source, so the
+// speaker "cannot be switched off" until several presses (#197, confirmed in a
+// diagnostic: UPNP->STANDBY->UPNP within ~170 ms, repeated). STR clears the
+// transport so the firmware has nothing to bounce back to.
+//
+// Conservative by design: it only runs when STR's own source (UPNP) was active,
+// never when the box is in a zone (a mirror/slave legitimately re-selects UPNP),
+// and is debounced so the flip does not issue a burst of Stops. Stopping a box
+// the user just powered off matches their intent, so the blast radius is small.
+func (s *Server) HandleEnterStandby() {
+	if !standbyBounceFixEnabled() || s.renderer == nil {
+		return
+	}
+	if s.boxInZone() {
+		return // a zone slave/master mirror re-selects UPNP on purpose; leave it
+	}
+	s.standbyStopMu.Lock()
+	if !s.lastStandbyStop.IsZero() && time.Since(s.lastStandbyStop) < standbyStopDebounce {
+		s.standbyStopMu.Unlock()
+		return
+	}
+	s.lastStandbyStop = time.Now()
+	s.standbyStopMu.Unlock()
+
+	// A power-off is a deliberate stop: hold the auto-re-push and drop any queue
+	// so neither fights the standby, then clear the transport.
+	s.NoteUserStop()
+	s.stopQueue()
+	s.logger.Info("standby bounce: box powered off STR's UPnP source, clearing transport so it stays off (#197)")
+	ctx, cancel := context.WithTimeout(s.queueCtx(), 5*time.Second)
+	defer cancel()
+	if err := s.renderer.Stop(ctx); err != nil {
+		s.logger.Debug("standby bounce: transport stop returned (expected if already off)", "err", err)
+	}
 }
 
 // HandleStreamDisconnect is called by the stream proxy when the Bose renderer

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -217,6 +217,11 @@ type Server struct {
 	recentMu          sync.Mutex
 	recentRadioCard   recentCardCtx
 	recentSpotifyCard recentCardCtx
+	// recentQueueCard remembers the DLNA folder currently playing as an
+	// auto-advancing queue, so each track the queue pushes is recorded under one
+	// "library" card (#220: folder plays were never added to Recently played).
+	// Cleared when the queue stops (a single play, a stop, or running out).
+	recentQueueCard recentCardCtx
 
 	// boxPresets is the box's OWN preset list as last reported over the gabbo
 	// presetsUpdated frame, including foreign sources (DEEZER etc.) STR did not
@@ -1167,7 +1172,8 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.logger.Info("preset slot recall (app): queue", "slot", slot, "tracks", len(items), "shuffle", p.Shuffle)
-		if err := s.startQueueLocked(r.Context(), items, 0, p.Shuffle, repeatOff); err != nil {
+		card := recentCardCtx{key: fmt.Sprintf("queue:slot:%d", slot), name: p.Name, art: p.Art}
+		if err := s.startQueueLocked(r.Context(), items, 0, p.Shuffle, repeatOff, card); err != nil {
 			writeJSON(w, http.StatusBadGateway, map[string]any{
 				"error": "Folder could not be played", "detail": guessErrorReason(err),
 				"slot": slot, "name": p.Name,
@@ -1433,6 +1439,40 @@ func (s *Server) recentNoteCard(source, key, name, art, url, account, homepage s
 		// even if its name happens to match the previous card's last track.
 		s.recentSpotifyCard = recentCardCtx{key: key, name: name, art: art, url: url, account: account}
 	}
+	s.recentMu.Unlock()
+}
+
+// recentNoteQueueCard records a DLNA folder played as an auto-advancing queue as
+// the start of a "library" (upnp) Recently-played card, and remembers it so each
+// track the queue pushes is hung under it (like radio ICY tracks under a station).
+// The replay target is the first track's URL; clicking the card re-plays it.
+func (s *Server) recentNoteQueueCard(key, name, art, url string) {
+	s.recentMu.Lock()
+	s.recentQueueCard = recentCardCtx{key: key, name: name, art: art, url: url}
+	s.recentMu.Unlock()
+	s.recentNoteCard("upnp", key, name, art, url, "", "")
+}
+
+// recentNoteQueueTrack hangs the track the play-queue just started under the
+// current folder card. No-op until a queue card has been recorded.
+func (s *Server) recentNoteQueueTrack(track string) {
+	if s.recent == nil || track == "" {
+		return
+	}
+	s.recentMu.Lock()
+	c := s.recentQueueCard
+	s.recentMu.Unlock()
+	if c.key == "" {
+		return
+	}
+	s.recent.Add(recent.Entry{Source: "upnp", CardKey: c.key, CardName: c.name, CardArt: c.art, CardURL: c.url, Track: track})
+}
+
+// recentClearQueueCard forgets the active folder card so later tracks (a single
+// play, a new radio station) are not mis-attributed to a folder that has stopped.
+func (s *Server) recentClearQueueCard() {
+	s.recentMu.Lock()
+	s.recentQueueCard = recentCardCtx{}
 	s.recentMu.Unlock()
 }
 


### PR DESCRIPTION
Bundles this session's fixes for the v0.8.15 release.

- **#219** Folder/queue playback: advances reliably even when the DLNA server (e.g. Synology) reports no track duration and the box freezes at PLAY_STATE on a file's EOF; and no longer resumes/advances when the speaker is switched off mid-folder (top switch, remote, or the app's Standby button) — a box in standby is treated as a definite stop.
- **#220** Folders played as a queue are now recorded in Recently played (one library card with each track under it).
- **#221** Recently played: the ambiguous "This speaker" chip is replaced with an explicit speaker dropdown (per speaker by name + All speakers).
- **#197** ST20 (scm): clears the UPnP transport when STR's source drops to STANDBY so firmware that oscillates UPNP↔STANDBY no longer switches the speaker back on. Conservative (prev==UPNP only, zone-guarded, debounced, `STR_STANDBY_STOP=0` to disable). Needs confirmation on real scm ST20.
- **Diagnostic privacy**: the bundle no longer leaks device IDs / speaker friendly names (agent log, now-playing XML, agent-version) despite Anonymized=true.

All builds (native + `GOOS=linux GOARCH=arm GOARM=7`) and tests green for both modules. Commits are kept separate so each fix lands as its own release-note bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbCsRsQx76vsbuAaMZky3h

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbCsRsQx76vsbuAaMZky3h)_