### PR TITLE
fix(diagnostics): capture the speaker-update attempt in the bundle

### DIFF
--- a/desktop-app/logexport.go
+++ b/desktop-app/logexport.go
@@ -118,6 +118,25 @@ Privacy:
 		return LogExportResult{}, err
 	}
 
+	// 2b. Previous-session app log + the persistent OTA journal. str.log is
+	// rotated to <name>.1 on each launch and app.log above is only the current
+	// session, so an update-failure exported in a LATER session has lost the
+	// attempt. The previous session (often where it happened) is in app.prev.log,
+	// and every speaker-update attempt with its outcome is in ota-history.log,
+	// which is never rotated away. Both best-effort, omitted when absent.
+	if prev, perr := os.ReadFile(LogFilePath() + ".1"); perr == nil && len(prev) > 0 {
+		if req.Anonymize {
+			prev = sanitizeLog(prev)
+		}
+		_ = writeZipEntry(zw, "app.prev.log", prev)
+	}
+	if oj, oerr := os.ReadFile(otaJournalPath()); oerr == nil && len(oj) > 0 {
+		if req.Anonymize {
+			oj = sanitizeLog(oj)
+		}
+		_ = writeZipEntry(zw, "ota-history.log", oj)
+	}
+
 	// 3. Per-box snapshots.
 	manifest := struct {
 		Timestamp string          `json:"timestamp"`

--- a/desktop-app/ota.go
+++ b/desktop-app/ota.go
@@ -58,11 +58,23 @@ func (a *App) BoxAgentVersion(host string, port int) (map[string]string, error) 
 // into /mnt/nv/streborn/bin/streborn-armv7l.new, size-verify, atomic-
 // rename, SIGTERM the running agent. run.sh's boot watchdog respawns it
 // from the new file within seconds.
-func (a *App) UpdateBoxAgent(host string, port int) error {
+func (a *App) UpdateBoxAgent(host string, port int) (err error) {
 	bin := agentbin.Bytes()
 	if len(bin) == 0 {
+		a.recordOTA(host, "start: aborted, no embedded agent binary in this build")
 		return fmt.Errorf("no embedded stick binary available")
 	}
+	a.recordOTA(host, fmt.Sprintf("start: port=%d bytes=%d app=%s build=%s", port, len(bin), appVersion, appBuild))
+	// Record the final outcome to the persistent OTA journal so an update-failure
+	// report is diagnosable even if the user exports the diagnostic in a later
+	// session: str.log is rotated away on the next launch, this journal is not.
+	defer func() {
+		if err != nil {
+			a.recordOTA(host, "outcome: reported failure: "+err.Error())
+		} else {
+			a.recordOTA(host, "outcome: no error (applied, or deferred to the version poll)")
+		}
+	}()
 	// Refresh the USB stick BEFORE the OTA push, while the box is still fully up.
 	// The push reboots the box ~1s after the binary swap (updateAgentViaSSH), and
 	// doing the stick write afterwards raced that reboot: the going-down
@@ -76,6 +88,7 @@ func (a *App) UpdateBoxAgent(host string, port int) error {
 	a.refreshStick(host)
 
 	if perr := a.updateAgentPreflight(host, port); perr != nil {
+		a.recordOTA(host, "HTTP preflight rejected -> trying SSH: "+perr.Error())
 		a.logger.Warn("update agent: HTTP preflight rejected, switching to SSH-OTA",
 			"host", host, "port", port, "reason", perr)
 		if sshErr := a.updateAgentViaSSH(host, bin); sshErr != nil {
@@ -96,6 +109,7 @@ func (a *App) UpdateBoxAgent(host string, port int) error {
 		return nil
 	}
 	if err := a.updateAgentViaHTTP(host, port, bin); err != nil {
+		a.recordOTA(host, "HTTP upload failed -> trying SSH: "+err.Error())
 		// The small preflight GET can pass while the 10 MB POST still fails: on
 		// BCO the :17008 REDIRECT path closes the connection mid-upload (live
 		// 2026-06-11, "connection forcibly closed"). Fall back to SSH-OTA instead

--- a/desktop-app/otajournal.go
+++ b/desktop-app/otajournal.go
@@ -1,0 +1,65 @@
+package main
+
+// Persistent OTA journal. Every speaker (agent) update attempt is appended here
+// with its phases and outcome. Unlike str.log it is NOT rotated away on the next
+// app launch and it is always included in the diagnostic bundle, so the most
+// common reason an OTA-failure report is undiagnosable, "the update attempt is
+// not in the bundle" (the user restarted the app between the failure and the
+// export, or str.log rolled past it), no longer applies. The file is capped so it
+// stays small.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const maxOTAJournalBytes = 64 * 1024
+
+// otaJournalPath is the OTA history file, next to str.log so it lands in the same
+// app-data dir the user already knows from logFile.
+func otaJournalPath() string {
+	return filepath.Join(filepath.Dir(LogFilePath()), "ota-history.log")
+}
+
+// recordOTA appends one timestamped phase/outcome line for a speaker update to
+// the persistent OTA journal. Best-effort: any error is swallowed (this is
+// diagnostics, it must never affect the update itself). Mirrored to the app
+// logger so a same-session export via str.log also has it.
+func (a *App) recordOTA(host, event string) {
+	if a != nil && a.logger != nil {
+		a.logger.Info("ota journal", "host", host, "event", event)
+	}
+	line := fmt.Sprintf("time=%s host=%s %s\n", time.Now().Format(time.RFC3339), host, event)
+	path := otaJournalPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	_, _ = f.WriteString(line)
+	_ = f.Close()
+	capOTAJournal(path)
+}
+
+// capOTAJournal keeps the journal under maxOTAJournalBytes by dropping the oldest
+// lines (keeps the tail at a line boundary). OTA attempts are rare, so reading
+// the small file on each append is cheap.
+func capOTAJournal(path string) {
+	data, err := os.ReadFile(path)
+	if err != nil || len(data) <= maxOTAJournalBytes {
+		return
+	}
+	tail := data[len(data)-maxOTAJournalBytes:]
+	// Start at the first full line so we never keep a half line.
+	for i := 0; i < len(tail); i++ {
+		if tail[i] == '\n' {
+			tail = tail[i+1:]
+			break
+		}
+	}
+	_ = os.WriteFile(path, tail, 0o644)
+}

--- a/desktop-app/otajournal_test.go
+++ b/desktop-app/otajournal_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCapOTAJournal(t *testing.T) {
+	dir := t.TempDir()
+
+	// Over-cap file: must be trimmed to under the cap and start at a line boundary.
+	path := filepath.Join(dir, "ota-history.log")
+	var b strings.Builder
+	for i := 0; i < 5000; i++ {
+		b.WriteString("time=2026-06-23T00:00:00Z host=192.0.2.1 outcome: " + strings.Repeat("x", 30) + "\n")
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	capOTAJournal(path)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) > maxOTAJournalBytes {
+		t.Errorf("journal not capped: %d > %d", len(data), maxOTAJournalBytes)
+	}
+	if !strings.HasPrefix(string(data), "time=") {
+		t.Errorf("trimmed journal does not start at a line boundary: %q", string(data[:40]))
+	}
+
+	// Under-cap file is left byte-for-byte untouched.
+	small := filepath.Join(dir, "small.log")
+	const content = "time=2026-06-23T00:00:00Z host=192.0.2.1 outcome: ok\n"
+	if err := os.WriteFile(small, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	capOTAJournal(small)
+	if d, _ := os.ReadFile(small); string(d) != content {
+		t.Errorf("under-cap file was modified: %q", string(d))
+	}
+}


### PR DESCRIPTION
Recurring blind spot (Dieter, Michal #Re25, others): an OTA-failure diagnostic almost never contains the actual update attempt. Cause: str.log is rotated to .1 on each app launch and the bundle exports only the current session, so a failure from a previous session (or after a restart between failure and export) is gone.

This adds:
- a dedicated, never-rotated OTA journal (ota-history.log) recording every speaker-update attempt + outcome, always included in the bundle;
- the previous session's log (app.prev.log) in the bundle.

Both sanitized when anonymizing. Build + desktop tests green (incl. cap test). No new bound methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)