### PR TITLE
ci(release): VirusTotal integration, scan link in the notes + detection gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -987,6 +987,57 @@ jobs:
             dist/STR-macOS-*.dmg
             dist/STR-Linux-x64-*.tar.gz
 
+      - name: VirusTotal gate (stop the release on heavy detection)
+        # Waits for the scans of the just-uploaded desktop apps to complete and
+        # stops the release if an artifact is flagged by too many engines. The
+        # apps are unsigned (code signing is post-1.0), so a handful of heuristic
+        # false-positives is normal and must NOT block a release; only a broad
+        # detection (>= 10 engines OR >= 15% of them calling it malicious) does.
+        # If VirusTotal does not finish in the time budget we proceed and warn,
+        # so a VT outage never holds a release hostage. Skipped without VT_API_KEY.
+        if: |
+          (startsWith(github.ref, 'refs/tags/') ||
+           (github.event_name == 'workflow_dispatch' && github.event.inputs.version != '')) &&
+          env.VT_API_KEY != ''
+        working-directory: dist
+        env:
+          VERSION: ${{ needs.build-agent.outputs.version }}
+        run: |
+          set -u
+          THRESHOLD=10   # fail if at least this many engines call it malicious
+          RATIO_PCT=15   # ...or at least this percent of all engines do
+          DEADLINE=$(( $(date +%s) + 360 ))  # ~6 min for the scans to finish
+          fail=0
+          for f in "STR-Windows-${VERSION}.exe" "STR-macOS-${VERSION}.dmg" "STR-Linux-x64-${VERSION}.tar.gz"; do
+            sha=$(awk -v n="$f" '$2==n{print $1}' SHA256SUMS)
+            if [ -z "$sha" ]; then echo "::warning::no SHA256 for $f, not gating it"; continue; fi
+            mal=""; total=""
+            while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+              resp=$(curl -s -H "x-apikey: $VT_API_KEY" "https://www.virustotal.com/api/v3/files/$sha" || true)
+              if printf '%s' "$resp" | jq -e '.data.attributes.last_analysis_stats' >/dev/null 2>&1; then
+                mal=$(printf '%s' "$resp" | jq -r '.data.attributes.last_analysis_stats.malicious // 0')
+                total=$(printf '%s' "$resp" | jq -r '[.data.attributes.last_analysis_stats[]] | add')
+                break
+              fi
+              sleep 20
+            done
+            if [ -z "$mal" ]; then
+              echo "::warning::VirusTotal scan for $f did not finish in time; releasing without gating it"
+              continue
+            fi
+            pct=0; if [ "${total:-0}" -gt 0 ]; then pct=$(( mal * 100 / total )); fi
+            echo "$f: $mal/$total engines malicious (${pct}%)"
+            if [ "$mal" -ge "$THRESHOLD" ] || [ "$pct" -ge "$RATIO_PCT" ]; then
+              echo "::error::$f is flagged malicious by $mal of $total engines (${pct}%), above the gate"
+              fail=1
+            fi
+          done
+          if [ "$fail" = 1 ]; then
+            echo "::error::VirusTotal gate: a release artifact is flagged above the threshold. Release stopped, investigate the report before retrying."
+            exit 1
+          fi
+          echo "VirusTotal gate passed (unsigned-app heuristic false-positives are below the threshold)."
+
       - name: Generate release notes
         working-directory: dist
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -958,6 +958,35 @@ jobs:
         with:
           subject-path: dist/manifest.json
 
+      - name: VirusTotal scan (upload binaries)
+        # Upload the desktop binaries to VirusTotal so each release's hash is
+        # known to VT. We do NOT use the action's update_release_body: it only
+        # works on a `release` event, and this pipeline publishes via a tag push
+        # (the release is created later in this same job), so there is no release
+        # object for it to edit. Instead the notes step below links to the
+        # permanent per-hash report (virustotal.com/gui/file/<sha256>), which is
+        # also what the website renders from manifest.json's sha256. The
+        # unsigned Windows/macOS apps draw heuristic false-positives in some
+        # engines, so a public scan link per release is the rebuttal a user can
+        # check. Runs before the notes so the links resolve at publish time.
+        # Skipped automatically when VT_API_KEY is absent (forks, dry-run), and
+        # never fails the release.
+        if: |
+          (startsWith(github.ref, 'refs/tags/') ||
+           (github.event_name == 'workflow_dispatch' && github.event.inputs.version != '')) &&
+          env.VT_API_KEY != ''
+        continue-on-error: true
+        uses: crazy-max/ghaction-virustotal@936d8c5c00afe97d3d9a1af26d017cfdf26800a2 # v5.0.0
+        with:
+          vt_api_key: ${{ secrets.VT_API_KEY }}
+          update_release_body: false
+          # Free public API allows 4 lookups/minute; stay within it.
+          request_rate: 4
+          files: |
+            dist/STR-Windows-*.exe
+            dist/STR-macOS-*.dmg
+            dist/STR-Linux-x64-*.tar.gz
+
       - name: Generate release notes
         working-directory: dist
         env:
