### PR TITLE
fix(update): updates no longer fail with "no space left" on a full speaker (ST30)

### DIFF
--- a/desktop-app/install_str.go
+++ b/desktop-app/install_str.go
@@ -593,6 +593,19 @@ func (a *App) RepairInstallViaSSH(host, model string) (InstallResult, error) {
 		return res, nil
 	}
 
+	// install.sh copied everything into /mnt/nv/streborn, so the ~28 MB staging
+	// dir is now pure leftover. Remove it before the reboot, otherwise it sits on
+	// the NAND forever and starves later OTA updates of the room they need for the
+	// atomic .new write: a stranded streborn-install filled a ST30 to 80% and
+	// every agent update then failed with "no space left on device" (#ST30
+	// Daniel). Best-effort: a cleanup failure must not fail an otherwise-good
+	// install (the boot-time cleanup_nand is the backstop).
+	if _, cerr := boxSSHOutput(host, "rm -rf "+stage, 20*time.Second); cerr != nil {
+		a.logger.Warn("repair_ssh: could not remove install staging dir; boot cleanup is the backstop", "host", host, "dir", stage, "err", cerr)
+	} else {
+		a.logger.Info("repair_ssh: removed install staging dir", "host", host, "dir", stage)
+	}
+
 	res.OK = true
 	res.Step = "reboot"
 	res.Message = "STR installed over SSH (USB stick bypassed). The speaker will reboot and join your Wi-Fi."

--- a/desktop-app/ota.go
+++ b/desktop-app/ota.go
@@ -283,6 +283,26 @@ func (a *App) stageSidecarBeforeReboot(host string, port int) {
 		a.recordOTA(host, "sidecar: box on a pre-sidecar agent, cannot stage over HTTP pre-reboot; will deliver after the box is on the new agent")
 		return
 	}
