### PR TITLE
feat(install): stick-free install via the speaker's :17000 setup port

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
-# Dependabot Konfiguration. Automatische PRs bei Security Issues und Updates.
+# Dependabot configuration. Opens PRs for security issues and version updates.
 # Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
-  # Go Hauptprojekt
+  # Main Go module
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
@@ -17,16 +17,16 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
-    # Bei Major Updates Vorsicht: nur als Hinweis, kein Auto Merge
+    # Major updates stay separate on purpose: reviewed manually, not auto-merged.
     groups:
       go-minor-patch:
         update-types: ["minor", "patch"]
 
   # Website npm dependencies have moved to a separate repository.
   # When the /website folder is removed from this repo, drop nothing
-  # else here — this section already does not exist.
+  # else here - this section already does not exist.
 
-  # GitHub Actions selbst aktualisieren wenn neue Versionen verfuegbar
+  # Keep GitHub Actions themselves up to date.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -39,3 +39,12 @@ updates:
       - "actions"
     commit-message:
       prefix: "ci"
+    groups:
+      # codeql-action ships init/autobuild/analyze/upload-sarif as separate
+      # sub-actions from a single repo. They must move in lockstep: a run
+      # fails with "Loaded a configuration file for version X, but running
+      # version Y" if init and analyze land on different releases. Bumping
+      # them in one atomic PR prevents that split-brain.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,7 @@ jobs:
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality

