### PR TITLE
fix(playback): keep the ST20 (scm) switched off after a power-off (#197)

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -444,6 +444,9 @@ func run() error {
 		// (scm) firmware that bounces UPNP<->STANDBY does not turn itself back on
 		// (#197). Zone-guarded and debounced in the webui.
 		onEnterStandby: webuiSrv.HandleEnterStandby,
+		// Let the hardware-recall verify stand down when the user powered the box
+		// off mid-recall, so it does not re-push the stream into a power-off (#197).
+		recentlyPoweredOff: webuiSrv.RecentlyPoweredOff,
 		// Surface the box's own presets (incl. foreign sources like Deezer) to the
 		// webui so the app can show/preserve them (Option C). Map boxws -> webui at
 		// the composition root to keep the two packages decoupled.
@@ -919,6 +922,13 @@ type presetWsHandler struct {
 	// oscillates UPNP<->STANDBY does not switch the speaker back on (#197). Wired to
 	// webui.HandleEnterStandby, which is zone-guarded and debounced. nil-safe.
 	onEnterStandby func()
+	// recentlyPoweredOff reports whether STR saw this box drop UPNP->STANDBY within
+	// the bounce window. The hardware-preset recall verify (verifyPlayURL) checks it
+	// so it does NOT re-push the stream when the user powered the box off mid-recall
+	// (the box reads "not playing" because it is in standby), which on scm ST20
+	// firmware switched the speaker back on (#197). Wired to webui.RecentlyPoweredOff.
+	// nil-safe.
+	recentlyPoweredOff func() bool
 	// noteBoxPresets records the box's OWN preset list (gabbo presetsUpdated),
 	// including foreign sources like Deezer that STR did not set, into the webui
 	// so the app can show and preserve them (Option C). Wired to
@@ -1428,6 +1438,16 @@ func (h *presetWsHandler) verifyPlayURL(slot int, url, name, icon string) {
 		if boxIsPlaying(h.boxHost) {
 			return
 		}
+		// The user powered the box off during the recall: the box reads "not
+		// playing" only because it is in standby. Re-pushing here re-arms the
+		// transport the power-off cleared, which on scm ST20 firmware bounces the
+		// speaker back on (#197, the "start via preset then power off" trigger). A
+		// genuine deep-standby wake (#183) carries no recent power-off, so the
+		// legitimate retry still runs.
+		if h.recentlyPoweredOff != nil && h.recentlyPoweredOff() {
+			h.logger.Info("hardware recall: box powered off mid-recall, not re-pushing (#197)", "slot", slot)
+			return
+		}
 		h.logger.Warn("hardware recall not playing yet, retrying", "slot", slot, "attempt", attempt)
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		_ = h.renderer.PlayURL(ctx, url, name, icon)
@@ -1449,6 +1469,12 @@ func (h *presetWsHandler) verifySpotifyPlaying(slot int, p presets.Preset) {
 		// re-attaches and restarts the track). boxPlayingSpotify keys off the
 		// now_playing location, so it is true only when Spotify really plays.
 		if h.spotify.Streaming() || boxPlayingSpotify(h.boxHost) {
+			return
+		}
+		// Stand down if the user powered the box off mid-recall, so the re-point
+		// below does not re-wake a box the user just switched off (#197).
+		if h.recentlyPoweredOff != nil && h.recentlyPoweredOff() {
+			h.logger.Info("spotify recall: box powered off mid-recall, not re-pointing (#197)", "slot", slot)
 			return
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)

--- a/internal/upnp/upnp.go
+++ b/internal/upnp/upnp.go
@@ -52,6 +52,16 @@ func (r *Renderer) SetURI(ctx context.Context, streamURL, metaTitle, iconURL str
 	return r.soapCall(ctx, "SetAVTransportURI", body)
 }
 
+// ClearURI removes any loaded stream by setting an empty AVTransport URI. A plain
+// Stop is not enough on scm ST20 firmware that oscillates UPNP<->STANDBY on a
+// power-off: the box re-selects STR's still-loaded URI the instant it leaves
+// STANDBY and switches itself back on (#197). Emptying the URI leaves the firmware
+// nothing to bounce back to.
+func (r *Renderer) ClearURI(ctx context.Context) error {
+	body := `<?xml version="1.0"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:SetAVTransportURI xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><CurrentURI></CurrentURI><CurrentURIMetaData></CurrentURIMetaData></u:SetAVTransportURI></s:Body></s:Envelope>`
+	return r.soapCall(ctx, "SetAVTransportURI", body)
+}
+
 // Play starts playback.
 func (r *Renderer) Play(ctx context.Context) error {
 	body := `<?xml version="1.0"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:Play xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><Speed>1</Speed></u:Play></s:Body></s:Envelope>`

--- a/internal/webui/standby_bounce_test.go
+++ b/internal/webui/standby_bounce_test.go
@@ -1,0 +1,38 @@
+package webui
+
+import (
+	"testing"
+	"time"
+)
+
+// TestStandbyStoppedRecently covers the discriminator ResumeLastPlay uses to tell
+// the scm power-off bounce (a DO_NOT_RESUME that follows a power-OFF, #197) from a
+// genuine power-on. HandleEnterStandby stamps lastStandbyStop when it clears the
+// transport; a DO_NOT_RESUME "wake" within standbyBounceWakeWindow of that stamp
+// is the bounce and must NOT resume.
+func TestStandbyStoppedRecently(t *testing.T) {
+	s := &Server{}
+
+	if s.standbyStoppedRecently() {
+		t.Fatal("no standby-stop recorded yet, want false")
+	}
+
+	// Mirrors HandleEnterStandby stamping the transport clear. The bounce's
+	// DO_NOT_RESUME wake fires ~200 ms later and ResumeLastPlay settles 2 s before
+	// it checks, so a stamp ~2 s old must still read as "recent".
+	s.standbyStopMu.Lock()
+	s.lastStandbyStop = time.Now().Add(-2 * time.Second)
+	s.standbyStopMu.Unlock()
+	if !s.standbyStoppedRecently() {
+		t.Fatal("standby-stop ~2s ago is within the bounce window, want true")
+	}
+
+	// A power-on long after a power-off (the overnight case the resume default is
+	// for) is past the window and must be allowed to resume.
+	s.standbyStopMu.Lock()
+	s.lastStandbyStop = time.Now().Add(-(standbyBounceWakeWindow + time.Second))
+	s.standbyStopMu.Unlock()
+	if s.standbyStoppedRecently() {
+		t.Fatal("standby-stop older than the bounce window, want false")
+	}
+}

--- a/internal/webui/standby_bounce_test.go
+++ b/internal/webui/standby_bounce_test.go
@@ -48,23 +48,14 @@ func TestNoteStandbyStopArmsSuppression(t *testing.T) {
 		t.Fatal("nothing armed yet, want both false")
 	}
 
-	// First flip of a burst: arms both signals and reports burstStart.
-	if !s.noteStandbyStop() {
-		t.Fatal("first standby-stop is the start of a burst, want true")
-	}
+	// A power-off arms BOTH the standby-bounce window (ResumeLastPlay) and the
+	// user-stop (maybeRePush / RecoverAfterReconnect), regardless of the transport-
+	// clear path the caller takes afterward.
+	s.noteStandbyStop()
 	if !s.standbyStoppedRecently() {
 		t.Fatal("standby-bounce window not armed after noteStandbyStop")
 	}
 	if !s.userStoppedRecently() {
 		t.Fatal("user-stop not armed after noteStandbyStop (maybeRePush/RecoverAfterReconnect rely on it)")
-	}
-
-	// A second flip within standbyStopDebounce is the same burst (no second
-	// transport-clear) but still refreshes the suppression.
-	if s.noteStandbyStop() {
-		t.Fatal("second flip within the debounce is not a new burst, want false")
-	}
-	if !s.standbyStoppedRecently() {
-		t.Fatal("suppression must stay armed across a debounced second flip")
 	}
 }

--- a/internal/webui/standby_bounce_test.go
+++ b/internal/webui/standby_bounce_test.go
@@ -36,3 +36,35 @@ func TestStandbyStoppedRecently(t *testing.T) {
 		t.Fatal("standby-stop older than the bounce window, want false")
 	}
 }
+
+// TestNoteStandbyStopArmsSuppression covers the decoupling: noteStandbyStop must
+// arm BOTH the standby-bounce window and the user-stop on every UPNP->STANDBY,
+// independent of the transport-clear, so a zoned/debounced power-off still
+// suppresses all three wake paths. It also debounces the burst.
+func TestNoteStandbyStopArmsSuppression(t *testing.T) {
+	s := &Server{}
+
+	if s.standbyStoppedRecently() || s.userStoppedRecently() {
+		t.Fatal("nothing armed yet, want both false")
+	}
+
+	// First flip of a burst: arms both signals and reports burstStart.
+	if !s.noteStandbyStop() {
+		t.Fatal("first standby-stop is the start of a burst, want true")
+	}
+	if !s.standbyStoppedRecently() {
+		t.Fatal("standby-bounce window not armed after noteStandbyStop")
+	}
+	if !s.userStoppedRecently() {
+		t.Fatal("user-stop not armed after noteStandbyStop (maybeRePush/RecoverAfterReconnect rely on it)")
+	}
+
+	// A second flip within standbyStopDebounce is the same burst (no second
+	// transport-clear) but still refreshes the suppression.
+	if s.noteStandbyStop() {
+		t.Fatal("second flip within the debounce is not a new burst, want false")
+	}
+	if !s.standbyStoppedRecently() {
+		t.Fatal("suppression must stay armed across a debounced second flip")
+	}
+}

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -2140,6 +2140,13 @@ func (s *Server) standbyStoppedRecently() bool {
 	return !s.lastStandbyStop.IsZero() && time.Since(s.lastStandbyStop) < standbyBounceWakeWindow
 }
 
+// RecentlyPoweredOff reports whether STR saw this box's UPnP source drop to
+// STANDBY within the bounce window. Exported for the agent's hardware-preset
+// recall verify (cmd/agent), which must abort its re-push retries when the user
+// powered the box off mid-recall instead of treating standby as "not playing yet"
+// and re-pushing the stream (#197).
+func (s *Server) RecentlyPoweredOff() bool { return s.standbyStoppedRecently() }
+
 // noteStandbyStop arms the power-off suppression seen on a UPNP->STANDBY drop: it
 // refreshes lastStandbyStop (the #197 standbyStoppedRecently window) and records a
 // user-stop, independent of whether the caller then clears the transport. This

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -198,6 +198,11 @@ type Server struct {
 	// burst of Stops.
 	standbyStopMu   sync.Mutex
 	lastStandbyStop time.Time
+	// lastStandbyClear rate-limits the transport clear during a power-off bounce
+	// (separate from lastStandbyStop, which gates the resume-suppression window):
+	// the clear re-fires on each flip of the UPNP<->STANDBY oscillation so a clear
+	// that lost the ~170 ms race is retried, bounded by standbyClearMinGap.
+	lastStandbyClear time.Time
 
 	// resumeOnPowerOnPath persists the per-box opt-out for "resume the last
 	// station when the speaker is switched on" (default on; file absent or "1").
@@ -2138,22 +2143,24 @@ func (s *Server) standbyStoppedRecently() bool {
 // noteStandbyStop arms the power-off suppression seen on a UPNP->STANDBY drop: it
 // refreshes lastStandbyStop (the #197 standbyStoppedRecently window) and records a
 // user-stop, independent of whether the caller then clears the transport. This
-// decoupling is deliberate: the zone / debounce / disabled guards in
-// HandleEnterStandby govern only the transport-clear, but the suppression must
-// stay armed for all three wake paths regardless. Returns whether this is the
-// first flip of a debounce burst, so the caller can coalesce the transport-clear.
-func (s *Server) noteStandbyStop() (burstStart bool) {
+// decoupling is deliberate: the zone / disabled guards in HandleEnterStandby
+// govern only the transport-clear, but the suppression must stay armed for all
+// three wake paths (ResumeLastPlay, maybeRePush, RecoverAfterReconnect) regardless.
+func (s *Server) noteStandbyStop() {
 	s.standbyStopMu.Lock()
-	burstStart = s.lastStandbyStop.IsZero() || time.Since(s.lastStandbyStop) >= standbyStopDebounce
 	s.lastStandbyStop = time.Now()
 	s.standbyStopMu.Unlock()
 	s.NoteUserStop()
-	return burstStart
 }
 
-// standbyStopDebounce coalesces the rapid UPNP<->STANDBY oscillation a power-off
-// produces on some ST20 (scm) firmware into a single transport Stop.
+// standbyStopDebounce bounds the resume-suppression burst detection for the rapid
+// UPNP<->STANDBY oscillation a power-off produces on some ST20 (scm) firmware.
 const standbyStopDebounce = 4 * time.Second
+
+// standbyClearMinGap rate-limits the transport clear during a power-off bounce so
+// the ~170 ms UPNP<->STANDBY oscillation re-clears the transport a few times
+// (covering a clear that lost the race) without flooding the box with SOAP calls.
+const standbyClearMinGap = 500 * time.Millisecond
 
 // standbyBounceFixEnabled gates the #197 mitigation. Default on; set
 // STR_STANDBY_STOP=0 on the box to disable it if it ever regresses, without an
@@ -2179,31 +2186,45 @@ func (s *Server) HandleEnterStandby() {
 		return
 	}
 
-	// Arm the suppression signal on EVERY observed power-off, BEFORE the zone and
-	// debounce guards that only govern the transport-clear. The stamp (read by
-	// ResumeLastPlay's standbyStoppedRecently #197 guard) and the user-stop (read
-	// by maybeRePush / RecoverAfterReconnect) must stay armed even when we go on to
-	// skip the clear: a zoned box, or a debounced second flip of the same burst,
-	// would otherwise leave all three wake paths un-suppressed and free to re-wake
-	// a box the user just powered off. Refresh on every flip so a rapid second
-	// press keeps the window alive (the reporter's "needs multiple presses").
-	burstStart := s.noteStandbyStop()
+	// Arm the suppression signal on EVERY observed power-off, BEFORE the zone guard
+	// that only governs the transport-clear. The stamp (read by ResumeLastPlay's
+	// standbyStoppedRecently #197 guard) and the user-stop (read by maybeRePush /
+	// RecoverAfterReconnect) must stay armed even when we go on to skip the clear
+	// (a zoned box), or all three wake paths would be free to re-wake a box the
+	// user just powered off. Refreshed on every flip so a rapid second press keeps
+	// the window alive (the reporter's "needs multiple presses").
+	s.noteStandbyStop()
 
 	if s.boxInZone() {
 		return // a zone slave/master mirror re-selects UPNP on purpose; leave its transport
 	}
-	if !burstStart {
-		return // coalesce the clear burst; the suppression above is already refreshed
+
+	// Re-issue the clear on each flip of the oscillation, not just the first: a
+	// single Stop loses the ~170 ms STANDBY->UPNP race and the firmware re-selects
+	// STR's still-loaded URI. A short min-gap keeps a fast flap from flooding the
+	// box with SOAP calls.
+	s.standbyStopMu.Lock()
+	doClear := s.lastStandbyClear.IsZero() || time.Since(s.lastStandbyClear) >= standbyClearMinGap
+	if doClear {
+		s.lastStandbyClear = time.Now()
+	}
+	s.standbyStopMu.Unlock()
+	if !doClear {
+		return
 	}
 
 	// A power-off is a deliberate stop: drop any queue so it does not fight the
-	// standby, then clear the transport so the firmware has nothing to bounce to.
+	// standby, then Stop and EMPTY the transport URI so the firmware has nothing to
+	// bounce back to (Stop alone leaves the URI loaded and the box re-selects it).
 	s.stopQueue()
-	s.logger.Info("standby bounce: box powered off STR's UPnP source, clearing transport so it stays off (#197)")
+	s.logger.Info("standby bounce: box powered off STR's UPnP source, stopping + clearing the transport URI so it stays off (#197)")
 	ctx, cancel := context.WithTimeout(s.queueCtx(), 5*time.Second)
 	defer cancel()
 	if err := s.renderer.Stop(ctx); err != nil {
 		s.logger.Debug("standby bounce: transport stop returned (expected if already off)", "err", err)
+	}
+	if err := s.renderer.ClearURI(ctx); err != nil {
+		s.logger.Debug("standby bounce: clear transport URI returned", "err", err)
 	}
 }
 

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -1738,6 +1738,24 @@ func (s *Server) ResumeLastPlay() {
 		// after, so settle then read the real state.
 		time.Sleep(2 * time.Second)
 
+		// scm power-off bounce guard (#197). Some ST20 (scm) firmware oscillates
+		// UPNP->STANDBY->UPNP on a power-off, and the STANDBY->UPNP restore arrives
+		// as the SAME DO_NOT_RESUME frame a genuine power-ON does, so this
+		// OnPowerWake can fire from a power-OFF. If HandleEnterStandby just cleared
+		// the transport for this box (a UPNP->STANDBY we saw moments ago), this
+		// "wake" is that bounce, not a user switching the box on: stand down and,
+		// crucially, leave the user-stop HandleEnterStandby set intact (do NOT fall
+		// through to the clear below) so neither this resume nor the parallel auto
+		// re-push pulls the box back up. Without this, a power-off taken while the
+		// stream was still buffering left the box briefly reporting BUFFERING/PLAY
+		// at this settle point, so the standby && !busy guard below missed and STR
+		// woke the box back on (deqw, ST20 #197: "turns back on and continues
+		// playing music").
+		if s.standbyStoppedRecently() {
+			s.logger.Info("wake resume: standby bounce detected (box just powered off STR's source), not resuming (#197)")
+			return
+		}
+
 		// Klaus guard: a box pulled out of standby by its stereo pair / zone emits
 		// the SAME DO_NOT_RESUME wake as a user power press, so the frame cannot
 		// tell them apart. But a STANDALONE box can only leave standby by a user
@@ -2090,6 +2108,25 @@ func (s *Server) userStoppedRecently() bool {
 	s.lastUserStopMu.Lock()
 	defer s.lastUserStopMu.Unlock()
 	return !s.lastUserStop.IsZero() && time.Since(s.lastUserStop) < userStopWindow
+}
+
+// standbyBounceWakeWindow is how long after HandleEnterStandby cleared the
+// transport (a power-off STR saw as UPNP->STANDBY) a following DO_NOT_RESUME
+// "wake" is treated as the scm power-off BOUNCE rather than a genuine power-on.
+// On the ST20 (scm) the STANDBY->UPNP restore arrives within ~200 ms of the
+// power-off and ResumeLastPlay then settles for 2 s before it decides, so the
+// window must comfortably exceed that settle. See standbyStoppedRecently.
+const standbyBounceWakeWindow = 6 * time.Second
+
+// standbyStoppedRecently reports whether HandleEnterStandby (the #197 standby
+// bounce mitigation) cleared the transport within standbyBounceWakeWindow, i.e.
+// STR saw this box's UPnP source drop to STANDBY moments ago. ResumeLastPlay uses
+// it to tell the scm power-off bounce (a DO_NOT_RESUME that follows a power-OFF)
+// from a genuine power-on.
+func (s *Server) standbyStoppedRecently() bool {
+	s.standbyStopMu.Lock()
+	defer s.standbyStopMu.Unlock()
+	return !s.lastStandbyStop.IsZero() && time.Since(s.lastStandbyStop) < standbyBounceWakeWindow
 }
 
 // standbyStopDebounce coalesces the rapid UPNP<->STANDBY oscillation a power-off

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -1843,6 +1843,12 @@ func (s *Server) RecoverAfterReconnect() {
 	if s.userStoppedRecently() {
 		return
 	}
+	// A gabbo reconnect can land mid power-off bounce (a flapping scm box keeps
+	// reconnecting). If STR saw this box drop UPNP->STANDBY moments ago, stand down
+	// so the reconnect recovery does not re-push a URI the firmware bounces on (#197).
+	if s.standbyStoppedRecently() {
+		return
+	}
 	s.lastPlayMu.Lock()
 	lp := s.lastPlay
 	if lp == nil || time.Since(lp.ts) >= 12*time.Hour {
@@ -2118,15 +2124,31 @@ func (s *Server) userStoppedRecently() bool {
 // window must comfortably exceed that settle. See standbyStoppedRecently.
 const standbyBounceWakeWindow = 6 * time.Second
 
-// standbyStoppedRecently reports whether HandleEnterStandby (the #197 standby
-// bounce mitigation) cleared the transport within standbyBounceWakeWindow, i.e.
-// STR saw this box's UPnP source drop to STANDBY moments ago. ResumeLastPlay uses
-// it to tell the scm power-off bounce (a DO_NOT_RESUME that follows a power-OFF)
-// from a genuine power-on.
+// standbyStoppedRecently reports whether STR saw this box's UPnP source drop to
+// STANDBY (a power-off) within standbyBounceWakeWindow. ResumeLastPlay, maybeRePush
+// and RecoverAfterReconnect use it to stand down on the scm power-off bounce (a
+// DO_NOT_RESUME / reconnect / stream-drop that follows a power-OFF) instead of
+// re-waking a box the user just switched off.
 func (s *Server) standbyStoppedRecently() bool {
 	s.standbyStopMu.Lock()
 	defer s.standbyStopMu.Unlock()
 	return !s.lastStandbyStop.IsZero() && time.Since(s.lastStandbyStop) < standbyBounceWakeWindow
+}
+
+// noteStandbyStop arms the power-off suppression seen on a UPNP->STANDBY drop: it
+// refreshes lastStandbyStop (the #197 standbyStoppedRecently window) and records a
+// user-stop, independent of whether the caller then clears the transport. This
+// decoupling is deliberate: the zone / debounce / disabled guards in
+// HandleEnterStandby govern only the transport-clear, but the suppression must
+// stay armed for all three wake paths regardless. Returns whether this is the
+// first flip of a debounce burst, so the caller can coalesce the transport-clear.
+func (s *Server) noteStandbyStop() (burstStart bool) {
+	s.standbyStopMu.Lock()
+	burstStart = s.lastStandbyStop.IsZero() || time.Since(s.lastStandbyStop) >= standbyStopDebounce
+	s.lastStandbyStop = time.Now()
+	s.standbyStopMu.Unlock()
+	s.NoteUserStop()
+	return burstStart
 }
 
 // standbyStopDebounce coalesces the rapid UPNP<->STANDBY oscillation a power-off
@@ -2156,20 +2178,26 @@ func (s *Server) HandleEnterStandby() {
 	if !standbyBounceFixEnabled() || s.renderer == nil {
 		return
 	}
-	if s.boxInZone() {
-		return // a zone slave/master mirror re-selects UPNP on purpose; leave it
-	}
-	s.standbyStopMu.Lock()
-	if !s.lastStandbyStop.IsZero() && time.Since(s.lastStandbyStop) < standbyStopDebounce {
-		s.standbyStopMu.Unlock()
-		return
-	}
-	s.lastStandbyStop = time.Now()
-	s.standbyStopMu.Unlock()
 
-	// A power-off is a deliberate stop: hold the auto-re-push and drop any queue
-	// so neither fights the standby, then clear the transport.
-	s.NoteUserStop()
+	// Arm the suppression signal on EVERY observed power-off, BEFORE the zone and
+	// debounce guards that only govern the transport-clear. The stamp (read by
+	// ResumeLastPlay's standbyStoppedRecently #197 guard) and the user-stop (read
+	// by maybeRePush / RecoverAfterReconnect) must stay armed even when we go on to
+	// skip the clear: a zoned box, or a debounced second flip of the same burst,
+	// would otherwise leave all three wake paths un-suppressed and free to re-wake
+	// a box the user just powered off. Refresh on every flip so a rapid second
+	// press keeps the window alive (the reporter's "needs multiple presses").
+	burstStart := s.noteStandbyStop()
+
+	if s.boxInZone() {
+		return // a zone slave/master mirror re-selects UPNP on purpose; leave its transport
+	}
+	if !burstStart {
+		return // coalesce the clear burst; the suppression above is already refreshed
+	}
+
+	// A power-off is a deliberate stop: drop any queue so it does not fight the
+	// standby, then clear the transport so the firmware has nothing to bounce to.
 	s.stopQueue()
 	s.logger.Info("standby bounce: box powered off STR's UPnP source, clearing transport so it stays off (#197)")
 	ctx, cancel := context.WithTimeout(s.queueCtx(), 5*time.Second)
@@ -2247,6 +2275,13 @@ func (s *Server) maybeRePush() {
 	// over gabbo) must hold. Genuine box-side drops carry no such stop and resume.
 	if s.userStoppedRecently() {
 		s.logger.Info("re-push: user stopped deliberately, not resuming")
+		return
+	}
+	// A power-off STR saw as UPNP->STANDBY (HandleEnterStandby) must also hold the
+	// re-push: on the scm bounce the box is flipping STANDBY<->UPNP and a re-push
+	// here would hand the firmware a fresh URI to switch back on with (#197).
+	if s.standbyStoppedRecently() {
+		s.logger.Info("re-push: box just powered off (standby bounce), not resuming (#197)")
 		return
 	}
 	standby, busy := s.boxPlayState()


### PR DESCRIPTION
Fixes the ST20 (scm) "needs to be powered off multiple times / turns back on and keeps playing" report (#197). A fresh diagnostic from @deqw (scm ST20, agent v0.8.32, captured right after reproducing) showed the exact live sequence and pinned down **four** distinct ways STR re-woke a box the user had just powered off, all racing the firmware's ~170 ms `UPNP -> STANDBY -> UPNP` oscillation.

## Root cause

On a power-off the scm firmware flaps its source `UPNP -> STANDBY -> UPNP` within ~170 ms. Because STR still has a stream URI loaded in the box's UPnP transport, the box re-selects it the instant it leaves STANDBY and switches itself back on. Several STR paths made this worse by actively re-pushing or re-waking during the bounce. It only reproduces when you power off in the first seconds of a station starting (and, per the reporter, specifically when the station was started with a **hardware preset button** — the recall verify is still running).

## What changed (one fix per commit)

- **`ResumeLastPlay` stands down on the bounce.** The `DO_NOT_RESUME` restore the firmware emits on the bounce is identical to a genuine power-on; the early-start case briefly read `BUFFERING`/`INVALID_SOURCE` (not a clean `STANDBY`), so the `standby && !busy` guard missed and STR re-pushed + toggled `sys power`. Now guarded by a recent-power-off window (`standbyStoppedRecently`).
- **Suppression armed on every wake path.** The window stamp + user-stop now fire on every observed `UPNP -> STANDBY`, before the zone/debounce guards (which govern only the transport-clear), and `maybeRePush` / `RecoverAfterReconnect` got the same guard, so a zoned or debounced power-off no longer leaves a path un-suppressed.
- **Empty the transport URI, not just Stop.** A plain Stop loses the ~170 ms race; the box re-selects the still-loaded URI. STR now also clears the AVTransport URI and re-issues it on each flip (bounded), so the firmware has nothing to bounce back to.
- **Hardware-preset recall verify no longer re-pushes into a power-off.** `verifyPlayURL` (and the Spotify recall verify) treated the post-power-off standby as the first-press race and re-pushed the stream (log: `hardware recall not playing yet, retrying` -> `stream proxy start`). They now stand down when STR saw the box power off mid-recall. A genuine deep-standby wake (#183) carries no recent power-off, so that legitimate retry still runs.

All suppression-only: nothing here can start playback, only hold it off. Still gated by `STR_STANDBY_STOP`.

## Testing

`gofmt`, `go vet`, the `internal/webui` / `boxws` / `boxcli` / `upnp` suites, and the `GOOS=linux GOARCH=arm GOARM=7` cross-build are green. Added unit coverage for the suppression window/arming.

## Verification note

The only bundle available predates these changes, so this still needs confirmation on a live scm ST20. Cutting a release so @deqw can retest on a real build is the next step.

Refs #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qsr3TEeDKjbqsnr3v2ULcs)_