### PR TITLE
fix(update): slow app and speaker updates no longer time out mid-transfer

### DIFF
--- a/desktop-app/boxssh.go
+++ b/desktop-app/boxssh.go
@@ -280,15 +280,47 @@ func boxSSHUploadStdin(host, cmd string, in io.Reader, timeout time.Duration) (s
 }
 
 func runSSHWithFlagsStdin(flags []string, host, cmd string, in io.Reader, timeout time.Duration) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	// Upload bounded by a STALL timeout (no progress for `timeout`), not a total
+	// deadline, so a large binary on a slow link is not cut off while it is still
+	// progressing. The watchdog cancels the context (killing ssh) only when no
+	// bytes have been consumed for `timeout`.
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	beat := make(chan struct{}, 1)
+	in = &countingReader{r: in, onProgress: func(int64) {
+		select {
+		case beat <- struct{}{}:
+		default:
+		}
+	}}
+	go func() {
+		t := time.NewTimer(timeout)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-beat:
+				if !t.Stop() {
+					select {
+					case <-t.C:
+					default:
+					}
+				}
+				t.Reset(timeout)
+			case <-t.C:
+				cancel()
+				return
+			}
+		}
+	}()
 	args := append(append([]string{}, flags...), "root@"+host, cmd)
 	c := exec.CommandContext(ctx, "ssh", args...)
 	hideCmdWindow(c)
 	c.Stdin = in
 	out, err := c.CombinedOutput()
-	if ctx.Err() == context.DeadlineExceeded {
-		return string(out), fmt.Errorf("ssh upload timeout after %s", timeout)
+	if ctx.Err() != nil {
+		return string(out), fmt.Errorf("ssh upload stalled (no progress for %s)", timeout)
 	}
 	return string(out), err
 }
@@ -440,14 +472,48 @@ func nativeSSHRun(host, cmd string, stdin io.Reader, timeout time.Duration) (str
 		return "", false, err
 	}
 	defer sess.Close()
-	if stdin != nil {
-		sess.Stdin = stdin
-	}
 	type res struct {
 		out []byte
 		err error
 	}
 	ch := make(chan res, 1)
