### PR TITLE
fix(app): show a wlan0 box's real Wi-Fi network after a band switch

### DIFF
--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -38,6 +38,7 @@ import (
 	"github.com/JRpersonal/streborn/internal/streamproxy"
 	"github.com/JRpersonal/streborn/internal/upnp"
 	"github.com/JRpersonal/streborn/internal/webhooks"
+	"github.com/JRpersonal/streborn/internal/wlanlive"
 	"github.com/JRpersonal/streborn/internal/zones"
 )
 
@@ -3300,6 +3301,32 @@ func (s *Server) handleBoxSettings(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
+	}
+	// wlan0/wpa boxes: STR changes Wi-Fi by rewriting wpa_supplicant directly,
+	// bypassing Bose, so Bose /networkInfo keeps reporting the OLD profile (stale
+	// SSID / frequency / signal even though the box is really associated
+	// elsewhere). Read the LIVE association from wpa_supplicant and let it win;
+	// /networkInfo is only the fallback when the live read is unavailable or the
+	// field is empty. BCO/eth0 boxes have no wpa_supplicant and keep the
+	// gabbo-signal + provisionedSSID path below untouched.
+	if iface, mech := detectWlanMechanism(); mech == "wpa" {
+		if live := wlanlive.Read(ctx, iface); live.Associated {
+			for i := range settings.Network.Interfaces {
+				ni := &settings.Network.Interfaces[i]
+				if ni.Type != "WIFI_INTERFACE" {
+					continue
+				}
+				if live.SSID != "" {
+					ni.SSID = live.SSID
+				}
+				if live.FrequencyKHz != 0 {
+					ni.Frequency = live.FrequencyKHz
+				}
+				if live.Signal != "" {
+					ni.Signal = live.Signal
+				}
+			}
+		}
 	}
 	// BCO speakers (Portable, scm ST20) report the connected interface as
 	// ethernet with no signal in /networkInfo, but the box does emit the

