### PR TITLE
fix(update): deliver the Spotify engine to speakers updated over the air

### DIFF
--- a/desktop-app/ota.go
+++ b/desktop-app/ota.go
@@ -11,6 +11,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -88,6 +90,17 @@ func (a *App) UpdateBoxAgent(host string, port int) (err error) {
 	a.notePostOTA(host)
 	a.refreshStick(host)
 
+	// Deliver the go-librespot Spotify sidecar over OTA too, so a box that was
+	// never successfully synced from a USB stick (e.g. an OTA-only SoundTouch 30
+	// whose USB port underpowers the stick) still gets Spotify. The sidecar
+	// historically shipped ONLY via the stick->NAND boot sync, so an OTA-only box
+	// had a synced login but no engine and Spotify silently never played
+	// (#45/#105). Pushed FIRST and strictly before the agent OTA: the agent OTA
+	// reboots ~1.5 s after its reply, and that reboot is what makes the fresh
+	// agent's Spotify manager pick up the now-present binary. Best-effort: a
+	// sidecar failure must never block the (more important) agent update.
+	a.pushSidecarIfNeeded(host, port)
+
 	if perr := a.updateAgentPreflight(host, port); perr != nil {
 		a.recordOTA(host, "HTTP preflight rejected -> trying SSH: "+perr.Error())
 		a.logger.Warn("update agent: HTTP preflight rejected, switching to SSH-OTA",
@@ -139,6 +152,46 @@ func (a *App) UpdateBoxAgent(host string, port int) (err error) {
 		a.logger.Info("update agent: SSH-OTA succeeded after HTTP failure", "host", host, "bytes", len(bin))
 	}
 	return nil
+}
+
+// pushSidecarIfNeeded delivers the embedded go-librespot Spotify sidecar to the
+// box over HTTP (POST /api/agent/sidecar) when the box is missing it or has a
+// different build. Strictly best-effort: any failure is logged to the OTA
+// journal and swallowed so it never aborts the agent OTA that follows. The
+// ~10 MB transfer is gated on the box's reported content hash so a steady-state
+// OTA (agent-only change, sidecar already current) costs just one cheap version
+// GET and sends zero sidecar bytes.
+func (a *App) pushSidecarIfNeeded(host string, port int) {
+	if !agentbin.GoLibrespotAvailable() {
+		// Dev build (empty stub): nothing real to deliver. Never write 0 bytes.
+		a.recordOTA(host, "sidecar: skipped, no embedded go-librespot in this build")
+		return
+	}
+	bin := agentbin.GoLibrespotBytes()
+	sum := sha256.Sum256(bin)
+	want := hex.EncodeToString(sum[:])
+
+	// Ask the box what it already has. boxDo self-heals across :8888/:17008 and
+	// caches the working port for the agent OTA that follows.
+	if ver, err := a.BoxAgentVersion(host, port); err == nil {
+		if ver["goLibrespot"] == "present" && ver["goLibrespotSha256"] == want {
+			a.recordOTA(host, "sidecar: box already has the current go-librespot, skipping ~10 MB push")
+			return
+		}
+	} else {
+		// Couldn't read the version: still try the push (a missing sidecar is the
+		// whole reason this exists); worst case the POST also fails and is logged.
+		a.logger.Info("sidecar push: version probe failed, pushing anyway", "host", host, "err", err)
+	}
+
+	a.recordOTA(host, fmt.Sprintf("sidecar: pushing go-librespot (%d bytes, sha %s)", len(bin), want[:12]))
+	if err := a.streamPostBinary(host, port, "/api/agent/sidecar", bin); err != nil {
+		a.recordOTA(host, "sidecar: push failed (agent OTA still proceeds): "+err.Error())
+		a.logger.Warn("sidecar push failed; agent OTA continues, Spotify may stay unavailable until next OTA", "host", host, "err", err)
+		return
+	}
+	a.recordOTA(host, "sidecar: go-librespot delivered")
+	a.logger.Info("sidecar push: go-librespot delivered over OTA", "host", host, "bytes", len(bin))
 }
 
 // refreshStick is a best-effort step run as part of an agent OTA, BEFORE the
@@ -390,7 +443,17 @@ func (a *App) updateAgentPreflight(host string, port int) error {
 }
 
 func (a *App) updateAgentViaHTTP(host string, port int, bin []byte) error {
-	url := a.baseURL(host, port) + "/api/agent/update"
+	return a.streamPostBinary(host, port, "/api/agent/update", bin)
+}
+
+// streamPostBinary POSTs bin to path on the agent, streaming the body with a
+// live progress event ("box:update:progress") and the same abort policy the
+// agent OTA settled on: no total deadline (a 10 MB push to a busy box over slow
+// Wi-Fi can take minutes), a 60 s upload-stall watchdog, and a bounded
+// post-upload reply window. Shared by the agent-binary update and the
+// go-librespot sidecar push so they cannot drift on transfer behavior.
+func (a *App) streamPostBinary(host string, port int, path string, bin []byte) error {
+	url := a.baseURL(host, port) + path
 	// No total-transfer deadline. Streaming the ~10 MB agent to a busy box over slow
 	// Wi-Fi can legitimately take minutes, and the old fixed 240 s cap killed
 	// still-progressing uploads with "context deadline exceeded (Client.Timeout ...
@@ -527,6 +590,44 @@ func (a *App) updateAgentViaSSH(host string, bin []byte) error {
 	// LAN. sync first so the just-renamed binary is flushed to NAND.
 	// boxReboot is the shared hardened form (this OTA path is where that
 	// form originated).
+	//
+	// Deliver the go-librespot sidecar over the SAME SSH session-class before
+	// the reboot, so a box that fell to the SSH path (HTTP preflight rejected)
+	// also gets Spotify. Best-effort: an SSH sidecar failure logs but never
+	// fails the agent OTA. The reboot below brings up the fresh agent that picks
+	// up the binary.
+	a.pushSidecarViaSSH(host)
 	_ = boxReboot(host)
 	return nil
+}
+
+// pushSidecarViaSSH writes the embedded go-librespot sidecar to
+// /mnt/nv/streborn/bin/go-librespot over SSH (the fallback delivery for boxes
+// whose HTTP listener is Bose's, taken alongside updateAgentViaSSH). Mirrors the
+// agent-binary upload: stream to .new, size-verify, chmod, atomic rename, then
+// stamp the content hash. Best-effort: every failure is logged and swallowed.
+func (a *App) pushSidecarViaSSH(host string) {
+	if !agentbin.GoLibrespotAvailable() {
+		return
+	}
+	bin := agentbin.GoLibrespotBytes()
+	const dst = "/mnt/nv/streborn/bin/go-librespot"
+	uploadCmd := "mkdir -p /mnt/nv/streborn/bin && cat > " + dst + ".new"
+	if out, err := boxSSHUploadStdin(host, uploadCmd, bytes.NewReader(bin), 120*time.Second); err != nil {
+		a.logger.Warn("sidecar SSH upload failed (agent OTA still proceeds)", "host", host, "err", err, "out", strings.TrimSpace(out))
+		return
+	}
+	sum := sha256.Sum256(bin)
+	sha := hex.EncodeToString(sum[:])
+	verifyCmd := fmt.Sprintf(
+		"size=$(wc -c < %s.new) && [ \"$size\" = \"%d\" ] && "+
+			"chmod 0755 %s.new && mv %s.new %s && "+
+			"printf %%s %s > %s.sha256 && echo OK_%d",
+		dst, len(bin), dst, dst, dst, sha, dst, len(bin))
+	sentinel := fmt.Sprintf("OK_%d", len(bin))
+	if out, err := boxSSHOutput(host, verifyCmd, 20*time.Second); err != nil || !strings.Contains(out, sentinel) {
+		a.logger.Warn("sidecar SSH size-verify/rename failed (agent OTA still proceeds)", "host", host, "err", err, "out", strings.TrimSpace(out))
+		return
+	}
+	a.logger.Info("sidecar push (SSH): go-librespot delivered over OTA", "host", host, "bytes", len(bin))
 }

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -6,7 +6,9 @@ package webui
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -563,6 +565,7 @@ func (s *Server) Run(ctx context.Context) error {
 	// /api/radio/* and no longer compiles in the radiobrowser package.
 	mux.HandleFunc("/api/agent/version", s.handleAgentVersion)
 	mux.HandleFunc("/api/agent/update", s.handleAgentUpdate)
+	mux.HandleFunc("/api/agent/sidecar", s.handleAgentSidecar)
 	mux.HandleFunc("/api/box/settings", s.handleBoxSettings)
 	mux.HandleFunc("/api/box/name", s.handleBoxName)
 	mux.HandleFunc("/api/box/volume", s.handleBoxVolume)
@@ -2446,7 +2449,60 @@ func (s *Server) handleAgentVersion(w http.ResponseWriter, _ *http.Request) {
 			}
 		}
 	}
+	// Report whether the go-librespot Spotify sidecar is deployed and which
+	// content it is, so the desktop app can decide whether to push it over OTA
+	// (it ships ~10 MB; we only want to send it when the box is missing it or
+	// has a different build). The binary historically reached the box ONLY via
+	// the stick->NAND boot sync, so a box that was ever only OTA-updated stayed
+	// without it and Spotify silently never played (#45/#105, e.g. an OTA-only
+	// SoundTouch 30). present/missing + the content hash drive that gate.
+	if present, sha := goLibrespotStamp(); present {
+		out["goLibrespot"] = "present"
+		if sha != "" {
+			out["goLibrespotSha256"] = sha
+		}
+	} else {
+		out["goLibrespot"] = "missing"
+	}
 	writeJSON(w, http.StatusOK, out)
+}
+
+// goLibrespotBinPath is where the agent runs the Spotify sidecar from; the
+// desktop OTA writes it here too. Kept in lock-step with cmd/agent's
+// goLibrespotPath and usb-stick/run.sh's NAND copy.
+const goLibrespotBinPath = "/mnt/nv/streborn/bin/go-librespot"
+
+// goLibrespotStamp reports whether the go-librespot sidecar is deployed
+// (>1 KB, i.e. a real binary not an empty stub) and the hex SHA256 of its
+// contents. The hash lets the desktop app skip re-pushing the ~10 MB binary
+// when the box already has the embedded build. It is cached in a sibling
+// .sha256 marker so a version poll does not re-hash 10 MB on the weak box CPU
+// every few minutes: the marker is trusted while it is at least as new as the
+// binary; otherwise (absent, or the binary was replaced by a stick install
+// that did not write a marker) it is computed once and cached. Best-effort:
+// a present binary with an unreadable hash reports present with an empty sha,
+// which the app treats as "push once" (correct and idempotent).
+func goLibrespotStamp() (present bool, sha string) {
+	fi, err := os.Stat(goLibrespotBinPath)
+	if err != nil || fi.Size() < 1024 {
+		return false, ""
+	}
+	marker := goLibrespotBinPath + ".sha256"
+	if mfi, err := os.Stat(marker); err == nil && !mfi.ModTime().Before(fi.ModTime()) {
+		if b, rerr := os.ReadFile(marker); rerr == nil {
+			if h := strings.TrimSpace(string(b)); h != "" {
+				return true, h
+			}
+		}
+	}
+	data, err := os.ReadFile(goLibrespotBinPath)
+	if err != nil {
+		return true, "" // present but hash unknown; app re-pushes once
+	}
+	sum := sha256.Sum256(data)
+	h := hex.EncodeToString(sum[:])
+	_ = os.WriteFile(marker, []byte(h), 0o644)
+	return true, h
 }
 
 // handleAgentUpdate receives a new stick agent binary, writes it
@@ -2456,48 +2512,13 @@ func (s *Server) handleAgentVersion(w http.ResponseWriter, _ *http.Request) {
 // On success the stick still returns 200 OK and then exits. The
 // rc.local bootstrap starts the new agent.
 func (s *Server) handleAgentUpdate(w http.ResponseWriter, r *http.Request) {
-	if !requireMethod(w, r, http.MethodPost) {
+	body, ok := readUploadedELF(w, r)
+	if !ok {
 		return
 	}
-	if !isLocalLAN(r.RemoteAddr) {
-		http.Error(w, "update only allowed from LAN", http.StatusForbidden)
-		return
-	}
-	const maxSize = 30 * 1024 * 1024
-	body, err := io.ReadAll(io.LimitReader(r.Body, maxSize+1))
-	if err != nil {
-		http.Error(w, "read: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-	if len(body) > maxSize {
-		http.Error(w, "binary too big", http.StatusRequestEntityTooLarge)
-		return
-	}
-	if len(body) < 1024 {
-		http.Error(w, "binary too small", http.StatusBadRequest)
-		return
-	}
-	// ELF Magic Check
-	if body[0] != 0x7f || body[1] != 'E' || body[2] != 'L' || body[3] != 'F' {
-		http.Error(w, "not an ELF binary", http.StatusBadRequest)
-		return
-	}
-
 	const dst = "/mnt/nv/streborn/bin/streborn-armv7l"
-	// On a fresh speaker the parent /mnt/nv/streborn/bin directory may
-	// not exist yet — first OTA after install hits this. Create it so
-	// the write does not 500 on "no such file or directory".
-	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		http.Error(w, "mkdir parent: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-	tmp := dst + ".new"
-	if err := os.WriteFile(tmp, body, 0o755); err != nil {
-		http.Error(w, "write tmp: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-	if err := os.Rename(tmp, dst); err != nil {
-		http.Error(w, "rename: "+err.Error(), http.StatusInternalServerError)
+	if err := writeBinaryAtomic(dst, body); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
@@ -2543,6 +2564,88 @@ func (s *Server) handleAgentUpdate(w http.ResponseWriter, r *http.Request) {
 			os.Exit(0)
 		}
 	}()
+}
+
+// readUploadedELF reads and validates a raw ARM ELF binary POSTed to an OTA
+// endpoint: LAN-only, size-bounded, ELF-magic checked. On any problem it writes
+// the HTTP error response and returns ok=false. Shared by handleAgentUpdate and
+// handleAgentSidecar so the two upload endpoints cannot drift on their guards.
+func readUploadedELF(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return nil, false
+	}
+	if !isLocalLAN(r.RemoteAddr) {
+		http.Error(w, "update only allowed from LAN", http.StatusForbidden)
+		return nil, false
+	}
+	const maxSize = 30 * 1024 * 1024
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxSize+1))
+	if err != nil {
+		http.Error(w, "read: "+err.Error(), http.StatusBadRequest)
+		return nil, false
+	}
+	if len(body) > maxSize {
+		http.Error(w, "binary too big", http.StatusRequestEntityTooLarge)
+		return nil, false
+	}
+	if len(body) < 1024 {
+		http.Error(w, "binary too small", http.StatusBadRequest)
+		return nil, false
+	}
+	// ELF magic check.
+	if body[0] != 0x7f || body[1] != 'E' || body[2] != 'L' || body[3] != 'F' {
+		http.Error(w, "not an ELF binary", http.StatusBadRequest)
+		return nil, false
+	}
+	return body, true
+}
+
+// writeBinaryAtomic writes body to dst via a .new temp + rename so a partial
+// write never becomes the live binary, creating the parent dir on a fresh box
+// (first OTA after install has no /mnt/nv/streborn/bin yet). 0755 so the file
+// is executable.
+func writeBinaryAtomic(dst string, body []byte) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("mkdir parent: %w", err)
+	}
+	tmp := dst + ".new"
+	if err := os.WriteFile(tmp, body, 0o755); err != nil {
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, dst); err != nil {
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}
+
+// handleAgentSidecar receives the go-librespot Spotify sidecar binary and
+// writes it atomically to /mnt/nv/streborn/bin/go-librespot. Unlike
+// handleAgentUpdate it does NOT reboot or restart anything: the desktop app
+// pushes the sidecar right BEFORE the agent OTA, and the agent OTA's own reboot
+// is what brings up the fresh agent whose Spotify manager then finds and
+// supervises the now-present binary (the manager checks for it once at start,
+// so the running agent does not pick it up live). This closes the gap where the
+// sidecar shipped only via the stick->NAND boot sync, leaving an OTA-only box
+// (e.g. a SoundTouch 30 whose USB stick never copied it) silently unable to
+// play Spotify despite a synced login (#45/#105).
+func (s *Server) handleAgentSidecar(w http.ResponseWriter, r *http.Request) {
+	body, ok := readUploadedELF(w, r)
+	if !ok {
+		return
+	}
+	if err := writeBinaryAtomic(goLibrespotBinPath, body); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// Stamp the content hash next to the binary so the next /api/agent/version
+	// reports it and the desktop app skips re-pushing this ~10 MB binary when the
+	// box already has the embedded build.
+	sum := sha256.Sum256(body)
+	if err := os.WriteFile(goLibrespotBinPath+".sha256", []byte(hex.EncodeToString(sum[:])), 0o644); err != nil {
+		s.logger.Warn("go-librespot sidecar: hash marker write failed (non-fatal)", "err", err)
+	}
+	s.logger.Info("go-librespot sidecar written via OTA", "size", len(body))
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
 // isLocalLAN true if the request comes from a private LAN IP


### PR DESCRIPTION
## Problem
The go-librespot Spotify sidecar reached a speaker only via the USB-stick to
NAND boot sync, never via the agent OTA. A speaker that was only ever updated
over the air (verified case: a SoundTouch 30 whose USB port underpowers a
stick) ended up with a synced Spotify login but no engine. Preset recall then
pointed the box at an empty /spotify/stream-N.ogg, the box reported
AUDIO_ERROR_BAD_URL and dropped to INVALID_SOURCE ("ready") with no audio.

## Evidence (remote diagnostic, two boxes, same v0.8.20 build)
- Failing ST30: Ready() (os.Stat of the binary) stayed false for the full 12s
  soft-recall wait; no go-librespot in the process tree; bin/ smaller than the
  working ST10; agent log "could not re-establish a live session for recall".
- Working ST10 (stick-installed): go-librespot running, live session, Ogg
  flowing. Same account, same build. The only difference was the missing binary.

## Fix
The desktop app already embeds go-librespot; it just was not pushed on OTA.
- Agent: new `POST /api/agent/sidecar` writes `/mnt/nv/streborn/bin/go-librespot`
  atomically (no reboot) plus a `.sha256` content marker. `/api/agent/version`
  now reports `goLibrespot` present/missing and its hash. Shared ELF validate +
  atomic-write helpers with the existing agent-binary handler.
- App: `pushSidecarIfNeeded` streams the sidecar before the agent OTA,
  best-effort (never aborts the agent update) and content-hash gated so the
  ~10 MB only ships when the box is missing it or has a different build. The
  SSH-OTA fallback delivers it too.

The new agent's Spotify manager picks the binary up on the post-OTA reboot (it
checks for it once at start), so one user OTA, one reboot, both binaries.

## Why not embed go-librespot in the agent binary
`/mnt/nv` is ~31 MB. Agent-with-embedded-sidecar (~21 MB) plus the extracted
copy (~10 MB) plus the staging `.new` would exceed the volume, so that approach
self-disables on exactly the constrained boxes this fixes. The second-file push
keeps the footprint at ~21 MB, same as a working stick-installed box.

## Not covered (follow-up)
`str-shim.so` is the one remaining stick-only file, but `run.sh` skips the shim
on both BCO and sm2, so it is narrow (scm/spotty only) and largely superseded
by the iptables redirect path. Tracked, not in this PR.

Refs #45 #105
