### PR TITLE
fix: NAND-full install brick (#302) + control-API volume/docs + setup wording

### DIFF
--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -803,7 +803,7 @@
   "setup.targetCardBadgeSTR": "nur Update",
   "setup.targetCardBadgeStock": "Erstinstallation",
   "setup.targetCardBadgeFactory": "Stick-Install",
-  "setup.targetCardFactoryHelp": "Für neuen oder zurückgesetzten Lautsprecher, der noch nicht im WLAN ist. Stick vorbereiten, einstecken, Strom kurz weg. Lautsprecher liest WLAN-Daten vom Stick und meldet sich automatisch an.",
+  "setup.targetCardFactoryHelp": "Für einen neuen oder zurückgesetzten Lautsprecher, der noch nicht im WLAN ist. Stick vorbereiten, einstecken und den Strom kurz trennen, damit der Lautsprecher die WLAN-Daten vom Stick liest und unten in der Liste erscheint. Die Installation von STR ist immer der letzte Schritt und du startest sie hier in der App: Lautsprecher auswählen und auf Installieren tippen. (Ein Lautsprecher, der schon im WLAN ist, braucht keinen Neustart, einfach den Stick einstecken und auf Installieren tippen.)",
   "setup.targetCardFactoryMacHint": "Unter macOS fragt die App eventuell nach Keychain-Zugriff, um dein WLAN-Passwort zu lesen und auf den Stick zu schreiben. Erlaube es, oder gib das Passwort selbst ein.",
   "setup.targetPickedFor": "Ausgewählt:",
   "setup.targetChange": "Ändern",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -803,7 +803,7 @@
   "setup.targetCardBadgeSTR": "update only",
   "setup.targetCardBadgeStock": "first install",
   "setup.targetCardBadgeFactory": "stick install",
-  "setup.targetCardFactoryHelp": "For a new or factory-reset speaker not yet on Wi-Fi. After preparing, plug stick into speaker and power-cycle. Speaker reads Wi-Fi credentials from stick and joins your Wi-Fi automatically.",
+  "setup.targetCardFactoryHelp": "For a new or factory-reset speaker not yet on Wi-Fi. Prepare the stick, plug it in and power-cycle the speaker so it joins your Wi-Fi from the stick and appears in the list below. Installing STR is always the last step and you start it here in the app: pick the speaker and press Install. (A speaker already on Wi-Fi needs no power-cycle, just insert the stick and press Install.)",
   "setup.targetCardFactoryMacHint": "On macOS the app may ask for Keychain permission to read your Wi-Fi password so it can put it on the stick. Allow it, or type the password in yourself.",
   "setup.targetPickedFor": "Selected:",
   "setup.targetChange": "Change",

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -723,7 +723,7 @@
   "setup.targetCardBadgeSTR": "solo actualizar",
   "setup.targetCardBadgeStock": "primera instalación",
   "setup.targetCardBadgeFactory": "instalación por memoria",
-  "setup.targetCardFactoryHelp": "Para un altavoz nuevo o restablecido que aún no está en el Wi-Fi. Tras prepararla, conecta la memoria al altavoz y reinícialo. El altavoz lee las credenciales de Wi-Fi de la memoria y se une a tu Wi-Fi automáticamente.",
+  "setup.targetCardFactoryHelp": "Para un altavoz nuevo o restablecido que aún no está en el Wi-Fi. Prepara la memoria, conéctala y reinicia el altavoz (corta la corriente) para que lea las credenciales de Wi-Fi de la memoria y aparezca en la lista de abajo. Instalar STR es siempre el último paso y se inicia aquí en la app: elige el altavoz y pulsa Instalar. (Un altavoz que ya está en el Wi-Fi no necesita reinicio, solo inserta la memoria y pulsa Instalar.)",
   "setup.targetCardFactoryMacHint": "En macOS, la app puede pedir acceso al Llavero (Keychain) para leer tu contraseña de Wi-Fi y escribirla en la memoria USB. Permítelo o escribe la contraseña tú mismo.",
   "setup.targetPickedFor": "Seleccionado:",
   "setup.targetChange": "Cambiar",

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -723,7 +723,7 @@
   "setup.targetCardBadgeSTR": "mise à jour uniquement",
   "setup.targetCardBadgeStock": "première installation",
   "setup.targetCardBadgeFactory": "installation par clé",
-  "setup.targetCardFactoryHelp": "Pour une enceinte neuve ou réinitialisée pas encore sur le Wi-Fi. Après préparation, branchez la clé dans l'enceinte et redémarrez-la. L'enceinte lit les identifiants Wi-Fi sur la clé et rejoint votre Wi-Fi automatiquement.",
+  "setup.targetCardFactoryHelp": "Pour une enceinte neuve ou réinitialisée pas encore sur le Wi-Fi. Préparez la clé, branchez-la et redémarrez l'enceinte (coupez l'alimentation) pour qu'elle lise les identifiants Wi-Fi de la clé et apparaisse dans la liste ci-dessous. L'installation de STR est toujours la dernière étape et vous la lancez ici dans l'app : choisissez l'enceinte et appuyez sur Installer. (Une enceinte déjà sur le Wi-Fi n'a pas besoin de redémarrage, insérez simplement la clé et appuyez sur Installer.)",
   "setup.targetCardFactoryMacHint": "Sur macOS, l'app peut demander l'accès au trousseau (Keychain) pour lire ton mot de passe Wi-Fi et l'écrire sur la clé. Autorise-le, ou saisis le mot de passe toi-même.",
   "setup.targetPickedFor": "Sélectionnée :",
   "setup.targetChange": "Changer",

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -723,7 +723,7 @@
   "setup.targetCardBadgeSTR": "alleen bijwerken",
   "setup.targetCardBadgeStock": "eerste installatie",
   "setup.targetCardBadgeFactory": "stick-installatie",
-  "setup.targetCardFactoryHelp": "Voor een nieuwe of fabrieksgereset speaker die nog niet op wifi zit. Na het voorbereiden steek je de stick in de speaker en herstart je hem via de stroom. De speaker leest de wifi-gegevens van de stick en sluit automatisch aan op je wifi.",
+  "setup.targetCardFactoryHelp": "Voor een nieuwe of fabrieksgereset speaker die nog niet op wifi zit. Bereid de stick voor, steek hem erin en herstart de speaker via de stroom, zodat hij de wifi-gegevens van de stick leest en in de lijst hieronder verschijnt. STR installeren is altijd de laatste stap en die start je hier in de app: kies de speaker en druk op Installeren. (Een speaker die al op wifi zit heeft geen herstart nodig, steek gewoon de stick erin en druk op Installeren.)",
   "setup.targetCardFactoryMacHint": "Op macOS kan de app om Keychain-toegang vragen om je wifi-wachtwoord te lezen en op de stick te zetten. Sta dit toe of typ het wachtwoord zelf in.",
   "setup.targetPickedFor": "Geselecteerd:",
   "setup.targetChange": "Wijzigen",

--- a/docs/CONTROL-API.md
+++ b/docs/CONTROL-API.md
@@ -1,0 +1,99 @@
+# STR local control API
+
+STR exposes a small HTTP control API on the speaker itself, so home
+automation (Home Assistant, ioBroker, Node-RED, a shell script, ...) can
+turn the speaker on and off, set the volume, recall presets and control
+playback without any Bose cloud and without a separate middleware.
+
+Everything here is local to your LAN. There is no authentication: treat
+reachability on your network as the trust boundary, the same as the
+speaker's own Bose API.
+
+## Base URL and discovery
+
+The agent listens on port **8888**:
+
+```
+http://<speaker-ip>:8888
+```
+
+On the BCO/whitelisted chassis (SoundTouch Portable, and some ST20), the
+same API is reached on port **17008** instead (the box redirects it to the
+agent), so if `:8888` is refused, use `:17008`.
+
+STR announces itself over mDNS as `_streborn._tcp.local`, so you can
+discover the speaker's address and port automatically.
+
+All request and response bodies are JSON.
+
+## Playback
+
+| Method | Path | Body | Notes |
+| ------ | ---- | ---- | ----- |
+| `GET`  | `/api/status` | - | Current now-playing (source, track, art, play state). |
+| `POST` | `/api/play` | `{"url":"https://...","title":"...","mime":"audio/mpeg"}` | Play any stream URL. `title`, `icon`, `mime` are optional. |
+| `POST` | `/api/play/<slot>` | - | Play STR preset slot `1`-`6`. |
+| `POST` | `/api/pause` | - | Pause. |
+| `POST` | `/api/resume` | - | Resume. |
+| `POST` | `/api/stop` | - | Stop. |
+| `POST` | `/api/next` | - | Next track (within a folder / playlist). |
+| `POST` | `/api/prev` | - | Previous track. |
+
+## Volume, power and source
+
+| Method | Path | Body | Notes |
+| ------ | ---- | ---- | ----- |
+| `GET`  | `/api/box/volume` | - | Returns `{"value":N,"target":N,"muted":bool}` (0-100). |
+| `PUT`  | `/api/box/volume` | `{"value":N}` | Set the absolute volume (0-100). |
+| `POST` | `/api/box/power` | `{"on":true}` / `{"on":false}` | Power on, or send to standby. |
+| `PUT`  | `/api/box/source` | `{"source":"AUX"}` | `AUX`, `BLUETOOTH` or `STANDBY`. |
+
+For a relative change ("volume up 5"), read `GET /api/box/volume`, add to
+`value`, and `PUT` the result.
+
+## Presets
+
+| Method | Path | Body | Notes |
+| ------ | ---- | ---- | ----- |
+| `GET`  | `/api/presets` | - | The STR preset store (what the six slots point at). |
+| `GET`  | `/api/box/presets` | - | The hardware preset buttons as the box reports them. |
+| `POST` | `/api/box/presets/recall` | `{"slot":N}` | Recall hardware preset `N` (1-6). |
+
+`POST /api/play/<slot>` is usually what you want to start a preset from
+automation; `presets/recall` mirrors a physical button press.
+
+## Examples
+
+```bash
+BOX=http://192.0.2.10:8888
+
+# Turn on and set the volume to 20
+curl -s -X POST "$BOX/api/box/power"  -d '{"on":true}'
+curl -s -X PUT  "$BOX/api/box/volume" -d '{"value":20}'
+
+# Read the current volume
+curl -s "$BOX/api/box/volume"          # -> {"value":20,"target":20,"muted":false}
+
+# Start preset 1, then pause
+curl -s -X POST "$BOX/api/play/1"
+curl -s -X POST "$BOX/api/pause"
+
+# Play an arbitrary internet radio stream
+curl -s -X POST "$BOX/api/play" -d '{"url":"https://example.com/stream.mp3"}'
+
+# Send to standby
+curl -s -X POST "$BOX/api/box/power" -d '{"on":false}'
+```
+
+## The speaker's own Bose API still works
+
+STR does not block the speaker's native Bose HTTP API on port **8090**, so
+existing setups that call it directly keep working alongside STR:
+
+- `POST http://<speaker-ip>:8090/key` with a `press`/`release` body for
+  `POWER`, `PRESET_1`..`PRESET_6`, `PLAY_PAUSE`, `VOLUME_UP`, `VOLUME_DOWN`.
+- `POST http://<speaker-ip>:8090/volume` with `<volume>NN</volume>`.
+
+The STR API on `:8888` is the more stable and documented surface and adds
+things the Bose cloud used to do (arbitrary stream URLs, the STR preset
+store), so new integrations should prefer it.

--- a/internal/boxapi/boxapi.go
+++ b/internal/boxapi/boxapi.go
@@ -563,6 +563,25 @@ func (c *Client) SetVolume(ctx context.Context, v int) error {
 	return c.postXML(ctx, "/volume", body)
 }
 
+// GetVolume reads the box's current volume state (0-100 target/actual plus
+// mute). Lets a caller read the level for a relative adjustment or a status
+// display without loading the full /volume+bass+network settings blob.
+func (c *Client) GetVolume(ctx context.Context) (Volume, error) {
+	var raw struct {
+		Target int    `xml:"targetvolume"`
+		Actual int    `xml:"actualvolume"`
+		Mute   string `xml:"muteenabled"`
+	}
+	if err := c.getXML(ctx, "/volume", &raw); err != nil {
+		return Volume{}, err
+	}
+	return Volume{
+		Target: raw.Target,
+		Actual: raw.Actual,
+		Muted:  strings.EqualFold(raw.Mute, "true"),
+	}, nil
+}
+
 // SetBass sets the bass value (range from bassCapabilities — typical
 // ST10 range -9..0).
 func (c *Client) SetBass(ctx context.Context, b int) error {

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -3422,9 +3422,25 @@ func (s *Server) handleBoxName(w http.ResponseWriter, r *http.Request) {
 
 // handleBoxVolume PUT sets the volume. Body {"value":N}.
 func (s *Server) handleBoxVolume(w http.ResponseWriter, r *http.Request) {
-	if !requireMethod(w, r, http.MethodPut) {
+	if !requireMethod(w, r, http.MethodGet, http.MethodPut) {
 		return
 	}
+	c := boxapi.New(s.boxHost)
+	// GET returns the current volume so home automation / a status display can
+	// read the level (and do relative up/down) without parsing the heavier
+	// /api/box/settings blob.
+	if r.Method == http.MethodGet {
+		ctx, cancel := context.WithTimeout(r.Context(), 6*time.Second)
+		defer cancel()
+		v, err := c.GetVolume(ctx)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"value": v.Actual, "target": v.Target, "muted": v.Muted})
+		return
+	}
+	// PUT sets the absolute volume (0-100).
 	s.boxCmdMu.Lock()
 	defer s.boxCmdMu.Unlock()
 	var req struct {
@@ -3433,7 +3449,6 @@ func (s *Server) handleBoxVolume(w http.ResponseWriter, r *http.Request) {
 	if !decodeJSONRequest(w, r, 256, &req) {
 		return
 	}
-	c := boxapi.New(s.boxHost)
 	ctx, cancel := context.WithTimeout(r.Context(), 6*time.Second)
 	defer cancel()
 	if err := c.SetVolume(ctx, req.Value); err != nil {

--- a/usb-stick/run.sh
+++ b/usb-stick/run.sh
@@ -639,58 +639,90 @@ cleanup_nand() {
     log "NAND cleanup done, ${free_kb:-?} KB free on /mnt/nv"
 }
 
+# NAND_BIN_CORRUPT is set to 1 when we wrote the agent binary to NAND but
+# could not flash-verify it (a full NAND lets the write land in the page
+# cache while the flash pages stay erased = 0xff, which exec later reads
+# back as an illegal instruction -> SIGILL crash-loop, live-seen on a tight
+# ST20, #302). The BIN selection then runs the agent from a RAM copy of the
+# stick binary instead. Unset/0 on a healthy or stickless boot.
+NAND_BIN_CORRUPT=0
 sync_stick_to_nand_always() {
-    # go-librespot (Spotify sidecar): cache stick -> NAND independently of
-    # the agent so it survives stick removal + reboot. Same atomic
-    # .new + mv pattern. Best-effort: absence just means no Spotify.
-    if [ -r "$STICK_GLR" ]; then
-        if cp "$STICK_GLR" "$CACHED_GLR.new" 2>/dev/null; then
-            chmod +x "$CACHED_GLR.new"
-            if mv "$CACHED_GLR.new" "$CACHED_GLR" 2>/dev/null; then
-                log "stick go-librespot deployed to NAND cache ($(wc -c < "$CACHED_GLR") bytes)"
-            else
-                log "stick -> NAND go-librespot mv failed, keeping previous"
-                rm -f "$CACHED_GLR.new"
-            fi
-        else
-            log "stick -> NAND go-librespot cp failed, keeping previous"
-            rm -f "$CACHED_GLR.new"
-        fi
-    fi
-
-    if [ ! -r "$STICK_BIN" ]; then
-        return 0
-    fi
-    if cp "$STICK_BIN" "$CACHED_BIN.new" 2>/dev/null; then
-        # chmod is part of the condition: a non-executable cache fails run.sh's
-        # [ -x "$CACHED_BIN" ] test at boot and would degrade to the stick
-        # fallback (or the "neither NAND cache" exit) with no clue why, so a
-        # silent chmod failure must keep the previous good cache instead.
-        if chmod +x "$CACHED_BIN.new" && mv "$CACHED_BIN.new" "$CACHED_BIN" 2>/dev/null; then
+    # The AGENT BINARY is essential and goes FIRST, before the optional
+    # Spotify engine, so a tight NAND can never let go-librespot crowd the
+    # agent out (the old order wrote the 16 MB engine first and left no room
+    # for the 12 MB agent to commit -> corrupt agent, #302).
+    if [ -r "$STICK_BIN" ]; then
+        if cp "$STICK_BIN" "$CACHED_BIN.new" 2>/dev/null && chmod +x "$CACHED_BIN.new" && mv "$CACHED_BIN.new" "$CACHED_BIN" 2>/dev/null; then
             log "stick binary deployed to NAND cache ($(wc -c < "$CACHED_BIN") bytes)"
-            # Hash both copies so a corrupt / half-written NAND binary (a
-            # suspect for the ST10 crash-loop where the agent SIGSEGVs at
-            # once) is visible: a mismatch means the copy did not land
-            # intact and the agent will crash regardless of environment.
+            # Verify against FLASH, not the page cache. Without the sync +
+            # drop_caches the md5 reads back the bytes we just wrote from RAM
+            # cache and passes even when the flash writeback silently failed on
+            # a full NAND (ENOSPC), so a corrupt agent looked fine here and
+            # only surfaced as a SIGILL at run time. Force the pages to flash,
+            # drop the cache, then re-read from flash and compare to the stick.
+            sync 2>/dev/null
+            [ -w /proc/sys/vm/drop_caches ] && echo 3 > /proc/sys/vm/drop_caches 2>/dev/null
             _sm5=$(md5sum "$STICK_BIN" 2>/dev/null | awk '{print $1}')
             _nm5=$(md5sum "$CACHED_BIN" 2>/dev/null | awk '{print $1}')
             if [ -n "$_sm5" ] && [ "$_sm5" = "$_nm5" ]; then
-                setup_log "binary deploy: md5 OK $_nm5 ($(wc -c < "$CACHED_BIN") bytes)"
+                setup_log "binary deploy: md5 OK (flash-verified) $_nm5 ($(wc -c < "$CACHED_BIN") bytes)"
+                if [ -r "$STICK_VER_FILE" ]; then
+                    cp "$STICK_VER_FILE" "$NAND_VER_FILE" 2>/dev/null
+                    log "NAND version.txt updated: $(cat "$NAND_VER_FILE" 2>/dev/null)"
+                fi
             else
-                setup_log "binary deploy: md5 MISMATCH stick=$_sm5 nand=$_nm5 — NAND copy is corrupt, agent will crash"
+                NAND_BIN_CORRUPT=1
+                setup_log "binary deploy: md5 MISMATCH after flash sync stick=$_sm5 nand=$_nm5 — the NAND write did not commit (full NAND?); the agent will be run from a RAM copy instead (see RAM-exec)"
             fi
-            if [ -r "$STICK_VER_FILE" ]; then
-                cp "$STICK_VER_FILE" "$NAND_VER_FILE" 2>/dev/null
-                log "NAND version.txt updated: $(cat "$NAND_VER_FILE" 2>/dev/null)"
+        else
+            log "stick -> NAND binary cp/chmod/mv failed, keeping previous NAND binary"
+            rm -f "$CACHED_BIN.new"
+        fi
+    fi
+
+    # go-librespot (Spotify sidecar) is OPTIONAL. Deploy it only when there is
+    # real headroom AFTER the essential agent, so it can never crowd the agent
+    # out of a small NAND. When it does not fit, defer it (Spotify simply stays
+    # unavailable until the next OTA finds room) rather than filling the volume.
+    if [ -r "$STICK_GLR" ]; then
+        _glr_kb=$(( $(wc -c < "$STICK_GLR" 2>/dev/null || echo 0) / 1024 ))
+        _free_kb=$(df -k /mnt/nv 2>/dev/null | tail -1 | awk '{print $(NF-2)}')
+        if [ "${_glr_kb:-0}" -gt 0 ] && [ "${_free_kb:-0}" -gt $(( _glr_kb + 3072 )) ]; then
+            if cp "$STICK_GLR" "$CACHED_GLR.new" 2>/dev/null && chmod +x "$CACHED_GLR.new" && mv "$CACHED_GLR.new" "$CACHED_GLR" 2>/dev/null; then
+                log "stick go-librespot deployed to NAND cache ($(wc -c < "$CACHED_GLR") bytes)"
+            else
+                log "stick -> NAND go-librespot deploy failed, keeping previous"
+                rm -f "$CACHED_GLR.new"
             fi
+        else
+            log "NAND tight (${_free_kb:-?}KB free, go-librespot needs ${_glr_kb}KB + margin), deferring the Spotify engine so it cannot crowd out the agent binary"
+        fi
+    fi
+    return 0
+}
+
+# stage_ram_binary copies the STICK agent binary into tmpfs (RAM) and points
+# RAM_BIN at it. Used when the NAND write could not be flash-verified: tmpfs
+# has no flash writeback, so the bytes exec mmaps are exactly what we copied,
+# which sidesteps a full/unwritable NAND entirely (#302). Needs the stick as a
+# clean source — a stickless boot with an already-corrupt NAND cannot use this.
+RAM_BIN=""
+stage_ram_binary() {
+    [ -r "$STICK_BIN" ] || { setup_log "RAM-exec: no stick binary to stage (stickless boot), cannot bypass an unwritable NAND"; return 1; }
+    _rd=/dev/shm
+    { [ -d "$_rd" ] && [ -w "$_rd" ]; } || _rd=/tmp
+    RAM_BIN="$_rd/streborn-armv7l"
+    if cp "$STICK_BIN" "$RAM_BIN.new" 2>/dev/null && chmod +x "$RAM_BIN.new" && mv "$RAM_BIN.new" "$RAM_BIN" 2>/dev/null; then
+        _rm5=$(md5sum "$RAM_BIN" 2>/dev/null | awk '{print $1}')
+        _sm5=$(md5sum "$STICK_BIN" 2>/dev/null | awk '{print $1}')
+        if [ -n "$_rm5" ] && [ "$_rm5" = "$_sm5" ]; then
+            setup_log "RAM-exec: staged agent to $RAM_BIN (tmpfs) md5=$_rm5, running from RAM to bypass the unwritable NAND"
             return 0
         fi
-        log "stick -> NAND chmod/mv failed, keeping previous NAND binary"
-        rm -f "$CACHED_BIN.new"
-        return 1
     fi
-    log "stick -> NAND cp failed (stick I/O error?), keeping previous NAND binary"
-    rm -f "$CACHED_BIN.new"
+    setup_log "RAM-exec: staging the agent to tmpfs FAILED, falling back to the NAND/stick binary"
+    rm -f "$RAM_BIN.new" 2>/dev/null
+    RAM_BIN=""
     return 1
 }
 
@@ -1189,8 +1221,15 @@ shim_late_swap() {
 }
 (shim_late_swap) &
 
-# Binary selection: NAND cache first, stick as fallback.
-if [ -x "$CACHED_BIN" ]; then
+# Binary selection: a flash-verified NAND cache is preferred. If the NAND
+# write could not be committed (tight NAND -> erased 0xff pages that crash the
+# agent with SIGILL, #302), run from a RAM copy of the stick binary instead.
+# A NAND cache that verified fine, or a healthy stickless boot, uses NAND as
+# before; the stick binary directly is the last resort.
+if [ "$NAND_BIN_CORRUPT" = "1" ] && stage_ram_binary; then
+    BIN="$RAM_BIN"
+    log "running the agent from RAM ($BIN): the NAND copy did not commit to flash"
+elif [ -x "$CACHED_BIN" ]; then
     BIN="$CACHED_BIN"
 elif [ -x "$STICK_BIN" ]; then
     BIN="$STICK_BIN"


### PR DESCRIPTION
Three changes for the next release.

## 1. Fix the ST20 that stayed stuck at the install progress bar (#302)

Root cause: on a nearly-full NAND the boot-time stick->NAND sync wrote the optional 16 MB Spotify engine **first** and then the essential ~12 MB agent, so the agent could not commit to flash. The write landed in the page cache (the md5 check read it back from cache and passed) while the flash pages stayed erased (`0xff`); at run time the kernel demand-pages `.text`, reads `0xff`, and the CPU faults on `0xFFFFFFFF` -> `SIGILL`, crash-looping the agent. Deterministic, md5-fooled, and independent of GOARM (the reporter's CPU has VFP; the earlier softfloat change did not help because floats were never the problem).

Fix in `usb-stick/run.sh`:
- deploy the **agent binary first**, before the optional Spotify engine;
- **verify against flash**, not the page cache (`sync` + `drop_caches`, then re-read and compare to the stick);
- when the NAND copy cannot be committed, **run the agent from a RAM copy** of the stick binary (tmpfs has no flash writeback);
- **defer the Spotify engine** when there is no headroom after the agent.

Reaches users via a fresh stick install (OTA replaces only the binary, not run.sh).

## 2. Local control API: read volume + documentation

- `GET /api/box/volume` -> `{"value":N,"target":N,"muted":bool}` (was write-only).
- New `docs/CONTROL-API.md` documenting every control endpoint (power, volume, source, presets, playback, arbitrary URL) with `curl` examples, so home automation can drop its own HTTP->Bose middleware.

## 3. Setup wording

Reword the factory-setup help so it is explicit that installing STR is always started from the app (a stock speaker has no hook to auto-run the stick). Updated in en/de/es/fr/nl (the locales that carry this string).

Refs #302