### PR TITLE
feat(spotify): hint when a speaker is on its built-in Spotify instead of STR's

### DIFF
--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -258,6 +258,7 @@
   "play.errSpotifyPremium": "Spotify-Recall braucht Premium",
   "play.errSpotifyLogin": "Diesen Lautsprecher einmal in Spotify auswählen",
   "play.errSpotifyLoginHelp": "STR spielt Spotify über diesen Lautsprecher als Spotify-Connect-Gerät. Öffne Spotify auf einem Gerät im selben WLAN, tippe auf das Geräte-Symbol, wähle diesen Lautsprecher und spiele einmal einen Titel. Danach lassen sich Spotify-Presets von selbst abrufen.",
+  "play.nativeSpotifyHint": "Wiedergabe läuft über das eingebaute Spotify des Lautsprechers. Drücke eine gespeicherte Spotify-Taste, um zu STRs Wiedergabe zu wechseln.",
   "play.errServer500": "Sender-Fehler",
   "play.errUnreachable": "Sender nicht erreichbar",
   "play.errGeneric": "Fehler",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -258,6 +258,7 @@
   "play.errSpotifyPremium": "Spotify recall needs Premium",
   "play.errSpotifyLogin": "Tap this speaker in Spotify once",
   "play.errSpotifyLoginHelp": "STR plays Spotify through this speaker as a Spotify Connect device. Open Spotify on a phone or computer on the same Wi-Fi, tap the devices icon, pick this speaker, and play any track once. After that, Spotify presets recall on their own.",
+  "play.nativeSpotifyHint": "Playing on the speaker's built-in Spotify. Press a saved Spotify button to switch to STR's playback.",
   "play.errServer500": "station error",
   "play.errUnreachable": "station unreachable",
   "play.errGeneric": "Error",

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -919,6 +919,7 @@
   "play.errSpotifyPremium": "Para retomar Spotify necesitas Premium",
   "play.errSpotifyLogin": "Selecciona este altavoz una vez en Spotify",
   "play.errSpotifyLoginHelp": "STR reproduce Spotify a través de este altavoz como dispositivo de Spotify Connect. Abre Spotify en un dispositivo de la misma red Wi-Fi, toca el icono de dispositivos, elige este altavoz y reproduce una canción una vez. Después, los preajustes de Spotify se recuperan solos.",
+  "play.nativeSpotifyHint": "Reproduciendo en el Spotify integrado del altavoz. Pulsa un botón de Spotify guardado para cambiar a la reproducción de STR.",
   "update.speakerUpdateAvailFor": "Actualización disponible para '{{name}}'",
   "update.versionLine": "instalada: {{installed}} → nueva: {{next}}",
   "update.appBehindTitle": "Esta app es más antigua que '{{name}}'",

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -919,6 +919,7 @@
   "play.errSpotifyPremium": "Le rappel Spotify nécessite Premium",
   "play.errSpotifyLogin": "Sélectionne cette enceinte une fois dans Spotify",
   "play.errSpotifyLoginHelp": "STR lit Spotify via cette enceinte comme appareil Spotify Connect. Ouvre Spotify sur un appareil du même Wi-Fi, touche l'icône des appareils, choisis cette enceinte et lis un titre une fois. Ensuite, les préréglages Spotify se rappellent tout seuls.",
+  "play.nativeSpotifyHint": "Lecture via le Spotify intégré de l'enceinte. Appuie sur un bouton Spotify enregistré pour passer à la lecture STR.",
   "update.speakerUpdateAvailFor": "Mise à jour disponible pour '{{name}}'",
   "update.versionLine": "installée : {{installed}} → nouvelle : {{next}}",
   "update.appBehindTitle": "Cette application est plus ancienne que '{{name}}'",

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -919,6 +919,7 @@
   "play.errSpotifyPremium": "Spotify の呼び出しには Premium が必要です",
   "play.errSpotifyLogin": "Spotify でこのスピーカーを一度選んでください",
   "play.errSpotifyLoginHelp": "STR はこのスピーカーを Spotify Connect デバイスとして再生します。同じ Wi-Fi 上の端末で Spotify を開き、デバイスアイコンをタップしてこのスピーカーを選び、一度曲を再生してください。その後は Spotify のプリセットが自動で呼び出せます。",