+	// Space gate (#ST30 Daniel). Staging the ~10 MB sidecar pre-reboot lands it
+	// on disk BEFORE the agent .new (~12 MB) is written, so on a tight box (e.g. a
+	// SoundTouch 30, ~31 MB NAND) the two second copies cannot coexist and the
+	// agent OTA then dies with "no space left on device". When the box cannot hold
+	// the agent AND the sidecar second copy together, skip the pre-reboot staging:
+	// the agent updates alone (it fits with the sidecar out of the way), and the
+	// post-OTA EnsureSpotifyEngine delivers the engine after the reboot, when the
+	// old agent's blocks have been reclaimed. Only a real, reported free figure
+	// gates this; an unknown free (older agent) keeps the previous behaviour.
+	if freeN, perr := strconv.ParseInt(ver["nandFreeBytes"], 10, 64); perr == nil && freeN > 0 {
+		agentLen := int64(len(agentbin.Bytes()))
+		sidecarLen := int64(len(agentbin.GoLibrespotBytes()))
+		const nandStageMargin = 2 * 1024 * 1024
+		if freeN < agentLen+sidecarLen+nandStageMargin {
+			a.recordOTA(host, fmt.Sprintf("sidecar: NAND tight (free=%dKB < agent %dKB + engine %dKB + margin), deferring the engine to the post-reboot delivery so the agent update fits", freeN/1024, agentLen/1024, sidecarLen/1024))
+			a.logger.Info("stageSidecarBeforeReboot: NAND too tight to stage the engine before the agent; deferring to post-OTA EnsureSpotifyEngine",
+				"host", host, "free", freeN, "agentLen", agentLen, "sidecarLen", sidecarLen)
+			return
+		}
+	}
 	for attempt := 1; attempt <= otaSidecarEnsureAttempts; attempt++ {
 		if _, err := a.pushSidecarIfNeeded(host, port); err == nil {
 			return
@@ -747,7 +767,15 @@ func (a *App) updateAgentViaSSH(host string, bin []byte) error {
 	// a freshly-installed box does not need a separate round-trip. The
 	// 120 s timeout covers a 10 MB upload over slow Wi-Fi with the
 	// speaker's modest CPU spending time on SSH crypto.
-	uploadCmd := "mkdir -p /mnt/nv/streborn/bin && cat > /mnt/nv/streborn/bin/streborn-armv7l.new"
+	// Pre-clean before staging the .new so the SSH path is a real rescue on a full
+	// box, not a second failure: drop a stranded SSH-repair staging dir (the ~28 MB
+	// streborn-install that filled a ST30, #ST30 Daniel) and the same regenerable
+	// junk the agent's reclaimNAND clears, then write the fresh temp. Mirrors
+	// reclaimNAND + run.sh cleanup_nand; the agent runs from streborn/bin so the
+	// staging dir is always safe to drop. Best-effort, folded into the one session.
+	uploadCmd := "rm -rf /mnt/nv/streborn-install /mnt/nv/streborn/streborn-install 2>/dev/null; " +
+		"rm -f /mnt/nv/sp-oauth.out /mnt/nv/streborn/cap*.ogg /mnt/nv/streborn/bin/*.new 2>/dev/null; " +
+		"mkdir -p /mnt/nv/streborn/bin && cat > /mnt/nv/streborn/bin/streborn-armv7l.new"
 	if out, err := boxSSHUploadStdin(host, uploadCmd, bytes.NewReader(bin), 120*time.Second); err != nil {
 		return fmt.Errorf("ssh upload (%d bytes) failed: %v (%s)", len(bin), err, strings.TrimSpace(out))
 	}

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -2642,7 +2643,7 @@ func (s *Server) handleAgentUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 	const dst = "/mnt/nv/streborn/bin/streborn-armv7l"
 	if err := writeBinaryAtomic(dst, body); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, err.Error(), nandWriteHTTPStatus(err))
 		return
 	}
 
@@ -2742,17 +2743,38 @@ func readUploadedELF(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
 // + foreign-firmware dirs) in the error so the desktop app surfaces it verbatim
 // and the user's report tells us whether the ST30 is genuinely tighter or is
 // carrying leftovers from a previous custom firmware.
+// errInsufficientNAND is returned by writeBinaryAtomic when, even after
+// reclaiming regenerable junk, the NAND cannot hold the second (.new) copy the
+// atomic write needs. The OTA handlers map it to 507 Insufficient Storage so the
+// desktop app can tell "the box is full" apart from a generic write failure and
+// show the inventory instead of a raw 500 after a full upload (#ST30 Daniel).
+var errInsufficientNAND = errors.New("insufficient NAND space")
+
+// nandWriteMargin is the slack required above the binary size before an atomic
+// write is attempted: filesystem overhead plus a cushion so a borderline write
+// does not ENOSPC mid-stream.
+const nandWriteMargin = 512 * 1024
+
 func writeBinaryAtomic(dst string, body []byte) error {
 	dir := filepath.Dir(dst)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("mkdir parent: %w", err)
 	}
 	tmp := dst + ".new"
-	// Drop a stale temp from an earlier interrupted OTA before the space check.
+	// Drop this target's stale temp, then proactively reclaim regenerable junk on
+	// EVERY OTA write (not only when already tight), so a previous failed
+	// attempt's leftovers, a stale OTHER-binary .new, or oversized logs never eat
+	// the headroom this write needs (#ST30 Daniel). reclaimNAND never touches Bose
+	// files or the live binaries.
 	_ = os.Remove(tmp)
+	reclaimNAND()
+	// Pre-flight space gate: re-check AFTER reclaim and refuse up front, rather
+	// than buffering the whole binary onto a full disk and ENOSPC'ing at the end.
+	// The error carries the NAND inventory so the app can show what is eating the
+	// space and what to free.
 	need := int64(len(body))
-	if _, avail, ok := diskFree(dir); ok && avail < need+512*1024 {
-		reclaimNAND()
+	if _, avail, ok := diskFree(dir); ok && avail < need+nandWriteMargin {
+		return fmt.Errorf("%w: need %dKB, have %dKB free [NAND %s]", errInsufficientNAND, need/1024, avail/1024, nandReportLine())
 	}
 	if err := os.WriteFile(tmp, body, 0o755); err != nil {
 		_ = os.Remove(tmp) // leave no partial behind for the next attempt
@@ -2763,6 +2785,16 @@ func writeBinaryAtomic(dst string, body []byte) error {
 		return fmt.Errorf("rename: %w [NAND %s]", err, nandReportLine())
 	}
 	return nil
+}
+
+// nandWriteHTTPStatus maps a writeBinaryAtomic error to an HTTP status: 507
+// Insufficient Storage when the box is out of NAND (so the desktop app can tell a
+// full box apart from a generic failure and surface the inventory), else 500.
+func nandWriteHTTPStatus(err error) int {
+	if errors.Is(err, errInsufficientNAND) {
+		return http.StatusInsufficientStorage
+	}
+	return http.StatusInternalServerError
 }
 
 // --- NAND disk diagnostics -------------------------------------------------
@@ -2929,6 +2961,13 @@ func reclaimNAND() {
 	}
 	_ = os.Remove(filepath.Join(strNANDDir, "agent.log.1"))
 	_ = os.Remove(filepath.Join(nandRoot, "sp-oauth.out"))
+	// Stranded SSH-repair staging dir: the desktop app stages the ~28 MB install
+	// file set into <base>/streborn-install and the install copies it into
+	// /mnt/nv/streborn, but an older app left the staging copy behind, filling the
+	// NAND so the next OTA's .new could not fit (#ST30 Daniel). The running agent
+	// never uses it (it runs from streborn/bin), so it is always safe to drop here.
+	_ = os.RemoveAll(filepath.Join(nandRoot, "streborn-install"))
+	_ = os.RemoveAll(filepath.Join(strNANDDir, "streborn-install"))
 	for _, name := range []string{"setup.log", "setup.log.prev", "agent.log", "previous.log", "boot.log"} {
 		p := filepath.Join(strNANDDir, name)
 		if fi, err := os.Stat(p); err == nil && fi.Size() > 131072 {
@@ -2955,7 +2994,7 @@ func (s *Server) handleAgentSidecar(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := writeBinaryAtomic(goLibrespotBinPath, body); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, err.Error(), nandWriteHTTPStatus(err))
 		return
 	}
 	// Stamp the content hash next to the binary so the next /api/agent/version

--- a/usb-stick/install.sh
+++ b/usb-stick/install.sh
@@ -49,6 +49,16 @@ phase1_install() {
         echo "Phase 2 is active, removing it first"
         phase2_remove
     fi
+    # Free a stranded SSH-repair staging dir and known regenerable junk before
+    # copying, so a re-install on a tight NAND has room. A leftover
+    # streborn-install (the ~28 MB SSH-repair staging set) filled a ST30 to 80%
+    # so every OTA then failed with "no space left on device" (#ST30). Never
+    # remove our own source ($STICK): on the SSH-repair path STR_STICK IS the
+    # streborn-install staging dir.
+    for d in /mnt/nv/streborn-install /mnt/nv/streborn/streborn-install; do
+        [ "$d" = "$STICK" ] || rm -rf "$d" 2>/dev/null
+    done
+    rm -f /mnt/nv/sp-oauth.out /mnt/nv/streborn/cap*.ogg /mnt/nv/streborn/bin/*.new 2>/dev/null
     echo "Copying $RC_SRC to $RC_DST"
     cp "$RC_SRC" "$RC_DST" || { echo "ERROR while copying" >&2; exit 1; }
     chmod +x "$RC_DST"

--- a/usb-stick/run.sh
+++ b/usb-stick/run.sh
@@ -603,6 +603,13 @@ cleanup_nand() {
     rm -f /mnt/nv/streborn/cap*.ogg "$STICK"/cap*.ogg 2>/dev/null
     rm -f /mnt/nv/streborn/bin/*.new 2>/dev/null
 
+    #    streborn-install: the SSH-repair install stages the ~28 MB file set into
+    #    <base>/streborn-install, and install.sh copies it into /mnt/nv/streborn,
+    #    but an older app left the staging copy behind. It filled a ST30 to 80% so
+    #    the next OTA could not write its .new (#ST30). The running agent never
+    #    uses it (it runs from streborn/bin), so it is always safe to drop on boot.
+    rm -rf /mnt/nv/streborn-install /mnt/nv/streborn/streborn-install 2>/dev/null
+
     # 2) Log caps. The agent rotates agent.log -> agent.log.1 at 1 MiB, so the
     #    pair can hold ~2 MiB; drop the rotated backup and trim any oversized
     #    log to its tail. setup.log is now per-boot-rotated at the top of run.sh,


### PR DESCRIPTION
ST30 reached 80% full NAND; every agent update failed with "no space left on device". Root causes (confirmed by Daniel's `df`/`du`):

1. **Stranded ~28 MB `streborn-install` staging folder.** The SSH repair stages the install set into `/mnt/nv/streborn-install`, runs `install.sh` from it (copies into `/mnt/nv/streborn`), then never removed the staging copy. Now cleaned in **every** path: after the SSH repair (`install_str.go`), on boot (`run.sh` cleanup_nand), at the start of a stick re-install (`install.sh`), the agent's `reclaimNAND` on each OTA write, and the SSH-OTA fallback pre-clean. The running agent runs from `streborn/bin`, so it is always safe to drop.
2. **Engine staged before the agent.** The ~10 MB sidecar landed before the ~12 MB agent `.new`; on a tight box the two second copies cannot coexist. When the box cannot hold both, the engine is deferred to the post-reboot `EnsureSpotifyEngine` delivery.

Plus: `reclaimNAND` now runs on every OTA write, and a pre-flight space gate returns 507 + the NAND inventory instead of a raw 500 after a full upload.

Agent cross-compiles, desktop builds, tests green, scripts shellcheck/bash -n clean (LF preserved).

Refs #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)