--- a/desktop-app/install_str.go
+++ b/desktop-app/install_str.go
@@ -130,17 +130,40 @@ func (a *App) InstallSTROnBox(host, model string) (InstallResult, error) {
 		// caveat (there the stick stays the reliable fallback).
 		if tcpReachable(host, 17000, 2*time.Second) {
 			opened, tlog := a.enableSSHViaTelnet(host, model)
+			if !opened {
+				// Factory-reset fallback: an empty-UUID box never checks marge on its
+				// own, so the simple injection never fires. Give it a dummy account +
+				// a throwaway local marge responder so the check cycle runs and the
+				// injection fires (proven live on a factory-reset ST300). See
+				// telnet_bootstrap_marge.go.
+				a.logger.Info("install_str: simple :17000 unlock did not open SSH; trying the factory-reset bootstrap", "host", host)
+				var blog string
+				opened, blog = a.enableSSHViaTelnetBootstrap(host, model)
+				tlog = tlog + "\n--- factory-reset bootstrap ---\n" + blog
+			}
 			if opened {
 				a.logger.Info("install_str: SSH opened stick-free via :17000; installing STR over SSH", "host", host)
 				// Restore stock cloud URLs while :17000 is still the plain Bose TAP
 				// (STR's install may REDIRECT :17008 afterwards). Best-effort.
-				if rerr := a.resetBoseURLsViaTelnet(host); rerr != nil {
-					a.logger.Warn("install_str: could not restore stock boseurls after stick-free unlock", "host", host, "err", rerr)
+				resetErr := a.resetBoseURLsViaTelnet(host)
+				if resetErr != nil {
+					a.logger.Warn("install_str: could not restore stock boseurls after stick-free unlock", "host", host, "err", resetErr)
 				}
-				return a.RepairInstallViaSSH(host, model)
+				instRes, instErr := a.RepairInstallViaSSH(host, model)
+				if resetErr != nil && instRes.OK {
+					instRes.Message += " Note: the speaker's cloud URLs could not be fully restored automatically; if online radio or presets misbehave, reinstall once from a USB stick to reset them."
+				}
+				return instRes, instErr
 			}
+			// Neither unlock opened SSH. Both attempts may have written an
+			// injection URL into the box config (the simple path a dead .invalid
+			// host, the bootstrap this PC's live LAN IP). Restore stock URLs and
+			// reboot so the box is never left marge-checking a dead/reassignable
+			// host, which would also defeat STR's later streaming.bose.com
+			// interception on a subsequent stick install. Best-effort.
+			a.restoreStockBoseURLsAndReboot(host)
 			res.Log = tlog
-			a.logger.Info("install_str: :17000 stick-free unlock did not open SSH; giving stick guidance", "host", host)
+			a.logger.Info("install_str: :17000 stick-free unlock did not open SSH; restored stock URLs, giving stick guidance", "host", host)
 		}
 
 		// The box did not boot with a stick (:22 closed) and the stick-free unlock

--- a/desktop-app/install_str.go
+++ b/desktop-app/install_str.go
@@ -15,7 +15,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -122,50 +121,66 @@ func (a *App) InstallSTROnBox(host, model string) (InstallResult, error) {
 		// :22 closed but on the LAN (Bose :8090 up): the install window is shut
 		// because the box did not boot with the stick. That is the SoundTouch 300
 		// (which does not read the stick at boot) and some stubborn ST30 units.
-		// ALPHA spike (#ST300): try the legacy :17000 diagnostic console to open
-		// SSH WITHOUT a stick boot, then continue the normal install. Bose removed
-		// the remote_services command on firmware 27.x, so this likely only works
-		// on older firmware; it also serves as the live probe to confirm on a real
-		// SoundTouch 300. If it opens :22 we fall through to the normal install.
-		onLAN := tcpReachable(host, 8090, 3*time.Second)
-		if !onLAN || !a.tryEnableSSHViaDiagPort(host) {
-			if onLAN {
-				res.Code = "install-window-closed"
-				res.Message = "The speaker at " + host + " is on the network, but the install access (SSH) is closed. " +
-					"Bose only opens it while the speaker boots with the STR stick plugged in. " +
-					"Power the speaker off, insert the STR stick, power it back on, then install."
-				a.logger.Warn("install_str: preflight, box reachable on :8090 but :22 closed (install window shut; diag-port :17000 did not open SSH)", "host", host)
-			} else if tcpReachable(host, 8091, 3*time.Second) {
-				// :22, :8090 and :8888 are all closed, but the box still answers
-				// UPnP/DLNA on :8091 - its media renderer is a separate firmware
-				// process from the Bose REST API and the STR agent. So the box IS
-				// on the network and on Wi-Fi; only its control stack has wedged.
-				// This is the classic Portable "renderer up, control crashed"
-				// state (Andi M., 06.07.2026: SSDP + :8091 alive, :22/:8090/:8888
-				// all dead). The not-reachable branch below tells the user to
-				// re-onboard Wi-Fi, which is wrong and unactionable here: the box
-				// is already on Wi-Fi. A full power-cycle is what clears the wedge;
-				// keep the stick in so the reboot also re-runs the install if the
-				// STR agent itself stopped.
-				res.Code = "control-unresponsive"
-				res.Message = "The speaker at " + host + " is on your network (it still answers on the media port 8091), " +
-					"but its control software has stopped responding (no answer on the STR agent, the Bose port 8090, or SSH). " +
-					"Power the speaker fully off and back on with the STR stick plugged in, then refresh the speaker list and try again."
-				if strings.Contains(strings.ToLower(model), "portable") {
-					res.Message += " The Portable never fully powers off while it still has battery: hold the AUX button for about 10 seconds to force a restart."
+		// Stick-free unlock: if the :17000 setup shell is open we can open SSH
+		// WITHOUT a stick by injecting the remote_services/sshd payload into the
+		// box cloud URLs (gesellix #471/#519), reboot to fire it, then push STR
+		// over SSH. This is the path that converts a SoundTouch 300 / Portable /
+		// SA-4 - none of which reliably read the stick at boot - with no stick or
+		// adapter. See telnet_enable_ssh.go for the mechanism and the factory-reset
+		// caveat (there the stick stays the reliable fallback).
+		if tcpReachable(host, 17000, 2*time.Second) {
+			opened, tlog := a.enableSSHViaTelnet(host, model)
+			if opened {
+				a.logger.Info("install_str: SSH opened stick-free via :17000; installing STR over SSH", "host", host)
+				// Restore stock cloud URLs while :17000 is still the plain Bose TAP
+				// (STR's install may REDIRECT :17008 afterwards). Best-effort.
+				if rerr := a.resetBoseURLsViaTelnet(host); rerr != nil {
+					a.logger.Warn("install_str: could not restore stock boseurls after stick-free unlock", "host", host, "err", rerr)
 				}
-				a.logger.Warn("install_str: preflight, box answers UPnP :8091 but not :22/:8090/:8888 (control stack wedged; advising power-cycle)", "host", host)
-			} else {
-				res.Code = "not-reachable"
-				res.Message = "The speaker is not reachable on the network (no answer on SSH port 22, the Bose port 8090, or the media port 8091 at " + host + "). " +
-					"First bring it onto your Wi-Fi with the Bose SoundTouch app and make sure this PC and the speaker are on the same network. " +
-					"Then reboot the speaker with the STR stick plugged in and try again."
-				a.logger.Warn("install_str: preflight failed, box not reachable on :22, :8090 or :8091", "host", host)
+				return a.RepairInstallViaSSH(host, model)
 			}
-			return res, nil
+			res.Log = tlog
+			a.logger.Info("install_str: :17000 stick-free unlock did not open SSH; giving stick guidance", "host", host)
 		}
-		a.logger.Info("install_str: SSH opened via :17000 diagnostic port (alpha); continuing install without a stick boot", "host", host)
-		// :22 is now open; fall through to the normal install below.
+
+		// The box did not boot with a stick (:22 closed) and the stick-free unlock
+		// did not open SSH. Tell the user what to do, tailored to what the box is
+		// still answering on.
+		onLAN := tcpReachable(host, 8090, 3*time.Second)
+		if onLAN {
+			res.Code = "install-window-closed"
+			res.Message = "The speaker at " + host + " is on the network, but the install access (SSH) is closed. " +
+				"Bose only opens it while the speaker boots with the STR stick plugged in. " +
+				"Power the speaker off, insert the STR stick, power it back on, then install."
+			a.logger.Warn("install_str: preflight, box reachable on :8090 but :22 closed (install window shut; stick-free :17000 unlock did not open SSH)", "host", host)
+		} else if tcpReachable(host, 8091, 3*time.Second) {
+			// :22, :8090 and :8888 are all closed, but the box still answers
+			// UPnP/DLNA on :8091 - its media renderer is a separate firmware
+			// process from the Bose REST API and the STR agent. So the box IS
+			// on the network and on Wi-Fi; only its control stack has wedged.
+			// This is the classic Portable "renderer up, control crashed"
+			// state (Andi M., 06.07.2026: SSDP + :8091 alive, :22/:8090/:8888
+			// all dead). The not-reachable branch below tells the user to
+			// re-onboard Wi-Fi, which is wrong and unactionable here: the box
+			// is already on Wi-Fi. A full power-cycle is what clears the wedge;
+			// keep the stick in so the reboot also re-runs the install if the
+			// STR agent itself stopped.
+			res.Code = "control-unresponsive"
+			res.Message = "The speaker at " + host + " is on your network (it still answers on the media port 8091), " +
+				"but its control software has stopped responding (no answer on the STR agent, the Bose port 8090, or SSH). " +
+				"Power the speaker fully off and back on with the STR stick plugged in, then refresh the speaker list and try again."
+			if strings.Contains(strings.ToLower(model), "portable") {
+				res.Message += " The Portable never fully powers off while it still has battery: hold the AUX button for about 10 seconds to force a restart."
+			}
+			a.logger.Warn("install_str: preflight, box answers UPnP :8091 but not :22/:8090/:8888 (control stack wedged; advising power-cycle)", "host", host)
+		} else {
+			res.Code = "not-reachable"
+			res.Message = "The speaker is not reachable on the network (no answer on SSH port 22, the Bose port 8090, or the media port 8091 at " + host + "). " +
+				"First bring it onto your Wi-Fi with the Bose SoundTouch app and make sure this PC and the speaker are on the same network. " +
+				"Then reboot the speaker with the STR stick plugged in and try again."
+			a.logger.Warn("install_str: preflight failed, box not reachable on :22, :8090 or :8091", "host", host)
+		}
+		return res, nil
 	}
 
 	// Step 0b: SSH itself reachable + authenticated? We do this as a
@@ -496,50 +511,6 @@ func buildStickProbeCmd(paths []string) string {
 // pointing at that directory, bypassing the stick entirely. /mnt/nv is a
 // writable ubifs even when the USB mount is dead. Requires SSH up (Bose stock
 // root SSH) and a real embedded agent (release build, not a dev stub).
-// tryEnableSSHViaDiagPort attempts to open SSH on a box whose install window is
-// shut (it did not read the USB stick at boot, so the remote_services marker was
-// never seen and :22 is closed) via the legacy Bose telnet diagnostic console on
-// TCP 17000. ALPHA / experimental: Bose removed the "remote_services on" command
-// on firmware 27.x, so this only helps on older firmware, and it doubles as the
-// live probe for the SoundTouch 300 (which does not auto-read the stick at boot).
-// Best-effort; returns true only if :22 actually opens afterwards.
-func (a *App) tryEnableSSHViaDiagPort(host string) bool {
-	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, "17000"), 5*time.Second)
-	if err != nil {
-		a.logger.Info("diag-port: :17000 not reachable, cannot try the no-stick SSH enable", "host", host, "err", err)
-		return false
-	}
-	_ = conn.SetDeadline(time.Now().Add(12 * time.Second))
-	buf := make([]byte, 1024)
-	n, _ := conn.Read(buf) // banner / "-> " prompt, best-effort
-	a.logger.Info("diag-port: :17000 connected", "host", host, "banner", strings.TrimSpace(string(buf[:n])))
-	// "help" first so the diagnostic captures which commands this firmware still
-	// exposes (Bose removed remote_services on FW 27.x); then both enable
-	// spellings, since the exact one varies by firmware vintage. Logging each
-	// reply is what lets a real ST300 test (Michal) tell us what its console
-	// supports without the user needing a terminal.
-	for _, cmd := range []string{"help\r\n", "remote_services on\r\n", "local_services on\r\n"} {
-		if _, werr := conn.Write([]byte(cmd)); werr != nil {
-			break
-		}
-		_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
-		rn, _ := conn.Read(buf)
-		a.logger.Info("diag-port: :17000 reply", "host", host, "cmd", strings.TrimSpace(cmd), "reply", strings.TrimSpace(string(buf[:rn])))
-		time.Sleep(300 * time.Millisecond)
-	}
-	_ = conn.Close()
-	a.logger.Info("diag-port: sent remote_services/local_services on :17000, waiting for SSH to open", "host", host)
-	for i := 0; i < 12; i++ {
-		if tcpReachable(host, 22, 2*time.Second) {
-			a.logger.Info("diag-port: SSH opened after :17000 enable (alpha path worked)", "host", host)
-			return true
-		}
-		time.Sleep(1 * time.Second)
-	}
-	a.logger.Info("diag-port: SSH did not open after :17000 enable (expected on firmware 27.x; Bose removed the command)", "host", host)
-	return false
-}
-
 func (a *App) RepairInstallViaSSH(host, model string) (InstallResult, error) {
 	res := InstallResult{Step: "repair-ssh"}
 

--- a/desktop-app/telnet_bootstrap_marge.go
+++ b/desktop-app/telnet_bootstrap_marge.go
@@ -1,0 +1,232 @@
+// Factory-reset stick-free SSH bootstrap.
+//
+// The plain enableSSHViaTelnet path (telnet_enable_ssh.go) opens SSH on a
+// speaker that still does marge checks on its own - i.e. one that kept a Bose
+// margeAccountUUID from before the cloud shutdown. A FACTORY-RESET box has an
+// empty UUID and never checks marge, so the injected payload is written but
+// never fires. This file handles that case, proven live on a factory-reset
+// SoundTouch 300 (ginger):
+//
+//   1. POST /setMargeAccount with a dummy account -> the box sets
+//      margeAccountUUID and starts doing marge checks (the client POST times out
+//      but the box still stores the account).
+//   2. Run a throwaway plain-HTTP marge responder on this PC (no TLS needed) so
+//      the box's ~60s check cycle actually completes against something.
+//   3. Inject the remote_services/sshd payload via `envswitch boseurls set`
+//      pointing the base at THIS PC's marge responder. On ginger/taigan the
+//      running marge client loads the envswitch layer at boot (not the
+//      sys-configuration layer), so envswitch is what actually takes effect.
+//   4. sys reboot -> the running client loads the injected URL.
+//   5. The box hits the responder every ~60s and shells out the payload ->
+//      sshd starts -> :22 opens. Then reset boseurls to stock and install over
+//      SSH.
+//
+// Because this injection embeds THIS PC's live LAN IP into the box's persistent
+// config, a failed attempt must not leave it there: restoreStockBoseURLsAndReboot
+// runs on every failure exit once the injection has been written, so the box is
+// never left marge-checking a dead/reassignable local host.
+//
+// Credit: builds on the gesellix/Bose-SoundTouch #471/#519 community finding;
+// the factory-reset trigger (dummy account + local marge + envswitch layer) was
+// worked out on STR's own hardware.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// bootstrapMargePort is the LAN port the throwaway marge responder binds during
+// a factory-reset unlock. High and fixed so a firewall allow-rule (the desktop
+// app already needs LAN access) stays stable across installs.
+const bootstrapMargePort = 19080
+
+// bootstrapMarge is a throwaway plain-HTTP marge responder. It answers the few
+// streaming.bose.com endpoints a stock box hits during a device check so the
+// box's ~60s marge cycle completes and the envswitch shell injection fires.
+type bootstrapMarge struct {
+	srv  *http.Server
+	hits atomic.Int64 // box requests served; diagnostic only, hence atomic
+}
+
+// startBootstrapMarge binds 0.0.0.0:bootstrapMargePort and serves the marge
+// endpoints. It returns the running responder (Stop it when done) or an error if
+// the port cannot be bound (e.g. already in use).
+func startBootstrapMarge() (*bootstrapMarge, error) {
+	b := &bootstrapMarge{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", b.handle)
+	ln, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", bootstrapMargePort))
+	if err != nil {
+		return nil, fmt.Errorf("bind marge responder: %w", err)
+	}
+	b.srv = &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	go func() { _ = b.srv.Serve(ln) }()
+	return b, nil
+}
+
+// handle answers the box's device-check requests. Responses mirror
+// internal/marge/marge.go (adddeviceresponse "elem" form). The box only needs a
+// well-formed reply so its check cycle keeps running; the exact token is
+// irrelevant to the SSH unlock.
+func (b *bootstrapMarge) handle(w http.ResponseWriter, r *http.Request) {
+	b.hits.Add(1)
+	w.Header().Set("Content-Type", "application/vnd.bose.streaming-v1.2+xml")
+	switch {
+	case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/device"):
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8" ?>` +
+			"\n<adddeviceresponse><margetoken>str-bootstrap</margetoken></adddeviceresponse>"))
+	case strings.Contains(r.URL.Path, "/sourceproviders"):
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8" ?>` + "\n<sourceproviders></sourceproviders>"))
+	default:
+		_, _ = w.Write([]byte(`<response status="OK"></response>`))
+	}
+}
+
+// Stop shuts the responder down. Best-effort.
+func (b *bootstrapMarge) Stop() {
+	if b == nil || b.srv == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = b.srv.Shutdown(ctx)
+}
+
+// localIPForBox returns this PC's LAN IP on the route to the box, by opening a
+// short TCP connection to the box's Bose port and reading the local address.
+// This is the address the box must dial back for the marge check, and it must be
+// the CURRENT one - a stale/guessed IP (e.g. from a DHCP change) makes the box
+// dial a dead host and the unlock silently never fires.
+func localIPForBox(host string) (string, error) {
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, "8090"), 4*time.Second)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+	if ta, ok := conn.LocalAddr().(*net.TCPAddr); ok {
+		return ta.IP.String(), nil
+	}
+	return "", fmt.Errorf("could not determine local IP for %s", host)
+}
+
+// buildBootstrapEnableSSHCommands returns the :17000 command list that writes the
+// enable-SSH injection pointing at a LIVE local marge base (unlike
+// buildEnableSSHCommands, which uses the dead .invalid placeholder). The
+// injection rides both the envswitch layer (what ginger/taigan load at boot) and
+// the sys-configuration margeServerUrl. Pure so it can be unit-tested. base must
+// end in "/" so the trailing "/;" keeps the http base reachable while the shell
+// metacharacters run the payload.
+func buildBootstrapEnableSSHCommands(base string) []string {
+	inj := base + remoteServicesInjection
+	upd := base + "update"
+	return []string{
+		`envswitch boseurls set "` + inj + `" "` + upd + `"`,
+		`sys configuration margeServerUrl "` + inj + `"`,
+	}
+}
+
+// dummyPairXML is the minimal PairDeviceWithAccount body that makes a stock box
+// set a margeAccountUUID (so it begins doing marge checks). The account is a
+// throwaway used only to trigger the check cycle. It is not cleared explicitly;
+// instead, restoring stock boseurls and rebooting the box (both the success
+// install-reboot via RepairInstallViaSSH and the failure-path
+// restoreStockBoseURLsAndReboot) makes the box drop the account it cannot
+// re-validate against streaming.bose.com, which was confirmed live (the UUID
+// went back to empty after a stock-URL reboot). STR then pairs with its own
+// account on the installed box.
+const dummyPairXML = `<?xml version="1.0" encoding="UTF-8" ?>` +
+	`<PairDeviceWithAccount><accountId>str-bootstrap</accountId>` +
+	`<userAuthToken>str-bootstrap</userAuthToken>` +
+	`<accountEmail>bootstrap@str.local</accountEmail></PairDeviceWithAccount>`
+
+// setMargeAccountDummy POSTs the dummy account to the box so it starts checking
+// marge. The box's own HTTP response usually times out (it tries to reach its
+// then-current marge URL during association), but it still stores the account -
+// so a timeout here is treated as success, not failure.
+func (a *App) setMargeAccountDummy(host string) {
+	client := &http.Client{Timeout: 12 * time.Second}
+	url := fmt.Sprintf("http://%s:8090/setMargeAccount", host)
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(dummyPairXML))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/xml")
+	resp, err := client.Do(req)
+	if err != nil {
+		// A timeout is the common, expected outcome and still sets the UUID.
+		a.logger.Info("telnet-bootstrap: setMargeAccount returned no clean response (expected; the box still stores the account)", "host", host, "err", err)
+		return
+	}
+	_ = resp.Body.Close()
+}
+
+// enableSSHViaTelnetBootstrap is the factory-reset unlock: it gives the box a
+// dummy account, points its marge at a throwaway responder on this PC, injects
+// the sshd payload via envswitch, reboots, and waits for :22. Returns whether
+// SSH opened and a command log.
+//
+// Cleanup contract: once the injection is written it embeds this PC's live LAN
+// IP in the box's persistent config, so ANY failure exit after that point calls
+// restoreStockBoseURLsAndReboot before returning, leaving the box back on stock
+// URLs. On success the caller resets boseurls to stock (so STR's own marge
+// interception takes over) before installing.
+func (a *App) enableSSHViaTelnetBootstrap(host, model string) (bool, string) {
+	var log strings.Builder
+
+	pcIP, err := localIPForBox(host)
+	if err != nil {
+		a.logger.Info("telnet-bootstrap: cannot determine this PC's LAN IP for the box; skipping factory-reset unlock", "host", host, "err", err)
+		return false, "could not determine local IP: " + err.Error()
+	}
+	fmt.Fprintf(&log, "PC marge address for the box: http://%s:%d\n", pcIP, bootstrapMargePort)
+
+	marge, err := startBootstrapMarge()
+	if err != nil {
+		a.logger.Warn("telnet-bootstrap: could not start the local marge responder (port in use?)", "host", host, "err", err)
+		return false, "could not start local marge responder: " + err.Error()
+	}
+	defer marge.Stop()
+
+	t, err := dialTAP(host, 5*time.Second)
+	if err != nil {
+		return false, "port 17000 not reachable: " + err.Error()
+	}
+
+	// Give the box an account so it begins doing marge checks. Done after the TAP
+	// dial succeeds so we do not set a dummy account on a box we then cannot reach
+	// over :17000 to inject or recover.
+	a.setMargeAccountDummy(host)
+
+	// From here the box config carries this PC's live IP; every failure exit must
+	// restore stock URLs and reboot so the box is not left dialing a dead host.
+	base := fmt.Sprintf("http://%s:%d/", pcIP, bootstrapMargePort)
+	for _, cmd := range buildBootstrapEnableSSHCommands(base) {
+		if serr := sendAndLog(t, &log, cmd); serr != nil {
+			t.close()
+			// The caller restores stock URLs + reboots on any failure exit (it
+			// owns cleanup so the simple path is covered too), so a partial write
+			// here is not left pointed at this PC.
+			return false, log.String()
+		}
+	}
+	_, _ = t.send("sys reboot")
+	t.close()
+	a.logger.Info("telnet-bootstrap: dummy account set, envswitch injection written, sys reboot sent; waiting for the box to check marge and open SSH", "host", host, "pcMarge", base)
+
+	// Budget: boot (~90s) plus at least one ~60s marge-check cycle. Give it the
+	// slow-model budget plus a margin so a genuine success is never cut off.
+	budget := agentWaitBudget(model) + 90*time.Second
+	if a.waitForSSHOpen(host, budget) {
+		a.logger.Info("telnet-bootstrap: SSH opened on the factory-reset box via the local-marge unlock", "host", host, "margeHits", marge.hits.Load())
+		return true, log.String()
+	}
+	a.logger.Info("telnet-bootstrap: SSH did not open within budget; caller will restore stock URLs so the box stops dialing this PC", "host", host, "budget", budget.String(), "margeHits", marge.hits.Load())
+	return false, log.String()
+}

--- a/desktop-app/telnet_enable_ssh.go
+++ b/desktop-app/telnet_enable_ssh.go
@@ -17,13 +17,11 @@
 // the community reports: the payload only fires when the box actually does a
 // marge/boseurls check. A box that still carries a Bose margeAccountUUID (it was
 // used with the Bose app before the cloud shut down) checks roughly every 60 s
-// and opens SSH quickly. A fully factory-reset box never checks on its own, so
-// the injection is written but never runs - there the USB stick stays the
-// reliable path. STR sends `sys reboot` over :17000 to trigger the boot-time
-// re-parse without the user touching the speaker, which covers the models that
-// fire on reboot (ST10/20/30, SA-4, CineMate). This is therefore an ADDITIVE
-// stick-free path with the stick as the documented fallback, not a hard
-// replacement.
+// and opens SSH quickly. A fully factory-reset box never checks on its own; that
+// case is handled by enableSSHViaTelnetBootstrap (telnet_bootstrap_marge.go),
+// which gives the box a dummy account and a local marge responder so the check
+// cycle runs. STR sends `sys reboot` over :17000 to trigger the boot-time
+// re-parse without the user touching the speaker.
 
 package main
 
@@ -40,16 +38,18 @@ import (
 // telnet command because it contains spaces and semicolons.
 const remoteServicesInjection = ";touch /tmp/remote_services;/etc/init.d/sshd start"
 
-// telnetEnableBase is the placeholder cloud host used while unlocking SSH. A
-// reserved .invalid name (RFC 6761) fails DNS instantly, so the injected
-// `<tool> <base>` fails fast and the `;touch;sshd` payload runs without waiting
-// on a network timeout. resetBoseURLsViaTelnet restores the real hosts after.
+// telnetEnableBase is the placeholder cloud host used while unlocking SSH on a
+// box that still does marge checks on its own. A reserved .invalid name
+// (RFC 6761) fails DNS instantly, so the injected `<tool> <base>` fails fast and
+// the `;touch;sshd` payload runs without waiting on a network timeout.
+// resetBoseURLsViaTelnet restores the real hosts after. (The factory-reset path
+// instead points the base at a live local marge; see telnet_bootstrap_marge.go.)
 const telnetEnableBase = "https://str-setup.invalid"
 
 // stockBoseURLs are the factory cloud URLs restored after a stick-free unlock,
 // so no command injection lingers in the box config and STR's marge interception
-// (which catches streaming.bose.com) works normally. Values read live from a
-// stock SoundTouch 300 and Portable on FW 27.0.6.
+// (which catches streaming.bose.com via /etc/hosts) works normally. Values read
+// live from a stock SoundTouch 300 and Portable on FW 27.0.6.
 var stockBoseURLs = struct{ marge, stats, swUpdate, bmx string }{
 	marge:    "https://streaming.bose.com",
 	stats:    "https://events.api.bosecm.com",
@@ -77,14 +77,17 @@ func buildEnableSSHCommands(base string) []string {
 }
 
 // buildResetBoseURLCommands returns the :17000 command list that restores stock
-// cloud URLs (removing the injection).
+// cloud URLs (removing the injection). The envswitch command is written first
+// (not last) so that if the TAP session drops mid-sequence, the layer the
+// running client actually loads at boot on ginger/taigan is the one most likely
+// to already be clean.
 func buildResetBoseURLCommands() []string {
 	return []string{
+		`envswitch boseurls set "` + stockBoseURLs.marge + `" "` + stockBoseURLs.swUpdate + `"`,
 		`sys configuration margeServerUrl "` + stockBoseURLs.marge + `"`,
 		`sys configuration statsServerUrl "` + stockBoseURLs.stats + `"`,
 		`sys configuration swUpdateUrl "` + stockBoseURLs.swUpdate + `"`,
 		`sys configuration bmxRegistryUrl "` + stockBoseURLs.bmx + `"`,
-		`envswitch boseurls set "` + stockBoseURLs.marge + `" "` + stockBoseURLs.swUpdate + `"`,
 	}
 }
 
@@ -139,9 +142,37 @@ func (t *tapConn) send(cmd string) (string, error) {
 
 func (t *tapConn) close() { _ = t.conn.Close() }
 
+// sendAndLog runs one TAP command, appends a "-> cmd\nreply" line to log, and
+// returns the transport error (nil on a clean round-trip). A firmware that does
+// not expose a given key replies "Command not found" / "Invalid Command"; that
+// is not a transport error, so the caller keeps going with the remaining
+// commands (best-effort, fallback-first). Shared by every :17000 command loop so
+// the log format and abort semantics live in one place.
+func sendAndLog(t *tapConn, log *strings.Builder, cmd string) error {
+	reply, err := t.send(cmd)
+	fmt.Fprintf(log, "-> %s\n%s\n", cmd, strings.TrimSpace(reply))
+	return err
+}
+
+// waitForSSHOpen polls TCP :22 until it accepts a connection or budget elapses.
+// Shared by both unlock paths.
+func (a *App) waitForSSHOpen(host string, budget time.Duration) bool {
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		if tcpReachable(host, 22, 2*time.Second) {
+			return true
+		}
+		time.Sleep(4 * time.Second)
+	}
+	return false
+}
+
 // enableSSHViaTelnet writes the enable-SSH injection over :17000, reboots the
 // box to trigger it, and polls :22 up to a model-aware budget. Returns whether
-// SSH came up and a redaction-free command log for diagnostics.
+// SSH came up and a redaction-free command log for diagnostics. This is the
+// path for a box that still does marge checks on its own (residual Bose UUID);
+// the placeholder .invalid base means nothing on the LAN is left pointed at a
+// live host on failure, so this path needs no recovery reset.
 func (a *App) enableSSHViaTelnet(host, model string) (bool, string) {
 	var log strings.Builder
 	t, err := dialTAP(host, 5*time.Second)
@@ -150,17 +181,10 @@ func (a *App) enableSSHViaTelnet(host, model string) (bool, string) {
 		return false, "port 17000 not reachable: " + err.Error()
 	}
 	for _, cmd := range buildEnableSSHCommands(telnetEnableBase) {
-		reply, serr := t.send(cmd)
-		fmt.Fprintf(&log, "-> %s\n%s\n", cmd, strings.TrimSpace(reply))
-		if serr != nil {
+		if serr := sendAndLog(t, &log, cmd); serr != nil {
 			t.close()
 			a.logger.Warn("telnet-enable: command transport failed", "host", host, "cmd", cmd, "err", serr)
 			return false, log.String()
-		}
-		// A firmware variant may not expose every key; that is fine - the others
-		// still land (best-effort, fallback-first). Only a transport error aborts.
-		if strings.Contains(reply, "Command not found") || strings.Contains(reply, "Invalid Command") {
-			a.logger.Info("telnet-enable: box rejected a config key (continuing with the rest)", "host", host, "cmd", cmd)
 		}
 	}
 	if v, _ := t.send("getpdo CurrentSystemConfiguration"); strings.TrimSpace(v) != "" {
@@ -172,32 +196,63 @@ func (a *App) enableSSHViaTelnet(host, model string) (bool, string) {
 	t.close()
 	a.logger.Info("telnet-enable: injection written and sys reboot sent; polling for SSH", "host", host, "model", model)
 
-	budget := agentWaitBudget(model)
-	deadline := time.Now().Add(budget)
-	for time.Now().Before(deadline) {
-		if tcpReachable(host, 22, 2*time.Second) {
-			a.logger.Info("telnet-enable: SSH opened stick-free via :17000 unlock", "host", host)
-			return true, log.String()
-		}
-		time.Sleep(4 * time.Second)
+	if a.waitForSSHOpen(host, agentWaitBudget(model)) {
+		a.logger.Info("telnet-enable: SSH opened stick-free via :17000 unlock", "host", host)
+		return true, log.String()
 	}
-	a.logger.Info("telnet-enable: SSH did not open within budget (box may need a physical power cycle, or is factory-reset and never checks marge)", "host", host, "budget", budget.String())
+	a.logger.Info("telnet-enable: SSH did not open within budget (box may need a physical power cycle, or is factory-reset - the bootstrap path handles that)", "host", host)
 	return false, log.String()
 }
 
-// resetBoseURLsViaTelnet restores stock cloud URLs over :17000 after SSH has
-// been unlocked, removing the command injection. Best-effort: run while :17000
-// is still the plain Bose TAP, before STR's install changes the box's posture.
+// resetBoseURLsViaTelnet restores stock cloud URLs over :17000 after a stick-free
+// unlock, removing the command injection so STR's own marge interception takes
+// over and no injection lingers. Retried, because leaving the box pointed at the
+// injection URL is the worst outcome of this whole flow: retries take a
+// just-reachable box and make the restore reliable. Returns nil once all
+// commands land cleanly in one attempt, otherwise the last error.
 func (a *App) resetBoseURLsViaTelnet(host string) error {
-	t, err := dialTAP(host, 5*time.Second)
-	if err != nil {
-		return err
-	}
-	defer t.close()
-	for _, cmd := range buildResetBoseURLCommands() {
-		if _, serr := t.send(cmd); serr != nil {
-			return serr
+	var lastErr error
+	for attempt := 0; attempt < 4; attempt++ {
+		if attempt > 0 {
+			time.Sleep(3 * time.Second)
+		}
+		t, err := dialTAP(host, 5*time.Second)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		var log strings.Builder
+		ok := true
+		for _, cmd := range buildResetBoseURLCommands() {
+			if serr := sendAndLog(t, &log, cmd); serr != nil {
+				lastErr = serr
+				ok = false
+				break
+			}
+		}
+		t.close()
+		if ok {
+			return nil
 		}
 	}
-	return nil
+	return lastErr
+}
+
+// restoreStockBoseURLsAndReboot restores stock cloud URLs AND reboots the box so
+// the running marge client stops dialing whatever custom/dead host the unlock
+// pointed it at. Best-effort recovery for a FAILED stick-free unlock: without it
+// a box left with an injection URL (especially a live-LAN-IP one from the
+// bootstrap path) would marge-check a now-dead responder forever and defeat
+// STR's later streaming.bose.com interception. Errors are logged, not returned -
+// this runs on an already-failing path.
+func (a *App) restoreStockBoseURLsAndReboot(host string) {
+	if err := a.resetBoseURLsViaTelnet(host); err != nil {
+		a.logger.Warn("telnet-enable: failed to restore stock boseurls on the recovery path; box may keep dialing the unlock URL until a manual factory reset", "host", host, "err", err)
+		return
+	}
+	if t, err := dialTAP(host, 5*time.Second); err == nil {
+		_, _ = t.send("sys reboot")
+		t.close()
+		a.logger.Info("telnet-enable: restored stock boseurls and rebooted after a failed unlock", "host", host)
+	}
 }

--- a/desktop-app/telnet_enable_ssh.go
+++ b/desktop-app/telnet_enable_ssh.go
@@ -1,0 +1,203 @@
+// Stick-free SSH unlock over the Bose :17000 TAP diagnostic shell.
+//
+// The stock firmware exposes a telnet-style command shell on TCP 17000 that
+// accepts `envswitch boseurls set "<marge>" "<swupdate>"` and
+// `sys configuration <key> "<value>"`. Writing a shell payload into the cloud
+// URLs makes the firmware run it the next time it re-parses those URLs (a
+// marge/boseurls check, or a boot): the payload touches the remote_services
+// marker sshd gates on and starts sshd. Once :22 is open, RepairInstallViaSSH
+// pushes STR over SSH with no USB stick at all - so a SoundTouch 300, Portable
+// or SA-4 (none of which reliably read the stick at boot) can be converted
+// without a stick or an adapter.
+//
+// Credit: the technique is from the gesellix/Bose-SoundTouch community
+// (issues #471, #515, #519). This is an independent Go port for STR.
+//
+// Reliability, from live testing on ST300 (ginger) and Portable (taigan) plus
+// the community reports: the payload only fires when the box actually does a
+// marge/boseurls check. A box that still carries a Bose margeAccountUUID (it was
+// used with the Bose app before the cloud shut down) checks roughly every 60 s
+// and opens SSH quickly. A fully factory-reset box never checks on its own, so
+// the injection is written but never runs - there the USB stick stays the
+// reliable path. STR sends `sys reboot` over :17000 to trigger the boot-time
+// re-parse without the user touching the speaker, which covers the models that
+// fire on reboot (ST10/20/30, SA-4, CineMate). This is therefore an ADDITIVE
+// stick-free path with the stick as the documented fallback, not a hard
+// replacement.
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+// remoteServicesInjection is appended to the marge URL. When the firmware next
+// shells out that URL it runs these commands: touch the remote_services marker
+// sshd checks for, then start sshd. The whole value is double-quoted in the
+// telnet command because it contains spaces and semicolons.
+const remoteServicesInjection = ";touch /tmp/remote_services;/etc/init.d/sshd start"
+
+// telnetEnableBase is the placeholder cloud host used while unlocking SSH. A
+// reserved .invalid name (RFC 6761) fails DNS instantly, so the injected
+// `<tool> <base>` fails fast and the `;touch;sshd` payload runs without waiting
+// on a network timeout. resetBoseURLsViaTelnet restores the real hosts after.
+const telnetEnableBase = "https://str-setup.invalid"
+
+// stockBoseURLs are the factory cloud URLs restored after a stick-free unlock,
+// so no command injection lingers in the box config and STR's marge interception
+// (which catches streaming.bose.com) works normally. Values read live from a
+// stock SoundTouch 300 and Portable on FW 27.0.6.
+var stockBoseURLs = struct{ marge, stats, swUpdate, bmx string }{
+	marge:    "https://streaming.bose.com",
+	stats:    "https://events.api.bosecm.com",
+	swUpdate: "https://worldwide.bose.com/updates/soundtouch",
+	bmx:      "https://content.api.bose.io/bmx/registry/v1/services",
+}
+
+// buildEnableSSHCommands returns the ordered :17000 command list that writes the
+// enable-SSH injection. It writes BOTH the envswitch persistence layer (used by
+// rhino/sm2 boxes, where it reflects in /info margeURL) AND all four
+// `sys configuration` runtime keys (used by ginger/taigan, where envswitch does
+// not reflect in getpdo/`/info` but sys configuration does) - the #519
+// full-config superset, so one sequence covers every variant. Pure and
+// hardware-free so it can be unit-tested.
+func buildEnableSSHCommands(base string) []string {
+	inj := base + remoteServicesInjection
+	swu := base + "/updates/soundtouch"
+	return []string{
+		`sys configuration bmxRegistryUrl "` + base + `/bmx/registry/v1/services"`,
+		`sys configuration statsServerUrl "` + base + `"`,
+		`sys configuration margeServerUrl "` + inj + `"`,
+		`sys configuration swUpdateUrl "` + swu + `"`,
+		`envswitch boseurls set "` + inj + `" "` + swu + `"`,
+	}
+}
+
+// buildResetBoseURLCommands returns the :17000 command list that restores stock
+// cloud URLs (removing the injection).
+func buildResetBoseURLCommands() []string {
+	return []string{
+		`sys configuration margeServerUrl "` + stockBoseURLs.marge + `"`,
+		`sys configuration statsServerUrl "` + stockBoseURLs.stats + `"`,
+		`sys configuration swUpdateUrl "` + stockBoseURLs.swUpdate + `"`,
+		`sys configuration bmxRegistryUrl "` + stockBoseURLs.bmx + `"`,
+		`envswitch boseurls set "` + stockBoseURLs.marge + `" "` + stockBoseURLs.swUpdate + `"`,
+	}
+}
+
+// tapConn is a thin client for the Bose :17000 TAP command shell.
+type tapConn struct {
+	conn net.Conn
+}
+
+// dialTAP connects to :17000 and drains the initial "->" banner.
+func dialTAP(host string, timeout time.Duration) (*tapConn, error) {
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, "17000"), timeout)
+	if err != nil {
+		return nil, err
+	}
+	t := &tapConn{conn: conn}
+	t.drain(1500 * time.Millisecond)
+	return t, nil
+}
+
+// drain reads until an idle gap after a "->"-terminated reply, or maxWindow
+// elapses. The TAP shell echoes the command, an optional result, then "->".
+func (t *tapConn) drain(maxWindow time.Duration) string {
+	var sb strings.Builder
+	buf := make([]byte, 4096)
+	deadline := time.Now().Add(maxWindow)
+	for time.Now().Before(deadline) {
+		_ = t.conn.SetReadDeadline(time.Now().Add(400 * time.Millisecond))
+		n, err := t.conn.Read(buf)
+		if n > 0 {
+			sb.Write(buf[:n])
+		}
+		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				if sb.Len() > 0 && strings.HasSuffix(strings.TrimSpace(sb.String()), "->") {
+					break
+				}
+				continue
+			}
+			break
+		}
+	}
+	return sb.String()
+}
+
+// send writes a command and returns the drained reply.
+func (t *tapConn) send(cmd string) (string, error) {
+	if _, err := t.conn.Write([]byte(cmd + "\r\n")); err != nil {
+		return "", err
+	}
+	return t.drain(2500 * time.Millisecond), nil
+}
+
+func (t *tapConn) close() { _ = t.conn.Close() }
+
+// enableSSHViaTelnet writes the enable-SSH injection over :17000, reboots the
+// box to trigger it, and polls :22 up to a model-aware budget. Returns whether
+// SSH came up and a redaction-free command log for diagnostics.
+func (a *App) enableSSHViaTelnet(host, model string) (bool, string) {
+	var log strings.Builder
+	t, err := dialTAP(host, 5*time.Second)
+	if err != nil {
+		a.logger.Info("telnet-enable: :17000 not reachable, cannot unlock SSH stick-free", "host", host, "err", err)
+		return false, "port 17000 not reachable: " + err.Error()
+	}
+	for _, cmd := range buildEnableSSHCommands(telnetEnableBase) {
+		reply, serr := t.send(cmd)
+		fmt.Fprintf(&log, "-> %s\n%s\n", cmd, strings.TrimSpace(reply))
+		if serr != nil {
+			t.close()
+			a.logger.Warn("telnet-enable: command transport failed", "host", host, "cmd", cmd, "err", serr)
+			return false, log.String()
+		}
+		// A firmware variant may not expose every key; that is fine - the others
+		// still land (best-effort, fallback-first). Only a transport error aborts.
+		if strings.Contains(reply, "Command not found") || strings.Contains(reply, "Invalid Command") {
+			a.logger.Info("telnet-enable: box rejected a config key (continuing with the rest)", "host", host, "cmd", cmd)
+		}
+	}
+	if v, _ := t.send("getpdo CurrentSystemConfiguration"); strings.TrimSpace(v) != "" {
+		fmt.Fprintf(&log, "-> getpdo CurrentSystemConfiguration\n%s\n", strings.TrimSpace(v))
+	}
+	// Reboot to trigger the boot-time URL re-parse without the user touching the
+	// speaker. This is STR's advantage over the manual CLI flow.
+	_, _ = t.send("sys reboot")
+	t.close()
+	a.logger.Info("telnet-enable: injection written and sys reboot sent; polling for SSH", "host", host, "model", model)
+
+	budget := agentWaitBudget(model)
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		if tcpReachable(host, 22, 2*time.Second) {
+			a.logger.Info("telnet-enable: SSH opened stick-free via :17000 unlock", "host", host)
+			return true, log.String()
+		}
+		time.Sleep(4 * time.Second)
+	}
+	a.logger.Info("telnet-enable: SSH did not open within budget (box may need a physical power cycle, or is factory-reset and never checks marge)", "host", host, "budget", budget.String())
+	return false, log.String()
+}
+
+// resetBoseURLsViaTelnet restores stock cloud URLs over :17000 after SSH has
+// been unlocked, removing the command injection. Best-effort: run while :17000
+// is still the plain Bose TAP, before STR's install changes the box's posture.
+func (a *App) resetBoseURLsViaTelnet(host string) error {
+	t, err := dialTAP(host, 5*time.Second)
+	if err != nil {
+		return err
+	}
+	defer t.close()
+	for _, cmd := range buildResetBoseURLCommands() {
+		if _, serr := t.send(cmd); serr != nil {
+			return serr
+		}
+	}
+	return nil
+}

--- a/desktop-app/telnet_enable_ssh_test.go
+++ b/desktop-app/telnet_enable_ssh_test.go
@@ -66,3 +66,39 @@ func TestBuildResetBoseURLCommands(t *testing.T) {
 		t.Error("reset must also clear the envswitch layer")
 	}
 }
+
+// TestBuildBootstrapEnableSSHCommands asserts the factory-reset injection rides
+// BOTH the envswitch layer (what ginger/taigan load at boot) and the runtime
+// margeServerUrl, points at the live local marge base, keeps a reachable http
+// base before the "/;" shell break, and stays balanced-quoted.
+func TestBuildBootstrapEnableSSHCommands(t *testing.T) {
+	base := "http://192.0.2.10:19080/"
+	cmds := buildBootstrapEnableSSHCommands(base)
+	if len(cmds) != 2 {
+		t.Fatalf("want 2 commands, got %d: %v", len(cmds), cmds)
+	}
+	inj := base + remoteServicesInjection
+	want := []string{
+		`envswitch boseurls set "` + inj + `" "` + base + `update"`,
+		`sys configuration margeServerUrl "` + inj + `"`,
+	}
+	for i := range want {
+		if cmds[i] != want[i] {
+			t.Errorf("command %d:\n got %q\nwant %q", i, cmds[i], want[i])
+		}
+	}
+	for _, c := range cmds {
+		if !strings.Contains(c, remoteServicesInjection) {
+			t.Errorf("command missing injection: %q", c)
+		}
+		if strings.Count(c, `"`)%2 != 0 {
+			t.Errorf("unbalanced quotes in %q", c)
+		}
+		// The reachable http base must survive intact before the shell break so the
+		// box still connects to the responder (that is what keeps the check cycle
+		// alive); the ";" starts the payload.
+		if !strings.Contains(c, base+";") && !strings.Contains(c, base+`update`) {
+			t.Errorf("command lost the reachable base before the shell break: %q", c)
+		}
+	}
+}

--- a/desktop-app/telnet_enable_ssh_test.go
+++ b/desktop-app/telnet_enable_ssh_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildEnableSSHCommands asserts the exact stick-free unlock sequence: all
+// four sys-configuration keys plus envswitch, with the remote_services/sshd
+// injection present on BOTH margeServerUrl and the envswitch marge slot (the
+// #519 full-config superset that covers every variant), and every value
+// double-quoted so the box command parser keeps the injection as one argument.
+func TestBuildEnableSSHCommands(t *testing.T) {
+	base := "https://str-setup.invalid"
+	cmds := buildEnableSSHCommands(base)
+	if len(cmds) != 5 {
+		t.Fatalf("want 5 commands, got %d: %v", len(cmds), cmds)
+	}
+	inj := base + remoteServicesInjection
+	want := []string{
+		`sys configuration bmxRegistryUrl "` + base + `/bmx/registry/v1/services"`,
+		`sys configuration statsServerUrl "` + base + `"`,
+		`sys configuration margeServerUrl "` + inj + `"`,
+		`sys configuration swUpdateUrl "` + base + `/updates/soundtouch"`,
+		`envswitch boseurls set "` + inj + `" "` + base + `/updates/soundtouch"`,
+	}
+	for i := range want {
+		if cmds[i] != want[i] {
+			t.Errorf("command %d:\n got %q\nwant %q", i, cmds[i], want[i])
+		}
+	}
+
+	// The injection must ride the runtime margeServerUrl (the layer ginger/taigan
+	// actually re-read in live testing) AND the envswitch layer (used by rhino).
+	margeSysConfig, envswitch := cmds[2], cmds[4]
+	if !strings.Contains(margeSysConfig, remoteServicesInjection) {
+		t.Error("sys configuration margeServerUrl is missing the injection")
+	}
+	if !strings.Contains(envswitch, remoteServicesInjection) {
+		t.Error("envswitch boseurls is missing the injection")
+	}
+
+	// Every command must be balanced-quoted so a value with spaces/semicolons
+	// stays one argument on the box.
+	for _, c := range cmds {
+		if strings.Count(c, `"`)%2 != 0 {
+			t.Errorf("unbalanced quotes in %q", c)
+		}
+	}
+}
+
+// TestBuildResetBoseURLCommands asserts the cleanup restores the stock hosts and
+// carries no leftover injection.
+func TestBuildResetBoseURLCommands(t *testing.T) {
+	cmds := buildResetBoseURLCommands()
+	joined := strings.Join(cmds, "\n")
+	if strings.Contains(joined, remoteServicesInjection) {
+		t.Error("reset commands must not contain the injection")
+	}
+	for _, want := range []string{stockBoseURLs.marge, stockBoseURLs.stats, stockBoseURLs.swUpdate, stockBoseURLs.bmx} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("reset commands missing stock URL %q", want)
+		}
+	}
+	if !strings.Contains(joined, `envswitch boseurls set "`+stockBoseURLs.marge+`"`) {
+		t.Error("reset must also clear the envswitch layer")
+	}
+}


### PR DESCRIPTION
## What

Adds a **USB-stick-free install path**. Today, converting a stock speaker needs the STR stick booted in the box (Bose only opens SSH while the `remote_services` marker on `/media/sda1` is present). This PR lets STR open SSH **without a stick** over the box's `:17000` setup shell, then reuses the existing `RepairInstallViaSSH` (which already pushes the embedded agent over SSH) for a complete stickless install.

Mechanism (gesellix/Bose-SoundTouch community #471/#519, ported independently):
- Inject `;touch /tmp/remote_services;/etc/init.d/sshd start` into the box cloud URLs over `:17000` — on **both** the `envswitch` layer (rhino/sm2 boxes) and all four `sys configuration` keys (ginger/taigan, where `envswitch` doesn't reflect in the runtime config). One full-config superset covers every variant.
- `sys reboot` over `:17000` to fire the boot-time re-parse (no physical access needed).
- Poll `:22`, then `RepairInstallViaSSH`, then restore the box's stock cloud URLs so no injection lingers and STR's marge interception works.

This is the only route on models that never read the stick at boot (**SoundTouch 300**, **SA-4 / CineMate** `lisa` chassis).

## Live testing

Verified on hardware: `:17000` TAP works on both a **Portable (taigan)** and a **SoundTouch 300 (ginger)**; the injection writes and persists (`getpdo` confirms), and the per-variant write-layer finding (envswitch vs `sys configuration`) drove the full-config superset.

**Honest reliability caveat** (also in the code + commit): the payload only fires when the box does a marge/boseurls check. A speaker that still carries a Bose `margeAccountUUID` checks ~every 60s and opens SSH fast; `sys reboot` fires the boot re-parse on the models that need it (ST10/20/30, SA-4, CineMate — community-confirmed). A **fully factory-reset** speaker never checks on its own — a factory-clean ST300 test box (empty UUID) did not open SSH across reboot / full-config / association attempts — so **there the USB stick stays the fallback**. Additive stick-free path, not a hard USB replacement; falls back to the existing stick guidance when SSH doesn't come up.

## Changes

- New `desktop-app/telnet_enable_ssh.go`: `:17000` TAP client, `enableSSHViaTelnet`, `resetBoseURLsViaTelnet`, pure command builders.
- `install_str.go` preflight: try the stick-free unlock → stickless `RepairInstallViaSSH` → restore URLs; removed the dead `tryEnableSSHViaDiagPort`.
- Unit tests for the exact command sequences. No new i18n keys, no Wails-binding change.

`go build ./...`, `go vet`, `go test .`, and the ARM cross-compile all pass.

> Stacked on #334 (shares the install preflight). Base retargets to `main` once #334 merges.