### PR TITLE
fix(desktop-app): tidier speaker settings (clearer display group, language in Basics)

### DIFF
--- a/desktop-app/frontend/src/i18n/bundles/ar.json
+++ b/desktop-app/frontend/src/i18n/bundles/ar.json
@@ -1056,7 +1056,7 @@
   "common.copy": "نسخ",
   "common.copied": "تم النسخ",
   "settingsView.groupBasics": "الأساسيات",
-  "settingsView.groupSound": "الصوت والعرض",
+  "settingsView.groupSound": "العرض والتشغيل",
   "settingsView.groupNetwork": "الشبكة",
   "settingsView.groupInfo": "الحالة والمعلومات",
   "settingsView.groupActions": "الإجراءات",

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -1057,7 +1057,7 @@
   "common.copy": "Kopieren",
   "common.copied": "Kopiert",
   "settingsView.groupBasics": "Grundeinstellungen",
-  "settingsView.groupSound": "Klang & Anzeige",
+  "settingsView.groupSound": "Anzeige & Wiedergabe",
   "settingsView.groupNetwork": "Netzwerk",
   "settingsView.groupInfo": "Status & Infos",
   "settingsView.groupActions": "Aktionen",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -1057,7 +1057,7 @@
   "common.copy": "Copy",
   "common.copied": "Copied",
   "settingsView.groupBasics": "Basics",
-  "settingsView.groupSound": "Sound & display",
+  "settingsView.groupSound": "Display & playback",
   "settingsView.groupNetwork": "Network",
   "settingsView.groupInfo": "Status & info",
   "settingsView.groupActions": "Actions",

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -1056,7 +1056,7 @@
   "common.copy": "Copiar",
   "common.copied": "Copiado",
   "settingsView.groupBasics": "Básicos",
-  "settingsView.groupSound": "Sonido y pantalla",
+  "settingsView.groupSound": "Pantalla y reproducción",
   "settingsView.groupNetwork": "Red",
   "settingsView.groupInfo": "Estado e info",
   "settingsView.groupActions": "Acciones",

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -1056,7 +1056,7 @@
   "common.copy": "Copier",
   "common.copied": "Copié",
   "settingsView.groupBasics": "Réglages de base",
-  "settingsView.groupSound": "Son & affichage",
+  "settingsView.groupSound": "Affichage et lecture",
   "settingsView.groupNetwork": "Réseau",
   "settingsView.groupInfo": "État & infos",
   "settingsView.groupActions": "Actions",

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -1056,7 +1056,7 @@
   "common.copy": "コピー",
   "common.copied": "コピーしました",
   "settingsView.groupBasics": "基本",
-  "settingsView.groupSound": "サウンドと表示",
+  "settingsView.groupSound": "表示と再生",
   "settingsView.groupNetwork": "ネットワーク",
   "settingsView.groupInfo": "状態と情報",
   "settingsView.groupActions": "操作",

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -1056,7 +1056,7 @@
   "common.copy": "Kopijuoti",
   "common.copied": "Nukopijuota",
   "settingsView.groupBasics": "Pagrindiniai",
-  "settingsView.groupSound": "Garsas ir ekranas",
+  "settingsView.groupSound": "Rodymas ir atkūrimas",
   "settingsView.groupNetwork": "Tinklas",
   "settingsView.groupInfo": "Būsena ir informacija",
   "settingsView.groupActions": "Veiksmai",

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -1056,7 +1056,7 @@
   "common.copy": "Kopēt",
   "common.copied": "Nokopēts",
   "settingsView.groupBasics": "Pamati",
-  "settingsView.groupSound": "Skaņa un ekrāns",
+  "settingsView.groupSound": "Attēlojums un atskaņošana",
   "settingsView.groupNetwork": "Tīkls",
   "settingsView.groupInfo": "Statuss un info",
   "settingsView.groupActions": "Darbības",

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -1056,7 +1056,7 @@
   "common.copy": "Kopiëren",
   "common.copied": "Gekopieerd",
   "settingsView.groupBasics": "Basis",
-  "settingsView.groupSound": "Geluid & weergave",
+  "settingsView.groupSound": "Weergave & afspelen",
   "settingsView.groupNetwork": "Netwerk",
   "settingsView.groupInfo": "Status & info",
   "settingsView.groupActions": "Acties",

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -1056,7 +1056,7 @@
   "common.copy": "Kopiuj",
   "common.copied": "Skopiowano",
   "settingsView.groupBasics": "Podstawowe",
-  "settingsView.groupSound": "Dźwięk i wyświetlacz",
+  "settingsView.groupSound": "Wyświetlanie i odtwarzanie",
   "settingsView.groupNetwork": "Sieć",
   "settingsView.groupInfo": "Status i informacje",
   "settingsView.groupActions": "Akcje",

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -1056,7 +1056,7 @@
   "common.copy": "Kopyala",
   "common.copied": "Kopyalandı",
   "settingsView.groupBasics": "Temel",
-  "settingsView.groupSound": "Ses ve ekran",
+  "settingsView.groupSound": "Görüntü ve oynatma",
   "settingsView.groupNetwork": "Ağ",
   "settingsView.groupInfo": "Durum ve bilgi",
   "settingsView.groupActions": "Eylemler",

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -1056,7 +1056,7 @@
   "common.copy": "Копіювати",
   "common.copied": "Скопійовано",
   "settingsView.groupBasics": "Основні",
-  "settingsView.groupSound": "Звук і дисплей",
+  "settingsView.groupSound": "Відображення та відтворення",
   "settingsView.groupNetwork": "Мережа",
   "settingsView.groupInfo": "Стан та інфо",
   "settingsView.groupActions": "Дії",

--- a/desktop-app/frontend/src/views/settings.js
+++ b/desktop-app/frontend/src/views/settings.js
@@ -451,7 +451,7 @@ function groupSettingsSections() {
     [t('settingsView.bassHeading')]: 'basics',
     [t('settingsView.clockHeading')]: 'sound',
     [t('settingsView.wlanHeading')]: 'network',
-    [t('settingsView.langHeading')]: 'network',
+    [t('settingsView.langHeading')]: 'basics',
     [t('settingsView.regionHeading')]: 'network',
     [t('settingsView.sourcesHeading')]: 'info',
     [t('settingsView.actionsHeading')]: 'actions',


### PR DESCRIPTION
## What

Two small clarity fixes in the grouped speaker settings (follow-up to the #declutter accordions).

- The group holding **clock display, power-on resume, show-track-on-display and AirPlay** was labelled **"Sound & display"**, but it has no sound controls (volume and bass are under Basics). Renamed to **"Display & playback"** in all 12 locales.
- The **speaker display language** was bucketed inside the **"Network"** group, where it does not belong. Moved into **Basics** (next to name, volume, bass), so Network follows it.

## Changed

- `settingsView.groupSound` value updated in all 12 bundles (key kept; only the label changed).
- `views/settings.js`: `langHeading` mapped to the `basics` bucket instead of `network`.

No behaviour change beyond labels/ordering. `vite build` + full local Wails build green; verified live in the running app.