--- a/internal/wlanlive/wlanlive.go
+++ b/internal/wlanlive/wlanlive.go
@@ -1,0 +1,181 @@
+// Package wlanlive reads the live Wi-Fi association from the OS on wlan0/wlan1
+// (wpa_supplicant) boxes.
+//
+// STR changes a box's Wi-Fi by rewriting wpa_supplicant directly, bypassing the
+// Bose firmware. When it does, Bose's /networkInfo keeps reporting the OLD
+// profile (stale SSID / frequency / signal), so the settings screen shows the
+// wrong network even though the box is really associated elsewhere. This package
+// asks wpa_supplicant itself, via wpa_cli, for the current association and maps
+// the RSSI onto STR's signal-class strings so a wlan0 box renders identically to
+// a BCO box.
+//
+// It is deliberately read-only: fixed "wpa_cli" argv (no shell, no untrusted
+// interpolation), short exec timeouts so a wedged wpa_supplicant can never block
+// a settings fetch. It applies ONLY to wpa boxes; BCO/eth0 boxes have no
+// wpa_supplicant and must keep their existing gabbo/provisioned path.
+package wlanlive
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// cmdTimeout bounds each wpa_cli invocation. wpa_cli talks to a local ctrl
+// socket, so a healthy call returns in milliseconds; a few seconds is a generous
+// ceiling that still guarantees a settings fetch never hangs on a wedged daemon.
+const cmdTimeout = 3 * time.Second
+
+// Status is the live association read from wpa_supplicant.
+type Status struct {
+	SSID         string // current SSID, "" if unknown
+	FrequencyKHz int    // channel frequency in kHz (wpa_cli reports MHz; *1000), 0 if unknown
+	Signal       string // STR signal class (EXCELLENT_SIGNAL/.../POOR_SIGNAL), "" if unknown
+	Associated   bool   // wpa_state=COMPLETED
+}
+
+// Read returns the live Wi-Fi association on iface via wpa_cli. It runs
+// "wpa_cli -i <iface> status" (for SSID + freq) and "wpa_cli -i <iface>
+// signal_poll" (for RSSI), each under a short timeout. If the box is not
+// associated, or wpa_cli is unavailable, it returns a zero Status
+// (Associated=false) so callers fall back to Bose /networkInfo.
+//
+// Callers MUST gate on a wpa mechanism (e.g. detectWlanMechanism()=="wpa")
+// before calling; wpa_cli does not exist on BCO/eth0 boxes.
+func Read(ctx context.Context, iface string) Status {
+	out, err := runWpaCli(ctx, iface, "status")
+	if err != nil {
+		return Status{}
+	}
+	ssid, freqKHz, associated := parseStatus(out)
+	if !associated {
+		return Status{}
+	}
+	st := Status{SSID: ssid, FrequencyKHz: freqKHz, Associated: true}
+
+	// Live RSSI via signal_poll (nl80211 driver these boxes use). Falls back to
+	// the kernel's /proc/net/wireless if signal_poll is unsupported/FAILs.
+	if pollOut, perr := runWpaCli(ctx, iface, "signal_poll"); perr == nil {
+		if rssi, ok := parseSignalPoll(pollOut); ok {
+			st.Signal = RSSIToClass(rssi)
+		}
+	}
+	if st.Signal == "" {
+		if rssi, ok := readProcWireless(iface); ok {
+			st.Signal = RSSIToClass(rssi)
+		}
+	}
+	return st
+}
+
+// runWpaCli runs "wpa_cli -i <iface> <sub>" under a bounded timeout and returns
+// its stdout. Fixed argv, no shell.
+func runWpaCli(ctx context.Context, iface, sub string) (string, error) {
+	cctx, cancel := context.WithTimeout(ctx, cmdTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(cctx, "wpa_cli", "-i", iface, sub).Output()
+	return string(out), err
+}
+
+// parseStatus extracts ssid, frequency (kHz), and association from the
+// key=value lines of "wpa_cli status". ssid/freq are only reported when
+// wpa_state=COMPLETED, mirroring what wpaAssociatedTo already relies on.
+func parseStatus(out string) (ssid string, freqKHz int, associated bool) {
+	for _, line := range strings.Split(out, "\n") {
+		k, v, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if !ok {
+			continue
+		}
+		switch k {
+		case "wpa_state":
+			associated = v == "COMPLETED"
+		case "ssid":
+			ssid = v
+		case "freq":
+			if mhz, err := strconv.Atoi(v); err == nil && mhz > 0 {
+				freqKHz = mhz * 1000
+			}
+		}
+	}
+	if !associated {
+		return "", 0, false
+	}
+	return ssid, freqKHz, true
+}
+
+// parseSignalPoll extracts RSSI (dBm) from "wpa_cli signal_poll" output. It
+// rejects values outside a sane Wi-Fi range so a bogus/sentinel reading never
+// mislabels the signal.
+func parseSignalPoll(out string) (rssi int, ok bool) {
+	for _, line := range strings.Split(out, "\n") {
+		k, v, found := strings.Cut(strings.TrimSpace(line), "=")
+		if !found || k != "RSSI" {
+			continue
+		}
+		n, err := strconv.Atoi(strings.TrimSpace(v))
+		// Require a strictly negative dBm: a real associated-station RSSI is always
+		// below 0. Some drivers emit RSSI=0 as an "unavailable" sentinel, which
+		// would otherwise map to EXCELLENT_SIGNAL and show a full bar on a link of
+		// unknown strength.
+		if err != nil || n >= 0 || n < -100 {
+			return 0, false
+		}
+		return n, true
+	}
+	return 0, false
+}
+
+// RSSIToClass buckets an RSSI (dBm) into STR's box-native signal classes so a
+// wpa box renders identically to a BCO box in the settings UI. Thresholds are
+// the common Wi-Fi quality bands (~-55 excellent, ~-67 reliable, ~-75 the floor
+// for reliable service).
+func RSSIToClass(rssi int) string {
+	switch {
+	case rssi >= -55:
+		return "EXCELLENT_SIGNAL"
+	case rssi >= -67:
+		return "GOOD_SIGNAL"
+	case rssi >= -75:
+		return "MARGINAL_SIGNAL"
+	default:
+		return "POOR_SIGNAL"
+	}
+}
+
+// readProcWireless is the wpa_cli-free RSSI fallback: the kernel's
+// /proc/net/wireless "level" column is dBm for the cfg80211/nl80211 drivers
+// these boxes run.
+func readProcWireless(iface string) (int, bool) {
+	b, err := os.ReadFile("/proc/net/wireless")
+	if err != nil {
+		return 0, false
+	}
+	return parseProcWireless(string(b), iface)
+}
+
+// parseProcWireless pulls the level (dBm) for iface from /proc/net/wireless
+// content. The line is "iface: status link level noise ..."; level is the third
+// numeric column and carries a trailing '.'.
+func parseProcWireless(content, iface string) (int, bool) {
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, iface+":") {
+			continue
+		}
+		rest := strings.TrimSpace(strings.TrimPrefix(line, iface+":"))
+		fields := strings.Fields(rest)
+		if len(fields) < 3 {
+			return 0, false
+		}
+		lvl := strings.TrimSuffix(fields[2], ".")
+		n, err := strconv.Atoi(lvl)
+		if err != nil || n >= 0 || n < -100 { // strictly negative dBm only (0 = sentinel)
+			return 0, false
+		}
+		return n, true
+	}
+	return 0, false
+}

