### PR TITLE
fix(install): advise a power-cycle when a speaker is online but its controls are unresponsive

### DIFF
--- a/desktop-app/frontend/src/views/setup.js
+++ b/desktop-app/frontend/src/views/setup.js
@@ -1317,6 +1317,12 @@ const INSTALL_HELP_STEPS = {
   'agent-not-up': ['powerCycle', 'wifi', 'logs'],
   'not-reachable': ['wifi', 'freshBoot'],
   'install-window-closed': ['freshBoot'],
+  // The box answers UPnP on :8091 but not SSH / the Bose port / the STR agent:
+  // it is on the network with a wedged control stack (the Portable "renderer up,
+  // control crashed" state). A power-cycle clears the wedge; do NOT show the
+  // 'wifi' step here (the default fallback does) - the box is already on Wi-Fi,
+  // so re-onboarding advice would just mislead.
+  'control-unresponsive': ['powerCycle', 'freshBoot', 'logs'],
   // Media read error: the speaker found install.sh but could not read it.
   // Usually a large stick force-formatted to FAT32 with a block size the
   // speaker can't read (the 64 GB case), or a faulty stick.

--- a/desktop-app/install_str.go
+++ b/desktop-app/install_str.go
@@ -135,12 +135,32 @@ func (a *App) InstallSTROnBox(host, model string) (InstallResult, error) {
 					"Bose only opens it while the speaker boots with the STR stick plugged in. " +
 					"Power the speaker off, insert the STR stick, power it back on, then install."
 				a.logger.Warn("install_str: preflight, box reachable on :8090 but :22 closed (install window shut; diag-port :17000 did not open SSH)", "host", host)
+			} else if tcpReachable(host, 8091, 3*time.Second) {
+				// :22, :8090 and :8888 are all closed, but the box still answers
+				// UPnP/DLNA on :8091 - its media renderer is a separate firmware
+				// process from the Bose REST API and the STR agent. So the box IS
+				// on the network and on Wi-Fi; only its control stack has wedged.
+				// This is the classic Portable "renderer up, control crashed"
+				// state (Andi M., 06.07.2026: SSDP + :8091 alive, :22/:8090/:8888
+				// all dead). The not-reachable branch below tells the user to
+				// re-onboard Wi-Fi, which is wrong and unactionable here: the box
+				// is already on Wi-Fi. A full power-cycle is what clears the wedge;
+				// keep the stick in so the reboot also re-runs the install if the
+				// STR agent itself stopped.
+				res.Code = "control-unresponsive"
+				res.Message = "The speaker at " + host + " is on your network (it still answers on the media port 8091), " +
+					"but its control software has stopped responding (no answer on the STR agent, the Bose port 8090, or SSH). " +
+					"Power the speaker fully off and back on with the STR stick plugged in, then refresh the speaker list and try again."
+				if strings.Contains(strings.ToLower(model), "portable") {
+					res.Message += " The Portable never fully powers off while it still has battery: hold the AUX button for about 10 seconds to force a restart."
+				}
+				a.logger.Warn("install_str: preflight, box answers UPnP :8091 but not :22/:8090/:8888 (control stack wedged; advising power-cycle)", "host", host)
 			} else {
 				res.Code = "not-reachable"
-				res.Message = "The speaker is not reachable on the network (no answer on SSH port 22 or the Bose port 8090 at " + host + "). " +
+				res.Message = "The speaker is not reachable on the network (no answer on SSH port 22, the Bose port 8090, or the media port 8091 at " + host + "). " +
 					"First bring it onto your Wi-Fi with the Bose SoundTouch app and make sure this PC and the speaker are on the same network. " +
 					"Then reboot the speaker with the STR stick plugged in and try again."
-				a.logger.Warn("install_str: preflight failed, box not reachable on :22 or :8090", "host", host)
+				a.logger.Warn("install_str: preflight failed, box not reachable on :22, :8090 or :8091", "host", host)
 			}
 			return res, nil
 		}

