### PR TITLE
fix(spotify): play a Spotify preset when the speaker is streaming Spotify but has not saved a login

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -377,7 +377,7 @@ func run() error {
 		webui.WithSpotifyMeta(spotifyMgr.PlaylistMeta),
 		webui.WithSpotifyStreaming(spotifyMgr.Streaming),
 		webui.WithSpotifyReady(spotifyMgr.Ready),
-		webui.WithSpotifyLoggedIn(spotifyMgr.LoggedIn),
+		webui.WithSpotifyCanRecall(spotifyMgr.CanRecall),
 		webui.WithSpotifyPremiumRequired(spotifyMgr.PremiumRequired),
 		webui.WithSpotifyExportCred(spotifyMgr.ExportCredential),
 		webui.WithSpotifyImportCred(spotifyMgr.ImportCredential),
@@ -1219,11 +1219,16 @@ func (h *presetWsHandler) playSpotifyPreset(ctx context.Context, slot int, p pre
 		h.logger.Warn("spotify preset recall: preset has no Spotify URI, cannot autoplay", "slot", slot, "name", p.Name)
 		return
 	}
-	// No persisted Spotify login means go-librespot has no credential and cannot
-	// start playback on its own, so a hardware press would do nothing but thrash
+	// No live session AND no persisted Spotify login means go-librespot has no way
+	// to start playback on its own, so a hardware press would do nothing but thrash
 	// the box. Skip with a clear log instead of the silent retry loop (#45 Pierre).
-	if !h.spotify.LoggedIn() {
-		h.logger.Warn("spotify preset recall: speaker not logged into Spotify (no credential); log it into Spotify once first", "slot", slot, "name", p.Name)
+	// Gate on CanRecall (live session OR persisted credential), NOT a persisted
+	// credential alone: a box with a live-but-never-persisted zeroconf session
+	// plays Spotify fine yet LoggedIn() is false, and gating on the credential
+	// alone wrongly skipped its recall (Patrick, ST10, 2026-06-24). Mirror of the
+	// soft/app path in internal/webui (the two recall paths must stay in sync).
+	if !h.spotify.CanRecall(ctx) {
+		h.logger.Warn("spotify preset recall: speaker not logged into Spotify and no live session; log it into Spotify once first", "slot", slot, "name", p.Name)
 		return
 	}
 	if !h.spotify.Ready() {

--- a/internal/spotify/manager.go
+++ b/internal/spotify/manager.go
@@ -1072,6 +1072,24 @@ func (m *Manager) LoggedIn() bool {
 	return false
 }
 
+// CanRecall reports whether a Spotify preset recall can proceed: either
+// go-librespot holds a LIVE session right now (SessionActive, e.g. the user just
+// streamed to the box from their phone) OR a reusable credential is persisted on
+// disk (LoggedIn, so ensureSession can restart go-librespot and re-auth from it).
+//
+// Recall must gate on this, NOT on LoggedIn alone. A box with a live-but-never-
+// persisted zeroconf session (go-librespot authenticated the phone but wrote no
+// credential to state.json) reports LoggedIn()==false yet plays Spotify fine;
+// gating on LoggedIn alone refused recall on exactly such a box (Patrick, ST10
+// rhino, 2026-06-24: streamed Spotify, go-librespot running, box flipped to
+// source=SPOTIFY, yet the recall bailed "speaker not logged into Spotify"). Only
+// when BOTH are false is the recall genuinely impossible, so the "tap this
+// speaker in Spotify once" hint is correct. PlayAccount->ensureSession then
+// handles the live vs cold-restart decision from here.
+func (m *Manager) CanRecall(ctx context.Context) bool {
+	return m.SessionActive(ctx) || m.LoggedIn()
+}
+
 // stateHasCredential reports whether go-librespot's state.json at path holds a
 // persisted zeroconf credential (a non-empty credentials.username). go-librespot
 // writes state.json with only device_id/last_volume before any login, so file

--- a/internal/spotify/manager_test.go
+++ b/internal/spotify/manager_test.go
@@ -3,12 +3,16 @@ package spotify
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/binary"
 	"encoding/json"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -154,6 +158,63 @@ func TestLoggedIn(t *testing.T) {
 	}
 	if !m2.LoggedIn() {
 		t.Fatal("LoggedIn should be true once state.json carries a credential username")
+	}
+}
+
+// TestCanRecall verifies the recall-eligibility gate (#45; Patrick, ST10 rhino,
+// 2026-06-24). Recall must be allowed when go-librespot holds a LIVE session even
+// if no credential is persisted on disk (the box streams Spotify fine yet
+// LoggedIn() is false, which previously refused the recall), and when a
+// credential is persisted even if the session is momentarily down (ensureSession
+// restarts go-librespot and re-auths from it). It is refused only when BOTH are
+// false, which is the genuine "tap this speaker in Spotify once" case.
+func TestCanRecall(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// No persisted credential and no live session (/status unreachable): refuse.
+	cfg := filepath.Join(t.TempDir(), "cfg")
+	if err := os.MkdirAll(cfg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m := New("", cfg, "", nil, logger)
+	m.apiAddr = "127.0.0.1:0" // nothing listening -> currentUsername == ""
+	if m.CanRecall(ctx) {
+		t.Fatal("CanRecall should be false with no credential and no live session")
+	}
+
+	// A live go-librespot session (mock /status reports a username) makes recall
+	// possible even though nothing is persisted on disk: exactly the Patrick case
+	// (streamed from the phone, go-librespot authenticated, nothing on NAND yet).
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/status" {
+			_, _ = w.Write([]byte(`{"username":"live-listener"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+	m.apiAddr = strings.TrimPrefix(ts.URL, "http://")
+	if m.LoggedIn() {
+		t.Fatal("precondition: LoggedIn should be false (nothing persisted)")
+	}
+	if !m.CanRecall(ctx) {
+		t.Fatal("CanRecall should be true with a live session even with no persisted credential")
+	}
+
+	// A persisted credential alone (session down) also allows recall.
+	cfg2 := filepath.Join(t.TempDir(), "cfg")
+	if err := os.MkdirAll(cfg2, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m2 := New("", cfg2, "", nil, logger)
+	m2.apiAddr = "127.0.0.1:0" // session down
+	if err := os.WriteFile(filepath.Join(cfg2, "state.json"),
+		[]byte(`{"credentials":{"username":"alice","data":"AA=="}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !m2.CanRecall(ctx) {
+		t.Fatal("CanRecall should be true with a persisted credential even with no live session")
 	}
 }
 

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -100,13 +100,15 @@ type Server struct {
 	// at a not-yet-flowing stream (which starves and detaches). nil when Spotify
 	// is not configured.
 	spotifyReady func() bool
-	// spotifyLoggedIn reports whether the speaker has ever completed a Spotify
-	// Connect login (a credential is persisted). Without it go-librespot cannot
-	// start playback on its own, so a recall does nothing; the handler returns a
-	// clear "log this speaker into Spotify first" error instead of optimistically
-	// reporting "playing" and failing silently in the background (#45 Pierre). nil
+	// spotifyCanRecall reports whether a Spotify recall can proceed: go-librespot
+	// holds a live session right now OR a reusable credential is persisted (so it
+	// can re-auth from it). Gating on a persisted credential ALONE wrongly refused
+	// recall on a box with a live-but-never-persisted zeroconf session that played
+	// Spotify fine (Patrick, ST10, 2026-06-24). Only when this is false does the
+	// handler return the "log this speaker into Spotify first" hint instead of
+	// optimistically reporting "playing" and failing silently (#45 Pierre). nil
 	// until wired.
-	spotifyLoggedIn func() bool
+	spotifyCanRecall func(ctx context.Context) bool
 	// spotifyPremiumRequired reports whether the logged-in Spotify account is
 	// free/open and so cannot do the autonomous recall playback (#45). nil until
 	// wired; the recall handler uses it to return a clear "needs Premium" error.
@@ -470,11 +472,12 @@ func WithSpotifyPremiumRequired(f func() bool) Option {
 	return func(s *Server) { s.spotifyPremiumRequired = f }
 }
 
-// WithSpotifyLoggedIn registers the predicate that reports whether the speaker
-// has a persisted Spotify login, so a recall on a never-logged-in speaker fails
-// with a clear, actionable message instead of silently (#45).
-func WithSpotifyLoggedIn(f func() bool) Option {
-	return func(s *Server) { s.spotifyLoggedIn = f }
+// WithSpotifyCanRecall registers the predicate that reports whether a Spotify
+// recall can proceed (a live go-librespot session OR a persisted credential), so
+// a recall on a genuinely-never-logged-in speaker fails with a clear, actionable
+// message while one with a live session still plays (#45; Patrick, 2026-06-24).
+func WithSpotifyCanRecall(f func(ctx context.Context) bool) Option {
+	return func(s *Server) { s.spotifyCanRecall = f }
 }
 
 // WithSpotifyExportCred registers the function that returns this box's active
@@ -1240,12 +1243,16 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
-		// A speaker that has never been logged into Spotify has no credential for
-		// go-librespot, so it cannot start playback on its own and the recall would
-		// silently do nothing (#45 Pierre: saved preset account="" and go-librespot
-		// not running). Tell the user how to fix it instead of optimistically
-		// reporting "playing" and failing in the background.
-		if s.spotifyLoggedIn != nil && !s.spotifyLoggedIn() {
+		// A speaker that has never been logged into Spotify AND holds no live
+		// session has no way for go-librespot to start playback on its own, so the
+		// recall would silently do nothing (#45 Pierre: saved preset account="" and
+		// go-librespot not running). Tell the user how to fix it instead of
+		// optimistically reporting "playing" and failing in the background. Gate on
+		// CanRecall (live session OR persisted credential), NOT a persisted
+		// credential alone: a box with a live-but-never-persisted zeroconf session
+		// plays Spotify fine yet reports not-logged-in, and gating on the credential
+		// alone wrongly refused its recall (Patrick, ST10, 2026-06-24).
+		if s.spotifyCanRecall != nil && !s.spotifyCanRecall(r.Context()) {
 			s.logger.Info("spotify preset recall (app): speaker not logged into Spotify", "slot", slot)
 			// STR plays Spotify through this speaker as a Spotify Connect receiver
 			// (the go-librespot sidecar), not via any Bose account link. The


### PR DESCRIPTION
## Problem
Recalling a saved Spotify preset did nothing (button glowed orange, no audio) on a speaker that was actively streaming Spotify but had never persisted a reusable login. Both the app and hardware-button recall paths gated on a filesystem-only "logged in" check, which returns false on such a box even though go-librespot holds a live session and plays fine, so the recall bailed before the v0.8.16 session recovery could run.

## Fix
Gate recall on `Manager.CanRecall(ctx) = SessionActive(ctx) || LoggedIn()` in both recall paths (the `internal/webui` soft/app path and the `cmd/agent` hardware path). Allow recall when a live session exists OR a credential is persisted; only refuse (with the "tap this speaker in Spotify once" hint) when both are false.

## Testing
- New `TestCanRecall` unit test covering the live-but-unpersisted case.
- Verified live on a taigan box via HTTP OTA: recall plays, no regression on a logged-in box; the agent log shows the gate passing instead of the old "speaker not logged into Spotify" bail.

Refs #45.