### PR TITLE
fix(update): recover speaker updates when internal storage is nearly full

### DIFF
--- a/desktop-app/boxssh.go
+++ b/desktop-app/boxssh.go
@@ -178,13 +178,25 @@ func classifySSHError(out string, err error) string {
 	case strings.Contains(low, "permission denied"):
 		return "speaker refused passwordless root login. Bose's stock firmware allows it when /media/sda1 has the remote_services marker. Reboot the speaker with the STR stick plugged in, then retry."
 	case strings.Contains(low, "connection refused"):
-		return "speaker is reachable but not running sshd on port 22. It may be mid-reboot."
+		// Since v0.8.1 STR no longer force-opens root SSH on every boot: SSH is
+		// only open while the prepared STR stick is inserted (the remote_services
+		// marker). A reachable speaker that refuses :22 is almost always a normal
+		// stickless box, not a fault. For an over-the-air update this is expected
+		// (the update goes over the app's HTTP connection, SSH is only the
+		// fallback); a hard SSH dependency (uninstall) needs the stick in.
+		return "the speaker is reachable but SSH (port 22) is closed. Since v0.8.1 STR only opens SSH while the prepared STR stick is inserted, so on a normal (stickless) speaker this is expected. Over-the-air updates do not need SSH; if an operation does, re-insert the prepared STR stick and power-cycle the speaker, then retry."
 	case strings.Contains(low, "connection timed out"), strings.Contains(low, "operation timed out"):
 		return "TCP connection to the speaker timed out. Check that it is on your LAN."
 	case strings.Contains(low, "no route to host"), strings.Contains(low, "host is unreachable"):
 		return "speaker is not on the LAN (no route). It may have rebooted into a different IP."
 	}
 	if err != nil {
+		// A bare "exit status 255" with no recognised banner is OpenSSH's generic
+		// connect failure: on a stickless box that is the closed-SSH case above.
+		// Make it actionable instead of surfacing the raw exit code.
+		if strings.Contains(strings.ToLower(err.Error()), "exit status 255") && strings.TrimSpace(out) == "" {
+			return "could not open an SSH session to the speaker (it likely has SSH closed: since v0.8.1 STR only opens SSH while the prepared STR stick is inserted). Over-the-air updates do not need SSH; if an operation does, re-insert the prepared STR stick and power-cycle the speaker, then retry."
+		}
 		return err.Error()
 	}
 	return "no STR_SSH_OK marker received (check Wi-Fi to speaker)"

--- a/desktop-app/ota.go
+++ b/desktop-app/ota.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -48,6 +49,31 @@ func (a *App) BoxAgentVersion(host string, port int) (map[string]string, error) 
 	return out, nil
 }
 
+// recordNANDHeadroom logs the box's writable-volume headroom to the OTA journal
+// before a push. The agent reports nandFreeBytes/nandTotalBytes from /api/agent/
+// version (added 2026-06-24); a box on an older agent simply omits them, in which
+// case we note "unknown". Best-effort and non-blocking: it never fails the OTA.
+// need is the binary size, so the journal shows whether the second copy the
+// atomic write requires can fit.
+func (a *App) recordNANDHeadroom(host string, port int, need int64) {
+	ver, err := a.BoxAgentVersion(host, port)
+	if err != nil {
+		a.recordOTA(host, "nand: headroom unknown (version read failed: "+err.Error()+")")
+		return
+	}
+	free, total := ver["nandFreeBytes"], ver["nandTotalBytes"]
+	if free == "" && total == "" {
+		a.recordOTA(host, "nand: headroom unknown (agent predates the disk-usage report)")
+		return
+	}
+	freeN, _ := strconv.ParseInt(free, 10, 64)
+	fits := "ok"
+	if freeN > 0 && freeN < need+512*1024 {
+		fits = "TIGHT (a second copy for the atomic write may not fit)"
+	}
+	a.recordOTA(host, fmt.Sprintf("nand: free=%sB total=%sB need=%dB -> %s", free, total, need, fits))
+}
+
 // UpdateBoxAgent ships the embedded ARM binary to the speaker. Preferred
 // path is HTTP POST to /api/agent/update on host:port — but only when a
 // preflight confirms STR's agent really answers there. On Series-I boxes
