### PR TITLE
chore: scrub reporter names from new code/docs + document lisa chassis

### DIFF
--- a/desktop-app/app.go
+++ b/desktop-app/app.go
@@ -755,7 +755,7 @@ func (a *App) enrichSeenBoxes(ctx context.Context, seen map[string]BoxInfo) {
 // /24 sweep entirely. It is the manual fallback for networks where discovery
 // cannot reach the boxes at all: Wi-Fi AP/client isolation, the PC on a
 // different subnet, a VPN/virtual adapter, or a security suite that blocks the
-// sweep (Thomas, 2026-06-28: both mDNS and the /24 TCP fallback returned 0 while
+// sweep (a tester, 2026-06-28: both mDNS and the /24 TCP fallback returned 0 while
 // the boxes were plainly on the LAN and visible in Windows Explorer). On a hit
 // the box is cached like a discovered one, so it shows in the list and the
 // periodic RefreshKnownBoxes keeps it live.

--- a/docs/MODEL-VARIANTS.md
+++ b/docs/MODEL-VARIANTS.md
@@ -123,6 +123,18 @@ When the agent is up on `:8888`, the matching `setup.log` (in `debugState.setup_
 - `bose /etc/Variant:` line for the Bose variant marker (often blank if the file is unreadable; populated on intact boxes)
 - `writable:` lines for `/etc`, `/mnt/nv`, `/tmp`, `/media/sda1`
 
+## The `lisa` variant (SA-4, Wave SoundTouch, CineMate) — UNVERIFIED
+
+Seen in the 2026-06-28 triage bundles (#273 SA-4, plus a Wave SoundTouch):
+
+| `moduleType` | `variant` | `type` | Components | First-install state |
+| --- | --- | --- | --- | --- |
+| `scm` | `lisa` | `SoundTouch SA-4` | SCM, PackagedProduct, **Lightswitch**, **SMSC** | **blocked** — the box never reads the stick at boot, so the stick-gated SSH window never opens (`reachableSSH=false` while `:8090` is up). Same "install-window-closed" signature `install_str.go` documents for the ST300. |
+| `scm` | `lisa` | `Wave SoundTouch` | SCM, PackagedProduct, Lightswitch, SMSC | same family; the agent would likely run via the `:17008` REDIRECT like the `scm` ST20, but there is no validated first-install path. |
+| `sm2` | `lisa` | `CineMate` | SCM, PackagedProduct | unverified. |
+
+These are **Unknown/unsupported** (docs/MODELS.md). The UI should warn that a `variant=lisa` chassis is unverified instead of presenting it as installable/healable (#283). Note: in a diagnostic a stock `scm/lisa` box shows `reachable8888=true` because that field probes **:17008**, where Bose's own SoftwareUpdate answers; the authoritative "STR present" signal is the new `strDetected` field, not `reachable8888`.
+
 ## Why this matters for STR
 
 Code paths that diverge between hardware revisions (WLAN provisioning, USB-Ethernet bridge handling, watchdog behaviour, TLS bundle generation, hosts-file bind-mount) sit on top of these facts. New failure reports get their root cause matched against this matrix before we start speculating; if a row is missing we ask for a diagnostic before promising a fix.

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -17,7 +17,9 @@ been validated.
 | **SoundTouch 20** | TI AM335x ARMv7l, module `scm` + SMSC, variant `spotty` (BCO) | **Working (contributor-confirmed; final stability confirmation in progress)** |
 | **SoundTouch 20** | TI AM335x ARMv7l, module SM2 (codename still `spotty`) | **Expected**: provisions Wi-Fi the Series-II way (real `wlan0`), but `run.sh` still applies the whitelisted-chassis reachability path (REDIRECT `:17008`->`:8888`) because the codename is `spotty`. Awaiting a live SM2-ST20 report. |
 | **SoundTouch 30** | TI AM335x ARMv7l, module SM2, variant `mojo` | **Working** (live-confirmed via the #123 diagnostic, 2026-06-10: box healthy, agent up; full end-to-end pass pending) |
-| Wave SoundTouch IV | unknown, possibly different CPU | **Unknown** |
+| Wave SoundTouch (IV) | AM335x ARMv7l, module `scm`, variant `lisa` + SMSC/Lightswitch | **Unknown** (#283: the agent would likely run on the scm module, but there is no validated first-install path yet) |
+| **Bose SA-4 amplifier** | AM335x ARMv7l, module `scm`, variant `lisa` + SMSC/Lightswitch | **Unknown** (#273: the box never opens the stick-gated SSH window at boot, so STR has no first-install channel; not the agent's fault) |
+| CineMate (520, ...) | module `sm2`, variant `lisa` | **Unknown** (#283) |
 | other (Soundbar, ST300, ...) | unknown | **Unknown** |
 
 All ARMv7l models run the same agent binary (`streborn-armv7l`); the

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -3848,7 +3848,7 @@ func (s *Server) formStereoPair(w http.ResponseWriter, ctx context.Context, c *b
 	// announces its wlan0/SMSC MAC, not the deviceID the firmware keys /addGroup
 	// on. localDeviceID already corrects this for the master; the partner (RIGHT)
 	// needs the same, or AddGroup embeds the wrong chip's MAC and the firmware
-	// silently drops the channel (live: Dirk's ST10+ST10 pair never formed, #70).
+	// silently drops the channel (live: an ST10+ST10 pair never formed, #70).
 	if partner.IP != "" {
 		if pinfo, perr := boxapi.New(partner.IP).GetInfo(ctx); perr == nil {
 			if real := strings.TrimSpace(pinfo.DeviceID); real != "" {
@@ -3859,7 +3859,7 @@ func (s *Server) formStereoPair(w http.ResponseWriter, ctx context.Context, c *b
 				partner.DeviceID = real
 			}
 			// Bose stereo /addGroup needs both speakers set up on the SAME marge
-			// account; an empty account is the usual silent reject (box-4, Dirk).
+			// account; an empty account is the usual silent reject (a tester's box-4).
 			if strings.TrimSpace(pinfo.MargeAccountUUID) == "" {
 				s.logger.Warn("stereo: partner has no marge account, /addGroup will likely be rejected (set the speaker up first)", "partnerIP", partner.IP)
 			}


### PR DESCRIPTION
Removes real reporter names that slipped into this session's new code comments (app.go AddBoxByIP, webui.go formStereoPair) and docs, replacing them with 'a tester' / issue references per the no-reporter-names convention. Also documents the scm/sm2 `lisa` chassis (SA-4, Wave, CineMate) as Unknown. Refs #283.