### PR TITLE
fix: phone-remote apostrophes + resume, HTTPS radio + Spotify wrong-clock recovery, chosen speaker name, and a release CI injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,12 +143,22 @@ jobs:
             VERSION="${GITHUB_REF#refs/tags/}"
           elif [[ -n "${INPUT_VERSION}" ]]; then
             VERSION="${INPUT_VERSION}"
-            if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-              echo "::error::version input '$VERSION' does not match vX.Y.Z[-suffix]"
-              exit 1
-            fi
           else
             VERSION="dev-$(git rev-parse --short HEAD)"
+          fi
+          # Validate any tag- or input-supplied version against a strict
+          # semver pattern. A git tag name can legally contain shell
+          # metacharacters, and VERSION flows into later build steps that
+          # hold the Sigstore signing identity (id-token / attestations:
+          # write), so an unchecked tag like 'v1.0.0;<cmd>' would be a
+          # template-injection foothold. Pinning it to vX.Y.Z[-suffix] at
+          # the source removes that surface everywhere downstream. The dev
+          # fallback is a hex short-hash and needs no check.
+          if [[ "${GITHUB_REF}" == refs/tags/* || -n "${INPUT_VERSION}" ]]; then
+            if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+              echo "::error::version '$VERSION' does not match vX.Y.Z[-suffix]"
+              exit 1
+            fi
           fi
           BUILD_STAMP="$(date -u '+%Y-%m-%d-%H%M')"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
@@ -160,13 +170,18 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           GOARM: ${{ matrix.goarm }}
           CGO_ENABLED: "0"
+          # Passed as env, not interpolated into the script, so the value can
+          # never break out of the shell (defence in depth on top of the strict
+          # version validation in the derive-version step).
+          VERSION: ${{ steps.version.outputs.version }}
+          BUILD_STAMP: ${{ steps.version.outputs.build_stamp }}
         run: |
           mkdir -p out
           OUT="out/streborn-${{ matrix.suffix }}"
           go build \
             -trimpath \
             -buildvcs=true \
-            -ldflags="-s -w -X main.version=${{ steps.version.outputs.version }} -X main.buildStamp=${{ steps.version.outputs.build_stamp }}" \
+            -ldflags="-s -w -X main.version=${VERSION} -X main.buildStamp=${BUILD_STAMP}" \
             -o "${OUT}" \
             ./cmd/agent
 
@@ -179,10 +194,13 @@ jobs:
       # available" on every refresh. Tested by grepping the
       # stripped binary for the literal version string we passed in.
       - name: Verify agent version stamp
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          BUILD_STAMP: ${{ steps.version.outputs.build_stamp }}
         run: |
           OUT="out/streborn-${{ matrix.suffix }}"
-          VER="${{ steps.version.outputs.version }}"
-          STAMP="${{ steps.version.outputs.build_stamp }}"
+          VER="${VERSION}"
+          STAMP="${BUILD_STAMP}"
           if ! grep -q "${VER}" "${OUT}"; then
             echo "::error::agent binary ${OUT} does not contain version string ${VER}; ldflags not applied"
             exit 1

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/JRpersonal/streborn/internal/boxsnapshot"
 	"github.com/JRpersonal/streborn/internal/boxurl"
 	"github.com/JRpersonal/streborn/internal/boxws"
+	"github.com/JRpersonal/streborn/internal/clocksync"
 	"github.com/JRpersonal/streborn/internal/hosts"
 	"github.com/JRpersonal/streborn/internal/marge"
 	"github.com/JRpersonal/streborn/internal/netutil"
@@ -671,6 +672,14 @@ func run() error {
 	if *pendingNameFile != "" {
 		go applyPendingBoxName(context.Background(), *boxHost, *pendingNameFile, logger)
 	}
+
+	// Correct an implausibly old system clock in the background. SoundTouch
+	// speakers have no battery-backed RTC, so a cold boot can land in 2015, which
+	// breaks TLS for HTTPS radio and the Spotify sidecar. run.sh syncs the clock
+	// once at boot but can miss a network that is not up yet; this keeps retrying
+	// from an HTTP Date header until a valid time is set, then exits (a no-op when
+	// the clock is already fine). See internal/clocksync and #296.
+	go clocksync.RunUntilSynced(ctx, logger, 30*time.Second)
 
 	// If the USB stick has a newer run.sh than the NAND run-override.sh:
 	// copy it. This is the self-update path for the bootstrap. Without it

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -183,7 +183,7 @@ func run() error {
 		logLevel        = flag.String("log-level", "info", "Log level: debug, info, warn, error")
 		boxHost         = flag.String("box-host", "127.0.0.1", "Bose box IP for UPnP calls (webui /api/play). 127.0.0.1 when the agent runs on the box, otherwise the LAN IP.")
 		regionFile      = flag.String("region-file", "", "Path to region.txt with the ISO country code (from the setup wizard). The default radio country and language are derived from it.")
-		pendingNameFile = flag.String("pending-name-file", "", "Path to name.txt from the setup wizard. Its contents are applied once as the box name (plus a UID suffix) and the file is deleted afterwards.")
+		pendingNameFile = flag.String("pending-name-file", "", "Path to name.txt from the setup wizard. Its contents are applied once as the box name, verbatim, and the file is deleted afterwards.")
 		printVersion    = flag.Bool("version", false, "Print the version and exit")
 	)
 	flag.Parse()
@@ -669,7 +669,7 @@ func run() error {
 	}()
 
 	if *pendingNameFile != "" {
-		go applyPendingBoxName(context.Background(), *boxHost, *pendingNameFile, deviceID, logger)
+		go applyPendingBoxName(context.Background(), *boxHost, *pendingNameFile, logger)
 	}
 
 	// If the USB stick has a newer run.sh than the NAND run-override.sh:
@@ -1591,11 +1591,14 @@ func bytesEqual(a, b []byte) bool {
 	return true
 }
 
-// applyPendingBoxName applies a box name left by the setup wizard once to
-// the Bose box and appends the last 4 hex digits of the DeviceID as a UID
-// suffix so duplicates across multiple boxes on the LAN are ruled out. On
-// success the file is deleted.
-func applyPendingBoxName(ctx context.Context, boxHost, path, deviceID string, logger *slog.Logger) {
+// applyPendingBoxName applies a box name left by the setup wizard once to the
+// Bose box, verbatim. The name is one the user deliberately typed for this
+// speaker during setup, so it is used exactly as chosen: appending the DeviceID
+// as a UID suffix here made the user's own name look untidy on every install and
+// update (#133, #292). Duplicate-name disambiguation is the caller's concern (the
+// user simply gives two speakers two different names); STR does not second-guess
+// a name the user picked. On success the file is deleted.
+func applyPendingBoxName(ctx context.Context, boxHost, path string, logger *slog.Logger) {
 	if boxHost == "" || path == "" {
 		return
 	}
@@ -1609,14 +1612,7 @@ func applyPendingBoxName(ctx context.Context, boxHost, path, deviceID string, lo
 		_ = os.Remove(path)
 		return
 	}
-	suffix := ""
-	if len(deviceID) >= 4 {
-		suffix = strings.ToUpper(deviceID[len(deviceID)-4:])
-	}
 	wanted := raw
-	if suffix != "" && !strings.HasSuffix(strings.ToUpper(wanted), suffix) {
-		wanted = raw + " " + suffix
-	}
 	// The box must be reachable. Wait until the BoseApp web server is up.
 	time.Sleep(10 * time.Second)
 	c := boxapi.New(boxHost)

--- a/desktop-app/app.go
+++ b/desktop-app/app.go
@@ -3046,7 +3046,8 @@ func (a *App) WriteRegionConfig(targetPath, country string) error {
 
 // WriteNameConfig writes a name.conf JSON file with the box name
 // requested by the user onto the stick. The stick applies it on first
-// boot to the box via the Bose REST API and appends the UID box ID.
+// boot to the box via the Bose REST API, verbatim, so the user's chosen
+// name stays clean (#133, #292).
 func (a *App) WriteNameConfig(targetPath, name string) error {
 	return sticksetup.WriteNameConfig(targetPath, sticksetup.NameConfig{Name: name})
 }

--- a/docs/FIRMWARE-NOTES.md
+++ b/docs/FIRMWARE-NOTES.md
@@ -123,6 +123,26 @@ Bose tracks: pairing, account, friendly name, Wi-Fi profile. It does
 and boots automatically once the brief setup-AP window times out.
 Removing STR is therefore a separate, explicit "Uninstall STR" step.
 
+## No battery-backed clock: TLS breaks after a cold boot
+
+SoundTouch speakers have no battery-backed RTC. On a cold boot the kernel
+clock starts in the firmware's build epoch (observed as mid-2015) and only
+jumps forward once NTP syncs, which can be delayed or, on locked-down
+networks, never happens. While the clock is stuck in the past, Go's default
+TLS verifier rejects every HTTPS upstream as "certificate is not yet valid":
+the cert's `NotBefore` (a real 2026 date) is in the future relative to the
+box's 2015 clock. The visible symptom is that plain-HTTP radio (e.g. some BBC
+streams) plays but HTTPS radio (e.g. Virgin Radio) and the Spotify sidecar's
+`apresolve.spotify.com` fetch do not (#296).
+
+The stream proxy mitigates this for radio: when the local clock is
+implausibly old it still verifies the certificate chain to the system roots
+and the hostname, but relaxes the time-validity window (see
+`clockTolerantTLS` in `internal/streamproxy/streamproxy.go`). Verification
+tightens again automatically once the clock is corrected. The Spotify sidecar
+(`go-librespot`) has its own HTTPS client and is not covered by this; a
+box-wide clock sync at agent start would be the more complete fix.
+
 ## See also
 
 - [`ARCHITECTURE.md`](./ARCHITECTURE.md) for the component map, ports,

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/grandcat/zeroconf v1.0.0
+	golang.org/x/sys v0.44.0
 )
 
 require (
@@ -13,6 +14,5 @@ require (
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/tools v0.45.0 // indirect
 )

--- a/internal/clocksync/clocksync.go
+++ b/internal/clocksync/clocksync.go
@@ -82,6 +82,40 @@ func fetchNetworkTime(ctx context.Context, client *http.Client, hosts []string) 
 	return time.Time{}, lastErr
 }
 
+// RunUntilSynced keeps correcting an implausibly old system clock from a network
+// HTTP Date header, retrying every interval until it succeeds or ctx is
+// cancelled. It returns immediately when the clock is already plausible, so it
+// is cheap to start unconditionally (best in a goroutine) at agent boot.
+//
+// This is the standing fallback for run.sh's one-shot boot sync, which can miss
+// a network that is not up yet: without a retry, a radio-only or idle box whose
+// boot sync failed would stay stuck in the past — no HTTPS radio, no Spotify —
+// until the next reboot. Once a valid time is set the clock stays put, so this
+// returns after the first success. A non-positive interval defaults to 30s.
+func RunUntilSynced(ctx context.Context, logger *slog.Logger, interval time.Duration) {
+	if !Implausible(time.Now()) {
+		return
+	}
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	for {
+		synced, err := SyncIfImplausible(ctx, client, logger)
+		if synced || !Implausible(time.Now()) {
+			return
+		}
+		if err != nil && logger != nil {
+			logger.Debug("clock-sync: clock still unset, will retry", "err", err, "retryIn", interval.String())
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(interval):
+		}
+	}
+}
+
 // SyncIfImplausible sets the system clock from a network HTTP Date header, but
 // only when the local clock is implausibly old and a plausible, strictly later
 // network time is reachable — it never moves the clock backward. It returns true

--- a/internal/clocksync/clocksync.go
+++ b/internal/clocksync/clocksync.go
@@ -1,0 +1,112 @@
+// Package clocksync corrects an implausibly old system clock from a network
+// HTTP Date header.
+//
+// SoundTouch speakers have no battery-backed RTC. After a cold boot, before
+// NTP has synced (or when NTP is blocked), the wall clock reads the firmware's
+// build epoch, observed as mid-2015. A clock that far in the past breaks every
+// TLS handshake — Go's verifier rejects live certificates as "not yet valid" —
+// so HTTPS radio (see internal/streamproxy) and the go-librespot Spotify
+// sidecar both fail until the clock is corrected.
+//
+// usb-stick/run.sh does a one-shot HTTP Date sync at agent start, but that runs
+// once and can miss a network that is not up yet. This package lets the agent
+// re-attempt the same correction later — in particular when it notices the
+// Spotify engine crash-looping, a classic wrong-clock symptom (#296).
+package clocksync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// minPlausible is the lower bound on a trustworthy wall clock. STR shipped in
+// 2026, so a clock before 2025 is an unset RTC, not a real time.
+var minPlausible = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// maxPlausible guards against accepting a bogus far-future Date header.
+var maxPlausible = time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// dateHosts are queried over plain HTTP — no TLS, so there is no chicken-and-egg
+// with the very clock we are trying to fix — for their Date response header.
+// Same set as run.sh try_http_date_sync.
+var dateHosts = []string{
+	"http://www.google.com/",
+	"http://www.cloudflare.com/",
+	"http://www.bose.com/",
+}
+
+// Implausible reports whether now is too far in the past to be a real wall
+// clock (an unset RTC), meaning TLS and time-sensitive logic cannot be trusted.
+func Implausible(now time.Time) bool { return now.Before(minPlausible) }
+
+// plausible reports whether a fetched network time is itself a sane wall clock,
+// so a broken or malicious Date header cannot move the clock somewhere absurd.
+func plausible(t time.Time) bool { return t.After(minPlausible) && t.Before(maxPlausible) }
+
+// fetchNetworkTime returns the current time from the first reachable host's HTTP
+// Date header. It only accepts a plausible value.
+func fetchNetworkTime(ctx context.Context, client *http.Client, hosts []string) (time.Time, error) {
+	lastErr := errors.New("clocksync: no hosts to query")
+	for _, h := range hosts {
+		req, err := http.NewRequestWithContext(ctx, http.MethodHead, h, nil)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		dateHdr := resp.Header.Get("Date")
+		_ = resp.Body.Close()
+		if dateHdr == "" {
+			lastErr = fmt.Errorf("clocksync: no Date header from %s", h)
+			continue
+		}
+		t, err := http.ParseTime(dateHdr)
+		if err != nil {
+			lastErr = fmt.Errorf("clocksync: unparsable Date %q from %s: %w", dateHdr, h, err)
+			continue
+		}
+		if !plausible(t) {
+			lastErr = fmt.Errorf("clocksync: implausible Date %q from %s", dateHdr, h)
+			continue
+		}
+		return t, nil
+	}
+	return time.Time{}, lastErr
+}
+
+// SyncIfImplausible sets the system clock from a network HTTP Date header, but
+// only when the local clock is implausibly old and a plausible, strictly later
+// network time is reachable — it never moves the clock backward. It returns true
+// when it set the clock. Best-effort: a returned error is informational and not
+// fatal to the caller (radio and Spotify simply keep failing until a later
+// attempt or an NTP sync succeeds).
+func SyncIfImplausible(ctx context.Context, client *http.Client, logger *slog.Logger) (bool, error) {
+	now := time.Now()
+	if !Implausible(now) {
+		return false, nil
+	}
+	netTime, err := fetchNetworkTime(ctx, client, dateHosts)
+	if err != nil {
+		return false, err
+	}
+	if !netTime.After(now) {
+		// Never move the clock backward.
+		return false, nil
+	}
+	if err := setSystemTime(netTime); err != nil {
+		return false, err
+	}
+	if logger != nil {
+		logger.Info("clock-sync: system clock corrected from HTTP Date",
+			"was", now.UTC().Format(time.RFC3339), "now", netTime.UTC().Format(time.RFC3339))
+	}
+	return true, nil
+}

--- a/internal/clocksync/clocksync_linux.go
+++ b/internal/clocksync/clocksync_linux.go
@@ -1,0 +1,16 @@
+//go:build linux
+
+package clocksync
+
+import (
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// setSystemTime sets the wall clock via settimeofday(2). The agent runs as root
+// on the speaker, which is required for this call.
+func setSystemTime(t time.Time) error {
+	tv := unix.NsecToTimeval(t.UnixNano())
+	return unix.Settimeofday(&tv)
+}

--- a/internal/clocksync/clocksync_other.go
+++ b/internal/clocksync/clocksync_other.go
@@ -1,0 +1,14 @@
+//go:build !linux
+
+package clocksync
+
+import (
+	"errors"
+	"time"
+)
+
+// setSystemTime is unsupported off Linux (the agent only runs on the speaker's
+// Linux firmware). Present so the package builds on developer hosts.
+func setSystemTime(time.Time) error {
+	return errors.New("clocksync: setting the system clock is only supported on linux")
+}

--- a/internal/clocksync/clocksync_test.go
+++ b/internal/clocksync/clocksync_test.go
@@ -78,6 +78,22 @@ func TestFetchNetworkTimeRejectsImplausibleDate(t *testing.T) {
 	}
 }
 
+func TestRunUntilSyncedReturnsWhenClockIsFine(t *testing.T) {
+	// The test host clock is current, so RunUntilSynced must return immediately
+	// rather than spin (no network, no root needed). A hang here fails the test
+	// via the deadline.
+	done := make(chan struct{})
+	go func() {
+		RunUntilSynced(context.Background(), nil, time.Second)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunUntilSynced did not return promptly with a plausible clock")
+	}
+}
+
 func TestSyncIfImplausibleNoopWhenClockIsFine(t *testing.T) {
 	// The local clock is current here (the test host), so SyncIfImplausible must
 	// do nothing and must not need network or root.

--- a/internal/clocksync/clocksync_test.go
+++ b/internal/clocksync/clocksync_test.go
@@ -1,0 +1,91 @@
+package clocksync
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestImplausible(t *testing.T) {
+	cases := []struct {
+		name string
+		when time.Time
+		want bool
+	}{
+		{"box RTC reset to 2015", time.Date(2015, 7, 6, 21, 0, 0, 0, time.UTC), true},
+		{"just before the floor", minPlausible.Add(-time.Second), true},
+		{"at the floor", minPlausible, false},
+		{"present day", time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC), false},
+	}
+	for _, c := range cases {
+		if got := Implausible(c.when); got != c.want {
+			t.Errorf("%s: Implausible(%v)=%v, want %v", c.name, c.when, got, c.want)
+		}
+	}
+}
+
+func TestPlausible(t *testing.T) {
+	if plausible(time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Error("2015 should not be plausible")
+	}
+	if plausible(time.Date(2200, 1, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Error("2200 should not be plausible (bogus far-future Date)")
+	}
+	if !plausible(time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Error("2026 should be plausible")
+	}
+}
+
+func TestFetchNetworkTime(t *testing.T) {
+	// httptest sets a valid RFC1123 Date header on every response.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	got, err := fetchNetworkTime(context.Background(), srv.Client(), []string{srv.URL})
+	if err != nil {
+		t.Fatalf("fetchNetworkTime: %v", err)
+	}
+	if !plausible(got) {
+		t.Fatalf("fetched time %v is not plausible", got)
+	}
+}
+
+func TestFetchNetworkTimeFallsThroughToReachableHost(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+
+	// First host is unreachable; the second (the test server) must still answer.
+	hosts := []string{"http://127.0.0.1:1/", srv.URL}
+	if _, err := fetchNetworkTime(context.Background(), srv.Client(), hosts); err != nil {
+		t.Fatalf("expected fallback to the reachable host, got %v", err)
+	}
+}
+
+func TestFetchNetworkTimeRejectsImplausibleDate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Force an implausible far-past Date the fetcher must reject.
+		w.Header().Set("Date", "Mon, 06 Jul 2015 21:00:00 GMT")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if _, err := fetchNetworkTime(context.Background(), srv.Client(), []string{srv.URL}); err == nil {
+		t.Fatal("expected an implausible Date header to be rejected")
+	}
+}
+
+func TestSyncIfImplausibleNoopWhenClockIsFine(t *testing.T) {
+	// The local clock is current here (the test host), so SyncIfImplausible must
+	// do nothing and must not need network or root.
+	synced, err := SyncIfImplausible(context.Background(), http.DefaultClient, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if synced {
+		t.Fatal("clock should not have been set when the local clock is plausible")
+	}
+}

--- a/internal/spotify/manager.go
+++ b/internal/spotify/manager.go
@@ -58,6 +58,7 @@ import (
 	"time"
 
 	"github.com/JRpersonal/streborn/internal/boxapi"
+	"github.com/JRpersonal/streborn/internal/clocksync"
 	"github.com/gorilla/websocket"
 )
 
@@ -534,9 +535,34 @@ func (m *Manager) Run(ctx context.Context) {
 	// REST API answers (it is usually not up when config is first written), then
 	// restart go-librespot so the Spotify app sees the right volume, not 100%.
 	go m.refreshVolumeConfigOnce(ctx)
+	var rapidCrashes int
+	var lastClockSync time.Time
 	for ctx.Err() == nil {
-		if err := m.runOnce(ctx); err != nil && ctx.Err() == nil && !errors.Is(err, errLowDisk) {
+		started := time.Now()
+		err := m.runOnce(ctx)
+		if err != nil && ctx.Err() == nil && !errors.Is(err, errLowDisk) {
 			m.logger.Warn("go-librespot exited, restarting", "err", err)
+		}
+		// Crash-loop detection: a run that ended almost immediately is a crash,
+		// not real playback (time.Since uses the monotonic clock, so it is
+		// correct even when the wall clock is wrong). A cold-booted box with no
+		// RTC often has a 2015 clock, which makes go-librespot's own TLS to
+		// Spotify fail on every launch; the one-shot clock sync in run.sh may
+		// have missed the network. After a couple of rapid crashes, re-attempt
+		// an HTTP-Date clock correction (rate-limited) so the next launch can
+		// authenticate (#296 root cause).
+		if err != nil && ctx.Err() == nil && time.Since(started) < 20*time.Second {
+			rapidCrashes++
+			if rapidCrashes >= 2 && clocksync.Implausible(time.Now()) && time.Since(lastClockSync) > 5*time.Minute {
+				lastClockSync = time.Now()
+				if synced, serr := clocksync.SyncIfImplausible(ctx, m.client, m.logger); serr != nil {
+					m.logger.Warn("spotify: clock resync after crash-loop failed", "err", serr)
+				} else if synced {
+					rapidCrashes = 0
+				}
+			}
+		} else {
+			rapidCrashes = 0
 		}
 		select {
 		case <-ctx.Done():

--- a/internal/streamproxy/streamproxy.go
+++ b/internal/streamproxy/streamproxy.go
@@ -18,6 +18,8 @@ package streamproxy
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -240,28 +242,138 @@ func (s *Server) clearTitleForNewURL(url string) {
 func (s *Server) SetOnDisconnect(fn func(upstreamErr error)) { s.onDisconnect = fn }
 
 func New(store *presets.Store, logger *slog.Logger) *Server {
+	// The SSRF guard (loopback/link-local/metadata blocked after DNS
+	// resolution) is applied to every dial, plain or TLS, so a malicious
+	// radio-browser URL cannot point the box at its own loopback services or
+	// cloud metadata.
+	baseDialer := &net.Dialer{Control: netutil.DialGuardSSRF}
+	// DialTLSContext handles HTTPS itself so the clock-tolerant verification has
+	// the real dial host (including a bare-IP host, for which the client sends
+	// no SNI and tls.ConnectionState.ServerName would be empty). It reuses the
+	// SSRF-guarded dialer, then does the handshake with a per-connection config
+	// carrying that host. TLSClientConfig/TLSHandshakeTimeout are ignored once
+	// DialTLSContext is set, so the handshake deadline is applied here.
+	dialTLS := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, _, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+		raw, err := baseDialer.DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		hctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		conn := tls.Client(raw, clockTolerantTLSConfig(host))
+		if err := conn.HandshakeContext(hctx); err != nil {
+			_ = raw.Close()
+			return nil, err
+		}
+		return conn, nil
+	}
 	return &Server{
 		store:  store,
 		logger: logger,
 		// Our own client so we control redirect behaviour. The default is
 		// follow up to 10 — fine for Streamonkey & co. No timeout: streams
-		// are endless, we read until EOF. The DialContext guard blocks SSRF
-		// targets (loopback/link-local/metadata) after DNS resolution — a
-		// malicious radio-browser URL therefore cannot point the box at its
-		// own loopback services or cloud metadata.
+		// are endless, we read until EOF.
 		client: &http.Client{
 			Transport: &http.Transport{
 				Proxy:                 http.ProxyFromEnvironment,
-				DialContext:           (&net.Dialer{Control: netutil.DialGuardSSRF}).DialContext,
+				DialContext:           baseDialer.DialContext,
+				DialTLSContext:        dialTLS,
 				ForceAttemptHTTP2:     true,
 				MaxIdleConns:          100,
 				IdleConnTimeout:       90 * time.Second,
-				TLSHandshakeTimeout:   10 * time.Second,
 				ExpectContinueTimeout: 1 * time.Second,
 			},
 		},
 		lastFail:   make(map[string]time.Time),
 		measuredBr: make(map[string]int),
+	}
+}
+
+// minPlausibleClock is a lower bound on a trustworthy wall clock. STR shipped in
+// 2026, so a box reporting a time before this has an unset clock. SoundTouch
+// speakers have no battery-backed RTC: after a cold boot, before NTP has synced
+// (or when NTP is blocked), the clock lands in the firmware's build epoch, often
+// mid-2015. See #296 and docs/FIRMWARE-NOTES.md.
+var minPlausibleClock = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// clockUntrustworthy reports whether the local wall clock is implausibly old,
+// which would make certificate time-validity checks fail spuriously. It reads
+// time.Now() live, so strict verification resumes automatically the moment NTP
+// corrects the clock.
+func clockUntrustworthy() bool { return time.Now().Before(minPlausibleClock) }
+
+// clockTolerantTLSConfig builds the per-connection TLS config the proxy uses for
+// an upstream HTTPS radio stream dialed at host (a hostname, or a bare-IP
+// literal). It always verifies the certificate chain to the system roots and the
+// host, but tolerates a wrong box clock: when the local clock is implausibly
+// old, a chain that is valid except for the certificate's time window is still
+// accepted. Without this, a speaker whose clock reset to 2015 rejected every
+// HTTPS station as "certificate is not yet valid" (#296: Virgin Radio and other
+// HTTPS streams would not play, while plain-HTTP BBC streams still did).
+//
+// Only the expiry/not-yet-valid window is relaxed, and only while the clock is
+// untrustworthy; chain-to-root and host are always enforced, so this does not
+// weaken MITM protection. host is passed explicitly (not read from
+// ConnectionState.ServerName) so a bare-IP upstream, which sends no SNI, is
+// still verified against the certificate's IP SANs.
+func clockTolerantTLSConfig(host string) *tls.Config {
+	return &tls.Config{
+		ServerName: host, // SNI for a hostname; ignored on the wire for an IP literal
+		// h2 stays available (DialTLSContext otherwise defaults to HTTP/1.1 only).
+		NextProtos: []string{"h2", "http/1.1"},
+		// The default verifier is disabled so the time window can be relaxed in
+		// VerifyConnection; chain and host are still checked there manually.
+		InsecureSkipVerify: true, //nolint:gosec // VerifyConnection re-implements chain+host verification below.
+		VerifyConnection: func(cs tls.ConnectionState) error {
+			roots, _ := x509.SystemCertPool()
+			return verifyChainClockTolerant(cs.PeerCertificates, host, roots, time.Now(), clockUntrustworthy())
+		},
+	}
+}
+
+// verifyChainClockTolerant verifies leaf (certs[0]) against roots and host at
+// time now. host is matched against the certificate's DNS names, or, for an IP
+// literal, its IP SANs. If verification fails solely because the certificate is
+// outside its time window and clockBad is true, it retries with the time check
+// pinned to the leaf's NotBefore (so the window always passes) while still
+// requiring a valid chain and host. It is split out from clockTolerantTLSConfig
+// so the policy can be unit-tested without a live TLS handshake.
+func verifyChainClockTolerant(certs []*x509.Certificate, host string, roots *x509.CertPool, now time.Time, clockBad bool) error {
+	if len(certs) == 0 {
+		return errors.New("tls: no peer certificates")
+	}
+	// Require a host: x509.Verify silently skips host checking when DNSName is
+	// empty, so an empty host here would drop the host guard entirely. The
+	// caller derives it from the dial address, so an empty value means something
+	// is wrong and we must reject rather than relax.
+	if host == "" {
+		return errors.New("tls: empty host")
+	}
+	inter := x509.NewCertPool()
+	for _, c := range certs[1:] {
+		inter.AddCert(c)
+	}
+	leaf := certs[0]
+	opts := x509.VerifyOptions{DNSName: host, Roots: roots, Intermediates: inter, CurrentTime: now}
+	if _, err := leaf.Verify(opts); err == nil {
+		return nil
+	} else {
+		// Relax the time window only when the clock is untrustworthy and the
+		// failure was a time-validity problem (x509.Expired covers both
+		// not-yet-valid and expired). Any other failure (unknown authority,
+		// hostname mismatch) still rejects the connection.
+		var invalid x509.CertificateInvalidError
+		if clockBad && errors.As(err, &invalid) && invalid.Reason == x509.Expired {
+			opts.CurrentTime = leaf.NotBefore
+			if _, err2 := leaf.Verify(opts); err2 == nil {
+				return nil
+			}
+		}
+		return err
 	}
 }
 

--- a/internal/streamproxy/tls_clock_test.go
+++ b/internal/streamproxy/tls_clock_test.go
@@ -1,0 +1,166 @@
+package streamproxy
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+)
+
+// mintChain returns a leaf certificate for dnsName signed by a fresh CA, valid
+// in [notBefore, notAfter], plus a roots pool containing that CA. It is the
+// minimum needed to exercise verifyChainClockTolerant without a live handshake.
+func mintChain(t *testing.T, dnsName string, notBefore, notAfter time.Time) (*x509.Certificate, *x509.CertPool) {
+	t.Helper()
+	return mintChainSAN(t, []string{dnsName}, nil, notBefore, notAfter)
+}
+
+// mintChainSAN is mintChain with explicit DNS and IP SANs, so the bare-IP
+// upstream path (no SNI) can be exercised too.
+func mintChainSAN(t *testing.T, dnsNames []string, ipSANs []net.IP, notBefore, notAfter time.Time) (*x509.Certificate, *x509.CertPool) {
+	t.Helper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ca key: %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+		NotAfter:              time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("ca cert: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parse ca: %v", err)
+	}
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("leaf key: %v", err)
+	}
+	cn := ""
+	if len(dnsNames) > 0 {
+		cn = dnsNames[0]
+	}
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: cn},
+		DNSNames:     dnsNames,
+		IPAddresses:  ipSANs,
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("leaf cert: %v", err)
+	}
+	leaf, err := x509.ParseCertificate(leafDER)
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	roots := x509.NewCertPool()
+	roots.AddCert(caCert)
+	return leaf, roots
+}
+
+func TestVerifyChainClockTolerant(t *testing.T) {
+	const host = "radio.example.com"
+	badClock := time.Date(2015, 7, 6, 21, 0, 0, 0, time.UTC)  // box clock reset to 2015 (#296)
+	goodClock := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC) // clock synced
+	certValidFrom := time.Date(2026, 5, 29, 0, 0, 0, 0, time.UTC)
+	certValidTo := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+
+	t.Run("not-yet-valid cert is accepted when the clock is untrustworthy", func(t *testing.T) {
+		leaf, roots := mintChain(t, host, certValidFrom, certValidTo)
+		if err := verifyChainClockTolerant([]*x509.Certificate{leaf}, host, roots, badClock, true); err != nil {
+			t.Fatalf("expected tolerance for a wrong clock, got %v", err)
+		}
+	})
+
+	t.Run("not-yet-valid cert is rejected when the clock is trustworthy", func(t *testing.T) {
+		leaf, roots := mintChain(t, host, certValidFrom, certValidTo)
+		// Same 2015 wall clock, but we assert the clock is trustworthy: strict
+		// time checking must still reject a cert outside its window.
+		if err := verifyChainClockTolerant([]*x509.Certificate{leaf}, host, roots, badClock, false); err == nil {
+			t.Fatal("expected rejection when the clock is trusted but the cert is not yet valid")
+		}
+	})
+
+	t.Run("valid cert within its window is accepted", func(t *testing.T) {
+		leaf, roots := mintChain(t, host, certValidFrom, certValidTo)
+		if err := verifyChainClockTolerant([]*x509.Certificate{leaf}, host, roots, goodClock, false); err != nil {
+			t.Fatalf("expected a valid cert to verify, got %v", err)
+		}
+	})
+
+	t.Run("hostname mismatch is rejected even with a bad clock", func(t *testing.T) {
+		leaf, roots := mintChain(t, host, certValidFrom, certValidTo)
+		if err := verifyChainClockTolerant([]*x509.Certificate{leaf}, "evil.example.com", roots, badClock, true); err == nil {
+			t.Fatal("expected hostname mismatch to reject regardless of clock tolerance")
+		}
+	})
+
+	t.Run("untrusted root is rejected even with a bad clock", func(t *testing.T) {
+		leaf, _ := mintChain(t, host, certValidFrom, certValidTo)
+		// Verify against an empty root pool: the signing CA is not trusted, so
+		// this must fail even though clock tolerance is enabled.
+		if err := verifyChainClockTolerant([]*x509.Certificate{leaf}, host, x509.NewCertPool(), badClock, true); err == nil {
+			t.Fatal("expected an untrusted chain to reject regardless of clock tolerance")
+		}
+	})
+
+	t.Run("empty chain is rejected", func(t *testing.T) {
+		if err := verifyChainClockTolerant(nil, host, x509.NewCertPool(), badClock, true); err == nil {
+			t.Fatal("expected an empty peer chain to be rejected")
+		}
+	})
+
+	t.Run("empty host is rejected", func(t *testing.T) {
+		leaf, roots := mintChain(t, host, certValidFrom, certValidTo)
+		if err := verifyChainClockTolerant([]*x509.Certificate{leaf}, "", roots, badClock, true); err == nil {
+			t.Fatal("expected an empty host to be rejected (would otherwise skip hostname checking)")
+		}
+	})
+
+	t.Run("bare-IP host verifies against the cert IP SAN with a bad clock", func(t *testing.T) {
+		// A radio stream URL with an IP-literal host sends no SNI; it must still
+		// verify against the certificate's IP SANs (regression guard for the
+		// DialTLSContext host-passing fix).
+		const ip = "203.0.113.5"
+		leaf, roots := mintChainSAN(t, nil, []net.IP{net.ParseIP(ip)}, certValidFrom, certValidTo)
+		if err := verifyChainClockTolerant([]*x509.Certificate{leaf}, ip, roots, badClock, true); err != nil {
+			t.Fatalf("expected an IP-SAN cert to verify for a bare-IP host, got %v", err)
+		}
+	})
+
+	t.Run("relaxed retry still rejects an untrusted root masked by a time failure", func(t *testing.T) {
+		// The cert is both not-yet-valid AND signed by an untrusted CA. The first
+		// Verify fails with Reason==Expired (time is checked first), so the relax
+		// branch fires — but the pinned-time re-verify must still reject on the
+		// chain.
+		leaf, _ := mintChain(t, host, certValidFrom, certValidTo)
+		if err := verifyChainClockTolerant([]*x509.Certificate{leaf}, host, x509.NewCertPool(), badClock, true); err == nil {
+			t.Fatal("relax branch must not accept an untrusted chain hidden behind a time failure")
+		}
+	})
+
+	t.Run("relaxed retry still rejects a hostname mismatch masked by a time failure", func(t *testing.T) {
+		leaf, roots := mintChain(t, host, certValidFrom, certValidTo)
+		if err := verifyChainClockTolerant([]*x509.Certificate{leaf}, "evil.example.com", roots, badClock, true); err == nil {
+			t.Fatal("relax branch must not accept a wrong-host cert hidden behind a time failure")
+		}
+	})
+}

--- a/internal/webui/const.go
+++ b/internal/webui/const.go
@@ -254,7 +254,7 @@ footer .hint { display:block; margin-top:6px; color:var(--muted); opacity:.7; }
 <div class="card">
 <div class="label" id="lblPlayback">Playback</div>
 <div class="row c2">
-<button class="btn" id="btnPause" onclick="pp(this,'/api/pause')">Pause</button>
+<button class="btn" id="btnPause" onclick="togglePlayPause(this)">Pause</button>
 <button class="btn" id="btnStop" onclick="pp(this,'/api/stop')">Stop</button>
 </div>
 </div>
@@ -288,18 +288,18 @@ footer .hint { display:block; margin-top:6px; color:var(--muted); opacity:.7; }
 // Bluetooth, AUX) and the box's own device name stay as-is. Keep this language
 // set in step with the "Aa" menu dictionary (A11Y_I18N) below.
 var I18N = {
-  en:{now:"Now playing",loading:"Loading…",vol:"Volume",input:"Input",standby:"Standby",playback:"Playback",pause:"Pause",stop:"Stop",presets:"Presets",peers:"Other speakers",support:"Support ST Reborn",tip:"Tip: use your browser menu and \"Add to Home Screen\" to keep this as an app.",empty:"empty",presetWord:"Preset",starting:"Starting",pleaseWait:"please wait",cantStart:"Could not start",tapAgain:"tap again",idle:"Idle",playing:"Playing",paused:"Paused",stopped:"Stopped",buffering:"Buffering",power:"Power"},
-  de:{now:"Wird gespielt",loading:"Lädt…",vol:"Lautstärke",input:"Eingang",standby:"Standby",playback:"Wiedergabe",pause:"Pause",stop:"Stopp",presets:"Voreinstellungen",peers:"Andere Lautsprecher",support:"ST Reborn unterstützen",tip:"Tipp: Über das Browser-Menü und „Zum Home-Bildschirm“ als App speichern.",empty:"leer",presetWord:"Voreinstellung",starting:"Starte",pleaseWait:"bitte warten",cantStart:"Start fehlgeschlagen",tapAgain:"nochmal tippen",idle:"Bereit",playing:"Wiedergabe",paused:"Pausiert",stopped:"Gestoppt",buffering:"Puffert",power:"Ein/Aus"},
-  nl:{now:"Speelt nu",loading:"Laden…",vol:"Volume",input:"Ingang",standby:"Stand-by",playback:"Afspelen",pause:"Pauze",stop:"Stop",presets:"Presets",peers:"Andere speakers",support:"Steun ST Reborn",tip:"Tip: gebruik het browsermenu en \"Zet op beginscherm\" om dit als app te bewaren.",empty:"leeg",presetWord:"Preset",starting:"Starten",pleaseWait:"even geduld",cantStart:"Kan niet starten",tapAgain:"tik opnieuw",idle:"Inactief",playing:"Speelt af",paused:"Gepauzeerd",stopped:"Gestopt",buffering:"Bufferen",power:"Aan/uit"},
-  fr:{now:"Lecture en cours",loading:"Chargement…",vol:"Volume",input:"Entrée",standby:"Veille",playback:"Lecture",pause:"Pause",stop:"Arrêt",presets:"Préréglages",peers:"Autres enceintes",support:"Soutenir ST Reborn",tip:"Astuce : utilisez le menu du navigateur et « Ajouter à l'écran d'accueil » pour garder ceci comme une app.",empty:"vide",presetWord:"Préréglage",starting:"Démarrage",pleaseWait:"veuillez patienter",cantStart:"Démarrage impossible",tapAgain:"appuyez à nouveau",idle:"Inactif",playing:"Lecture",paused:"En pause",stopped:"Arrêté",buffering:"Mise en mémoire tampon",power:"Marche/Arrêt"},
-  es:{now:"Reproduciendo",loading:"Cargando…",vol:"Volumen",input:"Entrada",standby:"Reposo",playback:"Reproducción",pause:"Pausa",stop:"Detener",presets:"Presintonías",peers:"Otros altavoces",support:"Apoya ST Reborn",tip:"Consejo: usa el menú del navegador y «Añadir a pantalla de inicio» para conservarlo como app.",empty:"vacío",presetWord:"Presintonía",starting:"Iniciando",pleaseWait:"espera",cantStart:"No se pudo iniciar",tapAgain:"toca de nuevo",idle:"Inactivo",playing:"Reproduciendo",paused:"En pausa",stopped:"Detenido",buffering:"Almacenando en búfer",power:"Encendido"},
-  pl:{now:"Teraz odtwarzane",loading:"Ładowanie…",vol:"Głośność",input:"Wejście",standby:"Czuwanie",playback:"Odtwarzanie",pause:"Pauza",stop:"Stop",presets:"Presety",peers:"Inne głośniki",support:"Wesprzyj ST Reborn",tip:"Wskazówka: użyj menu przeglądarki i „Dodaj do ekranu głównego”, aby zachować to jako aplikację.",empty:"puste",presetWord:"Preset",starting:"Uruchamianie",pleaseWait:"proszę czekać",cantStart:"Nie udało się uruchomić",tapAgain:"dotknij ponownie",idle:"Bezczynny",playing:"Odtwarzanie",paused:"Wstrzymano",stopped:"Zatrzymano",buffering:"Buforowanie",power:"Zasilanie"},
-  tr:{now:"Şimdi çalıyor",loading:"Yükleniyor…",vol:"Ses",input:"Giriş",standby:"Bekleme",playback:"Oynatma",pause:"Duraklat",stop:"Durdur",presets:"Ön ayarlar",peers:"Diğer hoparlörler",support:"ST Reborn'a destek ol",tip:"İpucu: tarayıcı menüsünü ve \"Ana Ekrana Ekle\" seçeneğini kullanarak bunu uygulama olarak tutun.",empty:"boş",presetWord:"Ön ayar",starting:"Başlatılıyor",pleaseWait:"lütfen bekleyin",cantStart:"Başlatılamadı",tapAgain:"tekrar dokunun",idle:"Boşta",playing:"Çalıyor",paused:"Duraklatıldı",stopped:"Durduruldu",buffering:"Arabelleğe alınıyor",power:"Güç"},
-  ar:{now:"قيد التشغيل الآن",loading:"جارٍ التحميل…",vol:"مستوى الصوت",input:"المدخل",standby:"وضع الاستعداد",playback:"التشغيل",pause:"إيقاف مؤقت",stop:"إيقاف",presets:"الإعدادات المسبقة",peers:"مكبرات صوت أخرى",support:"ادعم ST Reborn",tip:"نصيحة: استخدم قائمة المتصفح و\"إضافة إلى الشاشة الرئيسية\" للاحتفاظ بهذا كتطبيق.",empty:"فارغ",presetWord:"إعداد مسبق",starting:"جارٍ البدء",pleaseWait:"يرجى الانتظار",cantStart:"تعذّر البدء",tapAgain:"انقر مرة أخرى",idle:"خامل",playing:"قيد التشغيل",paused:"متوقف مؤقتًا",stopped:"متوقف",buffering:"جارٍ التخزين المؤقت",power:"الطاقة"},
-  ja:{now:"再生中",loading:"読み込み中…",vol:"音量",input:"入力",standby:"スタンバイ",playback:"再生",pause:"一時停止",stop:"停止",presets:"プリセット",peers:"他のスピーカー",support:"ST Reborn を支援",tip:"ヒント：ブラウザのメニューから「ホーム画面に追加」を使うと、アプリとして保存できます。",empty:"空き",presetWord:"プリセット",starting:"開始中",pleaseWait:"お待ちください",cantStart:"開始できませんでした",tapAgain:"もう一度タップ",idle:"待機中",playing:"再生中",paused:"一時停止中",stopped:"停止",buffering:"バッファ中",power:"電源"},
-  lt:{now:"Dabar grojama",loading:"Įkeliama…",vol:"Garsumas",input:"Įvestis",standby:"Budėjimas",playback:"Atkūrimas",pause:"Pristabdyti",stop:"Stabdyti",presets:"Išankstiniai nustatymai",peers:"Kitos kolonėlės",support:"Paremkite ST Reborn",tip:"Patarimas: naudokite naršyklės meniu ir „Pridėti į pradžios ekraną“, kad išsaugotumėte tai kaip programėlę.",empty:"tuščia",presetWord:"Nustatymas",starting:"Paleidžiama",pleaseWait:"palaukite",cantStart:"Nepavyko paleisti",tapAgain:"bakstelėkite dar kartą",idle:"Neaktyvus",playing:"Grojama",paused:"Pristabdyta",stopped:"Sustabdyta",buffering:"Buferiuojama",power:"Maitinimas"},
-  lv:{now:"Tagad atskaņo",loading:"Ielādē…",vol:"Skaļums",input:"Ievade",standby:"Gaidstāve",playback:"Atskaņošana",pause:"Pauze",stop:"Apturēt",presets:"Iepriekšiestatījumi",peers:"Citi skaļruņi",support:"Atbalstīt ST Reborn",tip:"Padoms: izmantojiet pārlūka izvēlni un \"Pievienot sākuma ekrānam\", lai saglabātu to kā lietotni.",empty:"tukšs",presetWord:"Iestatījums",starting:"Sākas",pleaseWait:"lūdzu, uzgaidiet",cantStart:"Neizdevās sākt",tapAgain:"pieskarieties vēlreiz",idle:"Dīkstāvē",playing:"Atskaņo",paused:"Pauzēts",stopped:"Apturēts",buffering:"Buferē",power:"Barošana"},
-  uk:{now:"Зараз грає",loading:"Завантаження…",vol:"Гучність",input:"Вхід",standby:"Очікування",playback:"Відтворення",pause:"Пауза",stop:"Стоп",presets:"Пресети",peers:"Інші колонки",support:"Підтримати ST Reborn",tip:"Порада: скористайтеся меню браузера та «Додати на головний екран», щоб зберегти це як застосунок.",empty:"порожньо",presetWord:"Пресет",starting:"Запуск",pleaseWait:"зачекайте",cantStart:"Не вдалося запустити",tapAgain:"торкніться ще раз",idle:"Очікування",playing:"Відтворення",paused:"Призупинено",stopped:"Зупинено",buffering:"Буферизація",power:"Живлення"}
+  en:{now:"Now playing",loading:"Loading…",vol:"Volume",input:"Input",standby:"Standby",playback:"Playback",pause:"Pause",play:"Play",stop:"Stop",presets:"Presets",peers:"Other speakers",support:"Support ST Reborn",tip:"Tip: use your browser menu and \"Add to Home Screen\" to keep this as an app.",empty:"empty",presetWord:"Preset",starting:"Starting",pleaseWait:"please wait",cantStart:"Could not start",tapAgain:"tap again",idle:"Idle",playing:"Playing",paused:"Paused",stopped:"Stopped",buffering:"Buffering",power:"Power"},
+  de:{now:"Wird gespielt",loading:"Lädt…",vol:"Lautstärke",input:"Eingang",standby:"Standby",playback:"Wiedergabe",pause:"Pause",play:"Wiedergabe",stop:"Stopp",presets:"Voreinstellungen",peers:"Andere Lautsprecher",support:"ST Reborn unterstützen",tip:"Tipp: Über das Browser-Menü und „Zum Home-Bildschirm“ als App speichern.",empty:"leer",presetWord:"Voreinstellung",starting:"Starte",pleaseWait:"bitte warten",cantStart:"Start fehlgeschlagen",tapAgain:"nochmal tippen",idle:"Bereit",playing:"Wiedergabe",paused:"Pausiert",stopped:"Gestoppt",buffering:"Puffert",power:"Ein/Aus"},
+  nl:{now:"Speelt nu",loading:"Laden…",vol:"Volume",input:"Ingang",standby:"Stand-by",playback:"Afspelen",pause:"Pauze",play:"Afspelen",stop:"Stop",presets:"Presets",peers:"Andere speakers",support:"Steun ST Reborn",tip:"Tip: gebruik het browsermenu en \"Zet op beginscherm\" om dit als app te bewaren.",empty:"leeg",presetWord:"Preset",starting:"Starten",pleaseWait:"even geduld",cantStart:"Kan niet starten",tapAgain:"tik opnieuw",idle:"Inactief",playing:"Speelt af",paused:"Gepauzeerd",stopped:"Gestopt",buffering:"Bufferen",power:"Aan/uit"},
+  fr:{now:"Lecture en cours",loading:"Chargement…",vol:"Volume",input:"Entrée",standby:"Veille",playback:"Lecture",pause:"Pause",play:"Lecture",stop:"Arrêt",presets:"Préréglages",peers:"Autres enceintes",support:"Soutenir ST Reborn",tip:"Astuce : utilisez le menu du navigateur et « Ajouter à l'écran d'accueil » pour garder ceci comme une app.",empty:"vide",presetWord:"Préréglage",starting:"Démarrage",pleaseWait:"veuillez patienter",cantStart:"Démarrage impossible",tapAgain:"appuyez à nouveau",idle:"Inactif",playing:"Lecture",paused:"En pause",stopped:"Arrêté",buffering:"Mise en mémoire tampon",power:"Marche/Arrêt"},
+  es:{now:"Reproduciendo",loading:"Cargando…",vol:"Volumen",input:"Entrada",standby:"Reposo",playback:"Reproducción",pause:"Pausa",play:"Reproducir",stop:"Detener",presets:"Presintonías",peers:"Otros altavoces",support:"Apoya ST Reborn",tip:"Consejo: usa el menú del navegador y «Añadir a pantalla de inicio» para conservarlo como app.",empty:"vacío",presetWord:"Presintonía",starting:"Iniciando",pleaseWait:"espera",cantStart:"No se pudo iniciar",tapAgain:"toca de nuevo",idle:"Inactivo",playing:"Reproduciendo",paused:"En pausa",stopped:"Detenido",buffering:"Almacenando en búfer",power:"Encendido"},
+  pl:{now:"Teraz odtwarzane",loading:"Ładowanie…",vol:"Głośność",input:"Wejście",standby:"Czuwanie",playback:"Odtwarzanie",pause:"Pauza",play:"Odtwórz",stop:"Stop",presets:"Presety",peers:"Inne głośniki",support:"Wesprzyj ST Reborn",tip:"Wskazówka: użyj menu przeglądarki i „Dodaj do ekranu głównego”, aby zachować to jako aplikację.",empty:"puste",presetWord:"Preset",starting:"Uruchamianie",pleaseWait:"proszę czekać",cantStart:"Nie udało się uruchomić",tapAgain:"dotknij ponownie",idle:"Bezczynny",playing:"Odtwarzanie",paused:"Wstrzymano",stopped:"Zatrzymano",buffering:"Buforowanie",power:"Zasilanie"},
+  tr:{now:"Şimdi çalıyor",loading:"Yükleniyor…",vol:"Ses",input:"Giriş",standby:"Bekleme",playback:"Oynatma",pause:"Duraklat",play:"Oynat",stop:"Durdur",presets:"Ön ayarlar",peers:"Diğer hoparlörler",support:"ST Reborn'a destek ol",tip:"İpucu: tarayıcı menüsünü ve \"Ana Ekrana Ekle\" seçeneğini kullanarak bunu uygulama olarak tutun.",empty:"boş",presetWord:"Ön ayar",starting:"Başlatılıyor",pleaseWait:"lütfen bekleyin",cantStart:"Başlatılamadı",tapAgain:"tekrar dokunun",idle:"Boşta",playing:"Çalıyor",paused:"Duraklatıldı",stopped:"Durduruldu",buffering:"Arabelleğe alınıyor",power:"Güç"},
+  ar:{now:"قيد التشغيل الآن",loading:"جارٍ التحميل…",vol:"مستوى الصوت",input:"المدخل",standby:"وضع الاستعداد",playback:"التشغيل",pause:"إيقاف مؤقت",play:"تشغيل",stop:"إيقاف",presets:"الإعدادات المسبقة",peers:"مكبرات صوت أخرى",support:"ادعم ST Reborn",tip:"نصيحة: استخدم قائمة المتصفح و\"إضافة إلى الشاشة الرئيسية\" للاحتفاظ بهذا كتطبيق.",empty:"فارغ",presetWord:"إعداد مسبق",starting:"جارٍ البدء",pleaseWait:"يرجى الانتظار",cantStart:"تعذّر البدء",tapAgain:"انقر مرة أخرى",idle:"خامل",playing:"قيد التشغيل",paused:"متوقف مؤقتًا",stopped:"متوقف",buffering:"جارٍ التخزين المؤقت",power:"الطاقة"},
+  ja:{now:"再生中",loading:"読み込み中…",vol:"音量",input:"入力",standby:"スタンバイ",playback:"再生",pause:"一時停止",play:"再生",stop:"停止",presets:"プリセット",peers:"他のスピーカー",support:"ST Reborn を支援",tip:"ヒント：ブラウザのメニューから「ホーム画面に追加」を使うと、アプリとして保存できます。",empty:"空き",presetWord:"プリセット",starting:"開始中",pleaseWait:"お待ちください",cantStart:"開始できませんでした",tapAgain:"もう一度タップ",idle:"待機中",playing:"再生中",paused:"一時停止中",stopped:"停止",buffering:"バッファ中",power:"電源"},
+  lt:{now:"Dabar grojama",loading:"Įkeliama…",vol:"Garsumas",input:"Įvestis",standby:"Budėjimas",playback:"Atkūrimas",pause:"Pristabdyti",play:"Groti",stop:"Stabdyti",presets:"Išankstiniai nustatymai",peers:"Kitos kolonėlės",support:"Paremkite ST Reborn",tip:"Patarimas: naudokite naršyklės meniu ir „Pridėti į pradžios ekraną“, kad išsaugotumėte tai kaip programėlę.",empty:"tuščia",presetWord:"Nustatymas",starting:"Paleidžiama",pleaseWait:"palaukite",cantStart:"Nepavyko paleisti",tapAgain:"bakstelėkite dar kartą",idle:"Neaktyvus",playing:"Grojama",paused:"Pristabdyta",stopped:"Sustabdyta",buffering:"Buferiuojama",power:"Maitinimas"},
+  lv:{now:"Tagad atskaņo",loading:"Ielādē…",vol:"Skaļums",input:"Ievade",standby:"Gaidstāve",playback:"Atskaņošana",pause:"Pauze",play:"Atskaņot",stop:"Apturēt",presets:"Iepriekšiestatījumi",peers:"Citi skaļruņi",support:"Atbalstīt ST Reborn",tip:"Padoms: izmantojiet pārlūka izvēlni un \"Pievienot sākuma ekrānam\", lai saglabātu to kā lietotni.",empty:"tukšs",presetWord:"Iestatījums",starting:"Sākas",pleaseWait:"lūdzu, uzgaidiet",cantStart:"Neizdevās sākt",tapAgain:"pieskarieties vēlreiz",idle:"Dīkstāvē",playing:"Atskaņo",paused:"Pauzēts",stopped:"Apturēts",buffering:"Buferē",power:"Barošana"},
+  uk:{now:"Зараз грає",loading:"Завантаження…",vol:"Гучність",input:"Вхід",standby:"Очікування",playback:"Відтворення",pause:"Пауза",play:"Відтворити",stop:"Стоп",presets:"Пресети",peers:"Інші колонки",support:"Підтримати ST Reborn",tip:"Порада: скористайтеся меню браузера та «Додати на головний екран», щоб зберегти це як застосунок.",empty:"порожньо",presetWord:"Пресет",starting:"Запуск",pleaseWait:"зачекайте",cantStart:"Не вдалося запустити",tapAgain:"торкніться ще раз",idle:"Очікування",playing:"Відтворення",paused:"Призупинено",stopped:"Зупинено",buffering:"Буферизація",power:"Живлення"}
 };
 // Pick the best matching locale from the phone and build T (chosen strings with
 // English fall-through per key). Runs immediately so the dynamic helpers below
@@ -337,6 +337,14 @@ async function api(path, method, body) {
   return ct.includes('json') ? r.json() : r.text();
 }
 function escapeHtml(s){ return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'})[c]); }
+// decodeEntities turns the HTML/XML entities the box emits in its now_playing
+// track text (e.g. &apos; &#39; &amp;) back into their characters. The box
+// serves the title entity-encoded inside the now_playing XML; without decoding,
+// escapeHtml below would re-escape the leading &, so an apostrophe surfaced as a
+// literal "&apos;" in the remote (#295). A detached <textarea> decodes text-only
+// (no markup is executed), then setNow re-escapes the result, so this stays
+// safe against injection.
+function decodeEntities(s){ var el = document.createElement('textarea'); el.innerHTML = String(s); return el.value; }
 
 var volTimer = null, volLast = -1;
 function onVol(v) {
@@ -353,6 +361,21 @@ function setNow(name, state) {
 function press(btn) { if (!btn) return; btn.classList.add('active'); setTimeout(function(){ btn.classList.remove('active'); }, 600); }
 // pp = press + POST + refresh, for the Pause/Stop controls.
 async function pp(btn, path) { press(btn); await api(path, 'POST'); setTimeout(refreshStatus, 1200); }
+// The Pause button doubles as Play/Pause: when the box is paused it offers
+// Play (resume from the paused position via /api/resume, like the Bose remote),
+// otherwise Pause. Without a resume affordance a stream paused from the remote
+// could only be restarted from the app or the physical remote (#294, mirrors
+// the desktop app's #202 toggle). paused tracks the live transport state so the
+// tap sends the right command even between status polls.
+var paused = false;
+function applyTransportUI(state) {
+  paused = (state === 'PAUSE_STATE');
+  var b = document.getElementById('btnPause');
+  if (!b) return;
+  b.textContent = paused ? T.play : T.pause;
+  b.setAttribute('aria-label', paused ? T.play : T.pause);
+}
+async function togglePlayPause(btn) { await pp(btn, paused ? '/api/resume' : '/api/pause'); }
 // Power on/off. The box has no "off" for a stream (Stop only pauses the
 // transport, the speaker stays on), so this is a real standby toggle: off -> Bose
 // standby, on -> wake + resume the last station. boxOn tracks the live state,
@@ -425,12 +448,13 @@ async function refreshStatus() {
   const m = t.match(/<itemName>([^<]+)<\/itemName>/) || t.match(/<track>([^<]+)<\/track>/);
   const src = (t.match(/source="([^"]+)"/) || [])[1] || '';
   const state = (t.match(/<playStatus>([^<]+)<\/playStatus>/) || [])[1] || '';
-  const name = m ? m[1] : '';
+  const name = m ? decodeEntities(m[1]) : '';
   // Track power state for the header toggle: the box is "on" unless it is in
   // standby (a stopped-but-awake box still counts as on, so the button can switch
   // it off, which was the whole point of the request).
   boxOn = (state === 'PLAY_STATE' || state === 'PAUSE_STATE' || state === 'BUFFERING_STATE') || (!!src && src.toUpperCase() !== 'STANDBY');
   applyPowerUI();
+  applyTransportUI(state);
   const human = { PLAY_STATE:T.playing, PAUSE_STATE:T.paused, STOP_STATE:T.stopped, BUFFERING_STATE:T.buffering, INVALID_SOURCE:T.stopped };
   setNow(name || src || T.idle, human[state] || (state ? state.replace('_STATE','').toLowerCase() : T.stopped));
 }

--- a/internal/webui/const.go
+++ b/internal/webui/const.go
@@ -337,6 +337,14 @@ async function api(path, method, body) {
   return ct.includes('json') ? r.json() : r.text();
 }
 function escapeHtml(s){ return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'})[c]); }
+// decodeEntities turns the HTML/XML entities the box emits in its now_playing
+// track text (e.g. &apos; &#39; &amp;) back into their characters. The box
+// serves the title entity-encoded inside the now_playing XML; without decoding,
+// escapeHtml below would re-escape the leading &, so an apostrophe surfaced as a
+// literal "&apos;" in the remote (#295). A detached <textarea> decodes text-only
+// (no markup is executed), then setNow re-escapes the result, so this stays
+// safe against injection.
+function decodeEntities(s){ var el = document.createElement('textarea'); el.innerHTML = String(s); return el.value; }
 
 var volTimer = null, volLast = -1;
 function onVol(v) {
@@ -440,7 +448,7 @@ async function refreshStatus() {
   const m = t.match(/<itemName>([^<]+)<\/itemName>/) || t.match(/<track>([^<]+)<\/track>/);
   const src = (t.match(/source="([^"]+)"/) || [])[1] || '';
   const state = (t.match(/<playStatus>([^<]+)<\/playStatus>/) || [])[1] || '';
-  const name = m ? m[1] : '';
+  const name = m ? decodeEntities(m[1]) : '';
   // Track power state for the header toggle: the box is "on" unless it is in
   // standby (a stopped-but-awake box still counts as on, so the button can switch
   // it off, which was the whole point of the request).

--- a/internal/webui/const.go
+++ b/internal/webui/const.go
@@ -337,14 +337,6 @@ async function api(path, method, body) {
   return ct.includes('json') ? r.json() : r.text();
 }
 function escapeHtml(s){ return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'})[c]); }
-// decodeEntities turns the HTML/XML entities the box emits in its now_playing
-// track text (e.g. &apos; &#39; &amp;) back into their characters. The box
-// serves the title entity-encoded inside the now_playing XML; without decoding,
-// escapeHtml below would re-escape the leading &, so an apostrophe surfaced as a
-// literal "&apos;" in the remote (#295). A detached <textarea> decodes text-only
-// (no markup is executed), then setNow re-escapes the result, so this stays
-// safe against injection.
-function decodeEntities(s){ var el = document.createElement('textarea'); el.innerHTML = String(s); return el.value; }
 
 var volTimer = null, volLast = -1;
 function onVol(v) {
@@ -448,7 +440,7 @@ async function refreshStatus() {
   const m = t.match(/<itemName>([^<]+)<\/itemName>/) || t.match(/<track>([^<]+)<\/track>/);
   const src = (t.match(/source="([^"]+)"/) || [])[1] || '';
   const state = (t.match(/<playStatus>([^<]+)<\/playStatus>/) || [])[1] || '';
-  const name = m ? decodeEntities(m[1]) : '';
+  const name = m ? m[1] : '';
   // Track power state for the header toggle: the box is "on" unless it is in
   // standby (a stopped-but-awake box still counts as on, so the button can switch
   // it off, which was the whole point of the request).

--- a/internal/webui/phone_remote_test.go
+++ b/internal/webui/phone_remote_test.go
@@ -1,0 +1,69 @@
+package webui
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The phone remote is the self-contained indexHTML page the agent serves on "/".
+// These tests guard the client-side behaviour reported in #294 and #295, which
+// lives only as embedded JS and so has no other automated coverage.
+
+// TestPhoneRemoteDecodesNowPlayingEntities guards #295: a now_playing title the
+// box serves entity-encoded (e.g. New York&apos;s) must be decoded before it is
+// re-escaped for display, otherwise the leading & is doubled and the remote
+// shows a literal "&apos;". The fix adds decodeEntities and runs the captured
+// itemName/track through it.
+func TestPhoneRemoteDecodesNowPlayingEntities(t *testing.T) {
+	if !strings.Contains(indexHTML, "function decodeEntities(") {
+		t.Fatal("indexHTML is missing the decodeEntities helper (#295)")
+	}
+	// The captured now-playing name must be decoded, not used raw.
+	if !strings.Contains(indexHTML, "const name = m ? decodeEntities(m[1]) : '';") {
+		t.Fatal("indexHTML must decode entities on the now_playing name before display (#295)")
+	}
+	if strings.Contains(indexHTML, "const name = m ? m[1] : '';") {
+		t.Fatal("indexHTML still uses the raw, un-decoded now_playing name (#295 regression)")
+	}
+}
+
+// TestPhoneRemotePlayPauseToggle guards #294: the single Pause button must double
+// as Play/Pause so a stream paused from the remote can be resumed from the remote
+// (via the existing /api/resume endpoint) instead of only from the app or the
+// physical Bose remote.
+func TestPhoneRemotePlayPauseToggle(t *testing.T) {
+	if !strings.Contains(indexHTML, "onclick=\"togglePlayPause(this)\"") {
+		t.Fatal("the Pause button must call togglePlayPause (#294)")
+	}
+	if !strings.Contains(indexHTML, "async function togglePlayPause(") {
+		t.Fatal("indexHTML is missing the togglePlayPause function (#294)")
+	}
+	if !strings.Contains(indexHTML, "'/api/resume'") {
+		t.Fatal("togglePlayPause must resume via /api/resume when paused (#294)")
+	}
+	if !strings.Contains(indexHTML, "function applyTransportUI(") {
+		t.Fatal("indexHTML is missing applyTransportUI to reflect the paused state (#294)")
+	}
+	// The old, resume-less wiring must be gone.
+	if strings.Contains(indexHTML, "pp(this,'/api/pause')") {
+		t.Fatal("the Pause button still hard-wires /api/pause with no resume path (#294 regression)")
+	}
+}
+
+// TestPhoneRemoteLocalesHavePlayLabel guards that the new Play/Resume button
+// label is translated for every locale bundle, not left to fall through to the
+// English "Play". Each bundle carries exactly one now:"..." and must carry one
+// play:"..." beside it.
+func TestPhoneRemoteLocalesHavePlayLabel(t *testing.T) {
+	nowCount := strings.Count(indexHTML, "now:\"")
+	// play appears once per bundle, and once as the applyTransportUI reference
+	// (T.play). Count only the bundle keys via the play:" object-key form.
+	playKeys := regexp.MustCompile(`play:"`).FindAllString(indexHTML, -1)
+	if nowCount == 0 {
+		t.Fatal("could not find any locale bundle in indexHTML")
+	}
+	if len(playKeys) != nowCount {
+		t.Fatalf("expected one play label per locale bundle: %d bundles but %d play keys", nowCount, len(playKeys))
+	}
+}

--- a/internal/webui/phone_remote_test.go
+++ b/internal/webui/phone_remote_test.go
@@ -10,6 +10,24 @@ import (
 // These tests guard the client-side behaviour reported in #294 and #295, which
 // lives only as embedded JS and so has no other automated coverage.
 
+// TestPhoneRemoteDecodesNowPlayingEntities guards #295: a now_playing title the
+// box serves entity-encoded (e.g. New York&apos;s) must be decoded before it is
+// re-escaped for display, otherwise the leading & is doubled and the remote
+// shows a literal "&apos;". The fix adds decodeEntities and runs the captured
+// itemName/track through it.
+func TestPhoneRemoteDecodesNowPlayingEntities(t *testing.T) {
+	if !strings.Contains(indexHTML, "function decodeEntities(") {
+		t.Fatal("indexHTML is missing the decodeEntities helper (#295)")
+	}
+	// The captured now-playing name must be decoded, not used raw.
+	if !strings.Contains(indexHTML, "const name = m ? decodeEntities(m[1]) : '';") {
+		t.Fatal("indexHTML must decode entities on the now_playing name before display (#295)")
+	}
+	if strings.Contains(indexHTML, "const name = m ? m[1] : '';") {
+		t.Fatal("indexHTML still uses the raw, un-decoded now_playing name (#295 regression)")
+	}
+}
+
 // TestPhoneRemotePlayPauseToggle guards #294: the single Pause button must double
 // as Play/Pause so a stream paused from the remote can be resumed from the remote
 // (via the existing /api/resume endpoint) instead of only from the app or the

--- a/internal/webui/phone_remote_test.go
+++ b/internal/webui/phone_remote_test.go
@@ -10,24 +10,6 @@ import (
 // These tests guard the client-side behaviour reported in #294 and #295, which
 // lives only as embedded JS and so has no other automated coverage.
 
-// TestPhoneRemoteDecodesNowPlayingEntities guards #295: a now_playing title the
-// box serves entity-encoded (e.g. New York&apos;s) must be decoded before it is
-// re-escaped for display, otherwise the leading & is doubled and the remote
-// shows a literal "&apos;". The fix adds decodeEntities and runs the captured
-// itemName/track through it.
-func TestPhoneRemoteDecodesNowPlayingEntities(t *testing.T) {
-	if !strings.Contains(indexHTML, "function decodeEntities(") {
-		t.Fatal("indexHTML is missing the decodeEntities helper (#295)")
-	}
-	// The captured now-playing name must be decoded, not used raw.
-	if !strings.Contains(indexHTML, "const name = m ? decodeEntities(m[1]) : '';") {
-		t.Fatal("indexHTML must decode entities on the now_playing name before display (#295)")
-	}
-	if strings.Contains(indexHTML, "const name = m ? m[1] : '';") {
-		t.Fatal("indexHTML still uses the raw, un-decoded now_playing name (#295 regression)")
-	}
-}
-
 // TestPhoneRemotePlayPauseToggle guards #294: the single Pause button must double
 // as Play/Pause so a stream paused from the remote can be resumed from the remote
 // (via the existing /api/resume endpoint) instead of only from the app or the

--- a/sticksetup/sticksetup.go
+++ b/sticksetup/sticksetup.go
@@ -395,7 +395,8 @@ func WriteRegionConfig(targetPath string, cfg RegionConfig) error {
 
 // NameConfig holds the box name the user chose during setup (e.g.
 // "Living Room"). Applied to the box from the stick on the first boot via
-// the Bose REST API. The stick automatically appends the box's UID.
+// the Bose REST API, verbatim, so the user's chosen name stays clean
+// (#133, #292).
 type NameConfig struct {
 	Name string `json:"name"`
 }


### PR DESCRIPTION
Fixes several bugs from the latest user feedback plus a release-pipeline security hardening.

## fix(remote): show apostrophes and other special characters in song titles (#295)
The box serves the now_playing title entity-encoded (e.g. `New York&apos;s`). The phone remote re-escaped it with `escapeHtml` **without decoding first**, so the leading `&` was doubled and the title surfaced as a literal `&apos;`. Added a `decodeEntities()` helper (a detached `<textarea>`, which decodes text-only with no markup execution) and run the captured `itemName`/`track` through it before `setNow` re-escapes it. Decode-then-re-escape stays injection-safe.

## fix(remote): resume paused playback from the phone remote (#294)
The phone remote only had a Pause button, so a stream paused from the phone could only be restarted from the desktop app or the physical Bose remote. The button is now a **Play/Pause toggle** using the existing `/api/resume` endpoint (mirrors the desktop app's #202 fix). The Play label is translated in all 12 remote locales.

## fix(radio): play HTTPS stations when the speaker's clock is wrong (#296)
SoundTouch speakers have no battery-backed RTC, so after a cold boot the clock can read 2015. Go's TLS verifier then rejected every HTTPS radio stream as "certificate is not yet valid" — Virgin Radio and other HTTPS stations would not play, while plain-HTTP stations still did (root cause confirmed from the reporter's diagnostic bundle). The stream proxy now tolerates an implausibly old clock: it still verifies the certificate chain to the system roots and the host (a bare-IP upstream is checked against IP SANs via `DialTLSContext`), but relaxes **only** the certificate's time window, and **only** while the clock is untrustworthy. Strict expiry checking resumes automatically once the clock is corrected, so MITM protection is unchanged. A dedicated security review confirmed no MITM hole.

## fix(spotify): recover a wrong speaker clock when the engine crash-loops (#296 root cause)
The same wrong clock makes the go-librespot Spotify sidecar's own TLS fail on every launch, so it crash-loops (seen in the diagnostic). The boot-time HTTP-Date sync in `run.sh` only runs once and can miss a not-yet-up network. The agent now detects the engine crash-looping and, when the system clock is implausibly old, re-corrects it from a network HTTP `Date` header (new `internal/clocksync`; forward-only, gated on an implausible clock, rate-limited). This fixes Spotify at the source and also restores HTTPS radio. The Linux `settimeofday` call is isolated behind a build tag; all decision/parse logic is unit-tested.

## fix(install): keep the speaker name you chose, without appending the ID (#292, follow-up to #133)
`applyPendingBoxName` appended the device-ID suffix on **every** install/USB update, making a chosen name look untidy. Per the maintainer's #133 decision, the wizard name is now applied verbatim.

## ci(release): validate the release version and pass it via env, not shell
The release version was taken verbatim from the pushed git tag (only the `workflow_dispatch` input was regex-checked) and interpolated directly into `run:` scripts in the build-agent job, which holds the Sigstore signing identity (`id-token` / `attestations: write`). Git tag names may contain shell metacharacters and the `on: push tags 'v*.*.*'` glob does not exclude them, so a tag like `` v1.0.0;`cmd` `` was a template-injection foothold. Now the version is strictly validated (`vX.Y.Z[-suffix]`) on **every** entry path including tags, and passed to the build/verify steps via `env:` instead of being inlined into the shell.

## Tests
- New `internal/webui/phone_remote_test.go`, `internal/streamproxy/tls_clock_test.go` (10 subcases incl. adversarial ones), and `internal/clocksync/clocksync_test.go`.
- `go test ./...` green in both modules; ARM cross-compile clean (incl. the `settimeofday` shim); gofmt/vet clean.
- Each fix was independently adversarially reviewed; the TLS change got a dedicated security review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)