@@ -68,6 +94,12 @@ func (a *App) UpdateBoxAgent(host string, port int) (err error) {
 		return fmt.Errorf("no embedded stick binary available")
 	}
 	a.recordOTA(host, fmt.Sprintf("start: port=%d bytes=%d app=%s build=%s", port, len(bin), appVersion, appBuild))
+	// Record the box's NAND headroom before the push so a "no space left on
+	// device" failure is diagnosable from the journal (the ~31 MB writable volume
+	// must hold a second ~10 MB copy during the atomic write). Older agents do not
+	// report these fields; absent means "unknown", never blocks the OTA. The agent
+	// also embeds a full inventory in the failure error itself (#ST30, 2026-06-24).
+	a.recordNANDHeadroom(host, port, int64(len(bin)))
 	// Record the final outcome to the persistent OTA journal so an update-failure
 	// report is diagnosable even if the user exports the diagnostic in a later
 	// session: str.log is rotated away on the next launch, this journal is not.

--- a/internal/webui/diskusage_test.go
+++ b/internal/webui/diskusage_test.go
@@ -1,0 +1,85 @@
+package webui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestIsForeignNANDDir guards the freshness check that answers Jens' question
+// for an over-full box: is a top-level /mnt/nv dir STR's, Bose's, or a leftover
+// from a third-party post-cloud tool / another custom firmware the owner ran
+// before STR (a candidate for what is eating the tiny ~31 MB NAND).
+func TestIsForeignNANDDir(t *testing.T) {
+	cases := []struct {
+		name    string
+		foreign bool
+	}{
+		{"streborn", false},
+		{"nv", false},
+		{"lost+found", false},
+		{"BoseApp-Persistence", false},
+		{"product-persistence", false}, // matches "persistence"
+		{"Bose", false},
+		{"bose-stuff", false},
+		{"soundtouch-mod", true}, // a community tool's dir
+		{"librespot", true},
+		{"shairport", true},
+	}
+	for _, c := range cases {
+		if got := isForeignNANDDir(c.name); got != c.foreign {
+			t.Errorf("isForeignNANDDir(%q) = %v, want %v", c.name, got, c.foreign)
+		}
+	}
+}
+
+// TestWriteBinaryAtomic checks the OTA write writes the body, leaves no temp
+// behind, and clears a stale .new from an earlier interrupted OTA first (the
+// repeat-failure trap on the tight NAND).
+func TestWriteBinaryAtomic(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "streborn-armv7l")
+
+	// A stale temp from a previous failed attempt must not survive.
+	stale := dst + ".new"
+	if err := os.WriteFile(stale, []byte("partial-garbage"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	body := make([]byte, 4096)
+	for i := range body {
+		body[i] = byte(i)
+	}
+	if err := writeBinaryAtomic(dst, body); err != nil {
+		t.Fatalf("writeBinaryAtomic: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if len(got) != len(body) || got[0] != body[0] || got[len(got)-1] != body[len(body)-1] {
+		t.Fatalf("written content mismatch: got %d bytes", len(got))
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("stale .new temp should be gone, stat err = %v", err)
+	}
+}
+
+// TestDirBytes sums file sizes recursively and ignores directories.
+func TestDirBytes(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a"), make([]byte, 100), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "b"), make([]byte, 200), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := dirBytes(dir); got != 300 {
+		t.Errorf("dirBytes = %d, want 300", got)
+	}
+}

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -2464,6 +2465,15 @@ func (s *Server) handleAgentVersion(w http.ResponseWriter, _ *http.Request) {
 	} else {
 		out["goLibrespot"] = "missing"
 	}
+	// NAND headroom on the tiny (~31 MB) writable volume, so the desktop app can
+	// see before an OTA whether the ~10 MB agent + sidecar will fit and warn
+	// instead of pushing into a "no space left on device" failure (the stickless
+	// SoundTouch 30 case where SSH is closed and the disk state was otherwise
+	// invisible). Strings to match this endpoint's map[string]string shape.
+	if total, avail, ok := diskFree(nandRoot); ok {
+		out["nandTotalBytes"] = strconv.FormatInt(total, 10)
+		out["nandFreeBytes"] = strconv.FormatInt(avail, 10)
+	}
 	writeJSON(w, http.StatusOK, out)
 }
 
