### PR TITLE
fix(wifi): refuse a Wi-Fi change to a network the speaker can't see (2.4 GHz-only boxes)

### DIFF
--- a/internal/boxapi/boxapi.go
+++ b/internal/boxapi/boxapi.go
@@ -576,6 +576,47 @@ func (c *Client) url(path string) string {
 	return fmt.Sprintf("http://%s:8090%s", c.Host, path)
 }
 
+// SiteSurvey kicks the box radio into a ~5 s scan via /performWirelessSiteSurvey
+// and returns the SSIDs the box can actually SEE. SoundTouch speakers are 2.4 GHz
+// only, so a 5 GHz-only network never appears here. STR uses this as a pre-flight
+// before a Wi-Fi change so it never strands the box on a network it cannot join
+// (the box would otherwise leave its current network and fail to join the new
+// one, forcing a Bose-app re-pair).
+func (c *Client) SiteSurvey(ctx context.Context) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url("/performWirelessSiteSurvey"), strings.NewReader(`<PerformWirelessSiteSurvey timeout="5"/>`))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "text/xml; charset=utf-8")
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("box site survey: %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return nil, err
+	}
+	var raw struct {
+		Items []struct {
+			SSID string `xml:"ssid,attr"`
+		} `xml:"items>item"`
+	}
+	if err := xml.Unmarshal(ensureUTF8(body), &raw); err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(raw.Items))
+	for _, it := range raw.Items {
+		if s := strings.TrimSpace(it.SSID); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out, nil
+}
+
 func (c *Client) getXML(ctx context.Context, path string, dst any) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url(path), nil)
 	if err != nil {

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -4990,6 +4990,9 @@ func (s *Server) handleBoxWLAN(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		SSID     string `json:"ssid"`
 		Password string `json:"password"`
+		// Force skips the site-survey pre-flight (the user chose to switch to a
+		// network the speaker cannot currently see, e.g. a momentarily-missed one).
+		Force bool `json:"force"`
 	}
 	if !decodeJSONRequest(w, r, 2048, &req) {
 		return
@@ -5004,6 +5007,39 @@ func (s *Server) handleBoxWLAN(w http.ResponseWriter, r *http.Request) {
 	if req.Password != "" && len(req.Password) < 8 {
 		http.Error(w, "password too short (at least 8 characters)", http.StatusBadRequest)
 		return
+	}
+
+	// Pre-flight: confirm the box can actually SEE the target network before the
+	// switch. SoundTouch speakers are 2.4 GHz only, so pointing one at a 5 GHz-only
+	// network strands it (it leaves the current network, cannot join the new one,
+	// and then needs a Bose-app re-pair). The box's own site survey only lists the
+	// bands it supports, so an invisible SSID is the clean signal to refuse; the
+	// `force` flag lets the user override a momentarily-missed but real network.
+	if !req.Force {
+		sctx, scancel := context.WithTimeout(r.Context(), 12*time.Second)
+		ssids, serr := boxapi.New(s.boxHost).SiteSurvey(sctx)
+		scancel()
+		if serr != nil {
+			s.logger.Warn("WLAN switch preflight: site survey failed, proceeding without it", "err", serr)
+		} else {
+			visible := false
+			for _, sid := range ssids {
+				if sid == req.SSID {
+					visible = true
+					break
+				}
+			}
+			if !visible {
+				s.logger.Info("WLAN switch refused: target SSID not visible to the speaker", "ssid", req.SSID, "visible", ssids)
+				writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+					"error":   "The speaker can't see that network. SoundTouch speakers only support 2.4 GHz Wi-Fi, so a 5 GHz network will not work. Pick a network the speaker can see, or switch anyway.",
+					"code":    "ssid-not-visible",
+					"ssid":    req.SSID,
+					"visible": ssids,
+				})
+				return
+			}
+		}
 	}
 
 	iface, mech := detectWlanMechanism()


### PR DESCRIPTION
Before a Wi-Fi change the agent now runs the box's own site survey (`boxapi.SiteSurvey` -> `/performWirelessSiteSurvey`) and refuses if the target SSID isn't visible to the speaker, returning the visible SSIDs + a clear 'SoundTouch is 2.4 GHz only' message (a `force` flag overrides). Fixes the strand-on-5GHz case where a 2.4 GHz-only box left its network and needed a Bose-app re-pair. Refs #281. The deeper NetManager/wpa robustness of the change apply itself is a separate issue.