+	if stdin != nil {
+		// Upload (the ~10 MB OTA binary): bound by a STALL timeout (no bytes copied
+		// to the box for `timeout`), not a total deadline, so a large transfer on a
+		// slow link is not cut off mid-stream while it is still progressing. The
+		// stdin copier reads from countingReader only as fast as the box accepts
+		// data (ssh flow control), so a beat tracks real upload throughput; a real
+		// freeze stops the beats and trips the timer. A short command (stdin == nil)
+		// keeps the total timeout below.
+		beat := make(chan struct{}, 1)
+		sess.Stdin = &countingReader{r: stdin, onProgress: func(int64) {
+			select {
+			case beat <- struct{}{}:
+			default:
+			}
+		}}
+		go func() { out, e := sess.CombinedOutput(cmd); ch <- res{out, e} }()
+		t := time.NewTimer(timeout)
+		defer t.Stop()
+		for {
+			select {
+			case r := <-ch:
+				return string(r.out), true, r.err
+			case <-beat:
+				if !t.Stop() {
+					select {
+					case <-t.C:
+					default:
+					}
+				}
+				t.Reset(timeout)
+			case <-t.C:
+				_ = sess.Signal(ssh.SIGKILL)
+				_ = sess.Close()
+				return "", true, fmt.Errorf("ssh native upload stalled (no progress for %s)", timeout)
+			}
+		}
+	}
 	go func() { out, e := sess.CombinedOutput(cmd); ch <- res{out, e} }()
 	select {
 	case r := <-ch:

--- a/desktop-app/ota.go
+++ b/desktop-app/ota.go
@@ -10,6 +10,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -390,26 +391,84 @@ func (a *App) updateAgentPreflight(host string, port int) error {
 
 func (a *App) updateAgentViaHTTP(host string, port int, bin []byte) error {
 	url := a.baseURL(host, port) + "/api/agent/update"
+	// No total-transfer deadline. Streaming the ~10 MB agent to a busy box over slow
+	// Wi-Fi can legitimately take minutes, and the old fixed 240 s cap killed
+	// still-progressing uploads with "context deadline exceeded (Client.Timeout ...
+	// while reading body)". The abort conditions instead: a genuine upload stall (no
+	// bytes for 60 s), the box failing to begin its reply after the upload
+	// (ResponseHeaderTimeout, which covers the NAND write on the modest ARM CPU), and
+	// app shutdown (appCtx). Matches the in-app self-update download.
+	ctx, cancel := context.WithCancel(a.appCtx())
+	defer cancel()
+
+	total := int64(len(bin))
 	// Stream the body through a counting reader so the UI can show an upload
 	// percentage and live throughput (the box reads the body as we send it),
 	// instead of a blind "uploading" spinner that looks frozen on a slow link.
-	prog := newTransferProgress(a, "box:update:progress", int64(len(bin)))
-	body := &countingReader{r: bytes.NewReader(bin), onProgress: prog.report}
-	req, err := http.NewRequestWithContext(a.appCtx(), http.MethodPost, url, body)
+	prog := newTransferProgress(a, "box:update:progress", total)
+	beat := make(chan struct{}, 1)
+	uploadDone := make(chan struct{})
+	finished := false
+	body := &countingReader{r: bytes.NewReader(bin), onProgress: func(n int64) {
+		prog.report(n)
+		if n >= total {
+			// Body fully streamed. Stop the upload-stall watchdog so the box's
+			// NAND-write + reply window (bounded by ResponseHeaderTimeout) is not
+			// mistaken for a stall. onProgress runs on the single body-read
+			// goroutine, so this flag needs no lock.
+			if !finished {
+				finished = true
+				close(uploadDone)
+			}
+			return
+		}
+		select {
+		case beat <- struct{}{}:
+		default:
+		}
+	}}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/octet-stream")
-	req.ContentLength = int64(len(bin))
-	// This single Timeout has to cover the whole operation: streaming the ~10 MB
-	// agent to the box, the box writing it to NAND on a modest ARM CPU, and the
-	// response. 60 s was too tight over slow Wi-Fi and surfaced to users as
-	// "context deadline exceeded (Client.Timeout ... while reading body)" with the
-	// update never completing. The SSH OTA path already budgets 120 s for the same
-	// upload alone, so match that with headroom for the NAND write and reply. A
-	// clean expiry here is NOT a hard failure: UpdateBoxAgent defers timeout-class
-	// errors (isTimeoutLikeErr) to the caller's post-OTA version poll.
-	client := &http.Client{Timeout: 240 * time.Second}
+	req.ContentLength = total
+
+	// Upload-stall watchdog: cancel only if no bytes move for 60 s while the body
+	// is still being sent. Exits cleanly once the upload completes or the context
+	// is done, so it never trips during the post-upload NAND write.
+	go func() {
+		t := time.NewTimer(60 * time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-uploadDone:
+				return
+			case <-beat:
+				if !t.Stop() {
+					select {
+					case <-t.C:
+					default:
+					}
+				}
+				t.Reset(60 * time.Second)
+			case <-t.C:
+				cancel()
+				return
+			}
+		}
+	}()
+
+	client := &http.Client{
+		// No total Timeout (see above); only connect and post-upload-reply are bounded.
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           (&net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}).DialContext,
+			ResponseHeaderTimeout: 180 * time.Second,
+		},
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return err

--- a/desktop-app/update_app.go
+++ b/desktop-app/update_app.go
@@ -297,7 +297,14 @@ func (a *App) DownloadUpdate(version string) (string, error) {
 // a client timeout, and a stall watchdog (no bytes for 45 s) turns a frozen
 // transfer into a prompt error the caller retries.
 func (a *App) downloadAssetOnce(url, wantSHA, partPath string) error {
-	ctx, cancel := context.WithTimeout(a.appCtx(), 15*time.Minute)
+	// No total-transfer deadline. A large asset on a slow link can legitimately
+	// take a long time, and a fixed cap (formerly 15 min) killed still-progressing
+	// downloads with "context deadline exceeded ... while reading body" on narrow
+	// bandwidth (the in-app update failing at ~70%). The only abort conditions are
+	// the stall watchdog below (no bytes for 45 s) via cancel, and the parent
+	// appCtx (app shutdown); the download client itself sets no total Timeout, only
+	// connect/TLS/response-header timeouts.
+	ctx, cancel := context.WithCancel(a.appCtx())
 	defer cancel()
 	req, err := newGETRequest(ctx, url)
 	if err != nil {


### PR DESCRIPTION
Three update transfers had a **total-transfer deadline** that killed a still-progressing download/upload on narrow bandwidth, surfacing as `context deadline exceeded (Client.Timeout ... while reading body)` even while data flowed:

- in-app app self-update download — 15-minute context cap (`update_app.go`)
- HTTP OTA agent upload — 240s `http.Client.Timeout` (`ota.go`)
- SSH OTA agent upload — 120s total timeout on the native + system-ssh stdin runners (`boxssh.go`)

All three now have **no total cap**. They abort only on a genuine stall (no bytes for 45-60s via a progress-fed watchdog), a failed connect, or the box failing to begin its reply after the upload (`ResponseHeaderTimeout`, covering the box NAND write), plus app shutdown.

SSH: only the stdin **upload** path becomes stall-based; short SSH commands keep their total timeout, so the change is scoped to transfers. The HTTP OTA's existing post-OTA version-poll safety net is unaffected.

Reported by a user (#... email) whose in-app update failed at ~70% on a slow link.

## Verification
- `go vet ./...`, `go build ./...`, `go test ./...` all green in desktop-app.