### PR TITLE
ci(codeql): align codeql-action pins so init matches analyze/autobuild

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
-# Dependabot Konfiguration. Automatische PRs bei Security Issues und Updates.
+# Dependabot configuration. Opens PRs for security issues and version updates.
 # Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
-  # Go Hauptprojekt
+  # Main Go module
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
@@ -17,16 +17,16 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
-    # Bei Major Updates Vorsicht: nur als Hinweis, kein Auto Merge
+    # Major updates stay separate on purpose: reviewed manually, not auto-merged.
     groups:
       go-minor-patch:
         update-types: ["minor", "patch"]
 
   # Website npm dependencies have moved to a separate repository.
   # When the /website folder is removed from this repo, drop nothing
-  # else here — this section already does not exist.
+  # else here - this section already does not exist.
 
-  # GitHub Actions selbst aktualisieren wenn neue Versionen verfuegbar
+  # Keep GitHub Actions themselves up to date.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -39,3 +39,12 @@ updates:
       - "actions"
     commit-message:
       prefix: "ci"
+    groups:
+      # codeql-action ships init/autobuild/analyze/upload-sarif as separate
+      # sub-actions from a single repo. They must move in lockstep: a run
+      # fails with "Loaded a configuration file for version X, but running
+      # version Y" if init and analyze land on different releases. Bumping
+      # them in one atomic PR prevents that split-brain.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,7 @@ jobs:
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality


### PR DESCRIPTION
## Problem

The scheduled CodeQL run on `main` and every open `codeql-action` Dependabot PR fail with:

```
##[error]We were unable to automatically build your code. ...
Loaded a configuration file for version '4.36.2', but running version '4.36.3'
CodeQL job status was configuration error.
```

`github/codeql-action` ships `init`, `autobuild`, `analyze` and `upload-sarif` as separate sub-actions of a single repo, and Dependabot bumps each in its own PR. `main` ended up with `autobuild`/`analyze` on **4.36.3** (#327, #328) while `init` stayed on **4.36.2** (#329 still open). CodeQL requires the sub-actions to be on the same release, so the analyze job errors out before it produces any results.

## Fix

- Bump `codeql-action/init` to 4.36.3 so all three pins match.
- Group every `github/codeql-action*` update into one atomic Dependabot PR, so the sub-actions can no longer land on different releases.

Supersedes #329 (its change is included here). The CodeQL check on this PR runs all sub-actions on 4.36.3 and should pass green.