### PR TITLE
fix(spotify): preset buttons play your saved Spotify playlists again

### DIFF
--- a/internal/spotify/manager.go
+++ b/internal/spotify/manager.go
@@ -1010,12 +1010,26 @@ func (m *Manager) ensureSession(ctx context.Context) bool {
 // it stays true while go-librespot is mid-restart, distinguishing "never logged
 // in" (actionable: log the speaker into Spotify first) from "logged in but
 // momentarily down" (recovers on its own).
+//
+// Current go-librespot persists the zeroconf credential into configDir/state.json
+// (under .credentials.username); credentials.json is only its read-only LEGACY
+// fallback for installs predating that merged-state layout, so a box logged in
+// via a current binary has state.json and NO credentials.json. Checking only
+// credentials.json reported every fresh install as not-logged-in and silently
+// blocked all Spotify recall, even with an active session (a user diagnostic,
+// 2026-06-23: go-librespot loaded its persisted credential and authenticated,
+// yet LoggedIn() was false). So check state.json too. go-librespot
+// also writes a bare state.json (device_id/last_volume only) before any login, so
+// require a non-empty persisted username there rather than mere file presence.
 func (m *Manager) LoggedIn() bool {
+	if stateHasCredential(filepath.Join(m.configDir, "state.json")) {
+		return true
+	}
 	if _, err := os.Stat(filepath.Join(m.configDir, "credentials.json")); err == nil {
 		return true
 	}
 	// A per-account credential copy (multi-account swap store) also counts: the
-	// active credentials.json can be briefly absent during a SwitchAccount swap.
+	// active credential can be briefly absent during a SwitchAccount swap.
 	if entries, err := os.ReadDir(m.credStore); err == nil {
 		for _, e := range entries {
 			if strings.HasSuffix(e.Name(), ".json") {
@@ -1024,6 +1038,26 @@ func (m *Manager) LoggedIn() bool {
 		}
 	}
 	return false
+}
+
+// stateHasCredential reports whether go-librespot's state.json at path holds a
+// persisted zeroconf credential (a non-empty credentials.username). go-librespot
+// writes state.json with only device_id/last_volume before any login, so file
+// presence alone is not proof of a credential.
+func stateHasCredential(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var st struct {
+		Credentials struct {
+			Username string `json:"username"`
+		} `json:"credentials"`
+	}
+	if json.Unmarshal(data, &st) != nil {
+		return false
+	}
+	return st.Credentials.Username != ""
 }
 
 // sanitizeUser maps a Spotify username to a filesystem-safe credential filename.

--- a/internal/spotify/manager_test.go
+++ b/internal/spotify/manager_test.go
@@ -130,4 +130,28 @@ func TestLoggedIn(t *testing.T) {
 	if !m.LoggedIn() {
 		t.Fatal("LoggedIn should be true with a per-account stored credential")
 	}
+
+	// state.json is the current go-librespot credential layout (credentials.json
+	// is only a legacy read fallback). It counts as logged in when it carries a
+	// persisted username, but a bare state.json written before any login (only
+	// device_id/last_volume) must NOT count (a user diagnostic, 2026-06-23).
+	dir2 := t.TempDir()
+	cfg2 := filepath.Join(dir2, "cfg")
+	if err := os.MkdirAll(cfg2, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m2 := New("", cfg2, "", nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	stateFile := filepath.Join(cfg2, "state.json")
+	if err := os.WriteFile(stateFile, []byte(`{"device_id":"d","last_volume":42}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if m2.LoggedIn() {
+		t.Fatal("LoggedIn should be false for a state.json with no credential username")
+	}
+	if err := os.WriteFile(stateFile, []byte(`{"device_id":"d","credentials":{"username":"alice","data":"AA=="},"last_volume":42}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !m2.LoggedIn() {
+		t.Fatal("LoggedIn should be true once state.json carries a credential username")
+	}
 }


### PR DESCRIPTION
## Problem

Saving a Spotify playlist to a preset worked, but recalling it (app or hardware button) did nothing and showed *"pick this speaker in Spotify once"*, even on a speaker that was already connected to Spotify and actively playing.

A user diagnostic (ST10 + ST30, v0.8.16) showed the speaker's go-librespot loading its persisted credential and authenticating as the exact account stamped on the preset, yet STR still reported the box as not-logged-in and refused every recall.

## Root cause

The current go-librespot build (`JRpersonal/go-librespot` master, `./cmd/daemon`) persists the zeroconf credential to `<config_dir>/state.json` via `FileStateStore.Save()`; `credentials.json` is now only its **read-only legacy fallback** ("for installations that predate the merged state.json layout"). But `Manager.LoggedIn()` only `os.Stat`'d `credentials.json`, so **every speaker first logged in via a current binary reported not-logged-in**. Both recall guards (`internal/webui/webui.go` soft path and `cmd/agent/main.go` hardware path) return before `PlayAccount`/`ensureSession`, so the v0.8.16 session-recovery fix never even ran.

This is why recall worked only on boxes carrying a *legacy* `credentials.json` from an older binary and failed on every fresh install.

## Fix

`LoggedIn()` now also recognizes `state.json`, requiring a non-empty `credentials.username` so a bare `state.json` (`device_id`/`last_volume` only, written before any login) does not false-positive. `credentials.json` and the per-account store remain as fallbacks. `TestLoggedIn` is extended to cover the `state.json` layout (the old test only ever wrote `credentials.json`, which masked this).

Follow-ups (not in this PR): the multi-account capture/swap/export/import paths also read/write `credentials.json` and need porting to the `AppState.credentials` sub-object; an optional `SessionActive()` escape hatch in the guards.

## Verification

- `go test ./internal/spotify/...` green
- `GOOS=linux GOARCH=arm GOARM=7 go build ./...` clean