### PR TITLE
ci(release): wait for the VirusTotal scan to complete + name flagging engines

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1011,22 +1011,32 @@ jobs:
           for f in "STR-Windows-${VERSION}.exe" "STR-macOS-${VERSION}.dmg" "STR-Linux-x64-${VERSION}.tar.gz"; do
             sha=$(awk -v n="$f" '$2==n{print $1}' SHA256SUMS)
             if [ -z "$sha" ]; then echo "::warning::no SHA256 for $f, not gating it"; continue; fi
-            mal=""; total=""
+            mal=""; total=""; resp=""
             while [ "$(date +%s)" -lt "$DEADLINE" ]; do
               resp=$(curl -s -H "x-apikey: $VT_API_KEY" "https://www.virustotal.com/api/v3/files/$sha" || true)
-              if printf '%s' "$resp" | jq -e '.data.attributes.last_analysis_stats' >/dev/null 2>&1; then
+              # Wait for the scan to actually carry engine verdicts. A freshly
+              # uploaded file briefly reports an all-zero stats block (total 0)
+              # before engines report; breaking on that would pass the gate
+              # trivially and could miss a real detection (seen v0.8.30: 0/0).
+              total=$(printf '%s' "$resp" | jq -r '[.data.attributes.last_analysis_stats[]?] | add // 0' 2>/dev/null || echo 0)
+              if [ "${total:-0}" -gt 0 ]; then
                 mal=$(printf '%s' "$resp" | jq -r '.data.attributes.last_analysis_stats.malicious // 0')
-                total=$(printf '%s' "$resp" | jq -r '[.data.attributes.last_analysis_stats[]] | add')
                 break
               fi
               sleep 20
             done
             if [ -z "$mal" ]; then
-              echo "::warning::VirusTotal scan for $f did not finish in time; releasing without gating it"
+              echo "::warning::VirusTotal scan for $f did not complete in time; releasing without gating it"
               continue
             fi
             pct=0; if [ "${total:-0}" -gt 0 ]; then pct=$(( mal * 100 / total )); fi
             echo "$f: $mal/$total engines malicious (${pct}%)"
+            # Name the flagging engines + their detection names, so an unsigned-app
+            # heuristic false-positive can be reported to the vendor, and a real
+            # detection is identifiable at a glance instead of just a count.
+            if [ "${mal:-0}" -gt 0 ]; then
+              printf '%s' "$resp" | jq -r '.data.attributes.last_analysis_results | to_entries[] | select(.value.category=="malicious" or .value.category=="suspicious") | "    \(.value.category): \(.key) -> \(.value.result)"' 2>/dev/null || true
+            fi
             if [ "$mal" -ge "$THRESHOLD" ] || [ "$pct" -ge "$RATIO_PCT" ]; then
               echo "::error::$f is flagged malicious by $mal of $total engines (${pct}%), above the gate"
               fail=1


### PR DESCRIPTION
Two refinements to the detection gate:
- **Wait for a real verdict.** Poll until the scan has engine results (total > 0); a fresh upload briefly reports an all-zero stats block, which the old check passed trivially (v0.8.30 logged 0/0) and could have let a slow-reporting detection through.
- **Name the engines.** When an artifact is flagged, log each flagging engine + its detection name, so an unsigned-app false-positive can be reported to the vendor and a real hit is identifiable at a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)