@@ -1013,6 +1042,24 @@ jobs:
 
           Windows installers are not signed with an EV certificate yet; SmartScreen may warn on first download. macOS builds are not notarized yet; Gatekeeper may warn. Both are tracked under post-1.0 in CLAUDE.md.
           MD
+          # VirusTotal: linked to the permanent per-hash report so it survives and
+          # matches what the website renders from manifest.json's sha256. Only when
+          # VT_API_KEY is set (the upload step above ran), else the links would 404.
+          if [ -n "${VT_API_KEY}" ]; then
+            wsha=$(awk -v f="STR-Windows-${VERSION}.exe" '$2==f{print $1}' SHA256SUMS)
+            msha=$(awk -v f="STR-macOS-${VERSION}.dmg" '$2==f{print $1}' SHA256SUMS)
+            lsha=$(awk -v f="STR-Linux-x64-${VERSION}.tar.gz" '$2==f{print $1}' SHA256SUMS)
+            echo
+            echo "### VirusTotal scan"
+            echo
+            echo "Each binary in this release is uploaded to VirusTotal on build, so the unsigned apps' heuristic false-positives are checkable. Live reports for this exact build:"
+            echo
+            echo "| Platform | Report |"
+            echo "|---|---|"
+            [ -n "$wsha" ] && echo "| Windows | [VirusTotal](https://www.virustotal.com/gui/file/$wsha) |"
+            [ -n "$msha" ] && echo "| macOS | [VirusTotal](https://www.virustotal.com/gui/file/$msha) |"
+            [ -n "$lsha" ] && echo "| Linux | [VirusTotal](https://www.virustotal.com/gui/file/$lsha) |"
+          fi
           } > release-notes.md
           cat release-notes.md
 
@@ -1048,32 +1095,6 @@ jobs:
           generate_release_notes: false
           draft: false
           prerelease: false
-
-      - name: VirusTotal scan (append analysis links to the release)
-        # Upload the published desktop binaries to VirusTotal and append the
-        # per-file analysis links to the release notes, so every release carries
-        # a current, third-party scan. The Windows/macOS apps are unsigned (code
-        # signing is post-1.0), which triggers heuristic false-positives in some
-        # engines; a public VirusTotal link per release is the rebuttal a user
-        # can check, and the per-release history shows when a detection appears.
-        # Skipped automatically when the VT_API_KEY secret is absent (forks, the
-        # weekly dry-run), and never fails an already-published release.
-        if: |
-          (startsWith(github.ref, 'refs/tags/') ||
-           (github.event_name == 'workflow_dispatch' && github.event.inputs.version != '')) &&
-          env.VT_API_KEY != ''
-        continue-on-error: true
-        uses: crazy-max/ghaction-virustotal@936d8c5c00afe97d3d9a1af26d017cfdf26800a2 # v5.0.0
-        with:
-          vt_api_key: ${{ secrets.VT_API_KEY }}
-          update_release_body: true
-          # Free public API allows 4 lookups/minute; stay within it.
-          request_rate: 4
-          files: |
-            dist/STR-Windows-*.exe
-            dist/STR-Windows-*.zip
-            dist/STR-macOS-*.dmg
-            dist/STR-Linux-x64-*.tar.gz
 
       # Releases created via the default GITHUB_TOKEN deliberately do
       # NOT fire `release: published` workflow triggers downstream — a


### PR DESCRIPTION
Two related fixes to the VirusTotal release integration:

**1. Scan link on the release page (tag-push fix).** The scan uploaded fine, but the action's `update_release_body` only fires on a `release` event; our tag-push pipeline creates the release later in the same job, so there was nothing to edit. Now the scan step uploads only (before the notes), and the notes link the permanent per-hash report `https://www.virustotal.com/gui/file/<sha256>` (the same recipe the website uses from manifest.json). Works on tag-push.

**2. Detection gate.** After upload, the pipeline waits for the scans and **stops the release** if an artifact is flagged malicious by **>= 10 engines or >= 15%** of them. Unsigned-app heuristic false-positives (a handful of engines) deliberately do NOT block; only a broad detection does. On a VT timeout (~6 min budget) it proceeds with a warning, so a VT outage never blocks a release.

Both gated on `VT_API_KEY` (skipped on forks / dry-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)