+  "play.nativeSpotifyHint": "スピーカー内蔵の Spotify で再生中です。保存した Spotify ボタンを押すと STR の再生に切り替わります。",
   "update.speakerUpdateAvailFor": "'{{name}}' のアップデートがあります",
   "update.versionLine": "現在: {{installed}} → 新しいバージョン: {{next}}",
   "update.appBehindTitle": "このアプリは '{{name}}' より古いバージョンです",

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -919,6 +919,7 @@
   "play.errSpotifyPremium": "Spotify atkūrimui reikia Premium",
   "play.errSpotifyLogin": "Vieną kartą pasirink šią kolonėlę Spotify",
   "play.errSpotifyLoginHelp": "STR groja Spotify per šią kolonėlę kaip Spotify Connect įrenginį. Tame pačiame Wi-Fi tinkle atidaryk Spotify, paliesk įrenginių piktogramą, pasirink šią kolonėlę ir vieną kartą paleisk dainą. Po to Spotify išankstiniai nustatymai bus iškviečiami savaime.",
+  "play.nativeSpotifyHint": "Grojama per kolonėlės integruotą „Spotify“. Paspausk išsaugotą „Spotify“ mygtuką, kad perjungtum į STR atkūrimą.",
   "update.speakerUpdateAvailFor": "Yra atnaujinimas garsiakalbiui „{{name}}“",
   "update.versionLine": "įdiegta: {{installed}} → nauja: {{next}}",
   "update.appBehindTitle": "Ši programa senesnė nei „{{name}}“",

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -919,6 +919,7 @@
   "play.errSpotifyPremium": "Spotify atsaukšanai nepieciešams Premium",
   "play.errSpotifyLogin": "Vienreiz izvēlies šo skaļruni Spotify",
   "play.errSpotifyLoginHelp": "STR atskaņo Spotify caur šo skaļruni kā Spotify Connect ierīci. Atver Spotify ierīcē tajā pašā Wi-Fi tīklā, pieskaries ierīču ikonai, izvēlies šo skaļruni un vienreiz atskaņo dziesmu. Pēc tam Spotify priekšiestatījumi tiks izsaukti paši.",
+  "play.nativeSpotifyHint": "Atskaņo, izmantojot skaļruņa iebūvēto Spotify. Nospied saglabātu Spotify pogu, lai pārslēgtos uz STR atskaņošanu.",
   "update.speakerUpdateAvailFor": "Pieejams atjauninājums skaļrunim '{{name}}'",
   "update.versionLine": "uzstādīta: {{installed}} → jauna: {{next}}",
   "update.appBehindTitle": "Šī lietotne ir vecāka nekā '{{name}}'",

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -919,6 +919,7 @@
   "play.errSpotifyPremium": "Spotify terughalen vereist Premium",
   "play.errSpotifyLogin": "Kies deze speaker één keer in Spotify",
   "play.errSpotifyLoginHelp": "STR speelt Spotify af via deze speaker als Spotify Connect-apparaat. Open Spotify op een apparaat in hetzelfde wifi-netwerk, tik op het apparaten-icoon, kies deze speaker en speel één keer een nummer af. Daarna worden Spotify-presets vanzelf opgehaald.",
+  "play.nativeSpotifyHint": "Speelt af via de ingebouwde Spotify van de speaker. Druk op een opgeslagen Spotify-knop om naar STR-weergave te wisselen.",
   "update.speakerUpdateAvailFor": "Update beschikbaar voor '{{name}}'",
   "update.versionLine": "geïnstalleerd: {{installed}} → nieuw: {{next}}",
   "update.appBehindTitle": "Deze app is ouder dan '{{name}}'",

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -919,6 +919,7 @@
   "play.errSpotifyPremium": "Przywoływanie Spotify wymaga konta Premium",
   "play.errSpotifyLogin": "Wybierz ten głośnik raz w Spotify",
   "play.errSpotifyLoginHelp": "STR odtwarza Spotify przez ten głośnik jako urządzenie Spotify Connect. Otwórz Spotify na urządzeniu w tej samej sieci Wi-Fi, dotknij ikony urządzeń, wybierz ten głośnik i odtwórz jeden utwór. Potem zapisane stacje Spotify będą przywoływane samodzielnie.",
