### PR TITLE
fix(agent): stop scm SoundTouch 20 losing Wi-Fi after install

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -312,14 +312,12 @@ func run() error {
 		logger.Warn("recent history load failed, starting empty", "err", rErr)
 	}
 
-	// Modify the hosts file
+	// Create the /etc/hosts manager now (so the shutdown path can Restore it),
+	// but DEFER the actual redirect until the marge listeners answer — see the
+	// deferred Apply after the listener boot below.
 	var hostsMgr *hosts.Manager
 	if *applyHosts {
 		hostsMgr = hosts.New(*hostsPath, logger)
-		if err := hostsMgr.Apply(hosts.DefaultEntries()); err != nil {
-			logger.Warn("hosts file could not be modified", "err", err)
-			hostsMgr = nil
-		}
 	}
 
 	// Initialize subsystems
@@ -736,6 +734,34 @@ func run() error {
 	logger.Warn("agent listeners spawned, deferred init continues in background",
 		"webui", *webuiAddr, "marge", *margeAddr, "bmx", *bmxAddr, "tlsEnabled", *tlsEnabled, "margeTLS", *margeTLSAddr)
 
+	// Deferred /etc/hosts redirect. Applying it at agent start pointed the box's
+	// Bose hosts (streaming.bose.com / content.api.bose.io) at 127.0.0.1 while
+	// marge-TLS on :443 was not listening yet (that listener waits on first-boot
+	// CA generation). On the BCO/scm SoundTouch 20 the box's NetManager runs a
+	// connectivity probe against those hosts; a connection-refused during that
+	// window is read as "no internet", so NetManager re-associates the Wi-Fi.
+	// The scm ethernet-only path persists no Wi-Fi profile, so that re-associate
+	// drops the speaker offline ("Wi-Fi Not Provided", #302/#303). Waiting until
+	// the marge endpoint actually accepts closes the window; on healthy boxes the
+	// redirect just lands a few seconds later, which is harmless.
+	if hostsMgr != nil {
+		waitAddr := *margeAddr
+		if *tlsEnabled {
+			waitAddr = *margeTLSAddr
+		}
+		go func() {
+			waitListenerReady(ctx, waitAddr, 30*time.Second, logger)
+			if ctx.Err() != nil {
+				return
+			}
+			if err := hostsMgr.Apply(hosts.DefaultEntries()); err != nil {
+				logger.Warn("hosts file could not be modified", "err", err)
+			} else {
+				logger.Info("hosts redirect applied after marge endpoint ready", "endpoint", waitAddr)
+			}
+		}()
+	}
+
 	// Self-probe loopback connect to each listener address. When the
 	// box is reachable but :8888 silently does not answer, the bash
 	// watchdog (agent_port_bound in run.sh) cannot always tell on a
@@ -831,6 +857,42 @@ func newHTTPErrorLog(logger *slog.Logger, name string) *log.Logger {
 //
 // Phase-marker logs are at WARN level on purpose: visible on any
 // --log-level setting and in the diagnostic bundle's tail capture.
+// waitListenerReady blocks until a plain TCP dial to the loopback side of addr
+// succeeds (proving the local listener accepts), ctx is cancelled, or timeout
+// elapses. Used to hold the /etc/hosts redirect until marge is actually up. A
+// TLS listener still accepts the TCP connection, so this works for :443 too.
+func waitListenerReady(ctx context.Context, addr string, timeout time.Duration, logger *slog.Logger) {
+	port := addr
+	if _, p, err := net.SplitHostPort(addr); err == nil {
+		port = p
+	} else {
+		port = strings.TrimPrefix(addr, ":")
+	}
+	target := net.JoinHostPort("127.0.0.1", port)
+	deadline := time.Now().Add(timeout)
+	for {
+		d := net.Dialer{Timeout: time.Second}
+		if c, err := d.DialContext(ctx, "tcp", target); err == nil {
+			_ = c.Close()
+			return
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			if logger != nil {
+				logger.Warn("marge endpoint not ready before timeout, applying hosts redirect anyway", "endpoint", target)
+			}
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(300 * time.Millisecond):
+		}
+	}
+}
+
 func startHTTP(ctx context.Context, wg *sync.WaitGroup, errs chan<- error, name, addr string, handler http.Handler, logger *slog.Logger) {
 	logger.Warn("listener phase: spawn", "comp", name, "addr", addr)
 	wg.Add(1)

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -862,7 +862,7 @@ func newHTTPErrorLog(logger *slog.Logger, name string) *log.Logger {
 // elapses. Used to hold the /etc/hosts redirect until marge is actually up. A
 // TLS listener still accepts the TCP connection, so this works for :443 too.
 func waitListenerReady(ctx context.Context, addr string, timeout time.Duration, logger *slog.Logger) {
-	port := addr
+	var port string
 	if _, p, err := net.SplitHostPort(addr); err == nil {
 		port = p
 	} else {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -453,9 +453,14 @@ the app. The complete picture of what talks to what:
 | Website (`st-reborn.de`) | GoatCounter | Privacy-friendly, cookieless page analytics: no cookies, no cross-site tracking, the visitor IP is not stored. |
 
 Bose's own telemetry endpoint (`events.api.bosecm.com`) and software
-update endpoint (`worldwide.bose.com`) are likewise redirected to
-localhost and answered with a benign `200`, so the speaker emits nothing
-to Bose.
+update endpoint (`worldwide.bose.com`) are **not** redirected: since the
+Bose cloud shutdown they no longer resolve, so the speaker cannot reach
+them anyway. STR used to black-hole them to `0.0.0.0`, but that produced an
+instant connection reset that the BCO/scm SoundTouch 20's NetManager
+connectivity probe read as a broken link and reacted to by re-associating
+Wi-Fi (fatal on the ethernet-only path, which persists no Wi-Fi profile).
+Left at real DNS they simply fail the benign way the post-cloud box already
+tolerates.
 
 ## Storage layout on the speaker
 

--- a/internal/hosts/hosts.go
+++ b/internal/hosts/hosts.go
@@ -30,12 +30,19 @@ type Entry struct {
 // can emulate the TuneIn API and STSCertified BMXTuneInClient believes the
 // Bose TuneIn cloud is reachable.
 func DefaultEntries() []Entry {
+	// Only the three hosts marge actively emulates are redirected. We used to
+	// also black-hole events.api.bosecm.com and worldwide.bose.com to 0.0.0.0,
+	// but that served no STR function and hurt the BCO/scm ST20: connecting to
+	// 0.0.0.0 resolves to loopback and returns an instant RST, which the box's
+	// NetManager connectivity probe reads as an actively broken link and reacts
+	// to by re-associating the Wi-Fi. On the ethernet-only scm path STR persists
+	// no Wi-Fi profile, so that re-association drops the speaker offline
+	// ("Wi-Fi Not Provided", #302/#303). Left at real DNS these dead hosts just
+	// NXDOMAIN/time out, the benign way the stock post-cloud box already tolerates.
 	return []Entry{
 		{IP: "127.0.0.1", Host: "streaming.bose.com"},
 		{IP: "127.0.0.1", Host: "content.api.bose.io"},
 		{IP: "127.0.0.1", Host: "7f5055e9ff15f2a5035a488b81ec10f4.api.radiotime.com"},
-		{IP: "0.0.0.0", Host: "events.api.bosecm.com"},
-		{IP: "0.0.0.0", Host: "worldwide.bose.com"},
 	}
 }
 


### PR DESCRIPTION
On the BCO/scm SoundTouch 20, the speaker drops Wi-Fi (LED white->orange, "Wi-Fi Not Provided", offline) moments after a **successful** STR install. It only happens once the agent runs healthy; while the agent crash-looped, Wi-Fi stayed up (#302/#303, plus a second scm reporter).

**Cause:** the running agent rewrites `/etc/hosts` to redirect the Bose cloud hostnames. That makes the box's NetManager connectivity probe fail, so NetManager re-associates Wi-Fi. On the scm ethernet-only path STR persists **no** Wi-Fi profile, so the re-association lands on "not provided" and the box goes offline. Other models re-join from their persisted profile, which is why only scm ST20s are affected.

**Fix** (both only soften/delay the redirect, remove nothing STR needs):
1. `internal/hosts`: stop black-holing `events.api.bosecm.com` / `worldwide.bose.com` to `0.0.0.0` (no STR function; the instant RST is what a probe reads as a broken link). Left at real DNS they fail benignly.
2. `cmd/agent`: apply the `/etc/hosts` redirect only after marge / marge-TLS (`:443`) is actually listening, closing the first-boot connection-refused window.

Found via a multi-agent analysis of the post-deploy code paths. Reaches affected boxes via a fresh stick (they go offline, so OTA can't). Needs an Ethernet-tethered confirmation from the reporters.

Refs #302, #303