### PR TITLE
fix(spotify): resume a preset where you left off instead of a random song

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -372,7 +372,9 @@ func run() error {
 		webui.WithRegionFile(*regionFile),
 		webui.WithStreamProxy(streamProxySrv),
 		webui.WithSpotifyStream(spotifyMgr.ServeOgg),
-		webui.WithSpotifyControl(spotifyMgr.PlayAccount),
+		webui.WithSpotifyControl(func(ctx context.Context, uri, account string, shuffle bool) error {
+			return spotifyMgr.PlayAccount(ctx, uri, account, spotify.PlayOptions{Shuffle: shuffle})
+		}),
 		webui.WithSpotifyUser(spotifyMgr.CurrentUsername),
 		webui.WithSpotifyMeta(spotifyMgr.PlaylistMeta),
 		webui.WithSpotifyStreaming(spotifyMgr.Streaming),
@@ -1292,8 +1294,9 @@ func (h *presetWsHandler) playSpotifyPreset(ctx context.Context, slot int, p pre
 		h.autoPair.TriggerNow(pairCtx)
 		c()
 	}
-	// Load the playlist (audio): paused -> shuffle -> skip-to-random -> resume.
-	if err := h.spotify.PlayAccount(playCtx, p.URI, p.Account); err != nil {
+	// Load the playlist (audio): a default preset resumes where the user left off
+	// (shuffle off, in-order); a shuffle preset starts on a fresh random track.
+	if err := h.spotify.PlayAccount(playCtx, p.URI, p.Account, spotify.PlayOptions{Shuffle: p.Shuffle}); err != nil {
 		h.logger.Warn("spotify play (initial) failed, will verify+retry", "slot", slot, "err", err)
 	}
 	// Verify+retry in the background: the first press after a cold boot races
@@ -1348,7 +1351,7 @@ func (h *presetWsHandler) verifySpotifyPlaying(slot int, p presets.Preset) {
 		// where the playlist never loaded at all.
 		if attempt == 3 {
 			h.logger.Warn("spotify recall not playing, full re-Play (last resort)", "slot", slot)
-			_ = h.spotify.PlayAccount(ctx, p.URI, p.Account)
+			_ = h.spotify.PlayAccount(ctx, p.URI, p.Account, spotify.PlayOptions{Shuffle: p.Shuffle})
 		} else {
 			h.logger.Warn("spotify recall not playing yet, re-pointing box", "slot", slot, "attempt", attempt)
 		}

--- a/internal/spotify/manager.go
+++ b/internal/spotify/manager.go
@@ -180,6 +180,12 @@ type Manager struct {
 	// write to exactly once, so there is no per-track flash wear.
 	hdrPath      string
 	hdrPersisted bool
+	// resume remembers, per context, the last track played from it so a default
+	// (non-shuffle) recall can continue where the user left off instead of
+	// restarting the context. curTrackURI is the current track's spotify: URI,
+	// captured from /status and metadata events to feed the resume store.
+	resume      *resumeStore
+	curTrackURI string
 }
 
 // New returns a Manager. binPath is the go-librespot binary, configDir
@@ -208,6 +214,10 @@ func New(binPath, configDir, fallbackName string, box *boxapi.Client, logger *sl
 		playClient: &http.Client{Timeout: 25 * time.Second},
 		hdrPath:    filepath.Join(configDir, "stream-headers.ogg"),
 	}
+	// Per-context resume memory lives next to the per-account credential store
+	// on NAND (a sibling of configDir), so it survives reboots and OTA agent
+	// swaps (which replace only the binary).
+	m.resume = newResumeStore(filepath.Join(filepath.Dir(configDir), "sp-resume.json"), logger)
 	// Warm the Ogg header cache from the last session so the very first box
 	// attach after a cold boot gets valid Ogg (buffers) instead of nothing
 	// (the "service unavailable" flash). Best-effort; absent on a fresh install.
@@ -338,6 +348,8 @@ func (m *Manager) Run(ctx context.Context) {
 	// building the per-account library that SwitchAccount swaps between for
 	// multi-account preset recall.
 	go m.captureLoop(ctx)
+	// Debounced writer for the per-context resume memory.
+	go m.resume.run(ctx)
 	// One-shot: rewrite config with the box's real name + volume once the box
 	// REST API answers (it is usually not up when config is first written), then
 	// restart go-librespot so the Spotify app sees the right volume, not 100%.
@@ -715,36 +727,64 @@ func readOggPage(r *bufio.Reader) ([]byte, error) {
 	return page, nil
 }
 
-// Play asks go-librespot to start playing a Spotify URI on this device,
-// using its own cached credential. This is the autonomous-recall path:
-// the agent calls it on a Spotify preset press, with no app involved.
+// PlayOptions tunes a Spotify context recall.
+type PlayOptions struct {
+	// Shuffle starts the context on a random track with shuffle enabled, the
+	// behaviour a preset saved with "shuffle" wants. When false (the default),
+	// recall RESUMES the context on the last track that played from it (the
+	// Spotify Connect "continue where you left off" behaviour) with shuffle OFF,
+	// so the speaker's remote next/prev walk the playlist in order.
+	Shuffle bool
+}
+
+// Play asks go-librespot to start playing a Spotify context (playlist/album/
+// track) on this device, using its own cached credential. This is the
+// autonomous-recall path: the agent calls it on a Spotify preset press, with no
+// app involved.
 //
 // The recall calls Play FIRST, then points the box at /spotify/stream.ogg.
 // With the sink-gated drain (see runOnce) go-librespot blocks on its full
 // output pipe until the box attaches, so the pipe holds the track's start
 // incl. the Ogg headers; the box therefore receives the stream from the
 // beginning and can decode it.
-func (m *Manager) Play(ctx context.Context, uri string) error {
-	// Start the playlist on a RANDOM track, shuffled, every recall.
-	// go-librespot's /player/play has no shuffle option, and shuffle_context
-	// only randomises the UPCOMING queue: the current track stays the context's
-	// first one, so play+shuffle alone replays the same first song each time
-	// (live-observed). So: load + play, enable shuffle, then skip once to land
-	// on a shuffled (random) track. It starts at the track's beginning; the
-	// flush-on-BOS in the drain keeps the boundary clean (no mid-track restart).
+//
+// Shuffle is driven by opts, NOT forced on. The previous code force-enabled
+// shuffle on EVERY recall, skipped to a random track, and never turned shuffle
+// off again, so every preset press landed on a random song AND the remote's
+// next key jumped around a still-shuffled queue (Patrick + Jens, 2026-06-25).
+// Now: a default (non-shuffle) recall resumes the context where the user left
+// off and keeps shuffle off; a shuffle preset starts on a fresh random track.
+func (m *Manager) Play(ctx context.Context, uri string, opts PlayOptions) error {
 	// Mark a recall in progress so ServeOgg does not resume the OLD (mid) track
-	// when the box attaches; this path drives the new track from its start.
+	// when the box attaches; this path drives the chosen track from its start.
 	m.SetRecalling()
-	// Load the context PAUSED so the speaker never hears the playlist's first
-	// (non-shuffled) track. The old flow played first, THEN shuffled + skipped,
-	// and because go-librespot takes a few seconds to load the context the skip
-	// landed late: the box audibly played the first track ("Real Love Baby") for
-	// ~6-24 s before jumping to a random one (live box log 2026-06-12). Now we:
-	// load paused -> wait for the context to load -> shuffle -> skip to a random
-	// track -> resume, so audio starts cleanly on the shuffled track from its
-	// start. The box buffers on the Ogg headers during the short paused window,
+	// Point the resume tracker at the context we are loading right now and drop
+	// the previous track. The will_play event that normally sets lastContext can
+	// lag or be missed, so without this a metadata/status event arriving after
+	// the recall window would record the NEW context against the OLD track and
+	// corrupt the resume store (review, 2026-06-25).
+	m.mu.Lock()
+	m.lastContext = uri
+	m.curTrackURI = ""
+	m.mu.Unlock()
+	// Default recall resumes on the last track that played from this context
+	// (skip_to_uri). A shuffle preset ignores the resume point and starts random.
+	resumeURI := ""
+	if !opts.Shuffle {
+		resumeURI = m.resume.trackFor(uri)
+	}
+	// Load the context PAUSED so the speaker never hears the wrong (non-resumed /
+	// non-shuffled) track. skip_to_uri positions the queue on the resume track
+	// before any audio flows; an empty skip_to_uri starts at the context's first
+	// track. We then wait for the context to load, set the desired shuffle state,
+	// and resume, so audio starts cleanly on the intended track from its start.
+	// The box buffers on the cached Ogg headers during the short paused window,
 	// the same way it already buffers during a cold load.
-	playBody, _ := json.Marshal(map[string]any{"uri": uri, "paused": true})
+	playReq := map[string]any{"uri": uri, "paused": true}
+	if resumeURI != "" {
+		playReq["skip_to_uri"] = resumeURI
+	}
+	playBody, _ := json.Marshal(playReq)
 	if err := m.apiPostC(ctx, m.playClient, "/player/play", string(playBody)); err != nil {
 		return err
 	}
@@ -754,19 +794,27 @@ func (m *Manager) Play(ctx context.Context, uri string) error {
 	// shuffle_context is a no-op against an unloaded context (live: cold preset 6
 	// then skipped to the deterministic 2nd track), so wait for the track to load.
 	m.waitContextLoaded(ctx, 5*time.Second)
-	if err := m.apiPost(ctx, "/player/shuffle_context", `{"shuffle_context":true}`); err != nil {
-		m.logger.Debug("spotify: shuffle_context (post-load) failed", "err", err)
+	// Set shuffle EXPLICITLY to the desired state every recall. Setting it to
+	// false is what clears a stale shuffle left on by a previous shuffled recall
+	// (the cross-recall stickiness that made an unshuffled preset still shuffle
+	// and the remote next jump to a random song).
+	if err := m.apiPost(ctx, "/player/shuffle_context",
+		fmt.Sprintf(`{"shuffle_context":%t}`, opts.Shuffle)); err != nil {
+		m.logger.Debug("spotify: shuffle_context failed", "err", err, "shuffle", opts.Shuffle)
 	}
-	// shuffle_context only randomises the UPCOMING queue (the current track stays
-	// the context's first), so one skip lands on a random track. Still paused, so
-	// nothing reaches the speaker yet.
-	if err := m.apiPost(ctx, "/player/next", ""); err != nil {
-		m.logger.Debug("spotify: skip-to-random after shuffle failed", "err", err)
+	if opts.Shuffle {
+		// shuffle_context only randomises the UPCOMING queue (the current track
+		// stays the context's first), so one skip lands on a random track. Still
+		// paused, so nothing reaches the speaker yet.
+		if err := m.apiPost(ctx, "/player/next", ""); err != nil {
+			m.logger.Debug("spotify: skip-to-random after shuffle failed", "err", err)
+		}
 	}
-	// Resume: audio now flows, starting on the shuffled track from its beginning.
+	// Resume: audio now flows, starting on the chosen track from its beginning.
 	if err := m.apiPost(ctx, "/player/resume", ""); err != nil {
-		m.logger.Debug("spotify: resume after shuffle failed", "err", err)
+		m.logger.Debug("spotify: resume after recall failed", "err", err)
 	}
+	m.logger.Info("spotify: recall play", "uri", uri, "shuffle", opts.Shuffle, "resumeTrack", resumeURI != "")
 	// Debounce the will_play context change this recall triggers (this path
 	// already drives the box separately, so no extra re-point needed).
 	m.mu.Lock()
@@ -1295,10 +1343,11 @@ func (m *Manager) SwitchAccount(ctx context.Context, username string) (bool, err
 	return true, fmt.Errorf("account switch to %q timed out", username)
 }
 
-// PlayAccount switches to the preset's account (if needed) then plays the URI.
-// This is the recall entry point used by both the hardware-button and the
-// desktop/API paths.
-func (m *Manager) PlayAccount(ctx context.Context, uri, account string) error {
+// PlayAccount switches to the preset's account (if needed) then plays the URI
+// with the given options (shuffle vs resume). This is the recall entry point
+// used by both the hardware-button and the desktop/API paths, so both honour
+// the preset's shuffle flag and the per-context resume point identically.
+func (m *Manager) PlayAccount(ctx context.Context, uri, account string, opts PlayOptions) error {
 	// Diagnostic: log the live session state at the recall boundary so a bundle
 	// disambiguates "never logged in" vs "dead session" vs "playing fine" without
 	// guesswork (every Spotify-recall investigation hit this blind spot).
@@ -1320,7 +1369,32 @@ func (m *Manager) PlayAccount(ctx context.Context, uri, account string) error {
 	if !m.ensureSession(ctx) {
 		return ErrNoSpotifySession
 	}
-	return m.Play(ctx, uri)
+	return m.Play(ctx, uri, opts)
+}
+
+// noteResume records the current track as the resume point for the current
+// context, so a later default (non-shuffle) recall of that context continues on
+// it. No-op during an in-flight recall (the track is still settling) and when
+// the context or track URI is unknown. Called after every metadata/status
+// update; the resume store itself ignores unchanged tracks, so this is cheap.
+func (m *Manager) noteResume() {
+	if m.resume == nil {
+		return
+	}
+	// Take the recall-in-flight check and the context/track snapshot under one
+	// lock, so the pair recorded is exactly the state at this instant (no
+	// recheck-then-relock window). note() ignores an empty or non-spotify pair.
+	m.mu.Lock()
+	if time.Now().Before(m.recallUntil) {
+		m.mu.Unlock()
+		return
+	}
+	ctxURI, trackURI := m.lastContext, m.curTrackURI
+	m.mu.Unlock()
+	if ctxURI == "" || trackURI == "" {
+		return
+	}
+	m.resume.note(ctxURI, trackURI)
 }
 
 // ExportCredential returns the active go-librespot credential (credentials.json)
@@ -1570,6 +1644,7 @@ func (m *Manager) liveNowPlaying(ctx context.Context) (track, artist, cover stri
 	}
 	var st struct {
 		Track *struct {
+			URI           string   `json:"uri"`
 			Name          string   `json:"name"`
 			ArtistNames   []string `json:"artist_names"`
 			AlbumCoverURL string   `json:"album_cover_url"`
@@ -1583,8 +1658,12 @@ func (m *Manager) liveNowPlaying(ctx context.Context) (track, artist, cover stri
 	cover = st.Track.AlbumCoverURL
 	m.mu.Lock()
 	m.curName, m.curArtist, m.curCover = track, artist, cover
+	if st.Track.URI != "" {
+		m.curTrackURI = st.Track.URI
+	}
 	m.mu.Unlock()
 	m.notifyTrack()
+	m.noteResume()
 	return track, artist, cover, true
 }
 
@@ -1715,6 +1794,12 @@ func (m *Manager) volumeStream(ctx context.Context, url string) error {
 				m.mu.Lock()
 				changed := m.lastContext != "" && wp.ContextURI != m.lastContext
 				m.lastContext = wp.ContextURI
+				if changed {
+					// New context: drop the previous track so noteResume cannot
+					// pair this context with the old track before its own
+					// metadata lands (review, 2026-06-25).
+					m.curTrackURI = ""
+				}
 				m.mu.Unlock()
 				if changed {
 					m.repointBox()
@@ -1723,6 +1808,7 @@ func (m *Manager) volumeStream(ctx context.Context, url string) error {
 		case "metadata":
 			// Current track info for the desktop (and later box) display.
 			var md struct {
+				URI           string   `json:"uri"`
 				Name          string   `json:"name"`
 				ArtistNames   []string `json:"artist_names"`
 				AlbumCoverURL string   `json:"album_cover_url"`
@@ -1734,8 +1820,15 @@ func (m *Manager) volumeStream(ctx context.Context, url string) error {
 			m.curName = md.Name
 			m.curArtist = strings.Join(md.ArtistNames, ", ")
 			m.curCover = md.AlbumCoverURL
+			if md.URI != "" {
+				m.curTrackURI = md.URI
+			}
 			m.mu.Unlock()
 			m.notifyTrack()
+			// Remember this track as the resume point for its context, so a
+			// later default recall continues here instead of restarting the
+			// playlist (the events stream covers the no-desktop-app case).
+			m.noteResume()
 		case "volume":
 			if m.box == nil {
 				continue // no box client: metadata only, no volume mirror

--- a/internal/spotify/manager_test.go
+++ b/internal/spotify/manager_test.go
@@ -13,7 +13,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 // makeOggPage builds a minimal valid Ogg page (single segment, body < 255).
@@ -215,6 +217,206 @@ func TestCanRecall(t *testing.T) {
 	}
 	if !m2.CanRecall(ctx) {
 		t.Fatal("CanRecall should be true with a persisted credential even with no live session")
+	}
+}
+
+// recordedCall is one go-librespot API request the mock server saw.
+type recordedCall struct {
+	path string
+	body string
+}
+
+// mockLibrespot stands in for go-librespot's local HTTP API: it records every
+// POST and answers /status with a loaded track so waitContextLoaded returns
+// promptly. The returned cleanup closes the server.
+func mockLibrespot(t *testing.T) (m *Manager, calls *[]recordedCall, cleanup func()) {
+	t.Helper()
+	var mu sync.Mutex
+	var got []recordedCall
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/status" {
+			_, _ = w.Write([]byte(`{"username":"u","track":{"uri":"spotify:track:cur","name":"Cur"}}`))
+			return
+		}
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		got = append(got, recordedCall{path: r.URL.Path, body: string(b)})
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	mgr := New("", filepath.Join(t.TempDir(), "cfg"), "", nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	mgr.apiAddr = strings.TrimPrefix(ts.URL, "http://")
+	return mgr, &got, ts.Close
+}
+
+func pathsOf(calls []recordedCall) []string {
+	out := make([]string, len(calls))
+	for i, c := range calls {
+		out[i] = c.path
+	}
+	return out
+}
+
+func bodyForPath(calls []recordedCall, path string) (string, bool) {
+	for _, c := range calls {
+		if c.path == path {
+			return c.body, true
+		}
+	}
+	return "", false
+}
+
+// TestPlayDefaultResumesWithoutShuffle is the core fix (Patrick + Jens,
+// 2026-06-25): a default (non-shuffle) recall must (1) set shuffle OFF so the
+// remote next/prev walk the playlist in order, (2) NOT skip to a random track,
+// and (3) resume on the last-played track of that context via skip_to_uri.
+func TestPlayDefaultResumesWithoutShuffle(t *testing.T) {
+	m, calls, cleanup := mockLibrespot(t)
+	defer cleanup()
+	const ctxURI = "spotify:playlist:abc"
+	m.resume.note(ctxURI, "spotify:track:resume-here")
+
+	if err := m.Play(context.Background(), ctxURI, PlayOptions{Shuffle: false}); err != nil {
+		t.Fatalf("Play: %v", err)
+	}
+
+	playBody, ok := bodyForPath(*calls, "/player/play")
+	if !ok {
+		t.Fatal("no /player/play call recorded")
+	}
+	if !strings.Contains(playBody, `"skip_to_uri":"spotify:track:resume-here"`) {
+		t.Errorf("default recall must resume via skip_to_uri, play body = %s", playBody)
+	}
+	shufBody, ok := bodyForPath(*calls, "/player/shuffle_context")
+	if !ok || !strings.Contains(shufBody, `"shuffle_context":false`) {
+		t.Errorf("default recall must set shuffle OFF, got %q ok=%v", shufBody, ok)
+	}
+	for _, p := range pathsOf(*calls) {
+		if p == "/player/next" {
+			t.Error("default recall must NOT skip to a random track (/player/next)")
+		}
+	}
+}
+
+// TestPlayShuffleStartsRandom verifies a shuffle preset still gets the random
+// start: shuffle ON + one /player/next, and it ignores any resume point.
+func TestPlayShuffleStartsRandom(t *testing.T) {
+	m, calls, cleanup := mockLibrespot(t)
+	defer cleanup()
+	const ctxURI = "spotify:playlist:abc"
+	m.resume.note(ctxURI, "spotify:track:ignored-when-shuffling")
+
+	if err := m.Play(context.Background(), ctxURI, PlayOptions{Shuffle: true}); err != nil {
+		t.Fatalf("Play: %v", err)
+	}
+
+	playBody, _ := bodyForPath(*calls, "/player/play")
+	if strings.Contains(playBody, "skip_to_uri") {
+		t.Errorf("shuffle recall must NOT resume a track, play body = %s", playBody)
+	}
+	shufBody, ok := bodyForPath(*calls, "/player/shuffle_context")
+	if !ok || !strings.Contains(shufBody, `"shuffle_context":true`) {
+		t.Errorf("shuffle recall must set shuffle ON, got %q ok=%v", shufBody, ok)
+	}
+	sawNext := false
+	for _, p := range pathsOf(*calls) {
+		if p == "/player/next" {
+			sawNext = true
+		}
+	}
+	if !sawNext {
+		t.Error("shuffle recall must skip once (/player/next) to land on a random track")
+	}
+}
+
+// TestNoteResumeContextTracking locks in the review fix (2026-06-25): Play must
+// point lastContext at the context it is loading (so noteResume never records a
+// track under a stale previous context), noteResume must suppress recording
+// while a recall is in flight, and record correctly once it settles.
+func TestNoteResumeContextTracking(t *testing.T) {
+	m, _, cleanup := mockLibrespot(t)
+	defer cleanup()
+	const ctxURI = "spotify:playlist:abc"
+
+	// Pre-set a different context as if a previous playlist had been playing.
+	m.mu.Lock()
+	m.lastContext = "spotify:playlist:OLD"
+	m.curTrackURI = "spotify:track:from-old-playlist"
+	m.mu.Unlock()
+
+	if err := m.Play(context.Background(), ctxURI, PlayOptions{Shuffle: false}); err != nil {
+		t.Fatalf("Play: %v", err)
+	}
+	// Play must retarget the resume context and drop the stale track.
+	m.mu.Lock()
+	gotCtx, gotTrack := m.lastContext, m.curTrackURI
+	m.mu.Unlock()
+	if gotCtx != ctxURI {
+		t.Errorf("Play must set lastContext to the loaded context, got %q", gotCtx)
+	}
+	if gotTrack != "" {
+		t.Errorf("Play must clear the stale curTrackURI, got %q", gotTrack)
+	}
+
+	// Still inside the recall window: noteResume must not record anything.
+	m.mu.Lock()
+	m.curTrackURI = "spotify:track:settling"
+	m.mu.Unlock()
+	m.noteResume()
+	if got := m.resume.trackFor(ctxURI); got != "" {
+		t.Errorf("noteResume must not record during a recall, got %q", got)
+	}
+
+	// Recall window over: the now-stable track records under the right context.
+	m.mu.Lock()
+	m.recallUntil = time.Time{}
+	m.curTrackURI = "spotify:track:playing-now"
+	m.mu.Unlock()
+	m.noteResume()
+	if got := m.resume.trackFor(ctxURI); got != "spotify:track:playing-now" {
+		t.Errorf("noteResume after the recall window = %q, want spotify:track:playing-now", got)
+	}
+}
+
+// TestResumeStore covers the per-context resume memory: it records the last
+// track per context, ignores non-spotify and unchanged values, evicts the
+// least-recently-used beyond the cap, and round-trips through NAND.
+func TestResumeStore(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sp-resume.json")
+	s := newResumeStore(path, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	s.note("spotify:playlist:a", "spotify:track:1")
+	if got := s.trackFor("spotify:playlist:a"); got != "spotify:track:1" {
+		t.Fatalf("trackFor = %q, want spotify:track:1", got)
+	}
+	// Non-spotify URIs are ignored.
+	s.note("http://x", "spotify:track:9")
+	s.note("spotify:playlist:b", "not-a-uri")
+	if s.trackFor("http://x") != "" || s.trackFor("spotify:playlist:b") != "" {
+		t.Error("resume store must ignore non-spotify context/track URIs")
+	}
+	// Update to a new track on the same context.
+	s.note("spotify:playlist:a", "spotify:track:2")
+	if got := s.trackFor("spotify:playlist:a"); got != "spotify:track:2" {
+		t.Fatalf("trackFor after update = %q, want spotify:track:2", got)
+	}
+
+	// Eviction: fill past the cap; the oldest, untouched context drops out.
+	s2 := newResumeStore(filepath.Join(t.TempDir(), "r.json"), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	first := "spotify:playlist:keep0"
+	s2.note(first, "spotify:track:x")
+	for i := 0; i < resumeMaxContexts+5; i++ {
+		s2.note("spotify:playlist:c"+string(rune('a'+i%26))+string(rune('a'+i/26)), "spotify:track:y")
+	}
+	if s2.trackFor(first) != "" {
+		t.Error("oldest context should have been evicted past the cap")
+	}
+
+	// Persistence round-trips through NAND.
+	s.flush()
+	reloaded := newResumeStore(path, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if got := reloaded.trackFor("spotify:playlist:a"); got != "spotify:track:2" {
+		t.Fatalf("reloaded trackFor = %q, want spotify:track:2", got)
 	}
 }
 

--- a/internal/spotify/resume.go
+++ b/internal/spotify/resume.go
@@ -1,0 +1,158 @@
+package spotify
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// resumeStore remembers, per Spotify context (a playlist or album URI), the
+// last track that played from it, so a later default (non-shuffle) preset
+// recall can continue on that track instead of restarting the context at its
+// first song. This is the "continue where you left off" behaviour a real
+// Spotify Connect device has. It is best-effort: a missing or stale entry just
+// falls back to starting the context from the top (go-librespot ignores a
+// skip_to_uri that is no longer in the context).
+//
+// Persistence is a small JSON map on NAND, written atomically and debounced (at
+// most once per resumeFlushEvery, and only when something changed) so flash
+// wear stays low; in practice a track changes only every few minutes. The map
+// is capped to resumeMaxContexts most-recently-touched contexts so a user with
+// many playlists cannot grow the file without bound.
+type resumeStore struct {
+	path   string
+	logger *slog.Logger
+
+	mu    sync.Mutex
+	track map[string]string // context URI -> last track URI
+	order []string          // LRU, most-recently touched last
+	dirty bool
+}
+
+const (
+	resumeMaxContexts = 64
+	resumeFlushEvery  = 30 * time.Second
+)
+
+// newResumeStore loads any persisted map from path (best-effort) and returns a
+// store ready to note/query. A path of "" disables persistence (the in-memory
+// map still works, used by tests).
+func newResumeStore(path string, logger *slog.Logger) *resumeStore {
+	s := &resumeStore{path: path, logger: logger, track: map[string]string{}}
+	s.load()
+	return s
+}
+
+func (s *resumeStore) load() {
+	if s.path == "" {
+		return
+	}
+	b, err := os.ReadFile(s.path)
+	if err != nil {
+		return
+	}
+	var m map[string]string
+	if json.Unmarshal(b, &m) != nil || m == nil {
+		return
+	}
+	s.mu.Lock()
+	s.track = m
+	for k := range m {
+		s.order = append(s.order, k)
+	}
+	s.mu.Unlock()
+}
+
+// note records that trackURI is the current track of contextURI. It is a no-op
+// unless both are spotify: URIs, and does not mark the store dirty when the
+// track is unchanged, so a repeated poll of the same track never churns NAND.
+func (s *resumeStore) note(contextURI, trackURI string) {
+	if !strings.HasPrefix(contextURI, "spotify:") || !strings.HasPrefix(trackURI, "spotify:") {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.track[contextURI] == trackURI {
+		s.touch(contextURI) // keep an active context from being evicted
+		return
+	}
+	s.track[contextURI] = trackURI
+	s.touch(contextURI)
+	s.evict()
+	s.dirty = true
+}
+
+// touch moves ctx to the most-recent end of the LRU order. Caller holds mu.
+func (s *resumeStore) touch(ctx string) {
+	for i, c := range s.order {
+		if c == ctx {
+			s.order = append(s.order[:i], s.order[i+1:]...)
+			break
+		}
+	}
+	s.order = append(s.order, ctx)
+}
+
+// evict drops the least-recently-touched contexts beyond the cap. Caller holds mu.
+func (s *resumeStore) evict() {
+	for len(s.order) > resumeMaxContexts {
+		old := s.order[0]
+		s.order = s.order[1:]
+		delete(s.track, old)
+	}
+}
+
+// trackFor returns the remembered last track URI for a context, or "".
+func (s *resumeStore) trackFor(contextURI string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.track[contextURI]
+}
+
+// run flushes the store to NAND on a slow tick whenever it changed, plus once
+// on shutdown, until ctx ends. A single debounced writer keeps flash wear low.
+func (s *resumeStore) run(ctx context.Context) {
+	if s.path == "" {
+		return
+	}
+	t := time.NewTicker(resumeFlushEvery)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			s.flush()
+			return
+		case <-t.C:
+			s.flush()
+		}
+	}
+}
+
+// flush writes the map to NAND atomically (temp + rename) when dirty, so a power
+// loss mid-write cannot leave a torn JSON file (the box loses power abruptly).
+func (s *resumeStore) flush() {
+	s.mu.Lock()
+	if !s.dirty {
+		s.mu.Unlock()
+		return
+	}
+	b, err := json.Marshal(s.track)
+	s.dirty = false
+	s.mu.Unlock()
+	if err != nil || s.path == "" {
+		return
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		s.logger.Debug("spotify: resume store write failed", "err", err)
+		return
+	}
+	if err := os.Rename(tmp, s.path); err != nil {
+		s.logger.Debug("spotify: resume store rename failed", "err", err)
+		_ = os.Remove(tmp) // don't orphan the temp file on NAND
+	}
+}

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -81,7 +81,8 @@ type Server struct {
 	// the username the preset was saved under; an empty account plays with
 	// go-librespot's current login (see manager PlayAccount / SwitchAccount).
 	// nil when Spotify is not configured. Injected as a func for decoupling.
-	spotifyPlay func(ctx context.Context, uri, account string) error
+	// shuffle selects a fresh random start vs the default resume-where-left-off.
+	spotifyPlay func(ctx context.Context, uri, account string, shuffle bool) error
 	// spotifyUser returns go-librespot's currently logged-in account, used to
 	// stamp the account onto a newly saved Spotify preset. nil when Spotify
 	// is not configured.
@@ -434,8 +435,9 @@ func WithSpotifyInfo(h http.HandlerFunc) Option {
 
 // WithSpotifyControl registers the function that starts playback of a
 // Spotify URI on a given account in go-librespot (the Spotify-preset
-// control plane). An empty account plays with the current login.
-func WithSpotifyControl(play func(ctx context.Context, uri, account string) error) Option {
+// control plane). An empty account plays with the current login; shuffle
+// selects a fresh random start over the default resume-where-left-off.
+func WithSpotifyControl(play func(ctx context.Context, uri, account string, shuffle bool) error) Option {
 	return func(s *Server) { s.spotifyPlay = play }
 }
 
@@ -1298,7 +1300,7 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 		}
 		s.setLastPlay(slotURL, p.Name, p.Art, "audio/ogg")
 		s.recentNoteCard("spotify", p.URI, p.Name, p.Art, p.URI, p.Account, "") // #135
-		uri, name, art, account := p.URI, p.Name, p.Art, p.Account
+		uri, name, art, account, shuffle := p.URI, p.Name, p.Art, p.Account, p.Shuffle
 		go func() {
 			bg := context.Background()
 			if s.spotifyReady != nil && !s.spotifyReady() {
@@ -1307,7 +1309,7 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 					time.Sleep(500 * time.Millisecond)
 				}
 			}
-			if err := s.spotifyPlay(bg, uri, account); err != nil {
+			if err := s.spotifyPlay(bg, uri, account, shuffle); err != nil {
 				s.logger.Warn("spotify play (initial) failed, will verify+retry", "slot", slot, "err", err)
 			}
 			s.verifyRecall(func(ctx context.Context, lastAttempt bool) {
@@ -1319,7 +1321,7 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 				// Only the last attempt does a full re-Play, to recover a genuine
 				// cold-boot auth race where the playlist never loaded at all.
 				if lastAttempt {
-					_ = s.spotifyPlay(ctx, uri, account)
+					_ = s.spotifyPlay(ctx, uri, account, shuffle)
 				}
 				_ = s.renderer.PlayURLMime(ctx, slotURL, name, art, "audio/ogg")
 			}, s.spotifyStreaming)


### PR DESCRIPTION
## What

Recalling a saved Spotify playlist preset used to force shuffle on and skip to
a random track on every press, and never turned shuffle off again, so the
speaker's remote next/prev key then jumped around a still-shuffled queue.

Recall now behaves like a Spotify Connect device:

- A default preset resumes the playlist on the track you last heard (via
  go-librespot `skip_to_uri`) and keeps shuffle off, so the remote walks the
  playlist in order.
- The last-played track per playlist/album is remembered on the speaker
  (`sp-resume.json`, debounced atomic write, LRU-capped), fed from the
  go-librespot `/status` and `metadata` events (both now read `track.uri`).
- Shuffle is driven by the preset's `shuffle` flag (default off) and honoured
  end to end on both the hardware-button and the app recall paths; a shuffle
  preset still starts on a fresh random track.

## Why

Two user-reported symptoms, one root cause (the forced shuffle in
`Manager.Play`): presets started on a random song every press, and the remote
next key jumped around instead of following the playlist.

## Fork

No go-librespot fork change needed: `skip_to_uri` + `shuffle_context` already
cover track-level resume. Mid-track (second-accurate) resume stays out of scope
because the Ogg passthrough source only supports restart-to-0.

## Testing

- New unit tests: recall call-sequence (resume vs shuffle) against a mock
  go-librespot, resume-store behaviour, and the context-tracking review fix.
- `go test ./internal/spotify/...`, `gofmt`, and `GOOS=linux GOARCH=arm` build
  + vet all green. Not yet verified on hardware.

## Follow-up (proposal, not in this PR)

A per-preset shuffle toggle in the save UI (backend already honours the flag;
needs a UI control + Wails binding arg + i18n in all locales).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