--- a/desktop-app/logexport.go
+++ b/desktop-app/logexport.go
@@ -310,6 +310,14 @@ type boxSnapshot struct {
 	ReachableSSH  bool           `json:"reachableSSH"`
 	Reachable8090 bool           `json:"reachable8090"`
 	Reachable8888 bool           `json:"reachable8888"`
+	// Reachable8091 is the box's UPnP/DLNA media-renderer port, served by a
+	// separate firmware process from the Bose REST API (:8090) and the STR
+	// agent. A box that answers here but nowhere else is ON the network with a
+	// WEDGED control stack (the Portable "renderer up, control crashed" state),
+	// not off the network. Without this probe the bundle reported such a box as
+	// fully unreachable, which read as "box is off / off Wi-Fi" and sent the
+	// user down the wrong recovery path (Andi M., 06.07.2026).
+	Reachable8091 bool `json:"reachable8091"`
 	// STRDetected is the authoritative "STR is actually installed and serving
 	// here" signal: true only when /api/agent/version returned a real version
 	// string. Reachable8888 alone is misleading because it probes :17008, where
@@ -377,6 +385,11 @@ func captureBoxSnapshot(host string) boxSnapshot {
 	// is loopback-only externally on all firmwares we have tested.
 	s.Reachable8888 = portOpen(host, 17008, 1200)
 	s.ReachableSSH = portOpen(host, 22, 1200)
+	// :8091 is the UPnP/DLNA media renderer, a separate firmware process. When
+	// :8090 is dead but :8091 answers, the box is online with a wedged control
+	// stack rather than off the network - the discriminator that keeps a
+	// diagnostic bundle from looking like a dead box (see field comment).
+	s.Reachable8091 = portOpen(host, 8091, 1200)
 	if s.Reachable8090 {
 		s.BoseInfo = httpGetText(fmt.Sprintf("http://%s:8090/info", host), 4096)
 	}


### PR DESCRIPTION
## Symptom

From a Portable owner's diagnostic (email, 06.07.2026): *"jetzt bekomme ich sie nicht mehr verbunden"* ("now I can't get it connected anymore"). The speaker was **on the network** the whole time - it answered SSDP (:1900) and served UPnP/DLNA on :8091 (MediaRenderer, AVTransport, RenderingControl all advertised, device XML resolvable) - but **:8090 (Bose REST), :8888 (STR agent), and :22 (SSH) were all dead**. Classic Portable wedge: the media renderer runs in a separate firmware process and stays up while the control stack crashes.

Two problems made this hard for the user and for triage:

1. The install preflight only probes :22 and :8090. With both closed it returned code `not-reachable` with *"the speaker is not reachable on the network... first bring it onto your Wi-Fi with the Bose SoundTouch app"* - wrong and unactionable, because the speaker is already on Wi-Fi. The frontend then showed the default help checklist, which leads with the **Wi-Fi** step.
2. The diagnostic bundle (`box-<n>.json`) probes :8090/:17008/:22 but never :8091, so it reported the box as **fully unreachable** even though the same app session had just resolved it over DLNA. The bundle looked like a dead/off-network box.

## Fix

- **Preflight** (`install_str.go`): when :22, :8090 and :8888 are all closed, also probe **:8091**. If it answers, the box is online with a wedged control stack -> new code `control-unresponsive` with an actionable message: power the speaker fully off and back on with the stick inserted (plus the Portable AUX-hold-10s hint), instead of Wi-Fi re-onboarding.
- **Frontend** (`setup.js`): map `control-unresponsive` to `powerCycle` / `freshBoot` / `logs` help steps (reusing existing localized strings), so the Wi-Fi step is not shown for a box that is already on Wi-Fi.
- **Diagnostic** (`logexport.go`): record `reachable8091` in every box snapshot, so an online-but-wedged box is distinguishable from one that is off the network.

`go build ./...`, `go vet`, and `go test .` in the desktop-app module all pass. No new i18n keys.