@@ -2604,18 +2614,215 @@ func readUploadedELF(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
 // write never becomes the live binary, creating the parent dir on a fresh box
 // (first OTA after install has no /mnt/nv/streborn/bin yet). 0755 so the file
 // is executable.
+//
+// The box's writable NAND (/mnt/nv) is tiny (~31 MB, shared with the Bose
+// firmware), and the atomic write needs room for a SECOND full copy of the
+// ~10 MB binary beside the live one. On a SoundTouch 30 that tipped /mnt/nv
+// over and the OTA failed with "no space left on device" (Daniel, 2026-06-24),
+// with no way to see what was eating the space because the box was stickless so
+// SSH was closed. Two defences: (1) before writing, drop a stale .new from an
+// earlier interrupted OTA (a half-written temp from a failed attempt otherwise
+// eats the very headroom the retry needs, so every retry keeps failing until
+// the next boot's run.sh cleanup_nand runs) and, if still short, reclaim
+// obvious junk; (2) on failure, embed the NAND inventory (df + biggest entries
+// + foreign-firmware dirs) in the error so the desktop app surfaces it verbatim
+// and the user's report tells us whether the ST30 is genuinely tighter or is
+// carrying leftovers from a previous custom firmware.
 func writeBinaryAtomic(dst string, body []byte) error {
-	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+	dir := filepath.Dir(dst)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("mkdir parent: %w", err)
 	}
 	tmp := dst + ".new"
+	// Drop a stale temp from an earlier interrupted OTA before the space check.
+	_ = os.Remove(tmp)
+	need := int64(len(body))
+	if _, avail, ok := diskFree(dir); ok && avail < need+512*1024 {
+		reclaimNAND()
+	}
 	if err := os.WriteFile(tmp, body, 0o755); err != nil {
-		return fmt.Errorf("write tmp: %w", err)
+		_ = os.Remove(tmp) // leave no partial behind for the next attempt
+		return fmt.Errorf("write tmp: %w [NAND %s]", err, nandReportLine())
 	}
 	if err := os.Rename(tmp, dst); err != nil {
-		return fmt.Errorf("rename: %w", err)
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename: %w [NAND %s]", err, nandReportLine())
 	}
 	return nil
+}
+
+// --- NAND disk diagnostics -------------------------------------------------
+//
+// These mirror run.sh's nand_inventory + cleanup_nand on the agent so the same
+// picture is available over plain HTTP, not just in the SSH-gated diagnostic
+// bundle: in /api/agent/version (free/total, every poll), in /api/debug/state
+// (full inventory), and embedded into the OTA failure error. A stickless box
+// (SSH closed since v0.8.1) can then still reveal its disk state to the app.
+
+const nandRoot = "/mnt/nv"
+const strNANDDir = "/mnt/nv/streborn"
+
+// diskFree reports total and available-to-non-root bytes on the filesystem
+// backing path. ok is false if the statfs failed.
+func diskFree(path string) (total, avail int64, ok bool) {
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(path, &st); err != nil {
+		return 0, 0, false
+	}
+	bs := int64(st.Bsize)
+	return int64(st.Blocks) * bs, int64(st.Bavail) * bs, true
+}
+
+// dirBytes is a du -s in bytes for path, best-effort: unreadable entries are
+// skipped, never fatal. Cheap on the tiny NAND.
+func dirBytes(path string) int64 {
+	var total int64
+	_ = filepath.Walk(path, func(_ string, fi os.FileInfo, err error) error {
+		if err != nil || fi == nil {
+			return nil
+		}
+		if !fi.IsDir() {
+			total += fi.Size()
+		}
+		return nil
+	})
+	return total
+}
+
+// isForeignNANDDir reports whether a top-level /mnt/nv dir is neither STR's nor
+// one of Bose's, i.e. a candidate leftover from a third-party post-cloud tool
+// or another custom firmware the owner ran before STR. Mirrors run.sh's
+// nand_inventory freshness check.
+func isForeignNANDDir(name string) bool {
+	switch name {
+	case "streborn", "nv", "lost+found":
+		return false
+	}
+	l := strings.ToLower(name)
+	if strings.Contains(l, "bose") || strings.Contains(l, "persistence") {
+		return false
+	}
+	return true
+}
+
+// nandEntry is one top-level /mnt/nv entry with its recursive size.
+type nandEntry struct {
+	Name    string `json:"name"`
+	Bytes   int64  `json:"bytes"`
+	IsDir   bool   `json:"isDir"`
+	Foreign bool   `json:"foreign"`
+}
+
+// nandInventory is the structured disk report used by /api/debug/state: df for
+// the writable filesystems plus per-entry sizes under /mnt/nv (sorted biggest
+// first) with foreign dirs flagged.
+func nandInventory() map[string]any {
+	rep := map[string]any{}
+	if total, avail, ok := diskFree(nandRoot); ok {
+		rep["nvTotalBytes"] = total
+		rep["nvFreeBytes"] = avail
+		rep["nvUsedBytes"] = total - avail
+	}
+	if total, avail, ok := diskFree("/"); ok {
+		rep["rootTotalBytes"] = total
+		rep["rootFreeBytes"] = avail
+	}
+	entries, err := os.ReadDir(nandRoot)
+	if err != nil {
+		rep["nvEntriesErr"] = err.Error()
+		return rep
+	}
+	list := make([]nandEntry, 0, len(entries))
+	foreign := []string{}
+	for _, e := range entries {
+		ne := nandEntry{
+			Name:  e.Name(),
+			Bytes: dirBytes(filepath.Join(nandRoot, e.Name())),
+			IsDir: e.IsDir(),
+		}
+		if e.IsDir() && isForeignNANDDir(e.Name()) {
+			ne.Foreign = true
+			foreign = append(foreign, e.Name())
+		}
+		list = append(list, ne)
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].Bytes > list[j].Bytes })
+	rep["nvEntries"] = list
+	rep["foreignDirs"] = foreign // empty => STR/Bose-only ("fresh")
+	return rep
+}
+
+// nandReportLine is a compact one-line inventory for embedding in an OTA error
+// (which the desktop app surfaces verbatim and the user pastes into a report):
+// free/total, the biggest few /mnt/nv entries, and any foreign dirs.
+func nandReportLine() string {
+	var b strings.Builder
+	if total, avail, ok := diskFree(nandRoot); ok {
+		fmt.Fprintf(&b, "/mnt/nv free=%dKB total=%dKB", avail/1024, total/1024)
+	} else {
+		b.WriteString("/mnt/nv df unavailable")
+	}
+	entries, err := os.ReadDir(nandRoot)
+	if err != nil {
+		return b.String()
+	}
+	type es struct {
+		name    string
+		bytes   int64
+		foreign bool
+	}
+	list := make([]es, 0, len(entries))
+	foreign := []string{}
+	for _, e := range entries {
+		f := e.IsDir() && isForeignNANDDir(e.Name())
+		list = append(list, es{e.Name(), dirBytes(filepath.Join(nandRoot, e.Name())), f})
+		if f {
+			foreign = append(foreign, e.Name())
+		}
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].bytes > list[j].bytes })
+	b.WriteString("; top:")
+	for i, e := range list {
+		if i >= 6 {
+			break
+		}
+		fmt.Fprintf(&b, " %s=%dKB", e.name, e.bytes/1024)
+	}
+	if len(foreign) > 0 {
+		b.WriteString("; foreign(non-STR/Bose): " + strings.Join(foreign, ","))
+	} else {
+		b.WriteString("; foreign: none")
+	}
+	return b.String()
+}
+
+// reclaimNAND frees obvious, regenerable junk so a tight OTA write has room:
+// stale .new temps from an interrupted OTA and oversized/rotated logs. The
+// agent-side mirror of run.sh's cleanup_nand for the OTA path, which (unlike a
+// stick boot) does not pass through a reboot. Best-effort throughout; never
+// touches Bose files or the live binaries.
+func reclaimNAND() {
+	binDir := filepath.Join(strNANDDir, "bin")
+	for _, pat := range []string{
+		filepath.Join(binDir, "*.new"),
+		filepath.Join(strNANDDir, "cap*.ogg"),
+	} {
+		if matches, _ := filepath.Glob(pat); matches != nil {
+			for _, m := range matches {
+				_ = os.Remove(m)
+			}
+		}
+	}
+	_ = os.Remove(filepath.Join(strNANDDir, "agent.log.1"))
+	_ = os.Remove(filepath.Join(nandRoot, "sp-oauth.out"))
+	for _, name := range []string{"setup.log", "setup.log.prev", "agent.log", "previous.log", "boot.log"} {
+		p := filepath.Join(strNANDDir, name)
+		if fi, err := os.Stat(p); err == nil && fi.Size() > 131072 {
+			if b, rerr := os.ReadFile(p); rerr == nil && int64(len(b)) > 65536 {
+				_ = os.WriteFile(p, b[int64(len(b))-65536:], 0o644)
+			}
+		}
+	}
 }
 
 // handleAgentSidecar receives the go-librespot Spotify sidecar binary and
