### PR TITLE
chore(security): resolve actionable code-scanning findings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,10 +11,9 @@ on:
     # scheduler congestion.
     - cron: "30 6 * * 1"
 
+# Minimal at the top level; the analyze job below elevates only what it needs.
 permissions:
   contents: read
-  security-events: write
-  actions: read
 
 concurrency:
   group: codeql-${{ github.ref }}
@@ -24,6 +23,10 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write   # upload CodeQL results
+      actions: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -9,14 +9,17 @@ name: Dependabot auto-merge
 # pass first. If a check fails, the PR is not merged.
 on: pull_request
 
+# Minimal at the top level; the single job below elevates only what it needs.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   automerge:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write        # enable auto-merge on the PR
+      pull-requests: write    # approve / comment on the PR
     steps:
       - name: Fetch Dependabot metadata
         id: meta

--- a/desktop-app/install_str.go
+++ b/desktop-app/install_str.go
@@ -987,7 +987,10 @@ func boxInstallDiag(host string) string {
 func boxCoreCount(host string) int {
 	out, err := boxSSHOutput(host, "grep -c ^processor /proc/cpuinfo", 8*time.Second)
 	if err == nil {
-		if n, ok := lastIntField(out); ok && n > 0 {
+		// Bound the value before the int64->int conversion: it is a CPU-core count
+		// parsed from box output, so anything outside a sane range is bogus and the
+		// bound also keeps the conversion safe on 32-bit builds.
+		if n, ok := lastIntField(out); ok && n > 0 && n <= 4096 {
 			return int(n)
 		}
 	}

--- a/desktop-app/logfile.go
+++ b/desktop-app/logfile.go
@@ -103,9 +103,13 @@ func logCrash(where string, r any) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
 	fmt.Fprintf(f, "time=%s level=ERROR msg=PANIC where=%q value=%v\n%s\n",
 		time.Now().Format(time.RFC3339), where, r, debug.Stack())
+	// Surface a close error on this writable crash log rather than discarding it;
+	// we are already on the crash path, so stderr is the only place left to note it.
+	if cerr := f.Close(); cerr != nil {
+		fmt.Fprintf(os.Stderr, "logCrash: closing %s failed: %v\n", LogFilePath(), cerr)
+	}
 }
 
 // newFileLogger returns a slog.Logger that writes to the file at

--- a/desktop-app/update_app.go
+++ b/desktop-app/update_app.go
@@ -536,11 +536,15 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	if _, err := io.Copy(out, in); err != nil {
-		out.Close()
-		return err
+	// Close exactly once and surface its error: a discarded close on a writable
+	// file can hide a flush failure that leaves a truncated app binary. The copy
+	// error dominates when both fail.
+	_, copyErr := io.Copy(out, in)
+	closeErr := out.Close()
+	if copyErr != nil {
+		return copyErr
 	}
-	return out.Close()
+	return closeErr
 }
 
 // extractLargestFile writes the largest regular file inside a .tar.gz to dst. The
@@ -604,11 +608,14 @@ func extractLargestFile(tgz, dst string) error {
 		if err != nil {
 			return err
 		}
-		if _, err := io.Copy(out, io.LimitReader(tr2, bestSize)); err != nil {
-			out.Close()
-			return err
+		// Close once and surface its error (a discarded close can hide a truncated
+		// extracted binary); the copy error dominates when both fail.
+		_, copyErr := io.Copy(out, io.LimitReader(tr2, bestSize))
+		closeErr := out.Close()
+		if copyErr != nil {
+			return copyErr
 		}
-		return out.Close()
+		return closeErr
 	}
 	return fmt.Errorf("archive entry vanished between passes")
 }

--- a/internal/tlsgen/truststore.go
+++ b/internal/tlsgen/truststore.go
@@ -85,12 +85,16 @@ func appendRootIfNew(target string, rootCAPEM []byte) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 	block := buildAppendBlock(rootCAPEM)
-	if _, err := f.Write(block); err != nil {
-		return err
+	// Close once and surface its error: a discarded close on this writable trust
+	// store can hide a flush failure that leaves a truncated CA appended. The write
+	// error dominates when both fail.
+	_, writeErr := f.Write(block)
+	closeErr := f.Close()
+	if writeErr != nil {
+		return writeErr
 	}
-	return nil
+	return closeErr
 }
 
 // containsRootBlock checks whether current already contains a marker


### PR DESCRIPTION
Clears the code-scanning alerts that are genuinely worth fixing. The remaining alerts are by-design for a LAN speaker tool (SSRF on user-provided stream URLs, disabled TLS for radio streams, SSH host-key-checking off for the rotating box key, the committed str-shim.so, and Scorecard meta checks that don't apply to a solo self-merging maintainer) and are dismissed separately with a reason.

Fixed here:
- **Unhandled writable-file close** (update_app.go x2, internal/tlsgen/truststore.go, logfile.go): the Close() error on a file being written was discarded, which could hide a flush failure that leaves a truncated self-update binary or an incomplete CA append. Now each path closes once and returns/logs the close error.
- **Integer conversion** (install_str.go): the CPU-core count is bounded to a sane range before the int64->int conversion.
- **Workflow token permissions** (codeql.yml, dependabot-automerge.yml): top-level GITHUB_TOKEN is now minimal (`contents: read`); the write scopes moved to the single job that needs them. (release.yml's publish job legitimately needs `contents: write` to create the release, so that one stays and is dismissed as required.)

Verified: desktop-app build+vet, agent cross-compile (arm GOARM=5), both workflow YAMLs valid.