### PR TITLE
fix(library): open music folders whose file tags contain invalid characters (#262)

### DIFF
--- a/dlna/dlna.go
+++ b/dlna/dlna.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 )
 
 const (
@@ -542,7 +543,46 @@ type didlR struct {
 	Value        string `xml:",chardata"`
 }
 
+// stripIllegalXMLChars drops bytes/runes that are not valid characters in XML
+// 1.0, keeping tab, newline and carriage return. DLNA servers that surface ID3
+// metadata verbatim can leak control characters into their SOAP/DIDL responses
+// (#262); Go's xml parser then rejects the entire document. Removing only the
+// offending characters preserves the rest of the listing. Invalid UTF-8 is left
+// as the replacement rune (U+FFFD), which is itself valid XML.
+func stripIllegalXMLChars(b []byte) []byte {
+	if utf8.Valid(b) && !hasIllegalXMLByte(b) {
+		return b // common case: nothing to strip, no copy
+	}
+	out := make([]byte, 0, len(b))
+	for _, r := range string(b) {
+		if r == 0x09 || r == 0x0A || r == 0x0D ||
+			(r >= 0x20 && r <= 0xD7FF) ||
+			(r >= 0xE000 && r <= 0xFFFD) ||
+			(r >= 0x10000 && r <= 0x10FFFF) {
+			out = utf8.AppendRune(out, r)
+		}
+	}
+	return out
+}
+
+// hasIllegalXMLByte is a cheap scan for the ASCII control bytes that are illegal
+// in XML 1.0, so the all-valid common case avoids a full rune walk + copy.
+func hasIllegalXMLByte(b []byte) bool {
+	for _, c := range b {
+		if c < 0x20 && c != 0x09 && c != 0x0A && c != 0x0D {
+			return true
+		}
+	}
+	return false
+}
+
 func parseBrowseResponse(raw []byte) (BrowseResult, error) {
+	// Some DLNA servers embed raw control characters (e.g. U+0001 out of an ID3
+	// comment or genre tag) into the metadata they return, which makes Go's strict
+	// XML parser reject the WHOLE response ("illegal character code U+0001", #262).
+	// Strip the characters that are illegal in XML 1.0 so the rest of the library
+	// listing still parses, instead of failing the entire folder.
+	raw = stripIllegalXMLChars(raw)
 	var env soapBrowseEnvelope
 	if err := xml.Unmarshal(raw, &env); err != nil {
 		return BrowseResult{}, fmt.Errorf("soap envelope: %w", err)
@@ -555,7 +595,9 @@ func parseBrowseResponse(raw []byte) (BrowseResult, error) {
 		}, nil
 	}
 	var didl didlLite
-	if err := xml.Unmarshal([]byte(res), &didl); err != nil {
+	// The DIDL-Lite inside <Result> can carry the same bad characters once it is
+	// un-escaped, so sanitise it too before the second parse.
+	if err := xml.Unmarshal(stripIllegalXMLChars([]byte(res)), &didl); err != nil {
 		return BrowseResult{}, fmt.Errorf("didl-lite: %w", err)
 	}
 	out := BrowseResult{

--- a/dlna/dlna_test.go
+++ b/dlna/dlna_test.go
@@ -40,3 +40,38 @@ func TestPickPlayableRes(t *testing.T) {
 		t.Errorf("empty: want zero res, got %q", got.Value)
 	}
 }
+
+// TestParseBrowseResponse_StripsIllegalXMLChars guards #262: a DLNA server that
+// surfaced an ID3 comment/genre with a raw U+0001 control character made the
+// strict XML parser reject the entire folder ("illegal character code U+0001").
+// The offending character must be stripped so the rest of the listing parses.
+func TestParseBrowseResponse_StripsIllegalXMLChars(t *testing.T) {
+	didl := "&lt;DIDL-Lite&gt;&lt;item id=\"1\" parentID=\"0\"&gt;&lt;title&gt;Song\x01 One&lt;/title&gt;" +
+		"&lt;class&gt;object.item.audioItem.musicTrack&lt;/class&gt;&lt;/item&gt;&lt;/DIDL-Lite&gt;"
+	soap := "<?xml version=\"1.0\"?>\n<Envelope><Body><BrowseResponse><Result>" + didl +
+		"</Result><NumberReturned>1</NumberReturned><TotalMatches>1</TotalMatches></BrowseResponse></Body></Envelope>"
+	res, err := parseBrowseResponse([]byte(soap))
+	if err != nil {
+		t.Fatalf("parseBrowseResponse must tolerate U+0001, got error: %v", err)
+	}
+	if len(res.Items) != 1 {
+		t.Fatalf("want 1 item, got %d", len(res.Items))
+	}
+	if res.Items[0].Title != "Song One" {
+		t.Errorf("title = %q, want %q (control char stripped)", res.Items[0].Title, "Song One")
+	}
+}
+
+func TestStripIllegalXMLChars(t *testing.T) {
+	for _, tc := range []struct{ name, in, want string }{
+		{"clean", "Hello World", "Hello World"},
+		{"keeps tab/newline/cr", "a\tb\nc\rd", "a\tb\nc\rd"},
+		{"drops U+0001", "Song\x01 One", "Song One"},
+		{"drops vertical tab and form feed", "a\x0Bb\x0Cc", "abc"},
+		{"keeps unicode", "Café é你", "Café é你"},
+	} {
+		if got := string(stripIllegalXMLChars([]byte(tc.in))); got != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Reported in #262: browsing a NAS folder failed with `soap envelope: XML syntax error ... illegal character code U+0001`. Some DLNA servers surface ID3 comment/genre fields verbatim, leaking control characters into the SOAP/DIDL response, which Go's XML parser rejects, killing the whole folder.

`parseBrowseResponse` now strips characters illegal in XML 1.0 (keeping tab/newline/CR) from both the SOAP envelope and the embedded DIDL-Lite before parsing, with a cheap fast-path for the clean common case. Regression + unit tests added.

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)