### PR TITLE
ci(release): scan release binaries with VirusTotal and link the report

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -788,6 +788,10 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+    # Job-level so the VirusTotal step can gate its `if` on the secret being
+    # present (a step's own env block is not reliably visible to its own `if`).
+    env:
+      VT_API_KEY: ${{ secrets.VT_API_KEY }}
 
     steps:
       - name: Checkout
@@ -1044,6 +1048,32 @@ jobs:
           generate_release_notes: false
           draft: false
           prerelease: false
+
+      - name: VirusTotal scan (append analysis links to the release)
+        # Upload the published desktop binaries to VirusTotal and append the
+        # per-file analysis links to the release notes, so every release carries
+        # a current, third-party scan. The Windows/macOS apps are unsigned (code
+        # signing is post-1.0), which triggers heuristic false-positives in some
+        # engines; a public VirusTotal link per release is the rebuttal a user
+        # can check, and the per-release history shows when a detection appears.
+        # Skipped automatically when the VT_API_KEY secret is absent (forks, the
+        # weekly dry-run), and never fails an already-published release.
+        if: |
+          (startsWith(github.ref, 'refs/tags/') ||
+           (github.event_name == 'workflow_dispatch' && github.event.inputs.version != '')) &&
+          env.VT_API_KEY != ''
+        continue-on-error: true
+        uses: crazy-max/ghaction-virustotal@936d8c5c00afe97d3d9a1af26d017cfdf26800a2 # v5.0.0
+        with:
+          vt_api_key: ${{ secrets.VT_API_KEY }}
+          update_release_body: true
+          # Free public API allows 4 lookups/minute; stay within it.
+          request_rate: 4
+          files: |
+            dist/STR-Windows-*.exe
+            dist/STR-Windows-*.zip
+            dist/STR-macOS-*.dmg
+            dist/STR-Linux-x64-*.tar.gz
 
       # Releases created via the default GITHUB_TOKEN deliberately do
       # NOT fire `release: published` workflow triggers downstream — a


### PR DESCRIPTION
## What

Each published release now runs its desktop binaries through VirusTotal and
appends the per-file analysis links to the GitHub Release notes.

## Why

The Windows and macOS apps are not code-signed yet (post-1.0), so some
antivirus engines raise a heuristic false-positive on the unsigned binaries
(a user report on v0.8.27). A public VirusTotal link in every release gives
users a checkable third-party scan, and the per-release history makes it
obvious the moment a detection starts (so a regression can be pinned to a
specific release).

## How

- New step in the `release` job, after the GitHub Release is published, using
  `crazy-max/ghaction-virustotal` (pinned by SHA).
- Runs only on a real release (tag push or a dispatch with a version) and is
  skipped automatically when the `VT_API_KEY` secret is absent (forks and the
  weekly dry-run), via a job-level env gate.
- `continue-on-error: true` so a VirusTotal API hiccup never fails an
  already-published release.
- `request_rate: 4` to stay within the free public API limit.

## Action required before this helps

Add a repository secret **`VT_API_KEY`** (a free virustotal.com API key). Until
then the step no-ops cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
