### PR TITLE
fix(agent): keep the stick diagnostic log readable after a power-cycle

### DIFF
--- a/usb-stick/run.sh
+++ b/usb-stick/run.sh
@@ -245,8 +245,16 @@ start_stick_log_mirror() {
         sleep 60
         while :; do
             if [ -d "$STICK" ] && [ -r "$SETUP_LOG_NAND" ]; then
-                cp "$SETUP_LOG_NAND" "$SETUP_LOG.mirror" 2>/dev/null \
-                    && mv "$SETUP_LOG.mirror" "$SETUP_LOG" 2>/dev/null
+                # sync after the rename so the FAT directory entry + cluster
+                # chain actually reach the stick. Without it the write sits in
+                # the OS buffer and a power-cycle (users cut power to reboot the
+                # speaker) corrupts the file that is mid-mirror: Windows then
+                # reports setup.log as "corrupted and unreadable" and the one
+                # diagnostic we need is lost (live-seen on an ST20 install).
+                if cp "$SETUP_LOG_NAND" "$SETUP_LOG.mirror" 2>/dev/null \
+                    && mv "$SETUP_LOG.mirror" "$SETUP_LOG" 2>/dev/null; then
+                    sync 2>/dev/null
+                fi
             fi
             sleep 25
         done


### PR DESCRIPTION
The setup.log the speaker mirrors to the FAT32 stick was written with cp+mv and no sync, so a power-cycle (how users reboot the speaker) left the file with a broken FAT chain and the computer reported it as corrupt/unreadable (live-seen on an ST20). That file is exactly the diagnostic we ask users to send. Sync after the rename so it reaches the stick before the next power-cycle can truncate it.

Refs #302