+  "play.nativeSpotifyHint": "Odtwarzanie przez wbudowane Spotify głośnika. Naciśnij zapisany przycisk Spotify, aby przełączyć na odtwarzanie STR.",
   "update.speakerUpdateAvailFor": "Dostępna aktualizacja dla „{{name}}”",
   "update.versionLine": "zainstalowana: {{installed}} → nowa: {{next}}",
   "update.appBehindTitle": "Ta aplikacja jest starsza niż „{{name}}”",

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -919,6 +919,7 @@
   "play.errSpotifyPremium": "Spotify geri çağırma için Premium gerekir",
   "play.errSpotifyLogin": "Bu hoparlörü Spotify'da bir kez seç",
   "play.errSpotifyLoginHelp": "STR, Spotify'ı bu hoparlör üzerinden Spotify Connect cihazı olarak çalar. Aynı Wi-Fi'deki bir cihazda Spotify'ı aç, cihazlar simgesine dokun, bu hoparlörü seç ve bir parçayı bir kez çal. Bundan sonra Spotify ön ayarları kendiliğinden geri çağrılır.",
+  "play.nativeSpotifyHint": "Hoparlörün dahili Spotify'ında çalıyor. STR oynatmasına geçmek için kayıtlı bir Spotify düğmesine bas.",
   "update.speakerUpdateAvailFor": "'{{name}}' için güncelleme mevcut",
   "update.versionLine": "yüklü: {{installed}} → yeni: {{next}}",
   "update.appBehindTitle": "Bu uygulama '{{name}}' cihazından daha eski",

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -919,6 +919,7 @@
   "play.errSpotifyPremium": "Для виклику Spotify потрібен Premium",
   "play.errSpotifyLogin": "Виберіть цей динамік у Spotify один раз",
   "play.errSpotifyLoginHelp": "STR відтворює Spotify через цей динамік як пристрій Spotify Connect. Відкрийте Spotify на пристрої в тій самій мережі Wi-Fi, торкніться значка пристроїв, виберіть цей динамік і відтворіть один трек. Після цього пресети Spotify викликатимуться самі.",
+  "play.nativeSpotifyHint": "Відтворення через вбудований Spotify динаміка. Натисни збережену кнопку Spotify, щоб перейти до відтворення STR.",
   "update.speakerUpdateAvailFor": "Доступне оновлення для «{{name}}»",
   "update.versionLine": "встановлено: {{installed}} → нове: {{next}}",
   "update.appBehindTitle": "Цей застосунок старіший за «{{name}}»",

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -3399,6 +3399,20 @@ async function refreshStatus() {
     const src = (xml.match(/source="([^"]+)"/) || [])[1] || '';
     state.nowSource = src;
 
+    // Native Bose Spotify receiver detection: source=SPOTIFY means the phone
+    // connected to the speaker's built-in Spotify Connect, not STR's go-librespot
+    // (STR's own playback is always source=UPNP via the stream proxy). STR cannot
+    // recall a preset on the native receiver, so hint once per episode and reset
+    // when the box leaves SPOTIFY again.
+    if (src === 'SPOTIFY') {
+      if (!state.nativeSpotifyWarned) {
+        state.nativeSpotifyWarned = true;
+        showToast(t('play.nativeSpotifyHint'));
+      }
+    } else {
+      state.nativeSpotifyWarned = false;
+    }
+
     // Piggy-back an SSH status check on the polling we are doing
     // anyway. Toggle the global banner so the user sees it on every
     // tab rather than only after entering the Settings tab.


### PR DESCRIPTION
## What

When the box reports `now_playing source=SPOTIFY`, the phone connected to the speaker's **native** (Bose eSDK) Spotify Connect receiver, not STR's go-librespot. STR's own playback is always `source=UPNP` (it streams the go-librespot Ogg via UPnP), so `source=SPOTIFY` reliably identifies the native receiver. STR cannot recall a saved preset on the native receiver, which previously looked like a silent failure.

The app now shows a one-per-episode toast hint (resets when the box leaves `SPOTIFY`) telling the user the speaker is on its built-in Spotify and to press a saved button to switch to STR's playback.

## Why this approach

App-side only, no box change (app-first direction). Reuses the `source` value `refreshStatus()` already parses; no new agent endpoint. Chosen over suppressing the native receiver at marge, which carries real risks (breaks Spotify Free users, unproven which marge list the firmware reads, possible hardware-button/display coupling, go-librespot zeroconf unreliable on no-IPv6 boxes).

## i18n

`play.nativeSpotifyHint` added to all 11 locale bundles.

## Verification

- Frontend compiles (full `wails build` green).
- Local build run and launched.