### PR TITLE
fix(i18n): localize the Spotify copy-login "no speaker logged in" message

### DIFF
--- a/desktop-app/frontend/src/views/spotify.js
+++ b/desktop-app/frontend/src/views/spotify.js
@@ -71,7 +71,15 @@ export function renderSpotifyAlpha() {
       else if (n > 0) showToast(t('spotify.syncPartial', { n, failed }));
       else showToast(t('spotify.syncNone'));
     } catch (e) {
-      showError(String(e));
+      const s = String(e);
+      // The backend rejects with a plain-English "no speaker is logged into
+      // Spotify yet" error; show the localized equivalent (same text as the
+      // empty-result path) instead of the raw string. Other errors fall through.
+      if (s.toLowerCase().includes('no speaker is logged into spotify')) {
+        showError(t('spotify.syncNone'));
+      } else {
+        showError(s);
+      }
     } finally {
       sync.disabled = false;
       sync.textContent = orig;


### PR DESCRIPTION
The "Spotify-Login auf alle kopieren" button showed a raw English error ("no speaker is logged into Spotify yet…") because `SyncSpotifyLogin` rejects with a plain Go error that the Spotify view printed verbatim via `showError`. Map that error to the existing localized `spotify.syncNone` string (same text as the empty-result path), so non-English users see it in their language. Other errors still surface raw. Frontend-only, no new i18n keys.