### PR TITLE
fix(agent): log thumb-key activity frames so unresponsive thumb keys can be diagnosed

### DIFF
--- a/internal/boxws/boxws.go
+++ b/internal/boxws/boxws.go
@@ -130,6 +130,11 @@ type Client struct {
 	thumbPending   *time.Timer
 	thumbExplained time.Time
 	thumbLastFire  time.Time
+	// lastUserActivityLog debounces the INFO log of an incoming userActivity
+	// frame so a volume ramp (which also emits userActivity) cannot churn the
+	// NAND log, while an isolated thumb press is still recorded. See
+	// noteUserActivity.
+	lastUserActivityLog time.Time
 }
 
 // thumbExplainWindow is how close an explained event (volume/preset/now
@@ -140,6 +145,11 @@ const (
 	thumbExplainWindow = 600 * time.Millisecond
 	thumbSettle        = 500 * time.Millisecond
 	thumbDebounce      = 2 * time.Second
+	// userActivityLogDedup is the minimum gap between INFO log lines for an
+	// incoming userActivity frame. A thumb press emits a single frame, so an
+	// isolated press is always logged; a volume ramp emits many, which collapse
+	// to one line per window so the NAND log does not churn (#187).
+	userActivityLogDedup = 3 * time.Second
 )
 
 // wsKeepaliveInterval is how often STR sends a WebSocket ping control frame to
