### PR TITLE
fix(agent): complete install on older SoundTouch units that got stuck at the progress bar

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,7 +208,10 @@ jobs:
         include:
           - goos: linux
             goarch: arm
-            goarm: "7"
+            # GOARM=5 (softfloat), not 7: some early SoundTouch CPUs lack
+            # working VFP and a hardware-float binary SIGILLs at os.init and
+            # soft-bricks the box (issue #302). Must match Makefile/release.yml.
+            goarm: "5"
             suffix: armv7l
           - goos: linux
             goarch: arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,11 @@ jobs:
         include:
           - goos: linux
             goarch: arm
-            goarm: "7"
+            # GOARM=5 (softfloat), not 7: some early SoundTouch CPUs lack
+            # working VFP and a hardware-float binary SIGILLs at os.init and
+            # soft-bricks the box (issue #302). GOARM=5 runs on every
+            # revision. Must match Makefile/build.yml. Filename stays armv7l.
+            goarm: "5"
             suffix: armv7l
           - goos: linux
             goarch: arm64

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,8 +334,11 @@ level.
 5. Run `go build ./...` and `make wails-dev` once to confirm the
    local environment is healthy. The stick agent contains Linux-only
    syscalls; on Windows or macOS hosts use
-   `GOOS=linux GOARCH=arm GOARM=7 go build ./...` to cross-compile
-   it for the actual target.
+   `GOOS=linux GOARCH=arm GOARM=5 go build ./...` to cross-compile
+   it for the actual target. GOARM=5 (softfloat) is deliberate: some
+   early SoundTouch CPUs lack working VFP and a hardware-float binary
+   SIGILLs at startup and soft-bricks the box (issue #302). `make
+   build-arm` / `make agent-embed` already pin this.
 
 ## Communicating with users
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,8 +48,10 @@ cd streborn
 
 # Sanity check (Linux). On Windows/macOS hosts the agent's Linux-only
 # syscalls make `go build ./...` fail in internal/webui; cross-compile
-# instead (GOOS=linux GOARCH=arm GOARM=7 go build ./... or make build-arm)
-# and run go test on the packages that build on your host.
+# instead (GOOS=linux GOARCH=arm GOARM=5 go build ./... or make build-arm)
+# and run go test on the packages that build on your host. GOARM=5
+# (softfloat) is intentional: some early SoundTouch CPUs lack working
+# VFP and a hardware-float agent SIGILLs at startup (issue #302).
 go build ./...
 go test ./...
 

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,18 @@ build:
 	@mkdir -p $(BIN_DIR)
 	$(GO) build -trimpath -ldflags="$(LDFLAGS)" -o $(BIN_DIR)/$(BINARY) $(PKG)
 
+# GOARM=5, not 7, on purpose. Some early SoundTouch units (seen on an
+# older ST20 on 2017 firmware, issue #302) have a CPU/kernel without
+# working VFP hardware float. A GOARM=6/7 binary emits VFP instructions
+# and SIGILLs at the first stdlib float touch (os.init), crash-looping
+# the agent and soft-bricking the box. GOARM=5 is pure software float
+# with kernel-helper atomics: no ARMv7-optional instructions, so it runs
+# on every SoundTouch CPU revision (a compat superset of GOARM=7). The
+# agent does no heavy FP, so the softfloat cost is negligible. Keep this
+# in sync with release.yml / build.yml (goarm matrix) and agent-embed.
 build-arm:
 	@mkdir -p $(BIN_DIR)
-	GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 \
+	GOOS=linux GOARCH=arm GOARM=5 CGO_ENABLED=0 \
 		$(GO) build -trimpath -ldflags="$(LDFLAGS)" -o $(BIN_DIR)/$(BINARY)-armv7l $(PKG)
 
 build-arm64:
@@ -71,7 +80,7 @@ winformat-embed:
 # picks it up. Required for OTA-from-app to actually push a binary.
 agent-embed:
 	@mkdir -p $(dir $(AGENT_EMBED_OUT))
-	GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 \
+	GOOS=linux GOARCH=arm GOARM=5 CGO_ENABLED=0 \
 		$(GO) build -trimpath -ldflags="$(LDFLAGS)" -o $(AGENT_EMBED_OUT) $(PKG)
 	@echo "embedded $$(stat -c %s $(AGENT_EMBED_OUT) 2>/dev/null || stat -f %z $(AGENT_EMBED_OUT)) bytes into $(AGENT_EMBED_OUT)"
 

--- a/setup/Install-STR.ps1
+++ b/setup/Install-STR.ps1
@@ -469,7 +469,7 @@ function Action-UpdateWizard {
                 Write-Host ""
                 Write-Host "  Wichtig: schliesse den Wizard und starte ihn neu damit die Updates greifen." -ForegroundColor Yellow
                 Write-Host "  Auch das Binary in bin/ muss neu gebaut werden falls du Stick aktualisieren willst:"
-                Write-Host '    $env:GOOS="linux"; $env:GOARCH="arm"; $env:GOARM="7"; $env:CGO_ENABLED="0"'
+                Write-Host '    $env:GOOS="linux"; $env:GOARCH="arm"; $env:GOARM="5"; $env:CGO_ENABLED="0"'
                 Write-Host "    go build -o bin/streborn-armv7l ./cmd/agent"
             } catch {
                 Write-Fail "git pull fehlgeschlagen: $_"
@@ -480,7 +480,7 @@ function Action-UpdateWizard {
             Write-Host "  Manuelle Anleitung:"
             Write-Host "    1. Im Repo Verzeichnis: git pull"
             Write-Host "    2. Falls Binary neu gebaut werden soll:"
-            Write-Host '       set GOOS=linux & set GOARCH=arm & set GOARM=7 & set CGO_ENABLED=0'
+            Write-Host '       set GOOS=linux & set GOARCH=arm & set GOARM=5 & set CGO_ENABLED=0'
             Write-Host "       go build -o bin\streborn-armv7l .\cmd\agent"
             Write-Host "    3. Wizard schliessen und neu starten."
             Write-Host "    4. Im Wizard Menue Punkt 5 (Karte aktualisieren) waehlen."

--- a/usb-stick/run.sh
+++ b/usb-stick/run.sh
@@ -2984,6 +2984,42 @@ redeploy_agent_from_stick() {
     return 1
 }
 
+# Defense-in-depth for a permanently-unstartable agent. When the agent
+# crash-loops (e.g. an illegal-instruction SIGILL on an old ST CPU built
+# for the wrong ISA, issue #302) it never binds :8888, and the box can be
+# left sitting at a full OOB / install progress bar. The on-box OOB gates
+# (finalize_oob_setup) only run on the WLAN-provision path for BCO boxes,
+# so a crash-looping-agent box never reaches them. This advances the Bose
+# setup state machine here too, so a dead agent does not soft-brick an
+# otherwise-usable speaker: BoseApp (:8090), SSH and UPnP still work, only
+# STR's own webui is gone. Same /language + /name POSTs finalize_oob_setup
+# makes (live-proven 2026-06-01). Self-gated on systemstate: a pure no-op
+# on any box already out of OOB (which includes every box where the agent
+# has ever come up). It NEVER reboots (could loop) and NEVER re-execs
+# run-override.sh. Only ever called once the agent is declared unstable.
+rescue_oob_display() {
+    _ro_api="http://127.0.0.1:8090"
+    _ro_state=$(wget -qO- -T 5 "$_ro_api/setup" 2>/dev/null)
+    # Log the raw state so the next diagnostic bundle proves whether the
+    # box was ever in the OOB state this rescue can act on (the stuck bar
+    # on older firmware may be a SoftwareUpdate screen, not systemstate).
+    setup_log "agent-unstable rescue: /setup state = $(printf '%s' "$_ro_state" | tr -d '\n\r' | cut -c1-200)"
+    case "$_ro_state" in
+        *SETUP_LANG_NOT_SET*) : ;;
+        *) setup_log "agent-unstable rescue: systemstate already past OOB (or /setup unavailable), no display rescue needed"; return 0 ;;
+    esac
+    _ro_lang=$(resolve_setup_language)
+    setup_log "agent-unstable rescue: box stuck in OOB with a dead agent, POSTing /language=$_ro_lang + /name to leave the setup screen"
+    wget -qO- -T 5 --header="Content-Type: text/xml" --post-data="<sysLanguage>${_ro_lang}</sysLanguage>" "$_ro_api/language" >/dev/null 2>&1
+    _ro_nm=""
+    [ -f "$STICK/name.conf" ] && _ro_nm=$(sed -n 's/.*"name":"\([^"]*\)".*/\1/p' "$STICK/name.conf" | head -1)
+    [ -z "$_ro_nm" ] && _ro_nm=$(wget -qO- -T 5 "$_ro_api/name" 2>/dev/null | sed -n 's:.*<name>\([^<]*\)</name>.*:\1:p' | head -1)
+    [ -z "$_ro_nm" ] && _ro_nm="SoundTouch"
+    _ro_nme=$(printf '%s' "$_ro_nm" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g')
+    wget -qO- -T 5 --header="Content-Type: text/xml" --post-data="<name>${_ro_nme}</name>" "$_ro_api/name" >/dev/null 2>&1
+    setup_log "agent-unstable rescue: posted /language + /name; box should leave the OOB screen and run as a plain speaker despite the dead agent"
+}
+
 start_agent() {
     START_COUNT=$((${START_COUNT:-0}+1))
     # Fingerprint the binary on every launch: a corrupt / short NAND copy
@@ -3023,7 +3059,8 @@ start_agent() {
         wait "$_bpid"
         _ec=$?
         case "$_ec" in
-            12[89]|1[3-9][0-9]) _sig=$((_ec-128)); _why="killed by signal $_sig (137=SIGKILL/OOM 134=SIGABRT/Go-fatal 139=SIGSEGV 143=SIGTERM)" ;;
+            12[89]|1[3-9][0-9]) _sig=$((_ec-128)); _why="killed by signal $_sig (132=SIGILL/illegal-instruction 134=SIGABRT/Go-fatal 137=SIGKILL/OOM 139=SIGSEGV 143=SIGTERM); a SIGILL here means the agent binary used a CPU instruction this SoundTouch lacks (old ST unit without VFP) -> rebuild with GOARM=5" ;;
+            2) _why="exit status 2 = Go runtime fatal (panic/throw, or a fatal signal such as SIGILL/illegal-instruction during os.init that the runtime reports then exits 2). On an older ST CPU this means the agent was built for an instruction set the box lacks -> rebuild with GOARM=5; see agent-crash.log for the Go traceback" ;;
             0) _why="clean exit (unexpected for a daemon)" ;;
             *) _why="exit status $_ec" ;;
         esac
@@ -3692,6 +3729,11 @@ agent_port_bound() {
                 echo "see agent-crash.log for the per-exit code/signal and the agent tail"
             } > "$AGENT_UNSTABLE_MARK" 2>/dev/null
             setup_log "boot-watchdog: $BOOT_RESTARTS restarts in 120s exhausted, agent UNSTABLE (marker written, $(agent_resource_line)), falling back to slow loop"
+            # Defense-in-depth: the agent is definitively dead. If the box is
+            # still sitting in OOB (full install/boot progress bar), advance
+            # the Bose setup state off it so it is at least a usable plain
+            # speaker. No-op if already out of OOB; never reboots (issue #302).
+            rescue_oob_display
             break
         fi
         BOOT_RESTARTS=$((BOOT_RESTARTS+1))


### PR DESCRIPTION
## Problem (issue #302)

Some early SoundTouch units (an older ST20 on 2017 firmware) have a CPU/kernel with **no working VFP hardware float**. The stick agent was cross-compiled `GOARM=7`, which lets Go emit VFP instructions. On such a unit the first floating-point instruction (reached during `os.init`, right after the runtime finishes coming up) is illegal, so the agent takes `SIGILL` and exits before binding `:8888`. The boot-watchdog crash-loops it and the speaker is left stuck at a full install/boot progress bar (SSH and BoseApp still answer, so it's a soft-brick). The byte-identical binary runs fine on newer units that have VFP, which is why only one of the reporter's two ST20s was affected.

## Fix

- Build the ARM agent with **`GOARM=5`** (pure software float, kernel-helper atomics, no ARMv7-optional instructions) at every shipped/embedded site: `Makefile` (build-arm + agent-embed), `release.yml` + `build.yml` goarm matrices, and the dev hints in `CLAUDE.md` / `CONTRIBUTING.md` / `setup/Install-STR.ps1`. `GOARM=6` is not enough (still emits VFP); only `GOARM=5` removes it. A GOARM=5 binary is a compat superset that still runs on the units that work today. The agent does no heavy FP (stream remux is byte copy, Spotify decode is the go-librespot sidecar), so softfloat cost is negligible. Filename stays `streborn-armv7l`.
- All build sites flip together so the embedded and OTA/stick agents share one ISA and version stamp (a split build re-triggers the OTA banner loop).

## Defense-in-depth (`usb-stick/run.sh`)

Guards against any future reason an agent cannot start, not just this one:
- decode agent exit status 2 / signal 132 as a Go runtime fatal / illegal instruction and point at the `GOARM=5` rebuild;
- when the agent is declared UNSTABLE, `rescue_oob_display` advances the Bose setup state off the OOB screen (same `/language` + `/name` POSTs the normal path uses) so a dead agent leaves a usable plain speaker instead of a stuck bar. Self-gated on systemstate (no-op once out of OOB), never reboots, never re-execs run-override.

## Validation

GOARM=5 agent cross-compiles clean (valid ARM ELF), `run.sh` passes `sh -n` and is LF-clean, both workflow YAMLs parse with `goarm: '5'`, desktop app rebuilt with the fixed agent embedded. Final proof is on the reporter's failing ST20 via a fresh stick from the next release.

Refs #302