--- a/internal/wlanlive/wlanlive_test.go
+++ b/internal/wlanlive/wlanlive_test.go
@@ -1,0 +1,92 @@
+package wlanlive
+
+import "testing"
+
+func TestRSSIToClass(t *testing.T) {
+	cases := []struct {
+		rssi int
+		want string
+	}{
+		{-30, "EXCELLENT_SIGNAL"},
+		{-55, "EXCELLENT_SIGNAL"},
+		{-56, "GOOD_SIGNAL"},
+		{-67, "GOOD_SIGNAL"},
+		{-68, "MARGINAL_SIGNAL"},
+		{-75, "MARGINAL_SIGNAL"},
+		{-76, "POOR_SIGNAL"},
+		{-90, "POOR_SIGNAL"},
+	}
+	for _, c := range cases {
+		if got := RSSIToClass(c.rssi); got != c.want {
+			t.Errorf("RSSIToClass(%d) = %q, want %q", c.rssi, got, c.want)
+		}
+	}
+}
+
+func TestParseStatus(t *testing.T) {
+	// Associated 5 GHz box: ssid + freq present, wpa_state COMPLETED.
+	const connected = `bssid=aa:bb:cc:dd:ee:ff
+freq=5180
+ssid=MyNetwork
+id=0
+mode=station
+wpa_state=COMPLETED
+ip_address=192.0.2.50
+address=aa:bb:cc:dd:ee:ff
+`
+	ssid, freqKHz, assoc := parseStatus(connected)
+	if !assoc {
+		t.Fatal("expected associated")
+	}
+	if ssid != "MyNetwork" {
+		t.Errorf("ssid = %q, want MyNetwork", ssid)
+	}
+	if freqKHz != 5180000 {
+		t.Errorf("freqKHz = %d, want 5180000 (MHz*1000)", freqKHz)
+	}
+
+	// SSID containing '=' must survive (Cut on first separator only).
+	const eqSSID = "ssid=a=b\nwpa_state=COMPLETED\nfreq=2437\n"
+	if ssid, freq, ok := parseStatus(eqSSID); !ok || ssid != "a=b" || freq != 2437000 {
+		t.Errorf("parseStatus(eqSSID) = %q,%d,%v; want a=b,2437000,true", ssid, freq, ok)
+	}
+
+	// Not associated (scanning): nothing reported even if a stale ssid line exists.
+	const scanning = "wpa_state=SCANNING\nssid=Old\nfreq=2412\n"
+	if ssid, freq, ok := parseStatus(scanning); ok || ssid != "" || freq != 0 {
+		t.Errorf("parseStatus(scanning) = %q,%d,%v; want empty,false", ssid, freq, ok)
+	}
+}
+
+func TestParseSignalPoll(t *testing.T) {
+	const poll = `RSSI=-52
+LINKSPEED=54
+NOISE=9999
+FREQUENCY=5180
+`
+	if rssi, ok := parseSignalPoll(poll); !ok || rssi != -52 {
+		t.Errorf("parseSignalPoll = %d,%v; want -52,true", rssi, ok)
+	}
+
+	// Out-of-range / bogus values are rejected, including the RSSI=0 sentinel
+	// (0 dBm is never a real associated-station reading and must not map to
+	// EXCELLENT_SIGNAL).
+	for _, bad := range []string{"RSSI=0\n", "RSSI=42\n", "RSSI=-9999\n", "RSSI=x\n", "LINKSPEED=54\n"} {
+		if rssi, ok := parseSignalPoll(bad); ok {
+			t.Errorf("parseSignalPoll(%q) = %d,true; want ok=false", bad, rssi)
+		}
+	}
+}
+
+func TestParseProcWireless(t *testing.T) {
+	const content = `Inter-| sta-|   Quality        |   Discarded packets
+ face | tus | link level noise |  nwid  crypt   frag
+ wlan0: 0000   58.  -52.  -256        0      0      0
+`
+	if lvl, ok := parseProcWireless(content, "wlan0"); !ok || lvl != -52 {
+		t.Errorf("parseProcWireless(wlan0) = %d,%v; want -52,true", lvl, ok)
+	}
+	if _, ok := parseProcWireless(content, "wlan1"); ok {
+		t.Error("parseProcWireless(wlan1) should not match")
+	}
+}


### PR DESCRIPTION
Derived from Albrecht's follow-up log: after switching box "Hurra" from 2.4 to 5 GHz, the app kept showing the old network (SSID FB40, 2437 MHz, INVALID_SIGNAL) while the router had it on 5 GHz.

Root cause: STR changes Wi-Fi by rewriting wpa_supplicant directly (bypassing Bose), so Bose's `/networkInfo` keeps reporting the stale old profile.

Fix: on wlan0/wpa boxes the on-box agent reads the LIVE association from wpa_supplicant (`wpa_cli status` for SSID/freq, `wpa_cli signal_poll` for RSSI, `/proc/net/wireless` as a further fallback) and shows the real SSID/frequency/signal (RSSI mapped to STR's signal classes). `/networkInfo` remains the fallback. BCO/eth0 boxes (no wpa_supplicant) keep their existing gabbo-signal + provisioned-SSID path untouched. Fixed argv, short exec timeouts, read-only. New `internal/wlanlive` package with unit tests.

Only exercisable on a wlan0 box (rhino ST10 / sm2 ST20); verified by cross-compile + unit tests. Built with ultracode (understand -> implement -> adversarial review).