@@ -177,15 +187,26 @@ func (c *Client) noteExplainedActivity() {
 // (debounced). Both the before- and after-cases are covered, so a volume key
 // (which emits volumeUpdated alongside userActivity, in either order) does not
 // misfire.
-func (c *Client) noteUserActivity(ctx context.Context) {
+func (c *Client) noteUserActivity(ctx context.Context, raw []byte) {
 	c.thumbMu.Lock()
 	defer c.thumbMu.Unlock()
+	// Record that a userActivity frame arrived at INFO (deduped), independent of
+	// whether the heuristic ends up firing. A "the thumb key does nothing" report
+	// (#187) is otherwise undiagnosable from a bundle: we cannot tell a frame that
+	// never arrived (box sends nothing for thumbs on this firmware) from one that
+	// arrived and was suppressed. The raw frame is also captured so we can see
+	// whether it carries any attribute that distinguishes thumb-up from -down.
+	if time.Since(c.lastUserActivityLog) > userActivityLogDedup {
+		c.lastUserActivityLog = time.Now()
+		c.logger.Info("box ws: user-activity frame received", "frame", preview(raw, 400))
+	}
 	if time.Since(c.thumbExplained) < thumbExplainWindow {
 		return // explained by a recent volume/preset/now-playing event
 	}
 	if c.thumbPending != nil {
 		return // already waiting to fire
 	}
+	framePrev := preview(raw, 400) // captured for the fire log below
 	c.thumbPending = time.AfterFunc(thumbSettle, func() {
 		c.thumbMu.Lock()
 		c.thumbPending = nil
@@ -210,7 +231,7 @@ func (c *Client) noteUserActivity(ctx context.Context) {
 		}
 		c.thumbLastFire = time.Now()
 		c.thumbMu.Unlock()
-		c.logger.Info("box ws: lone user-activity -> thumb trigger")
+		c.logger.Info("box ws: lone user-activity -> thumb trigger", "frame", framePrev)
 		if c.handler != nil {
 			c.handler.OnThumbActivity(ctx)
 		}
@@ -634,7 +655,7 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 		// identity). Treat a lone one as a thumb press; noteUserActivity
 		// debounces it and suppresses it when an explained event bracketed it.
 		known = true
-		c.noteUserActivity(ctx)
+		c.noteUserActivity(ctx, data)
 	case f.NowPlaying != nil && f.NowSelection == nil:
 		known = true
 		c.noteExplainedActivity()
@@ -711,7 +732,7 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 				// Lone thumb ping (see noteUserActivity). Regressed for bare frames
 				// when the parser went typed; this restores it (live box log
 				// 2026-06-12 showed bare <userActivityUpdate/> as unrecognized).
-				c.noteUserActivity(ctx)
+				c.noteUserActivity(ctx, data)
 				return
 			case "errorUpdate":
 				// The box reports playback/source failures as a bare <errorUpdate>

--- a/internal/boxws/boxws_test.go
+++ b/internal/boxws/boxws_test.go
@@ -1,9 +1,11 @@
 package boxws
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -267,6 +269,29 @@ func TestHandleMessage_BareUserActivityFiresThumb(t *testing.T) {
 	}
 	if h.thumbCount() != 1 {
 		t.Fatalf("bare userActivityUpdate must fire one thumb, got %d", h.thumbCount())
+	}
+}
+
+// TestHandleMessage_UserActivityLoggedAtInfo guards the #187 diagnostic: every
+// incoming userActivity frame must be recorded at INFO (deduped) so a bundle
+// shows whether the thumb key emits a frame at all, independent of whether the
+// heuristic fires. A second frame inside the dedup window must NOT add a second
+// "frame received" line, so a volume ramp cannot churn the NAND log.
+func TestHandleMessage_UserActivityLoggedAtInfo(t *testing.T) {
+	var buf bytes.Buffer
+	h := &recHandler{}
+	c := New(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})),
+		"ws://127.0.0.1:8080/", h)
+
+	c.handleMessage(context.Background(), []byte(`<userActivityUpdate deviceID="x" />`))
+	c.handleMessage(context.Background(), []byte(`<userActivityUpdate deviceID="x" />`))
+
+	got := buf.String()
+	if n := strings.Count(got, "user-activity frame received"); n != 1 {
+		t.Fatalf("want exactly one deduped 'frame received' INFO line, got %d:\n%s", n, got)
+	}
+	if !strings.Contains(got, "userActivityUpdate") {
+		t.Fatalf("the raw frame must be captured in the log, got:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## What

Makes unresponsive thumb keys (#187) diagnosable from a diagnostic bundle.

The remote thumb keys surface only as a generic `<userActivityUpdate>` frame with no up/down identity; STR infers a thumb press from a "lone" one (no volume/preset/power around it). When a user reports the thumb keys "do nothing", a bundle could not tell whether:
- the box sent **no frame at all** (this firmware emits nothing for thumbs), or
- a frame **arrived but the heuristic suppressed it** (explained/debounced).

At log level `info` the raw frame was only logged at `debug` (`box ws frame`), and an arriving userActivity that was explained-at-arrival produced no `info` line at all.

## Change

- Record every incoming `userActivityUpdate` frame at **INFO**, **deduped** (`userActivityLogDedup = 3s`) so a volume ramp (which also emits userActivity) collapses to one line per window and cannot churn the NAND log, while an isolated thumb press is always captured.
- Include the **raw frame** in the log so we can also inspect whether it carries any attribute that could distinguish thumb-up from thumb-down.
- Attach the raw frame to the existing `lone user-activity -> thumb trigger` info line too.
- New test asserts the deduped info line fires once for two rapid frames and that the raw frame is captured.

This is a diagnostic-only change; the thumb heuristic itself is unchanged. With it, the next isolated capture (wake box, press only a thumb key 3-4x, export immediately) will show in the bundle whether the frame arrives — settling whether the heuristic can work on this firmware at all.

## Verification

- `go build ./...`, `GOOS=linux GOARCH=arm GOARM=7 go build ./...`, `go vet ./internal/boxws/` clean.
- `go test ./internal/boxws/` passes incl. the new `TestHandleMessage_UserActivityLoggedAtInfo` and the existing `TestHandleMessage_BareUserActivityFiresThumb`.

Refs #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018toF5gpjCVofKphVfNn6xH

---
_Generated by [Claude Code](https://claude.ai/code/session_018toF5gpjCVofKphVfNn6xH)_