### PR TITLE
fix(spotify): play Spotify presets on speakers that were only ever updated through the app

### DIFF
--- a/desktop-app/frontend/src/api.js
+++ b/desktop-app/frontend/src/api.js
@@ -43,6 +43,7 @@ export {
   EjectDrive,
   BoxAgentVersion,
   UpdateBoxAgent,
+  EnsureSpotifyEngine,
   WriteWLANConfig,
   WriteRegionConfig,
   WriteNameConfig,

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -326,6 +326,7 @@
   "update.waitingForSpeaker": "Lautsprecher startet neu und verbindet sich wieder, noch {{remaining}} ...",
   "update.doneToast": "Update fertig.",
   "update.tookLongerToast": "Lautsprecher braucht länger als erwartet. Prüfe Strom / Netzwerk.",
+  "update.deliveringSpotify": "Spotify-Komponente wird auf den Lautsprecher übertragen...",
   "update.failed": "Update fehlgeschlagen: {{err}}\n\nFalls der Lautsprecher danach nicht mehr antwortet, trenne kurz den Strom und stecke ihn wieder an.",
   "update.otherBoxRunning": "Update läuft auf {{name}} ...",
   "update.stickInTitle": "USB-Stick noch eingesteckt",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -326,6 +326,7 @@
   "update.waitingForSpeaker": "Speaker is restarting and reconnecting, {{remaining}} left...",
   "update.doneToast": "Update done.",
   "update.tookLongerToast": "Speaker takes longer than expected. Check power / network.",
+  "update.deliveringSpotify": "Delivering the Spotify engine to the speaker...",
   "update.failed": "Update failed: {{err}}\n\nIf the speaker no longer answers, briefly unplug power and plug it back in.",
   "update.otherBoxRunning": "Update running on {{name}} ...",
   "update.stickInTitle": "USB stick still inserted",

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -281,6 +281,7 @@
   "update.waitingForSpeaker": "Esperando al altavoz, quedan {{remaining}}...",
   "update.doneToast": "Actualización completada.",
   "update.tookLongerToast": "El altavoz tarda más de lo previsto. Comprueba la alimentación / la red.",
+  "update.deliveringSpotify": "Enviando el motor de Spotify al altavoz...",
   "update.failed": "Error en la actualización: {{err}}\n\nSi el altavoz ya no responde, desconecta brevemente la alimentación y vuelve a conectarla.",
   "update.otherBoxRunning": "Actualización en curso en {{name}} ...",
   "update.stickInTitle": "Memoria USB aún insertada",

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -281,6 +281,7 @@
   "update.waitingForSpeaker": "En attente de l'enceinte, {{remaining}} restantes...",
   "update.doneToast": "Mise à jour terminée.",
   "update.tookLongerToast": "L'enceinte met plus de temps que prévu. Vérifiez l'alimentation / le réseau.",
+  "update.deliveringSpotify": "Installation du module Spotify sur l'enceinte...",
   "update.failed": "Échec de la mise à jour : {{err}}\n\nSi l'enceinte ne répond plus, débranchez brièvement l'alimentation puis rebranchez.",
   "update.otherBoxRunning": "Mise à jour en cours sur {{name}} ...",
   "update.stickInTitle": "Clé USB toujours insérée",

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -281,6 +281,7 @@
   "update.waitingForSpeaker": "スピーカーを待機中。残り {{remaining}}...",
   "update.doneToast": "更新が完了しました。",
   "update.tookLongerToast": "スピーカーの応答が想定より遅れています。電源/ネットワークを確認してください。",
+  "update.deliveringSpotify": "Spotifyエンジンをスピーカーに転送しています...",
   "update.failed": "更新に失敗しました: {{err}}\n\nスピーカーが応答しなくなった場合は、電源を一度抜いて入れ直してください。",
   "update.otherBoxRunning": "{{name}} で更新を実行中 ...",
   "update.stickInTitle": "USBメモリがまだ挿さっています",

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -281,6 +281,7 @@
   "update.waitingForSpeaker": "Laukiama garsiakalbio, liko {{remaining}}...",
   "update.doneToast": "Atnaujinimas baigtas.",
   "update.tookLongerToast": "Garsiakalbis užtrunka ilgiau nei tikėtasi. Patikrinkite maitinimą / tinklą.",
+  "update.deliveringSpotify": "Į garsiakalbį siunčiamas „Spotify“ modulis...",
   "update.failed": "Atnaujinti nepavyko: {{err}}\n\nJei garsiakalbis neatsako, trumpam atjunkite jį nuo maitinimo ir vėl prijunkite.",
   "update.otherBoxRunning": "Vykdomas atnaujinimas {{name}} ...",
   "update.stickInTitle": "USB atmintinė vis dar įkišta",

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -281,6 +281,7 @@
   "update.waitingForSpeaker": "Tiek gaidīts skaļrunis, atlikušas {{remaining}}...",
   "update.doneToast": "Atjaunināšana pabeigta.",
   "update.tookLongerToast": "Skaļrunim vajag ilgāk nekā gaidīts. Pārbaudiet strāvu / tīklu.",
+  "update.deliveringSpotify": "Spotify dzinis tiek nosūtīts uz skaļruni...",
   "update.failed": "Atjaunināt neizdevās: {{err}}\n\nJa skaļrunis neatbild, uz brīdi atvienojiet to no strāvas un pievienojiet atkal.",
   "update.otherBoxRunning": "Notiek atjaunināšana {{name}} ...",
   "update.stickInTitle": "USB zibatmiņa joprojām ievietota",

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -281,6 +281,7 @@
   "update.waitingForSpeaker": "Wachten op speaker, nog {{remaining}}...",
   "update.doneToast": "Update voltooid.",
   "update.tookLongerToast": "Speaker duurt langer dan verwacht. Controleer stroom / netwerk.",
+  "update.deliveringSpotify": "Spotify-onderdeel wordt naar de speaker gestuurd...",
   "update.failed": "Update mislukt: {{err}}\n\nAls de speaker niet meer antwoordt, haal kort de stekker eruit en steek hem weer in.",
   "update.otherBoxRunning": "Update bezig op {{name}} ...",
   "update.stickInTitle": "USB-stick zit er nog in",

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -281,6 +281,7 @@
   "update.waitingForSpeaker": "Oczekiwanie na głośnik, pozostało {{remaining}}...",
   "update.doneToast": "Aktualizacja zakończona.",
   "update.tookLongerToast": "Głośnik trwa dłużej niż oczekiwano. Sprawdź zasilanie / sieć.",
+  "update.deliveringSpotify": "Przesyłanie silnika Spotify do głośnika...",
   "update.failed": "Aktualizacja nie powiodła się: {{err}}\n\nJeśli głośnik nie odpowiada, odłącz go na chwilę od zasilania i podłącz ponownie.",
   "update.otherBoxRunning": "Trwa aktualizacja na {{name}} ...",
   "update.stickInTitle": "Pendrive USB nadal jest w głośniku",

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -281,6 +281,7 @@
   "update.waitingForSpeaker": "Hoparlör bekleniyor, kalan {{remaining}}...",
   "update.doneToast": "Güncelleme tamamlandı.",
   "update.tookLongerToast": "Hoparlör beklenenden uzun sürüyor. Gücü / ağı kontrol edin.",
+  "update.deliveringSpotify": "Spotify motoru hoparlöre aktarılıyor...",
   "update.failed": "Güncellenemedi: {{err}}\n\nHoparlör yanıt vermiyorsa, onu kısa süre güçten ayırıp tekrar takın.",
   "update.otherBoxRunning": "{{name}} güncelleniyor ...",
   "update.stickInTitle": "USB bellek hâlâ takılı",

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -281,6 +281,7 @@
   "update.waitingForSpeaker": "Очікування колонки, залишилось {{remaining}}...",
   "update.doneToast": "Оновлення завершено.",
   "update.tookLongerToast": "Колонка відповідає довше за звичайне. Перевірте живлення / мережу.",
+  "update.deliveringSpotify": "Передавання рушія Spotify на динамік...",
   "update.failed": "Не вдалося оновити: {{err}}\n\nЯкщо колонка більше не відповідає, ненадовго відключіть живлення та знову увімкніть.",
   "update.otherBoxRunning": "Оновлення виконується на {{name}} ...",
   "update.stickInTitle": "USB-накопичувач усе ще вставлено",

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -35,6 +35,7 @@ import {
   EjectDrive,
   BoxAgentVersion,
   UpdateBoxAgent,
+  EnsureSpotifyEngine,
   WriteWLANConfig,
   WriteRegionConfig,
   WriteNameConfig,
@@ -2205,6 +2206,21 @@ async function doBoxUpdate(targetBox) {
     }
     if (confirmed) {
       showToast(t('update.doneToast'));
+      // The box just came up on the new, sidecar-capable agent. If it still
+      // reports the Spotify engine missing (it was upgraded from a pre-v0.8.22
+      // agent, where the in-OTA sidecar push hit an old agent with no sidecar
+      // endpoint and silently no-op'd, #237), deliver it now. The agent's Spotify
+      // manager polls for the binary and starts go-librespot live, so no extra
+      // reboot is needed. Best-effort and silent on failure: it must never turn a
+      // successful agent update into an error.
+      if (confirmedVer && confirmedVer.goLibrespot && confirmedVer.goLibrespot !== 'present') {
+        try {
+          setStatus(t('update.deliveringSpotify'));
+          await EnsureSpotifyEngine(targetBox.host, targetBox.port);
+        } catch (engErr) {
+          try { console.warn('post-update Spotify engine delivery failed (non-fatal)', engErr); } catch {}
+        }
+      }
     } else {
       showToast(t('update.tookLongerToast'));
     }

--- a/desktop-app/frontend/wailsjs/go/main/App.d.ts
+++ b/desktop-app/frontend/wailsjs/go/main/App.d.ts
@@ -47,6 +47,8 @@ export function DownloadUpdate(arg1:string):Promise<string>;
 
 export function EjectDrive(arg1:string):Promise<void>;
 
+export function EnsureSpotifyEngine(arg1:string,arg2:number):Promise<string>;
+
 export function ExportDiagnosticLogs(arg1:main.LogExportRequest):Promise<main.LogExportResult>;
 
 export function FormZone(arg1:string,arg2:number,arg3:main.ZoneSpec):Promise<Record<string, any>>;

--- a/desktop-app/frontend/wailsjs/go/main/App.js
+++ b/desktop-app/frontend/wailsjs/go/main/App.js
@@ -86,6 +86,10 @@ export function EjectDrive(arg1) {
   return window['go']['main']['App']['EjectDrive'](arg1);
 }
 
+export function EnsureSpotifyEngine(arg1, arg2) {
+  return window['go']['main']['App']['EnsureSpotifyEngine'](arg1, arg2);
+}
+
 export function ExportDiagnosticLogs(arg1) {
   return window['go']['main']['App']['ExportDiagnosticLogs'](arg1);
 }

--- a/desktop-app/ota.go
+++ b/desktop-app/ota.go
@@ -98,8 +98,11 @@ func (a *App) UpdateBoxAgent(host string, port int) (err error) {
 	// (#45/#105). Pushed FIRST and strictly before the agent OTA: the agent OTA
 	// reboots ~1.5 s after its reply, and that reboot is what makes the fresh
 	// agent's Spotify manager pick up the now-present binary. Best-effort: a
-	// sidecar failure must never block the (more important) agent update.
-	a.pushSidecarIfNeeded(host, port)
+	// sidecar failure must never block the (more important) agent update. The
+	// returned error is intentionally ignored here (best-effort): when the box is
+	// still on a pre-v0.8.22 agent the push cannot land yet, and the desktop's
+	// post-OTA EnsureSpotifyEngine re-delivers it once the box is on the new agent.
+	_ = a.pushSidecarIfNeeded(host, port)
 
 	if perr := a.updateAgentPreflight(host, port); perr != nil {
 		a.recordOTA(host, "HTTP preflight rejected -> trying SSH: "+perr.Error())
@@ -156,16 +159,18 @@ func (a *App) UpdateBoxAgent(host string, port int) (err error) {
 
 // pushSidecarIfNeeded delivers the embedded go-librespot Spotify sidecar to the
 // box over HTTP (POST /api/agent/sidecar) when the box is missing it or has a
-// different build. Strictly best-effort: any failure is logged to the OTA
-// journal and swallowed so it never aborts the agent OTA that follows. The
-// ~10 MB transfer is gated on the box's reported content hash so a steady-state
-// OTA (agent-only change, sidecar already current) costs just one cheap version
-// GET and sends zero sidecar bytes.
-func (a *App) pushSidecarIfNeeded(host string, port int) {
+// different build, and verifies it actually landed. Returns nil when the engine
+// is already current or was delivered and confirmed; returns an error when a
+// push was needed but did not land. The agent-OTA caller treats it as
+// best-effort (the error is ignored, the OTA still proceeds); EnsureSpotifyEngine
+// surfaces the outcome. The ~10 MB transfer is gated on the box's reported
+// content hash so a steady state (sidecar already current) costs just one cheap
+// version GET and sends zero sidecar bytes.
+func (a *App) pushSidecarIfNeeded(host string, port int) error {
 	if !agentbin.GoLibrespotAvailable() {
 		// Dev build (empty stub): nothing real to deliver. Never write 0 bytes.
 		a.recordOTA(host, "sidecar: skipped, no embedded go-librespot in this build")
-		return
+		return nil
 	}
 	bin := agentbin.GoLibrespotBytes()
 	sum := sha256.Sum256(bin)
@@ -176,7 +181,7 @@ func (a *App) pushSidecarIfNeeded(host string, port int) {
 	if ver, err := a.BoxAgentVersion(host, port); err == nil {
 		if ver["goLibrespot"] == "present" && ver["goLibrespotSha256"] == want {
 			a.recordOTA(host, "sidecar: box already has the current go-librespot, skipping ~10 MB push")
-			return
+			return nil
 		}
 	} else {
 		// Couldn't read the version: still try the push (a missing sidecar is the
@@ -188,10 +193,51 @@ func (a *App) pushSidecarIfNeeded(host string, port int) {
 	if err := a.streamPostBinary(host, port, "/api/agent/sidecar", bin); err != nil {
 		a.recordOTA(host, "sidecar: push failed (agent OTA still proceeds): "+err.Error())
 		a.logger.Warn("sidecar push failed; agent OTA continues, Spotify may stay unavailable until next OTA", "host", host, "err", err)
-		return
+		return fmt.Errorf("sidecar upload failed: %w", err)
+	}
+	// Verify the push actually landed. A pre-v0.8.22 agent has NO
+	// /api/agent/sidecar route, so its ServeMux falls through to the "/" index
+	// handler and answers 200 with the web UI: streamPostBinary then reports a
+	// false success and the 16 MB body is discarded. That is the gap that left a
+	// SoundTouch 30 upgraded from an older agent without the engine despite a
+	// "delivered" log (#237). Re-read the version and require the box to now
+	// report the engine present with our content hash; otherwise treat it as not
+	// delivered so the caller retries once the box is on the new, capable agent.
+	if ver, err := a.BoxAgentVersion(host, port); err != nil {
+		a.recordOTA(host, "sidecar: delivered but could not verify (version read failed): "+err.Error())
+		a.logger.Warn("sidecar push: delivered but post-push version read failed", "host", host, "err", err)
+		return fmt.Errorf("sidecar verify failed: %w", err)
+	} else if ver["goLibrespot"] != "present" || ver["goLibrespotSha256"] != want {
+		a.recordOTA(host, "sidecar: push did not land (agent has no sidecar endpoint yet); will retry after the box is on the new agent")
+		a.logger.Warn("sidecar push did not land; box still reports the engine missing/mismatched (old agent without the sidecar endpoint)",
+			"host", host, "goLibrespot", ver["goLibrespot"])
+		return fmt.Errorf("sidecar did not land: box reports goLibrespot=%q", ver["goLibrespot"])
 	}
 	a.recordOTA(host, "sidecar: go-librespot delivered")
 	a.logger.Info("sidecar push: go-librespot delivered over OTA", "host", host, "bytes", len(bin))
+	return nil
+}
+
+// EnsureSpotifyEngine makes sure the go-librespot Spotify sidecar is present on
+// the box, delivering it over the air when missing. It is the post-upgrade
+// reconcile for #237: the sidecar is normally pushed during the agent OTA, but a
+// box upgraded FROM a pre-v0.8.22 agent received that push on an old agent with
+// no sidecar endpoint, so it silently no-op'd and the box came up on the new
+// agent with a synced Spotify login but no engine (Spotify then failed with the
+// "tap this speaker in Spotify once" hint). The desktop calls this right after
+// the post-OTA version poll confirms the box is on the new, sidecar-capable
+// agent: the push now lands, and the box's Spotify manager (which polls for a
+// late-delivered binary) starts go-librespot live, with no extra reboot.
+// Idempotent and cheap when the engine is already current (one version GET, zero
+// bytes). Bound for the frontend; safe to call on any box.
+func (a *App) EnsureSpotifyEngine(host string, port int) (string, error) {
+	if !agentbin.GoLibrespotAvailable() {
+		return "no embedded engine in this build", nil
+	}
+	if err := a.pushSidecarIfNeeded(host, port); err != nil {
+		return "", err
+	}
+	return "ok", nil
 }
 
 // refreshStick is a best-effort step run as part of an agent OTA, BEFORE the

--- a/internal/spotify/manager.go
+++ b/internal/spotify/manager.go
@@ -315,8 +315,12 @@ func (m *Manager) ensureConfig(ctx context.Context) error {
 // a short backoff if it exits. It returns immediately (idles) when not
 // Ready, so callers can start it unconditionally.
 func (m *Manager) Run(ctx context.Context) {
-	if !m.Ready() {
-		m.logger.Info("spotify manager idle: no go-librespot binary")
+	// The go-librespot binary can be absent at agent start: an OTA-only box that
+	// never received it from a USB stick (#45/#105), to be delivered later over
+	// the air (POST /api/agent/sidecar). Rather than idle forever after a single
+	// start-time check, wait for the binary so a late delivery is picked up live,
+	// with no extra reboot. Returns only when the binary appears or ctx ends.
+	if !m.waitForBinary(ctx) {
 		return
 	}
 	if err := m.ensureConfig(ctx); err != nil {
@@ -346,6 +350,34 @@ func (m *Manager) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-time.After(3 * time.Second):
+		}
+	}
+}
+
+// waitForBinary blocks until the go-librespot binary is present (m.Ready) or ctx
+// is cancelled, returning true the moment it appears. It returns immediately when
+// the binary is already there (the normal, stick-synced case), so it adds zero
+// latency to a box that has the engine. For an OTA-only box the binary lands
+// later via the sidecar push (webui.handleAgentSidecar); polling here makes the
+// manager start go-librespot as soon as it appears instead of needing another
+// reboot, closing the gap where a box upgraded to a sidecar-capable agent still
+// had no engine (the manager used to check exactly once and idle forever).
+func (m *Manager) waitForBinary(ctx context.Context) bool {
+	if m.Ready() {
+		return true
+	}
+	m.logger.Info("spotify manager: no go-librespot binary yet, waiting for an OTA sidecar delivery")
+	t := time.NewTicker(5 * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-t.C:
+			if m.Ready() {
+				m.logger.Info("spotify manager: go-librespot binary now present, starting")
+				return true
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Problem

A speaker updated **only over the air** (never re-synced from a USB stick) could save Spotify presets but not play them. Pressing one returned the *"tap this speaker in Spotify once"* hint even with a synced login, because the go-librespot engine was absent on the box. A diagnostic bundle from an app-only-updated SoundTouch 30 showed `goLibrespot: missing` while the box reported a synced Spotify login.

## Root cause

v0.8.22 added an in-OTA sidecar push to close this gap, but it ran against the agent **already on the box, before the update reboot**. When the box was upgraded from a pre-v0.8.22 agent, that agent has no `/api/agent/sidecar` route, so its `ServeMux` fell through to the `/` index handler and answered **200** — the desktop logged "delivered" while the 16 MB binary was discarded. The box then rebooted into a sidecar-capable agent with a synced login but no engine, and its Spotify manager checked for the binary **exactly once at startup** and idled forever (so the recall's restart-to-re-auth was a no-op: `runCancel` was nil → `ErrNoSpotifySession`).

## Fix (three layers)

- **agent** (`internal/spotify/manager.go`): the manager now waits/polls for the go-librespot binary instead of idling permanently after a single start-time check, so a late delivery (OTA sidecar or stick sync) is picked up live with no extra reboot.
- **desktop** (`desktop-app/ota.go`): the sidecar push now **verifies** the binary actually landed by re-reading `/api/agent/version` (`goLibrespot` present + matching sha) instead of trusting the old agent's false 200.
- **desktop** (`ota.go` + `main.js`): after the post-OTA version poll confirms the box is on the new, sidecar-capable agent, `EnsureSpotifyEngine` re-delivers the engine if it is still missing — so an upgrade-from-old box gets it without a manual re-update. Best-effort: it never turns a good agent update into a failure.

New i18n key `update.deliveringSpotify` added to all 11 locales.

## Test

- `go build` (ARM cross-compile) + `go vet` clean; `internal/spotify` tests pass.
- Full `wails build` green: bindings regenerated (`EnsureSpotifyEngine`), frontend + all locales compile.