### PR TITLE
fix(multiroom): stop a grouped speaker from hijacking others with an old station every 5 minutes

### DIFF
--- a/internal/webui/announce.go
+++ b/internal/webui/announce.go
@@ -185,26 +185,7 @@ func (s *Server) handleAnnounce(w http.ResponseWriter, r *http.Request) {
 // snapshotNowPlaying reads the box's current now_playing so STR can restore it
 // after the announcement. Best-effort: a read error yields an empty snapshot.
 func (s *Server) snapshotNowPlaying(ctx context.Context) nowPlayingSnapshot {
-	var snap nowPlayingSnapshot
-	b, err := boxGet(ctx, "http://"+s.boxHost+":8090/now_playing", 16<<10)
-	if err != nil {
-		return snap
-	}
-	var np struct {
-		Source      string `xml:"source,attr"`
-		ContentItem struct {
-			Location string `xml:"location,attr"`
-			ItemName string `xml:"itemName"`
-		} `xml:"ContentItem"`
-		PlayStatus string `xml:"playStatus"`
-	}
-	if xml.Unmarshal(b, &np) == nil {
-		snap.Source = np.Source
-		snap.Location = np.ContentItem.Location
-		snap.ItemName = np.ContentItem.ItemName
-		snap.PlayStatus = np.PlayStatus
-	}
-	return snap
+	return fetchNowPlaying(ctx, s.boxHost)
 }
 
 // readVolume returns the box's current target volume, or -1 on error.

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -199,6 +199,11 @@ type Server struct {
 	// "Preset not assigned", #119 Klaus). Empty disables persistence (tests).
 	lastPlayPath string
 
+	// mirrorSkips remembers, per zone member, why the last mirror reconcile
+	// tick skipped it, so the skip is logged at INFO only on a state change
+	// (#342). Touched only by the single reconcile goroutine — no lock.
+	mirrorSkips map[string]string
+
 	// lastUserStop is when the user last DELIBERATELY stopped playback, so the
 	// auto-re-push does not fight a wanted stop (v0.7.0: a single Stop
 	// did not hold because the proxy disconnect that a stop causes looks
@@ -684,6 +689,7 @@ func (s *Server) Run(ctx context.Context) error {
 	mux.HandleFunc("/announce/audio", s.handleAnnounceAudio)
 	mux.HandleFunc("/api/box/sync-presets", s.handleBoxSyncPresets)
 	mux.HandleFunc("/api/box/zone", s.handleBoxZone)
+	mux.HandleFunc("/api/box/zone/purge", s.handleZonePurge)
 	mux.HandleFunc("/api/box/group", s.handleBoxGroup)
 	mux.HandleFunc("/api/webhooks", s.handleWebhooks)
 	mux.HandleFunc("/api/webhooks/test", s.handleWebhooksTest)
@@ -3835,7 +3841,9 @@ func (s *Server) handleZoneForm(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if mode == "mirror" {
-		s.mirrorToSlaves(ctx, z)
+		// Deliberate user action: push unconditionally (reconcile=false), the
+		// user just asked for exactly this group.
+		s.mirrorToSlaves(ctx, z, false)
 		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "mode": "mirror"})
 		return
 	}
@@ -4119,13 +4127,32 @@ func (s *Server) formStereoPair(w http.ResponseWriter, ctx context.Context, c *b
 // master box to play (s.lastPlay), which the slaves can pull from the master
 // agent's stream proxy. Looser than firmware sync, but works when the firmware
 // refuses to distribute STR's source. Best-effort + heavily logged.
-func (s *Server) mirrorToSlaves(ctx context.Context, z zones.Zone) {
+//
+// reconcile marks the periodic 5-minute re-form (PeriodicZoneReconcile) as
+// opposed to the user just having formed the group. The reconcile must only
+// repair what is actually broken: lastPlay is PERSISTED across reboots, so
+// without state guards an idle or standby master sprayed its stale last stream
+// onto every slave each tick — a slave busy with a Spotify playlist was yanked
+// to the master's old radio station every 5 minutes (#342), and a healthy
+// mirroring slave was re-pushed into a re-buffer hiccup each tick. With
+// reconcile set, the master must be actively playing the mirrored stream, and
+// each slave is only (re)pointed per slaveMirrorAction (never woken from
+// standby, never taken off another source it is playing).
+func (s *Server) mirrorToSlaves(ctx context.Context, z zones.Zone, reconcile bool) {
 	s.lastPlayMu.Lock()
 	lp := s.lastPlay
 	s.lastPlayMu.Unlock()
 	if lp == nil || lp.boxURL == "" {
 		s.logger.Info("zone mirror: master is not playing yet; slaves will mirror once you start playback and the reconcile fires (beta)")
 		return
+	}
+	if reconcile {
+		np := s.snapshotNowPlaying(ctx)
+		if reason := masterMirrorSkipReason(np, lp.boxURL); reason != "" {
+			s.logMirrorSkip("master", reason)
+			return
+		}
+		s.clearMirrorSkip("master")
 	}
 	// lp.boxURL points the MASTER's own box at its loopback stream proxy
 	// (http://127.0.0.1:8888/...). A slave cannot fetch that; it must reach the
@@ -4136,6 +4163,15 @@ func (s *Server) mirrorToSlaves(ctx context.Context, z zones.Zone) {
 	for _, m := range z.Slaves {
 		if m.IP == "" {
 			continue
+		}
+		if reconcile {
+			push, reason := slaveMirrorAction(fetchNowPlaying(ctx, m.IP), slaveURL)
+			if !push {
+				s.logMirrorSkip("slave "+m.IP, reason)
+				continue
+			}
+			s.clearMirrorSkip("slave " + m.IP)
+			s.logger.Info("zone mirror: re-forming slave (beta)", "slave", m.IP, "reason", reason)
 		}
 		rr := upnp.NewBoseRenderer(m.IP)
 		var err error
@@ -4201,9 +4237,10 @@ const defaultZoneReconcilePath = "/mnt/nv/streborn/zone-reconcile"
 // zoneReconcileEnabled reports whether the periodic NATIVE zone re-assert runs on
 // this box. Default OFF (opt-in): the flag file must explicitly say
 // "1"/"true"/"on"/"yes" to turn it on. See defaultZoneReconcilePath for why the
-// default flipped to OFF. A mirror zone is unaffected: reconcileZoneOnce always
-// re-pushes a mirror group (that path works and does not drag a solo speaker), so
-// this gate only governs the broken/harmful native re-assert.
+// default flipped to OFF. A mirror zone is not gated here: its re-push has its
+// own per-tick state guards (see mirrorToSlaves/slaveMirrorAction — the master
+// must be actively playing, and standby or busy slaves are left alone, #342),
+// so this gate only governs the broken/harmful native re-assert.
 func (s *Server) zoneReconcileEnabled() bool {
 	b, err := os.ReadFile(defaultZoneReconcilePath)
 	if err != nil {
@@ -4243,11 +4280,14 @@ func (s *Server) reconcileZoneOnce() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if z.Mirror() {
-		// Re-push the master's current stream to the slaves (best-effort). This
-		// path is always allowed: it just re-streams to slaves that the user
-		// grouped and does not drag a solo speaker into anything, so it is not
-		// gated by the native opt-in below.
-		s.mirrorToSlaves(ctx, z)
+		// Re-form the mirror group, guarded (best-effort): the master must be
+		// actively playing the mirrored stream, and a slave is only (re)pointed
+		// when it is idle, dropped off the mirror, or on a stale master stream.
+		// A standby or otherwise-busy speaker is left alone — the unguarded
+		// version of this path hijacked a slave's Spotify playback with the
+		// master's persisted last station every 5 minutes (#342). Not gated by
+		// the native opt-in below; the guards make it safe on their own.
+		s.mirrorToSlaves(ctx, z, true)
 		return
 	}
 	if z.Stereo {
@@ -4347,6 +4387,12 @@ func (s *Server) handleZoneDissolve(w http.ResponseWriter, r *http.Request) {
 		if err := s.zones.Clear(); err != nil {
 			s.logger.Warn("zone: clear store failed", "err", err)
 		}
+	}
+	// Also clear the group from every member's own persisted store
+	// (best-effort, background): a member that itself persisted a zone naming
+	// this box would otherwise keep re-forming the group forever (#342).
+	if master.DeviceID != "" || master.IP != "" {
+		s.purgePeerZones(master, slaves)
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }

--- a/internal/webui/zone_mirror_test.go
+++ b/internal/webui/zone_mirror_test.go
@@ -2,9 +2,15 @@ package webui
 
 import (
 	"context"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/JRpersonal/streborn/internal/boxurl"
+	"github.com/JRpersonal/streborn/internal/zones"
 )
 
 // mirrorURLForSlaves must turn the master's own loopback stream URL
@@ -64,4 +70,163 @@ func TestMirrorURLForSlavesBadURL(t *testing.T) {
 	if got := s.mirrorURLForSlaves(context.Background(), in, "192.168.1.50"); got != in {
 		t.Errorf("mirrorURLForSlaves(bad) = %q, want unchanged %q", got, in)
 	}
+}
+
+// The periodic reconcile must only mirror when the master is audibly playing
+// the exact stream lastPlay points at. lastPlay is persisted on NAND, so an
+// idle or standby master still "remembers" a station from days ago; mirroring
+// that is how a stale group hijacked a slave's Spotify playback every five
+// minutes (#342).
+func TestMasterMirrorSkipReason(t *testing.T) {
+	lp := "http://127.0.0.1:8888/stream/1"
+	cases := []struct {
+		name     string
+		np       nowPlayingSnapshot
+		wantSkip bool
+	}{
+		{"unreadable", nowPlayingSnapshot{}, true},
+		{"standby", nowPlayingSnapshot{Source: "STANDBY"}, true},
+		{"other source", nowPlayingSnapshot{Source: "UPNP", Location: "http://127.0.0.1:8888/stream/2", PlayStatus: "PLAY_STATE"}, true},
+		{"stopped on lastPlay", nowPlayingSnapshot{Source: "UPNP", Location: lp, PlayStatus: "STOP_STATE"}, true},
+		{"paused on lastPlay", nowPlayingSnapshot{Source: "UPNP", Location: lp, PlayStatus: "PAUSE_STATE"}, true},
+		{"playing lastPlay", nowPlayingSnapshot{Source: "UPNP", Location: lp, PlayStatus: "PLAY_STATE"}, false},
+		{"buffering lastPlay", nowPlayingSnapshot{Source: "UPNP", Location: lp, PlayStatus: "BUFFERING_STATE"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reason := masterMirrorSkipReason(tc.np, lp)
+			if got := reason != ""; got != tc.wantSkip {
+				t.Errorf("masterMirrorSkipReason(%+v) = %q, want skip=%v", tc.np, reason, tc.wantSkip)
+			}
+		})
+	}
+}
+
+// The reconcile repairs the mirror without ever waking a speaker from standby
+// or taking it off another source it is playing: the user's direct action on a
+// box outranks the group (#342 was a slave's Spotify being yanked to the
+// master's old radio station).
+func TestSlaveMirrorAction(t *testing.T) {
+	slaveURL := "http://192.168.1.50:17008/stream/1"
+	cases := []struct {
+		name     string
+		np       nowPlayingSnapshot
+		wantPush bool
+	}{
+		{"unreadable", nowPlayingSnapshot{}, false},
+		{"standby stays asleep", nowPlayingSnapshot{Source: "STANDBY"}, false},
+		{"already mirroring", nowPlayingSnapshot{Source: "UPNP", Location: slaveURL, PlayStatus: "PLAY_STATE"}, false},
+		{"dropped off mirror", nowPlayingSnapshot{Source: "UPNP", Location: slaveURL, PlayStatus: "STOP_STATE"}, true},
+		{"stale master stream", nowPlayingSnapshot{Source: "UPNP", Location: "http://192.168.1.50:17008/stream/4", PlayStatus: "PLAY_STATE"}, true},
+		{"idle box joins", nowPlayingSnapshot{Source: "INVALID_SOURCE"}, true},
+		{"busy with spotify", nowPlayingSnapshot{Source: "UPNP", Location: "http://127.0.0.1:8888/spotify/stream-4.ogg", PlayStatus: "PLAY_STATE"}, false},
+		{"busy with bluetooth", nowPlayingSnapshot{Source: "BLUETOOTH", PlayStatus: "PLAY_STATE"}, false},
+		{"stopped on foreign source", nowPlayingSnapshot{Source: "UPNP", Location: "http://192.168.1.9:8200/track.flac", PlayStatus: "STOP_STATE"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			push, reason := slaveMirrorAction(tc.np, slaveURL)
+			if push != tc.wantPush {
+				t.Errorf("slaveMirrorAction(%+v) = push=%v (%q), want push=%v", tc.np, push, reason, tc.wantPush)
+			}
+		})
+	}
+}
+
+// zoneReferences must match by deviceID case-insensitively and by IP hint, as
+// master or member, so a dissolving peer can purge the mutual/stale zones the
+// wild has shown (two boxes each persisted as master naming the other, #342).
+func TestZoneReferences(t *testing.T) {
+	z := zones.Zone{
+		Master:   "AABBCCDDEEFF",
+		MasterIP: "192.168.1.50",
+		Slaves: []zones.Member{
+			{DeviceID: "112233445566", IP: "192.168.1.60"},
+		},
+	}
+	cases := []struct {
+		name         string
+		deviceID, ip string
+		want         bool
+	}{
+		{"master by id (case-insensitive)", "aabbccddeeff", "", true},
+		{"master by ip", "", "192.168.1.50", true},
+		{"slave by id", "112233445566", "", true},
+		{"slave by ip", "", "192.168.1.60", true},
+		{"unknown", "FFFFFFFFFFFF", "192.168.1.99", false},
+		{"empty request", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := zoneReferences(z, tc.deviceID, tc.ip); got != tc.want {
+				t.Errorf("zoneReferences(%q, %q) = %v, want %v", tc.deviceID, tc.ip, got, tc.want)
+			}
+		})
+	}
+}
+
+// A dissolving peer's purge request clears the persisted zone only when it
+// actually references that peer; an unrelated purge leaves the zone alone.
+func TestHandleZonePurge(t *testing.T) {
+	newServer := func(t *testing.T) (*Server, *zones.Store) {
+		t.Helper()
+		store, err := zones.Load(filepath.Join(t.TempDir(), "zones.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Set(zones.Zone{
+			Master: "AABBCCDDEEFF", MasterIP: "192.168.1.50", Mode: "mirror",
+			Slaves: []zones.Member{{DeviceID: "112233445566", IP: "192.168.1.60"}},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		return &Server{
+			zones:  store,
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}, store
+	}
+
+	t.Run("referenced peer clears the zone", func(t *testing.T) {
+		s, store := newServer(t)
+		req := httptest.NewRequest("POST", "/api/box/zone/purge",
+			strings.NewReader(`{"deviceID":"112233445566","ip":"192.168.1.60"}`))
+		w := httptest.NewRecorder()
+		s.handleZonePurge(w, req)
+		if w.Code != 200 {
+			t.Fatalf("status = %d, body %s", w.Code, w.Body.String())
+		}
+		if !strings.Contains(w.Body.String(), `"cleared":true`) {
+			t.Errorf("body = %s, want cleared:true", w.Body.String())
+		}
+		if _, ok := store.Get(); ok {
+			t.Error("zone still persisted after purge")
+		}
+	})
+
+	t.Run("unrelated peer leaves the zone", func(t *testing.T) {
+		s, store := newServer(t)
+		req := httptest.NewRequest("POST", "/api/box/zone/purge",
+			strings.NewReader(`{"deviceID":"FFFFFFFFFFFF"}`))
+		w := httptest.NewRecorder()
+		s.handleZonePurge(w, req)
+		if w.Code != 200 {
+			t.Fatalf("status = %d, body %s", w.Code, w.Body.String())
+		}
+		if !strings.Contains(w.Body.String(), `"cleared":false`) {
+			t.Errorf("body = %s, want cleared:false", w.Body.String())
+		}
+		if _, ok := store.Get(); !ok {
+			t.Error("zone was wrongly purged")
+		}
+	})
+
+	t.Run("empty identity is rejected", func(t *testing.T) {
+		s, _ := newServer(t)
+		req := httptest.NewRequest("POST", "/api/box/zone/purge", strings.NewReader(`{}`))
+		w := httptest.NewRecorder()
+		s.handleZonePurge(w, req)
+		if w.Code != 400 {
+			t.Fatalf("status = %d, want 400", w.Code)
+		}
+	})
 }

--- a/internal/webui/zonemirror.go
+++ b/internal/webui/zonemirror.go
@@ -1,0 +1,248 @@
+package webui
+
+// Zone-mirror reconcile guards and dissolve propagation (#342).
+//
+// The 5-minute PeriodicZoneReconcile used to re-push the master's persisted
+// lastPlay to every mirror slave unconditionally. Two real-world failures:
+// a master sitting in STANDBY sprayed its stale last stream onto slaves that
+// were busy playing something else (a Spotify playlist was yanked back to the
+// master's old radio station every 5 minutes), and a healthy mirroring slave
+// was re-pushed anyway, re-buffering its stream every tick. The pure decision
+// helpers here make the reconcile repair only what is actually broken; the
+// purge endpoint lets a dissolving master clear the group from every member's
+// persisted store, so a forgotten zones.json cannot keep re-asserting a group
+// the user tore down (both directions of a stale mutual group were seen in
+// the wild).
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/JRpersonal/streborn/internal/boxapi"
+	"github.com/JRpersonal/streborn/internal/zones"
+)
+
+// playingStates are the box playStatus values that mean audio is actually
+// coming out (or about to): anything else is stopped, paused, or unknown.
+func isPlayingStatus(playStatus string) bool {
+	return playStatus == "PLAY_STATE" || playStatus == "BUFFERING_STATE"
+}
+
+// masterMirrorSkipReason decides whether the periodic reconcile may mirror at
+// all. Empty means proceed. np is the MASTER box's live now_playing;
+// lastPlayURL is the loopback stream URL STR last told the master to play
+// (lastPlay.boxURL). The master must be audibly playing that exact stream:
+// lastPlay is persisted on NAND and survives reboots, so an idle master still
+// "remembers" a station from days ago — mirroring that onto the slaves is how
+// a dissolved-in-spirit group kept hijacking speakers (#342).
+func masterMirrorSkipReason(np nowPlayingSnapshot, lastPlayURL string) string {
+	switch {
+	case np.Source == "":
+		return "master state unreadable"
+	case np.Source == "STANDBY":
+		return "master in standby"
+	case np.Location != lastPlayURL:
+		return "master is on another source"
+	case !isPlayingStatus(np.PlayStatus):
+		return "master stream not playing (" + np.PlayStatus + ")"
+	}
+	return ""
+}
+
+// slaveMirrorAction decides whether the periodic reconcile (re)points one
+// slave at the master's stream. np is the SLAVE box's live now_playing and
+// slaveURL the LAN-reachable master stream URL (host = master's stream proxy).
+// The reconcile only repairs the mirror: it never wakes a speaker from
+// standby and never takes a speaker off another source it is playing — the
+// user's direct action on a box always outranks the group (#342).
+func slaveMirrorAction(np nowPlayingSnapshot, slaveURL string) (push bool, reason string) {
+	masterHost := hostPortOf(slaveURL)
+	switch {
+	case np.Source == "":
+		return false, "state unreadable"
+	case np.Source == "STANDBY":
+		return false, "in standby"
+	case np.Location == slaveURL:
+		if isPlayingStatus(np.PlayStatus) {
+			return false, "already mirroring"
+		}
+		return true, "dropped off the mirror stream"
+	case masterHost != "" && hostPortOf(np.Location) == masterHost:
+		// Still pulling from the master's stream proxy, but an old stream (the
+		// master changed station): re-point to the current one.
+		return true, "on a stale master stream"
+	case np.Source == "INVALID_SOURCE":
+		// Awake but idle (nothing selected): joining the group is what the
+		// user asked for when forming it.
+		return true, "idle"
+	default:
+		return false, "on another source"
+	}
+}
+
+// hostPortOf returns the host:port of a URL, or "" when it does not parse.
+func hostPortOf(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}
+
+// fetchNowPlaying reads a box's :8090/now_playing. Best-effort: any error
+// yields an empty snapshot (Source == ""), which every caller treats as
+// "state unreadable — do nothing".
+func fetchNowPlaying(ctx context.Context, host string) nowPlayingSnapshot {
+	var snap nowPlayingSnapshot
+	b, err := boxGet(ctx, "http://"+host+":8090/now_playing", 16<<10)
+	if err != nil {
+		return snap
+	}
+	var np struct {
+		Source      string `xml:"source,attr"`
+		ContentItem struct {
+			Location string `xml:"location,attr"`
+			ItemName string `xml:"itemName"`
+		} `xml:"ContentItem"`
+		PlayStatus string `xml:"playStatus"`
+	}
+	if xml.Unmarshal(b, &np) == nil {
+		snap.Source = np.Source
+		snap.Location = np.ContentItem.Location
+		snap.ItemName = np.ContentItem.ItemName
+		snap.PlayStatus = np.PlayStatus
+	}
+	return snap
+}
+
+// logMirrorSkip logs a reconcile skip at INFO only when the reason for that
+// key (master, or "slave <ip>") changed since the last tick, so a diagnostic
+// bundle shows every state transition without the 5-minute steady state
+// drowning the log. Only ever called from the single reconcile goroutine.
+func (s *Server) logMirrorSkip(key, reason string) {
+	if s.mirrorSkips == nil {
+		s.mirrorSkips = make(map[string]string)
+	}
+	if s.mirrorSkips[key] == reason {
+		s.logger.Debug("zone mirror: skip (unchanged)", "who", key, "reason", reason)
+		return
+	}
+	s.mirrorSkips[key] = reason
+	s.logger.Info("zone mirror: not pushing", "who", key, "reason", reason)
+}
+
+// clearMirrorSkip forgets a remembered skip reason once a push happens, so a
+// later identical skip is logged again as a fresh transition.
+func (s *Server) clearMirrorSkip(key string) {
+	if s.mirrorSkips != nil {
+		delete(s.mirrorSkips, key)
+	}
+}
+
+// zoneReferences reports whether z includes the given speaker — by deviceID
+// (case-insensitive) or by IP hint — as master or as a member. Used by the
+// purge endpoint to decide whether a peer's dissolve concerns this box's
+// persisted zone.
+func zoneReferences(z zones.Zone, deviceID, ip string) bool {
+	match := func(d, i string) bool {
+		return (deviceID != "" && strings.EqualFold(d, deviceID)) ||
+			(ip != "" && i != "" && i == ip)
+	}
+	if match(z.Master, z.MasterIP) {
+		return true
+	}
+	for _, m := range z.Slaves {
+		if match(m.DeviceID, m.IP) {
+			return true
+		}
+	}
+	return false
+}
+
+// handleZonePurge clears this box's persisted zone when it references the
+// calling speaker. POST {"deviceID": "...", "ip": "..."}. A master that
+// dissolves its group calls this on every member, so a stale zones.json on a
+// member (including the mutual master-of-each-other corruption seen in #342)
+// stops re-asserting a group the user tore down. Only the persisted store is
+// touched; the firmware zone was already dissolved by the caller.
+func (s *Server) handleZonePurge(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	var req struct {
+		DeviceID string `json:"deviceID"`
+		IP       string `json:"ip"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4*1024)).Decode(&req); err != nil {
+		http.Error(w, "bad json: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.DeviceID == "" && req.IP == "" {
+		http.Error(w, "deviceID or ip required", http.StatusBadRequest)
+		return
+	}
+	cleared := false
+	if s.zones != nil {
+		if z, ok := s.zones.Get(); ok && zoneReferences(z, req.DeviceID, req.IP) {
+			if err := s.zones.Clear(); err != nil {
+				s.logger.Warn("zone purge: clear store failed", "err", err)
+			} else {
+				cleared = true
+				s.logger.Info("zone purge: cleared persisted zone on request of a dissolving peer",
+					"peerDeviceID", req.DeviceID, "peerIP", req.IP)
+			}
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "cleared": cleared})
+}
+
+// purgePeerZones asks every member of a just-dissolved group to drop any
+// persisted zone that references this box (best-effort, in the background).
+// Without this, a member that itself persisted a zone naming this box kept
+// re-forming the group forever; the user dissolved it on one box and the
+// other dragged everyone back in (#342).
+func (s *Server) purgePeerZones(self boxapi.ZoneMember, members []boxapi.ZoneMember) {
+	body, err := json.Marshal(map[string]string{"deviceID": self.DeviceID, "ip": self.IP})
+	if err != nil {
+		return
+	}
+	client := &http.Client{Timeout: 4 * time.Second}
+	for _, m := range members {
+		if m.IP == "" {
+			continue
+		}
+		go func(ip string) {
+			ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+			defer cancel()
+			// :17008 is the externally reachable agent entry on every chassis
+			// (see mirrorStreamPort); plain :8888 covers agents where the
+			// REDIRECT is not in place.
+			for _, port := range []string{"17008", "8888"} {
+				req, rerr := http.NewRequestWithContext(ctx, http.MethodPost,
+					"http://"+net.JoinHostPort(ip, port)+"/api/box/zone/purge", strings.NewReader(string(body)))
+				if rerr != nil {
+					continue
+				}
+				req.Header.Set("Content-Type", "application/json")
+				resp, derr := client.Do(req)
+				if derr != nil {
+					continue
+				}
+				resp.Body.Close()
+				if resp.StatusCode == http.StatusOK {
+					s.logger.Info("zone: peer's persisted zone purged", "peer", ip)
+					return
+				}
+			}
+			// Unreachable, no STR, or an agent from before this endpoint: the
+			// mirror guards still keep a stale peer zone from hijacking anyone.
+			s.logger.Warn("zone: could not purge peer's persisted zone (older agent or unreachable)", "peer", ip)
+		}(m.IP)
+	}
+}

--- a/internal/zones/zones.go
+++ b/internal/zones/zones.go
@@ -82,7 +82,7 @@ func Load(path string) (*Store, error) {
 	}
 	var z Zone
 	if err := json.Unmarshal(b, &z); err != nil {
-		return s, fmt.Errorf("zones parsen: %w", err)
+		return s, fmt.Errorf("parse zones: %w", err)
 	}
 	// An object with no master is standalone.
 	if z.Master == "" {
@@ -125,18 +125,18 @@ func (s *Store) Save() error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.path == "" {
-		return fmt.Errorf("zones Store hat keinen Pfad")
+		return fmt.Errorf("zones store has no path")
 	}
 	var b []byte
 	var err error
 	if s.zone == nil {
 		b = []byte("{}\n")
 	} else if b, err = json.MarshalIndent(s.zone, "", "  "); err != nil {
-		return fmt.Errorf("zones serialisieren: %w", err)
+		return fmt.Errorf("marshal zones: %w", err)
 	}
 	tmp := s.path + ".tmp"
 	if err := os.WriteFile(tmp, b, 0o644); err != nil {
-		return fmt.Errorf("zones schreiben: %w", err)
+		return fmt.Errorf("write zones: %w", err)
 	}
 	return os.Rename(tmp, s.path)
 }


### PR DESCRIPTION
## What

The 5-minute mirror-zone reconcile (`PeriodicZoneReconcile`) re-pushed the master's **persisted** `lastPlay` to every slave unconditionally. Confirmed from the #342 diagnostic bundles (master's mirror push and slave's Spotify detach 53 ms apart): a master in **standby** replayed a days-old radio station onto a slave that was actively playing Spotify, every 5 minutes. A healthy mirroring slave was also re-pushed (re-buffer hiccup) each tick.

## How

- `mirrorToSlaves` gains a `reconcile` mode with state guards:
  - **Master guard**: only mirror when the master is audibly playing the exact `lastPlay` stream (never from standby / another source / stopped).
  - **Slave guard** (`slaveMirrorAction`): push only when the slave dropped off the mirror stream, is on a stale master stream, or is awake-idle. Never wakes a slave from standby, never takes it off another source.
  - Skips log at INFO on state change only, so bundles show transitions without 5-minute spam.
- The user-initiated zone form still pushes unconditionally (deliberate action).
- **Dissolve propagation**: dissolving a group now also POSTs `/api/box/zone/purge` to every member so a stale (or mutual master-of-each-other, as seen in the wild) `zones.json` on a peer stops re-asserting the dissolved group. Best-effort; older agents just log a warning.
- Fixes the misleading comments that claimed the mirror path "does not drag a solo speaker into anything".
- Drive-by: translates leftover German error strings in `internal/zones`.

## Tests

Table tests for `masterMirrorSkipReason`, `slaveMirrorAction`, `zoneReferences`, and an httptest suite for the purge endpoint (clears only when the zone references the dissolving peer).

Refs #342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)