@@ -3703,6 +3910,10 @@ func (s *Server) handleDebugState(w http.ResponseWriter, r *http.Request) {
 		"media_listing":  listDir("/media"),
 		"nv_listing":     listDir("/mnt/nv/streborn"),
 		"proc_mounts":    readTail("/proc/mounts"),
+		// Writable-volume usage: df for /mnt/nv + / and the per-entry sizes that
+		// answer "is this box genuinely tighter or carrying foreign firmware
+		// leftovers" without needing SSH (#ST30 OTA no-space, 2026-06-24).
+		"disk_usage": nandInventory(),
 	}
 	writeJSON(w, http.StatusOK, state)
 }


### PR DESCRIPTION
## Problem

A user updated a SoundTouch 10 fine but the SoundTouch 30 update failed:

```
HTTP OTA failed (status 500: write tmp: open /mnt/nv/streborn/bin/streborn-armv7l.new: no space left on device) and the SSH fallback also failed: ssh handshake failed: exit status 255
```

Two things were happening:

1. **No space.** The writable volume `/mnt/nv` is only ~31 MB, shared with the Bose firmware. The OTA writes the ~10 MB binary to a `.new` temp beside the live one before the atomic rename, so it needs that much free space on top of the agent + the go-librespot sidecar + presets + logs. On the ST30 that tipped over. The failed write also **left the partial `.new` behind**, so every retry failed the same way until the next reboot's `cleanup_nand`.
2. **SSH "exit status 255"** is not a separate bug: since v0.8.1 STR only opens root SSH while the prepared stick is inserted, so on a stickless box the SSH fallback (and the SSH-only uninstall) have nothing to connect to.

The agent OTA path had no equivalent of the stick's `cleanup_nand` / `nand_inventory`, and a stickless box could not be inspected over SSH at all — so there was no way to see whether the ST30 is genuinely tighter or carrying leftovers from another custom firmware.

## Change

**Agent (`internal/webui`)**
- `writeBinaryAtomic` drops a stale `.new` before writing, reclaims regenerable junk (old temps, oversized logs, ogg captures) when space is short, and leaves no partial behind on failure.
- Writable-volume state is now exposed over plain HTTP (no SSH needed):
  - `GET /api/agent/version` → `nandFreeBytes` / `nandTotalBytes`
  - `GET /api/debug/state` → `disk_usage` (df for `/mnt/nv` and `/`, every top-level entry by size, and `foreignDirs` flagging non-STR/non-Bose leftovers)
  - the update failure error embeds a compact inventory, so a future "no space" report is self-diagnosing.

**Desktop app**
- The OTA journal records the box's headroom before each push.
- `classifySSHError` explains a closed-SSH (stickless) box instead of surfacing a bare "exit status 255".

## Notes
- The fix cannot unstick the *already-failing* box over OTA (that write runs in its old agent); recovery there is a power-cycle (boot runs `cleanup_nand`) + retry, or the stick. This change prevents recurrence fleet-wide and makes the failure self-diagnosing.
- New unit tests cover the foreign-dir detection, the stale-`.new` removal, and recursive sizing.

## Test
- `GOOS=linux GOARCH=arm GOARM=7 go build ./...` and desktop `go build ./...` clean
- `gofmt` / `go vet` clean
- local Wails build produced a working `ST Reborn.exe` with the correct version stamp
