### PR TITLE
fix(presets): saving a station on a sleeping speaker no longer stores the previous station; AAC stations now play

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1082,6 +1082,10 @@ func (h *presetWsHandler) OnPresetSelected(ctx context.Context, slot int, locati
 	url := location
 	name := title
 	icon := ""
+	// mime is the DIDL protocolInfo label for the recall. Presets saved from an
+	// AAC/HE-AAC station carry their codec; labelling them with the audio/mpeg
+	// default made the box decode them as MPEG and play silence (#252).
+	mime := ""
 	if p, ok := h.store.Get(slot); ok {
 		// Recently-played (#135): record the pressed preset (radio or Spotify)
 		// from the authoritative store entry, before the source-specific recall.
@@ -1099,6 +1103,7 @@ func (h *presetWsHandler) OnPresetSelected(ctx context.Context, slot int, locati
 			name = p.Name
 		}
 		icon = p.Art
+		mime = upnp.MimeForCodec(p.Codec)
 		// Fallback: NetManager occasionally fires nowSelectionUpdated
 		// with an empty location — observed when Bose's preset cache
 		// was populated while BoseApp had not yet fully loaded the
@@ -1161,20 +1166,27 @@ func (h *presetWsHandler) OnPresetSelected(ctx context.Context, slot int, locati
 
 	playCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	if err := h.renderer.PlayURL(playCtx, url, name, icon); err != nil {
-		h.logger.Warn("upnp play (initial) failed, will verify+retry", "slot", slot, "err", err)
+	var playErr error
+	if mime != "" {
+		playErr = h.renderer.PlayURLMime(playCtx, url, name, icon, mime)
+	} else {
+		playErr = h.renderer.PlayURL(playCtx, url, name, icon)
+	}
+	if playErr != nil {
+		h.logger.Warn("upnp play (initial) failed, will verify+retry", "slot", slot, "err", playErr)
 	}
 	// Record this hardware recall as the last play so the auto-re-push and the
 	// power-button wake-resume know what to bring back (the webui only tracks its
-	// own soft plays otherwise).
+	// own soft plays otherwise). The mime rides along so those re-pushes keep
+	// the AAC label too.
 	if h.noteLastPlay != nil {
-		h.noteLastPlay(url, name, icon, "")
+		h.noteLastPlay(url, name, icon, mime)
 	}
 	// Verify+retry in the background: the first hardware press after a cold
 	// boot can race the box/agent bringup so nothing plays until a second
 	// press. This re-issues until the box actually plays. Affects radio too.
-	go h.verifyPlayURL(slot, url, name, icon)
-	h.logger.Info("hardware preset mapped to upnp", "slot", slot, "name", name)
+	go h.verifyPlayURL(slot, url, name, icon, mime)
+	h.logger.Info("hardware preset mapped to upnp", "slot", slot, "name", name, "mime", mime)
 }
 
 // isSTRStreamURL reports whether u is one of STR's own stream URLs (the radio
@@ -1522,8 +1534,11 @@ func (h *presetWsHandler) playSpotifyPreset(ctx context.Context, slot int, p pre
 
 // verifyPlayURL confirms the box started playing a UPnP (radio) recall and
 // re-issues it a few times if not, fixing the "first hardware press after
-// reboot does nothing" race for radio presets too.
-func (h *presetWsHandler) verifyPlayURL(slot int, url, name, icon string) {
+// reboot does nothing" race for radio presets too. mime is the DIDL label of
+// the initial play ("" = audio/mpeg default); the retries must re-issue with
+// the SAME label or an AAC station recovered here would fall back to silence
+// (#252).
+func (h *presetWsHandler) verifyPlayURL(slot int, url, name, icon, mime string) {
 	// Up to 5 attempts (~25s): a box waking from a deep/overnight standby can
 	// take longer than the old 3-attempt (~15s) window to finish bringing its
 	// network and playback subsystem back up before it accepts the stream (#183).
@@ -1544,7 +1559,11 @@ func (h *presetWsHandler) verifyPlayURL(slot int, url, name, icon string) {
 		}
 		h.logger.Warn("hardware recall not playing yet, retrying", "slot", slot, "attempt", attempt)
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-		_ = h.renderer.PlayURL(ctx, url, name, icon)
+		if mime != "" {
+			_ = h.renderer.PlayURLMime(ctx, url, name, icon, mime)
+		} else {
+			_ = h.renderer.PlayURL(ctx, url, name, icon)
+		}
 		cancel()
 	}
 	h.logger.Warn("hardware recall still not playing after retries", "slot", slot)

--- a/desktop-app/app.go
+++ b/desktop-app/app.go
@@ -1561,6 +1561,7 @@ type Preset struct {
 	Type      string `json:"type"`
 	Art       string `json:"art,omitempty"`
 	Bitrate   int    `json:"bitrate,omitempty"`
+	Codec     string `json:"codec,omitempty"`    // radio presets: station codec ("MP3", "AAC+"); recalls label AAC streams audio/aac (#252)
 	URI       string `json:"uri,omitempty"`      // Spotify presets: playlist/album URI
 	Account   string `json:"account,omitempty"`  // Spotify presets: owning account
 	Source    string `json:"source,omitempty"`   // DLNA presets: media server name (cosmetic badge)
@@ -2083,12 +2084,14 @@ func (a *App) GetPresets(host string, port int) ([]Preset, error) {
 }
 
 // SetPreset does PUT /api/presets/<slot>. art is the station logo URL,
-// sent to the box as upnp:albumArtURI on play. Routed through
+// sent to the box as upnp:albumArtURI on play. codec is radio-browser's
+// station codec ("MP3", "AAC+"); the agent labels AAC streams audio/aac on
+// recall so they do not decode to silence (#252). Routed through
 // boxPut so a preset save gets the same :8888<->:17008 port fallback as the
 // other box commands.
-func (a *App) SetPreset(host string, port int, slot int, name, streamURL, art string, bitrate int, homepage string) error {
+func (a *App) SetPreset(host string, port int, slot int, name, streamURL, art string, bitrate int, homepage, codec string) error {
 	return a.boxPut(host, port, fmt.Sprintf("%s/%d", presetAPIPath, slot),
-		Preset{Slot: slot, Name: name, StreamURL: streamURL, Type: "radio", Art: art, Bitrate: bitrate, Homepage: homepage})
+		Preset{Slot: slot, Name: name, StreamURL: streamURL, Type: "radio", Art: art, Bitrate: bitrate, Homepage: homepage, Codec: codec})
 }
 
 // SaveLibraryPreset stores a preset saved from a DLNA media server (the Library
@@ -2277,8 +2280,11 @@ func (a *App) waitAgentReady(host string, port int) bool {
 
 // PlayURL triggers POST /api/play with an arbitrary stream URL. icon is
 // the station logo URL (shown on the box), uuid lets
-// radio-browser count the click.
-func (a *App) PlayURL(host string, port int, streamURL, title, icon, uuid, mime, homepage string) error {
+// radio-browser count the click. mime is the library-file codec MIME (also
+// the "play direct" marker, #139) and stays empty for radio; codec is
+// radio-browser's station codec ("MP3", "AAC+"), which the agent maps to the
+// DIDL MIME so AAC stations do not decode to silence (#252).
+func (a *App) PlayURL(host string, port int, streamURL, title, icon, uuid, mime, homepage, codec string) error {
 	body, _ := json.Marshal(map[string]string{
 		"url":      streamURL,
 		"title":    title,
@@ -2286,6 +2292,7 @@ func (a *App) PlayURL(host string, port int, streamURL, title, icon, uuid, mime,
 		"uuid":     uuid,
 		"mime":     mime,
 		"homepage": homepage,
+		"codec":    codec,
 	})
 	resp, err := a.playPost(host, port, "/api/play", string(body))
 	if err != nil {

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -3288,6 +3288,14 @@ function attachPresetHandlers(el, slot, preset, opts = {}) {
   el.addEventListener('touchcancel', cancel);
 }
 
+// APP_PLAY_FRESH_MS is how long the app trusts its own record of an ad-hoc
+// station it started (state.lastAppPlay) over the box-reported now-playing
+// when saving to a key. Short on purpose: it only needs to cover the
+// play-then-save gesture and the wake window in which an agent-side resume
+// could have raced the play (#252); after that, whatever the box reports IS
+// what the user hears, so the box report wins again.
+const APP_PLAY_FRESH_MS = 2 * 60 * 1000;
+
 // saveCurrentToSlot saves the currently playing station onto the
 // given slot (overwrites whatever was there before). Uses the
 // now_playing data state.nowLocation + state.nowName plus the last
@@ -3378,6 +3386,32 @@ async function saveCurrentToSlot(slot) {
   // hardware press both often still hold the previous station.
   const sourceSlot = activeSlotFromLocation(state.nowLocation);
   if (sourceSlot !== null && sourceSlot !== slot) {
+    // The app itself started an ad-hoc station moments ago, yet the box
+    // reports a /stream/<slot> location: on a speaker that was asleep, an
+    // agent-side wake resume racing the play can have put the PREVIOUS
+    // preset back on (#252). Copying that preset here saved the OLD station
+    // onto the key while the user's chosen one silently vanished. The app
+    // knows exactly which station the user picked, so save its own record;
+    // the plain copy below remains for the true hardware-key case, where the
+    // app has no record of the play.
+    const app = state.lastAppPlay;
+    if (app && app.url && Date.now() - app.at < APP_PLAY_FRESH_MS) {
+      const aname = app.name || t('preset.placeholderSender');
+      try {
+        await SetPreset(
+          state.currentBox.host, state.currentBox.port,
+          slot, aname, app.url, app.icon || '', app.bitrate || 0, app.homepage || ''
+        );
+        showToast(t('preset.savedToKey', { n: slot, name: aname }));
+        await loadPresets();
+        if (app.uuid) {
+          VoteStation(state.currentBox.host, state.currentBox.port, app.uuid).catch(() => {});
+        }
+      } catch (err) {
+        showError(t('preset.saveFailed', { err: String(err) }));
+      }
+      return;
+    }
     const src = state.presets.find(p => p.slot === sourceSlot);
     if (src && src.stream_url) {
       try {
@@ -3448,6 +3482,9 @@ async function play(slot) {
   // so we re-apply the user's chosen level afterwards only in that case
   // (a normal preset switch while already playing keeps the live volume).
   const wasIdle = !state.nowPlayState || state.nowSource === 'STANDBY';
+  // A preset recall supersedes any ad-hoc station the app started: drop the
+  // record so a later long-press save goes back to trusting the box report.
+  state.lastAppPlay = null;
   const p = state.presets.find(x => x.slot === slot);
   if (p) {
     // Optimistic UI: set BUFFERING_STATE immediately so the user
@@ -4505,6 +4542,17 @@ async function playStation(s) {
     let fail = null;
     try {
       await PlayURL(box.host, box.port, url, s.name, chain, cur.stationuuid || '', '', s.homepage || '');
+      // Remember the station the APP itself just started. A long-press save
+      // must prefer this over the box-reported now-playing: on a speaker that
+      // was asleep, the agent's wake resume can race the play and briefly put
+      // the PREVIOUS preset back on, and saving from the box report then
+      // copied the OLD station onto the key (#252). Cleared by any other play
+      // the app issues (preset recall etc.), so a true hardware-key press
+      // still saves via the box report.
+      state.lastAppPlay = {
+        url, name: s.name || '', icon: chain, bitrate: cur.bitrate || 0,
+        uuid: cur.stationuuid || '', homepage: s.homepage || '', at: Date.now(),
+      };
       // Register the play with radio-browser, but ONLY for a real station UUID.
       // Recently-played cards reuse the stream URL as their identity (no UUID), so
       // a plain `if (stationuuid)` fired RadioClick with a URL, which 404s. Guard
@@ -4528,6 +4576,7 @@ async function playStation(s) {
     if (!alt) {
       state.nowPlayState = '';
       state.nowLocation = '';
+      state.lastAppPlay = null; // never long-press-save a station that failed to play
       renderPresets();
       showToast(streamErrorMessage(fail.reason) + ' ' + t('search.allSourcesFailed'));
       return;
@@ -4538,6 +4587,7 @@ async function playStation(s) {
   // Exhausted the retry budget without a working source.
   state.nowPlayState = '';
   state.nowLocation = '';
+  state.lastAppPlay = null; // never long-press-save a station that failed to play
   renderPresets();
   showToast(t('search.allSourcesFailed'));
 }

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -2899,7 +2899,7 @@ async function healPresetLogos() {
         // onto a Spotify preset or its URI is lost.
         if (p.type === 'spotify') return;
         p.art = logo;
-        SetPreset(state.currentBox.host, state.currentBox.port, p.slot, p.name, p.stream_url, logo, p.bitrate || 0, p.homepage || '').catch(() => {});
+        SetPreset(state.currentBox.host, state.currentBox.port, p.slot, p.name, p.stream_url, logo, p.bitrate || 0, p.homepage || '', p.codec || '').catch(() => {});
       } catch {}
     }));
   } finally {
@@ -3069,7 +3069,7 @@ function renderPresets() {
         addCands(state.nowIcon);
         // Auto-persist so the preset has its logo on the next load.
         p.art = state.nowIcon;
-        SetPreset(state.currentBox.host, state.currentBox.port, p.slot, p.name, p.stream_url, state.nowIcon, p.bitrate || 0, p.homepage || '').catch(() => {});
+        SetPreset(state.currentBox.host, state.currentBox.port, p.slot, p.name, p.stream_url, state.nowIcon, p.bitrate || 0, p.homepage || '', p.codec || '').catch(() => {});
       }
       const streamHost = extractHost(p.stream_url);
       const hostsToTry = [];
@@ -3101,7 +3101,7 @@ function renderPresets() {
         // SetPreset is radio-only and would overwrite the Spotify URI.
         if ((p.bitrate || 0) !== state.nowBitrate && p.type !== 'spotify') {
           p.bitrate = state.nowBitrate;
-          SetPreset(state.currentBox.host, state.currentBox.port, p.slot, p.name, p.stream_url, p.art || '', state.nowBitrate, p.homepage || '').catch(() => {});
+          SetPreset(state.currentBox.host, state.currentBox.port, p.slot, p.name, p.stream_url, p.art || '', state.nowBitrate, p.homepage || '', p.codec || '').catch(() => {});
         }
       }
       div.innerHTML = `
@@ -3400,7 +3400,7 @@ async function saveCurrentToSlot(slot) {
       try {
         await SetPreset(
           state.currentBox.host, state.currentBox.port,
-          slot, aname, app.url, app.icon || '', app.bitrate || 0, app.homepage || ''
+          slot, aname, app.url, app.icon || '', app.bitrate || 0, app.homepage || '', app.codec || ''
         );
         showToast(t('preset.savedToKey', { n: slot, name: aname }));
         await loadPresets();
@@ -3417,7 +3417,7 @@ async function saveCurrentToSlot(slot) {
       try {
         await SetPreset(
           state.currentBox.host, state.currentBox.port,
-          slot, src.name, src.stream_url, src.art || '', src.bitrate || 0, src.homepage || ''
+          slot, src.name, src.stream_url, src.art || '', src.bitrate || 0, src.homepage || '', src.codec || ''
         );
         showToast(t('preset.copiedToKey', { n: slot, name: src.name }));
         await loadPresets();
@@ -3433,10 +3433,15 @@ async function saveCurrentToSlot(slot) {
   // our proxy (for example a station started directly via the radio
   // search). Use state.nowLocation / nowName / nowIcon as before.
   const name = state.nowName || t('preset.placeholderSender');
+  // The codec is only known when this stream is the one the app itself
+  // started (radio-browser reported it at play time); the box does not
+  // report one.
+  const appRec = state.lastAppPlay;
+  const codec = (appRec && appRec.url === decodeProxyUrl(state.nowLocation)) ? (appRec.codec || '') : '';
   try {
     await SetPreset(
       state.currentBox.host, state.currentBox.port,
-      slot, name, decodeProxyUrl(state.nowLocation), state.nowIcon || '', state.nowBitrate || 0, ''
+      slot, name, decodeProxyUrl(state.nowLocation), state.nowIcon || '', state.nowBitrate || 0, '', codec
     );
     showToast(t('preset.savedToKey', { n: slot, name }));
     await loadPresets();
@@ -3612,7 +3617,7 @@ function scheduleLiveBitrate() {
           // uri), so persisting a Spotify preset would wipe its URI. The
           // Spotify rate stays live via state.nowBitrate + /spotify/info.
           if (!isSpotify) {
-            SetPreset(box.host, box.port, p.slot, p.name, p.stream_url, p.art || '', br, p.homepage || '').catch(() => {});
+            SetPreset(box.host, box.port, p.slot, p.name, p.stream_url, p.art || '', br, p.homepage || '', p.codec || '').catch(() => {});
           }
         }
         renderPresets();
@@ -4515,6 +4520,28 @@ async function findAlternativeStation(orig, triedHosts) {
   return candidates[0];
 }
 
+// preferMp3SiblingForBox returns an MP3-coded sibling entry (same station
+// name) when the chosen entry is AAC-coded and the given, already-loaded list
+// offers one (#252). The speaker's AAC decoding is the fragile path (HE-AAC
+// stations played silence for years under the fixed audio/mpeg label), while
+// the same station's MP3 mirror plays rock solid, so for BOX playback the MP3
+// sibling wins. No extra network round trip on purpose: with no list or no
+// sibling the chosen entry is returned unchanged and now plays with the
+// correct audio/aac label instead.
+function preferMp3SiblingForBox(s, list) {
+  if (!s || !/aac/i.test(s.codec || '') || !Array.isArray(list)) return s;
+  const wanted = (s.name || '').toLowerCase().trim();
+  if (!wanted) return s;
+  const siblings = list.filter(o => o && o !== s
+    && (o.name || '').toLowerCase().trim() === wanted
+    && /^mp3$/i.test(o.codec || '')
+    && (o.url_resolved || o.url));
+  if (siblings.length === 0) return s;
+  // Prefer a mirror radio-browser reached on its last check, then the best bitrate.
+  siblings.sort((a, b) => ((b.lastcheckok ? 1 : 0) - (a.lastcheckok ? 1 : 0)) || ((b.bitrate || 0) - (a.bitrate || 0)));
+  return siblings[0];
+}
+
 // playStation plays a radio station and, when its stream fails upstream
 // (403 geo-block, 503 down, dead URL), shows a clear reason and automatically
 // retries with another radio-browser entry of the SAME station before giving
@@ -4523,6 +4550,12 @@ async function findAlternativeStation(orig, triedHosts) {
 async function playStation(s) {
   const box = state.currentBox;
   if (!box) return;
+  // Box playback prefers an MP3 sibling over an AAC entry of the same station
+  // when the already-loaded result list offers one (#252): the speaker's AAC
+  // path is the fragile one, the MP3 mirror of the same station is rock solid.
+  // No sibling (or no list) plays the chosen entry unchanged; its AAC codec is
+  // now labelled correctly, so it works too.
+  s = preferMp3SiblingForBox(s, state.searchResults);
   const tried = new Set();
   let cur = s;
   for (let attempt = 0; attempt < 4; attempt++) {
@@ -4541,7 +4574,7 @@ async function playStation(s) {
 
     let fail = null;
     try {
-      await PlayURL(box.host, box.port, url, s.name, chain, cur.stationuuid || '', '', s.homepage || '');
+      await PlayURL(box.host, box.port, url, s.name, chain, cur.stationuuid || '', '', s.homepage || '', cur.codec || '');
       // Remember the station the APP itself just started. A long-press save
       // must prefer this over the box-reported now-playing: on a speaker that
       // was asleep, the agent's wake resume can race the play and briefly put
@@ -4551,7 +4584,8 @@ async function playStation(s) {
       // still saves via the box report.
       state.lastAppPlay = {
         url, name: s.name || '', icon: chain, bitrate: cur.bitrate || 0,
-        uuid: cur.stationuuid || '', homepage: s.homepage || '', at: Date.now(),
+        uuid: cur.stationuuid || '', homepage: s.homepage || '',
+        codec: cur.codec || '', at: Date.now(),
       };
       // Register the play with radio-browser, but ONLY for a real station UUID.
       // Recently-played cards reuse the stream URL as their identity (no UUID), so
@@ -4763,12 +4797,15 @@ function showSlotPicker({ title, subtitle, onPick }) {
 }
 
 function openPick(station) {
+  // Presets play on the box only, so the same MP3-over-AAC sibling preference
+  // as playStation applies to an assignment from the search list (#252).
+  station = preferMp3SiblingForBox(station, state.searchResults);
   showSlotPicker({
     title: t('preset.assignStationTitle'),
     subtitle: station.name + (station.bitrate ? ' (' + station.bitrate + ' kbit/s)' : ''),
     onPick: async (i) => {
       const logo = stationLogoChain(station);
-      await SetPreset(state.currentBox.host, state.currentBox.port, i, station.name, station.url_resolved || station.url, logo, station.bitrate || 0, station.homepage || '');
+      await SetPreset(state.currentBox.host, state.currentBox.port, i, station.name, station.url_resolved || station.url, logo, station.bitrate || 0, station.homepage || '', station.codec || '');
       if (station.stationuuid) {
         VoteStation(state.currentBox.host, state.currentBox.port, station.stationuuid).catch(() => {});
       }

--- a/desktop-app/frontend/src/state.js
+++ b/desktop-app/frontend/src/state.js
@@ -33,6 +33,13 @@ export const state = {
   nowPlayState: '',    // current PlayState
   nowIcon: '',         // last known station logo (favicon)
   nowUUID: '',         // last radio-browser UUID
+  // lastAppPlay is the ad-hoc radio station the APP itself last started
+  // ({url, name, icon, bitrate, uuid, homepage, at}). A long-press save
+  // prefers this fresh record over the box-reported now-playing, because an
+  // agent-side wake resume racing the play can leave the box briefly
+  // reporting the PREVIOUS preset (#252). Cleared by preset recalls and by
+  // failed plays; null when the app has not started a station itself.
+  lastAppPlay: null,
   queue: null,         // current box play queue: {active, pos, shuffle, repeat, items[]} or null
   optimisticUntil: 0,  // timestamp until which refreshStatus trusts our optimistic state over the box
   presetErrors: {},    // slot → last error message (rendered red)

--- a/desktop-app/frontend/src/views/library.js
+++ b/desktop-app/frontend/src/views/library.js
@@ -181,6 +181,9 @@ async function libraryPlay(item) {
     // correctly instead of being told audio/mpeg and rejecting it (#139).
     await PlayURL(state.currentBox.host, state.currentBox.port,
       item.streamURL, item.title || '', item.albumArtURL || '', '', item.mimeType || '', '');
+    // A library play supersedes any ad-hoc radio station the app started, so
+    // a later long-press save must not resurrect that station (#252).
+    state.lastAppPlay = null;
     showToast(t('library.toastPlaying') + ': ' + (item.title || ''));
     // Confirm it actually starts (see verifyLibraryPlayback, #139).
     verifyLibraryPlayback(item);
@@ -267,6 +270,8 @@ async function libraryPlayFolder() {
   };
   try {
     await StartQueue(state.currentBox.host, state.currentBox.port, JSON.stringify(payload));
+    // A folder play supersedes any ad-hoc radio station the app started (#252).
+    state.lastAppPlay = null;
     showToast(t('library.folderQueued', { n: items.length }));
   } catch (e) {
     showError(`StartQueue: ${e}`);

--- a/desktop-app/frontend/src/views/library.js
+++ b/desktop-app/frontend/src/views/library.js
@@ -180,7 +180,7 @@ async function libraryPlay(item) {
     // Pass the track's real codec MIME so the box decodes FLAC/ALAC/M4A
     // correctly instead of being told audio/mpeg and rejecting it (#139).
     await PlayURL(state.currentBox.host, state.currentBox.port,
-      item.streamURL, item.title || '', item.albumArtURL || '', '', item.mimeType || '', '');
+      item.streamURL, item.title || '', item.albumArtURL || '', '', item.mimeType || '', '', '');
     // A library play supersedes any ad-hoc radio station the app started, so
     // a later long-press save must not resurrect that station (#252).
     state.lastAppPlay = null;

--- a/desktop-app/frontend/src/views/settings.js
+++ b/desktop-app/frontend/src/views/settings.js
@@ -1825,7 +1825,7 @@ function renderBoxSettings(s, box) {
       if (!slot || !/^https?:\/\/\S+/i.test(url)) { showError(t('settingsView.urlPresetInvalid')); return; }
       urlPresetBtn.disabled = true;
       try {
-        await SetPreset(box.host, box.port, slot, name, url, '', 0, '');
+        await SetPreset(box.host, box.port, slot, name, url, '', 0, '', '');
         showToast(t('settingsView.urlPresetSaved', { n: slot }));
         if (state.currentBox && state.currentBox.host === box.host) await deps.loadPresets();
       } catch (e) { showError(e); }

--- a/desktop-app/frontend/wailsjs/go/main/App.d.ts
+++ b/desktop-app/frontend/wailsjs/go/main/App.d.ts
@@ -101,7 +101,7 @@ export function PhoneQR(arg1:string):Promise<string>;
 
 export function PlaySlot(arg1:string,arg2:number,arg3:number):Promise<void>;
 
-export function PlayURL(arg1:string,arg2:number,arg3:string,arg4:string,arg5:string,arg6:string,arg7:string,arg8:string):Promise<void>;
+export function PlayURL(arg1:string,arg2:number,arg3:string,arg4:string,arg5:string,arg6:string,arg7:string,arg8:string,arg9:string):Promise<void>;
 
 export function ProbeSetupAP():Promise<main.BoxInfo|boolean>;
 
@@ -179,7 +179,7 @@ export function SetClockDisplay(arg1:string,arg2:boolean,arg3:string,arg4:number
 
 export function SetDisplayTrack(arg1:string,arg2:number,arg3:boolean,arg4:string):Promise<void>;
 
-export function SetPreset(arg1:string,arg2:number,arg3:number,arg4:string,arg5:string,arg6:string,arg7:number,arg8:string):Promise<void>;
+export function SetPreset(arg1:string,arg2:number,arg3:number,arg4:string,arg5:string,arg6:string,arg7:number,arg8:string,arg9:string):Promise<void>;
 
 export function SetResumeOnPowerOn(arg1:string,arg2:number,arg3:boolean):Promise<void>;
 

--- a/desktop-app/frontend/wailsjs/go/main/App.js
+++ b/desktop-app/frontend/wailsjs/go/main/App.js
@@ -194,8 +194,8 @@ export function PlaySlot(arg1, arg2, arg3) {
   return window['go']['main']['App']['PlaySlot'](arg1, arg2, arg3);
 }
 
-export function PlayURL(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) {
-  return window['go']['main']['App']['PlayURL'](arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+export function PlayURL(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) {
+  return window['go']['main']['App']['PlayURL'](arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
 }
 
 export function ProbeSetupAP() {
@@ -350,8 +350,8 @@ export function SetDisplayTrack(arg1, arg2, arg3, arg4) {
   return window['go']['main']['App']['SetDisplayTrack'](arg1, arg2, arg3, arg4);
 }
 
-export function SetPreset(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) {
-  return window['go']['main']['App']['SetPreset'](arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+export function SetPreset(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) {
+  return window['go']['main']['App']['SetPreset'](arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
 }
 
 export function SetResumeOnPowerOn(arg1, arg2, arg3) {

--- a/desktop-app/frontend/wailsjs/go/models.ts
+++ b/desktop-app/frontend/wailsjs/go/models.ts
@@ -269,6 +269,7 @@ export namespace main {
 	    type: string;
 	    art?: string;
 	    bitrate?: number;
+	    codec?: string;
 	    uri?: string;
 	    account?: string;
 	    source?: string;
@@ -286,6 +287,7 @@ export namespace main {
 	        this.type = source["type"];
 	        this.art = source["art"];
 	        this.bitrate = source["bitrate"];
+	        this.codec = source["codec"];
 	        this.uri = source["uri"];
 	        this.account = source["account"];
 	        this.source = source["source"];

--- a/internal/presets/presets.go
+++ b/internal/presets/presets.go
@@ -33,6 +33,12 @@ type Preset struct {
 	// and in now-playing without a live lookup. Optional/additive: older
 	// presets simply have 0.
 	Bitrate int `json:"bitrate,omitempty"`
+	// Codec is the station codec radio-browser reported at save time ("MP3",
+	// "AAC", "AAC+", ...). Recalls use it to advertise the right DIDL MIME to
+	// the box (audio/aac for the AAC family), because an AAC station labelled
+	// with the audio/mpeg default plays silence (#252). Optional/additive:
+	// presets saved before this have "" and keep the audio/mpeg default.
+	Codec string `json:"codec,omitempty"`
 	// Spotify presets (Type=="spotify") carry these instead of a playable
 	// StreamURL: URI is the Spotify resource to play (e.g.
 	// "spotify:playlist:..."), recalled via librespot, not UPnP. Account
@@ -82,6 +88,7 @@ type rawPreset struct {
 	Type      string       `json:"type"`
 	Art       string       `json:"art"`
 	Bitrate   int          `json:"bitrate"`
+	Codec     string       `json:"codec"`
 	URI       string       `json:"uri"`
 	Account   string       `json:"account"`
 	Source    string       `json:"source"`
@@ -162,6 +169,7 @@ func normalize(in []rawPreset) []Preset {
 			Type:      typ,
 			Art:       p.Art,
 			Bitrate:   p.Bitrate,
+			Codec:     p.Codec,
 			URI:       p.URI,
 			Account:   p.Account,
 			Source:    p.Source,

--- a/internal/streamproxy/streamproxy.go
+++ b/internal/streamproxy/streamproxy.go
@@ -857,6 +857,11 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 	}
 	p, ok := s.store.Get(slot)
 	if !ok || p.StreamURL == "" {
+		// Log before 404ing: the box fetching a slot the store cannot serve is
+		// exactly the "preset button does nothing" symptom, and this used to be
+		// the only branch in the recall chain with no trace at all (#252).
+		s.logger.Warn("stream proxy: box fetched a slot with no playable preset",
+			"slot", slot, "found", ok)
 		http.Error(w, "no preset", http.StatusNotFound)
 		return
 	}

--- a/internal/upnp/upnp.go
+++ b/internal/upnp/upnp.go
@@ -240,6 +240,26 @@ func (r *Renderer) soapCall(ctx context.Context, action, body string) error {
 	return nil
 }
 
+// MimeForCodec maps a radio station's codec label (radio-browser's "codec"
+// field, e.g. "MP3", "AAC", "AAC+", or an upstream Content-Type like
+// "audio/aacp") to the DIDL res protocolInfo MIME the Bose renderer needs to
+// pick the right decoder. The box keys its decoder off this MIME, so an
+// HE-AAC station labelled with the historical audio/mpeg default decodes to
+// SILENCE while the proxy forwards its bytes just fine (#252, the "Absolut"
+// family on radio-browser). Returns "" when the codec is unknown or already
+// covered by the audio/mpeg default. Only the AAC family is mapped on
+// purpose: MP3 is the default anyway, and other codecs (Vorbis, FLAC radio)
+// are unverified on hardware, so they keep today's behavior rather than
+// trading a known failure for an unknown one.
+func MimeForCodec(codec string) string {
+	c := strings.ToLower(strings.TrimSpace(codec))
+	if strings.Contains(c, "aac") {
+		// Covers AAC, AAC+, AAC+ v2, aacp, HE-AAC, audio/aac, audio/aacp.
+		return "audio/aac"
+	}
+	return ""
+}
+
 // buildDIDL builds the CurrentURIMetaData XML for an audio stream.
 // DLNA renderers often want DIDL-Lite with upnp:class and res protocolInfo
 // to detect the stream codec. If iconURL is set it is embedded as

--- a/internal/upnp/upnp_test.go
+++ b/internal/upnp/upnp_test.go
@@ -40,6 +40,32 @@ func TestBuildDIDLMimeWellFormed(t *testing.T) {
 	}
 }
 
+// MimeForCodec must label the whole AAC family audio/aac (an AAC station
+// labelled audio/mpeg plays silence, #252) and leave everything else on the
+// audio/mpeg default ("" = caller keeps PlayURL).
+func TestMimeForCodec(t *testing.T) {
+	cases := map[string]string{
+		"AAC":        "audio/aac",
+		"AAC+":       "audio/aac",
+		"aacp":       "audio/aac",
+		"HE-AAC":     "audio/aac",
+		"audio/aac":  "audio/aac",
+		"audio/aacp": "audio/aac",
+		" aac ":      "audio/aac",
+		"MP3":        "",
+		"mp3":        "",
+		"OGG":        "",
+		"FLAC":       "",
+		"UNKNOWN":    "",
+		"":           "",
+	}
+	for codec, want := range cases {
+		if got := MimeForCodec(codec); got != want {
+			t.Errorf("MimeForCodec(%q) = %q, want %q", codec, got, want)
+		}
+	}
+}
+
 func TestBuildDIDLDefaults(t *testing.T) {
 	got := buildDIDL("http://x/y", "", "")
 	if !strings.Contains(got, "<dc:title>Stream</dc:title>") {

--- a/internal/webui/preset_save_gate_test.go
+++ b/internal/webui/preset_save_gate_test.go
@@ -1,0 +1,98 @@
+package webui
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/JRpersonal/streborn/internal/presets"
+)
+
+// newSaveGateServer builds a Server whose preset store persists into a temp
+// dir, with no box behind it (boxHost empty skips the hardware sync).
+func newSaveGateServer(t *testing.T) *Server {
+	t.Helper()
+	store, err := presets.Load(filepath.Join(t.TempDir(), "presets.json"))
+	if err != nil {
+		t.Fatalf("presets.Load: %v", err)
+	}
+	return &Server{
+		presets: store,
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+func putPreset(t *testing.T, s *Server, slot int, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest("PUT", fmt.Sprintf("/api/presets/%d", slot), strings.NewReader(body))
+	w := httptest.NewRecorder()
+	s.handlePresetSlot(w, r)
+	return w
+}
+
+// A type=radio preset with an EMPTY stream URL used to slip through the
+// invalid-URL gate ("StreamURL != "" && !isHTTPURL") and save as a dead
+// preset: assignable, but the box's /stream/<slot> fetch 404s forever (#252).
+// It must be rejected with 422 and never reach the store.
+func TestPresetSaveRejectsEmptyStreamURL(t *testing.T) {
+	s := newSaveGateServer(t)
+	w := putPreset(t, s, 3, `{"name":"Absolut Relax","type":"radio","stream_url":""}`)
+	if w.Code != 422 {
+		t.Fatalf("empty stream URL: status = %d, want 422 (body %s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "stream-url-missing") {
+		t.Errorf("want code stream-url-missing, got %s", w.Body.String())
+	}
+	if _, ok := s.presets.Get(3); ok {
+		t.Error("dead preset (empty stream URL) was stored anyway")
+	}
+}
+
+// A well-formed radio preset must still save.
+func TestPresetSaveAcceptsRadioURL(t *testing.T) {
+	s := newSaveGateServer(t)
+	w := putPreset(t, s, 2, `{"name":"Absolut Relax","type":"radio","stream_url":"http://stream.example/relax","codec":"AAC+"}`)
+	if w.Code != 200 {
+		t.Fatalf("valid radio preset: status = %d (body %s)", w.Code, w.Body.String())
+	}
+	p, ok := s.presets.Get(2)
+	if !ok || p.StreamURL != "http://stream.example/relax" {
+		t.Fatalf("stored preset = %+v, ok=%v", p, ok)
+	}
+	// The station codec must round-trip so recalls can label AAC correctly (#252).
+	if p.Codec != "AAC+" {
+		t.Errorf("stored codec = %q, want AAC+", p.Codec)
+	}
+}
+
+// A preset with no stream URL but a replayable Spotify URI is a mis-typed
+// Spotify preset: heal it instead of rejecting (keeps the other playable-content
+// path working).
+func TestPresetSaveHealsSpotifyURIWithEmptyStreamURL(t *testing.T) {
+	s := newSaveGateServer(t)
+	w := putPreset(t, s, 4, `{"name":"My List","type":"radio","stream_url":"","uri":"spotify:playlist:37i9dQZF1DWX7rdRjOECPW"}`)
+	if w.Code != 200 {
+		t.Fatalf("spotify-uri heal: status = %d (body %s)", w.Code, w.Body.String())
+	}
+	p, ok := s.presets.Get(4)
+	if !ok || p.Type != "spotify" {
+		t.Fatalf("stored preset = %+v, ok=%v, want healed type=spotify", p, ok)
+	}
+}
+
+// The pre-existing gate for a malformed (non-http, non-spotify) URL must keep
+// rejecting.
+func TestPresetSaveRejectsNonHTTPURL(t *testing.T) {
+	s := newSaveGateServer(t)
+	w := putPreset(t, s, 5, `{"name":"Broken","type":"radio","stream_url":"/v1/playback/station/x"}`)
+	if w.Code != 422 {
+		t.Fatalf("non-http stream URL: status = %d, want 422 (body %s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "stream-url-invalid") {
+		t.Errorf("want code stream-url-invalid, got %s", w.Body.String())
+	}
+}

--- a/internal/webui/queueplay.go
+++ b/internal/webui/queueplay.go
@@ -359,6 +359,10 @@ var (
 	// title), so a station/track literally named "STANDBY" cannot be mistaken for
 	// the box being off.
 	reNowPlaySource = regexp.MustCompile(`<nowPlaying[^>]*\bsource="([^"]*)"`)
+	// reNowPlayLocation reads the ContentItem location attribute: the URL the
+	// box is currently tuned to. Used by the recall verify to detect the box
+	// playing a DIFFERENT stream than the one just recalled (#252).
+	reNowPlayLocation = regexp.MustCompile(`\blocation="([^"]*)"`)
 )
 
 // nowPlayingStandby reports whether the box's now_playing says it is in standby

--- a/internal/webui/recall_race_test.go
+++ b/internal/webui/recall_race_test.go
@@ -1,0 +1,94 @@
+package webui
+
+import (
+	"testing"
+	"time"
+)
+
+// The wake resume captures lastPlay BEFORE it waits for the box command lock.
+// A recall that held the lock meanwhile updates lastPlay; the resume must then
+// stand down instead of pushing the captured PREVIOUS station over the user's
+// new one (#252: recall slot 5 on a sleeping ST30 ended up back on slot 4).
+func TestResumeIsStale(t *testing.T) {
+	ts := time.Date(2026, 7, 8, 10, 5, 49, 0, time.UTC)
+	oldURL := "http://127.0.0.1:8888/stream/4"
+	newURL := "http://127.0.0.1:8888/stream/5"
+
+	cases := []struct {
+		name    string
+		current *lastPlayInfo
+		want    bool
+	}{
+		{
+			// Bare power press: nothing played meanwhile, the capture is current.
+			name:    "unchanged target resumes",
+			current: &lastPlayInfo{boxURL: oldURL, ts: ts},
+			want:    false,
+		},
+		{
+			// The racing recall switched the station: stand down.
+			name:    "newer play on another url is stale",
+			current: &lastPlayInfo{boxURL: newURL, ts: ts.Add(5 * time.Second)},
+			want:    true,
+		},
+		{
+			// The racing recall re-played the SAME station: it already runs, a
+			// second push only causes a double-start hiccup.
+			name:    "same url replayed meanwhile is stale",
+			current: &lastPlayInfo{boxURL: oldURL, ts: ts.Add(5 * time.Second)},
+			want:    true,
+		},
+		{
+			name:    "no last play left is stale",
+			current: nil,
+			want:    true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resumeIsStale(oldURL, ts, tc.current); got != tc.want {
+				t.Errorf("resumeIsStale(%q, ts, %+v) = %v, want %v", oldURL, tc.current, got, tc.want)
+			}
+		})
+	}
+}
+
+// verifyRecall must treat "busy on a DIFFERENT stream" as a failed recall (the
+// box playing the wrong station used to count as success, #252), while staying
+// lenient when either side is unknown so a now_playing hiccup can never cause
+// a retry storm.
+func TestRecallLocationMatches(t *testing.T) {
+	slot5 := "http://127.0.0.1:8888/stream/5"
+	cases := []struct {
+		name               string
+		expected, location string
+		want               bool
+	}{
+		{"exact match", slot5, slot5, true},
+		{"wrong slot playing", slot5, "http://127.0.0.1:8888/stream/4", false},
+		{"no expectation is lenient", "", "http://127.0.0.1:8888/stream/4", true},
+		{"unreadable location is lenient", slot5, "", true},
+		{"raw stream mismatch", slot5, "http://127.0.0.1:8888/stream/raw?u=abc", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := recallLocationMatches(tc.expected, tc.location); got != tc.want {
+				t.Errorf("recallLocationMatches(%q, %q) = %v, want %v", tc.expected, tc.location, got, tc.want)
+			}
+		})
+	}
+}
+
+// The box entity-encodes attribute values in now_playing; the verify must
+// compare decoded URLs so a legitimate match with a query string is not
+// misread as a mismatch.
+func TestXMLAttrUnescape(t *testing.T) {
+	in := "http://127.0.0.1:8888/stream/raw?u=abc&amp;x=1"
+	want := "http://127.0.0.1:8888/stream/raw?u=abc&x=1"
+	if got := xmlAttrUnescape(in); got != want {
+		t.Errorf("xmlAttrUnescape(%q) = %q, want %q", in, got, want)
+	}
+	if got := xmlAttrUnescape("plain"); got != "plain" {
+		t.Errorf("xmlAttrUnescape(plain) = %q", got)
+	}
+}

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -890,7 +890,22 @@ func (s *Server) handlePresetSlot(w http.ResponseWriter, r *http.Request) {
 				})
 				return
 			}
-		} else if p.StreamURL != "" && !isHTTPURL(p.StreamURL) {
+		} else if p.StreamURL == "" {
+			// An EMPTY stream URL used to slip through the invalid-URL gate below
+			// and save as a dead radio preset: the box then fetches /stream/<slot>
+			// and the proxy 404s, i.e. a button that assigns fine but never plays
+			// (#252). A non-spotify, non-queue preset has nothing else playable,
+			// except a Spotify URI mis-typed as radio, which is healed instead.
+			if playableSpotifyURI(p.URI) {
+				p.Type = "spotify"
+			} else {
+				writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+					"error": "This selection can't be saved as a preset (no playable stream). Pick a radio station or a Spotify playlist and try again.",
+					"code":  "stream-url-missing",
+				})
+				return
+			}
+		} else if !isHTTPURL(p.StreamURL) {
 			if uri := legacySpotifyURI(p.StreamURL); uri != "" {
 				p.Type, p.URI, p.StreamURL = "spotify", uri, ""
 			} else {
@@ -1102,6 +1117,14 @@ type playRequest struct {
 	// Homepage is the station website (radio only), recorded into Recently-played
 	// so a card can offer a "website" link like the radio search rows do (#135).
 	Homepage string `json:"homepage"`
+	// Codec is the station codec as reported by radio-browser ("MP3", "AAC",
+	// "AAC+", ...). It selects the DIDL protocolInfo MIME for RADIO plays: the
+	// box keys its decoder off that MIME, and an HE-AAC station labelled with
+	// the fixed audio/mpeg default played SILENCE while the proxy forwarded
+	// its bytes fine (#252, "Absolut Relax"). Deliberately a separate field
+	// from Mime, which doubles as the "library file, play direct" marker
+	// (#139) and must not be set for radio.
+	Codec string `json:"codec"`
 }
 
 // handleWebhooks gets (GET) or replaces (PUT) the webhook config. The config
@@ -1212,15 +1235,21 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request) {
 	if playDirect {
 		playURL = req.URL
 	}
-	s.logger.Info("play request", "direct", playDirect, "mime", req.Mime, "url", req.URL)
+	s.logger.Info("play request", "direct", playDirect, "mime", req.Mime, "codec", req.Codec, "url", req.URL)
 	// Advertise the real codec to the box when the caller knows it (a network
 	// library track carries its DLNA-reported MIME, e.g. audio/flac, audio/mp4).
-	// Radio leaves it empty and defaults to audio/mpeg. The box keys its decoder
-	// off this protocolInfo MIME, so a FLAC/ALAC/M4A file mislabelled as
-	// audio/mpeg is rejected (AUDIO_ERROR_BAD_URL) while an MP3 plays (#139).
+	// The box keys its decoder off this protocolInfo MIME, so a FLAC/ALAC/M4A
+	// file mislabelled as audio/mpeg is rejected (AUDIO_ERROR_BAD_URL) while an
+	// MP3 plays (#139). Radio derives the MIME from the station codec instead:
+	// an AAC/HE-AAC station must be labelled audio/aac or the box decodes it as
+	// MPEG and plays silence (#252); MP3/unknown keeps the audio/mpeg default.
+	mime := req.Mime
+	if mime == "" {
+		mime = upnp.MimeForCodec(req.Codec)
+	}
 	var playErr error
-	if req.Mime != "" {
-		playErr = s.renderer.PlayURLMime(r.Context(), playURL, req.Title, req.Icon, req.Mime)
+	if mime != "" {
+		playErr = s.renderer.PlayURLMime(r.Context(), playURL, req.Title, req.Icon, mime)
 	} else {
 		playErr = s.renderer.PlayURL(r.Context(), playURL, req.Title, req.Icon)
 	}
@@ -1232,7 +1261,7 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	s.setLastPlay(playURL, req.Title, req.Icon, req.Mime)
+	s.setLastPlay(playURL, req.Title, req.Icon, mime)
 	// Recently-played (#135): a network-library file carries a MIME; radio does
 	// not. Record the original URL as the replayable card target, not the proxy.
 	if req.Mime != "" {
@@ -1460,25 +1489,39 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 	// Use the stream proxy URL so playback continues even after token
 	// expiry (Bose sees the stable loopback URL).
 	playURL := boxurl.StreamSlot(slot)
-	if err := s.renderer.PlayURL(r.Context(), playURL, p.Name, p.Art); err != nil {
+	// A preset saved from an AAC/HE-AAC station carries its codec: label the
+	// stream audio/aac in the DIDL so the box picks the right decoder. The
+	// fixed audio/mpeg label made those stations play silence (#252).
+	mime := upnp.MimeForCodec(p.Codec)
+	var playErr error
+	if mime != "" {
+		playErr = s.renderer.PlayURLMime(r.Context(), playURL, p.Name, p.Art, mime)
+	} else {
+		playErr = s.renderer.PlayURL(r.Context(), playURL, p.Name, p.Art)
+	}
+	if playErr != nil {
 		// Log the failed radio recall: this 502 used to be returned with no
 		// agent-side trace at all, so a remote diagnostic bundle showed a recall
 		// that apparently never happened (#252).
 		s.logger.Warn("preset slot recall (app): radio play failed",
-			"slot", slot, "name", p.Name, "playURL", playURL, "err", err)
+			"slot", slot, "name", p.Name, "playURL", playURL, "err", playErr)
 		writeJSON(w, http.StatusBadGateway, map[string]any{
 			"error":  "Station could not be played",
-			"detail": guessErrorReason(err),
+			"detail": guessErrorReason(playErr),
 			"slot":   slot,
 			"name":   p.Name,
 		})
 		return
 	}
-	s.setLastPlay(playURL, p.Name, p.Art, "")
+	s.setLastPlay(playURL, p.Name, p.Art, mime)
 	s.recentNoteCard("radio", p.StreamURL, p.Name, p.Art, p.StreamURL, "", p.Homepage) // #135
 	name, art := p.Name, p.Art
 	go s.verifyRecall(playURL, func(ctx context.Context, _ bool) {
-		_ = s.renderer.PlayURL(ctx, playURL, name, art)
+		if mime != "" {
+			_ = s.renderer.PlayURLMime(ctx, playURL, name, art, mime)
+		} else {
+			_ = s.renderer.PlayURL(ctx, playURL, name, art)
+		}
 	}, nil)
 	writeJSON(w, http.StatusOK, map[string]any{"status": "playing", "slot": slot, "name": p.Name})
 }
@@ -4636,8 +4679,8 @@ func (s *Server) handleDebugState(w http.ResponseWriter, r *http.Request) {
 		all := s.presets.All()
 		lines := make([]string, 0, len(all))
 		for _, p := range all {
-			lines = append(lines, fmt.Sprintf("slot %d: type=%s name=%q stream=%q uri=%q items=%d",
-				p.Slot, p.Type, p.Name, p.StreamURL, p.URI, len(p.Items)))
+			lines = append(lines, fmt.Sprintf("slot %d: type=%s name=%q codec=%q stream=%q uri=%q items=%d",
+				p.Slot, p.Type, p.Name, p.Codec, p.StreamURL, p.URI, len(p.Items)))
 		}
 		state["presets"] = lines
 	}

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -1408,7 +1408,7 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 				s.logger.Warn("spotify play (initial) failed, will verify+retry", "slot", slot, "err", err)
 			}
 			s.logger.Info("spotify soft recall: context load issued", "slot", slot, "warm", warm, "loadAfterMs", time.Since(t0).Milliseconds())
-			s.verifyRecall(func(ctx context.Context, lastAttempt bool) {
+			s.verifyRecall(slotURL, func(ctx context.Context, lastAttempt bool) {
 				// Re-point the box at the stream WITHOUT re-Play on the early
 				// tries: ServeOgg resumes go-librespot on attach, so this
 				// re-attaches without reshuffling/restarting the track (a re-Play
@@ -1450,7 +1450,7 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 			s.setLastPlay(directURL, p.Name, p.Art, mime)
 			s.recentNoteCard("upnp", p.StreamURL, p.Name, p.Art, p.StreamURL, "", "") // #135
 			name, art := p.Name, p.Art
-			go s.verifyRecall(func(ctx context.Context, _ bool) {
+			go s.verifyRecall(directURL, func(ctx context.Context, _ bool) {
 				_ = s.renderer.PlayURLMime(ctx, directURL, name, art, mime)
 			}, nil)
 			writeJSON(w, http.StatusOK, map[string]any{"status": "playing", "slot": slot, "name": p.Name})
@@ -1461,6 +1461,11 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 	// expiry (Bose sees the stable loopback URL).
 	playURL := boxurl.StreamSlot(slot)
 	if err := s.renderer.PlayURL(r.Context(), playURL, p.Name, p.Art); err != nil {
+		// Log the failed radio recall: this 502 used to be returned with no
+		// agent-side trace at all, so a remote diagnostic bundle showed a recall
+		// that apparently never happened (#252).
+		s.logger.Warn("preset slot recall (app): radio play failed",
+			"slot", slot, "name", p.Name, "playURL", playURL, "err", err)
 		writeJSON(w, http.StatusBadGateway, map[string]any{
 			"error":  "Station could not be played",
 			"detail": guessErrorReason(err),
@@ -1472,16 +1477,24 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 	s.setLastPlay(playURL, p.Name, p.Art, "")
 	s.recentNoteCard("radio", p.StreamURL, p.Name, p.Art, p.StreamURL, "", p.Homepage) // #135
 	name, art := p.Name, p.Art
-	go s.verifyRecall(func(ctx context.Context, _ bool) {
+	go s.verifyRecall(playURL, func(ctx context.Context, _ bool) {
 		_ = s.renderer.PlayURL(ctx, playURL, name, art)
 	}, nil)
 	writeJSON(w, http.StatusOK, map[string]any{"status": "playing", "slot": slot, "name": p.Name})
 }
 
-// verifyRecall confirms the box reached a playing state shortly after a recall
-// and re-issues the play a few times if not. Fixes the "first press after a
-// reboot does nothing, second press works" race (box/go-librespot not ready
-// yet) without any latency on the happy path (the initial play already ran).
+// verifyRecall confirms the box reached a playing state ON THE EXPECTED STREAM
+// shortly after a recall and re-issues the play a few times if not. Fixes the
+// "first press after a reboot does nothing, second press works" race
+// (box/go-librespot not ready yet) without any latency on the happy path (the
+// initial play already ran).
+//
+// expectedLocation is the box-side URL this recall pushed (e.g.
+// boxurl.StreamSlot(slot)). "Busy" alone used to count as success, which hid
+// exactly the #252 failure where a racing wake-resume replaced a just-issued
+// recall with the PREVIOUS station: the box was playing, just the wrong
+// stream. Now a busy box on a different location is re-issued like a silent
+// one. Empty expectedLocation keeps the busy-only check.
 //
 // retry receives lastAttempt=true only on the final try. Spotify uses it to
 // re-point the box without a full re-Play on the early tries (a re-Play
@@ -1489,7 +1502,7 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 // last-resort recovery. This is the same policy the hardware recall settled on
 // in v0.7.4 (cmd/agent verifySpotifyPlaying); routing both through one contract
 // keeps the soft and hardware paths from drifting again.
-func (s *Server) verifyRecall(retry func(ctx context.Context, lastAttempt bool), working func() bool) {
+func (s *Server) verifyRecall(expectedLocation string, retry func(ctx context.Context, lastAttempt bool), working func() bool) {
 	const attempts = 3
 	for attempt := 1; attempt <= attempts; attempt++ {
 		time.Sleep(5 * time.Second)
@@ -1501,15 +1514,65 @@ func (s *Server) verifyRecall(retry func(ctx context.Context, lastAttempt bool),
 		if working != nil && working() {
 			return
 		}
-		if _, busy := s.boxPlayState(); busy {
+		location, busy := s.boxPlayLocation()
+		if busy && recallLocationMatches(expectedLocation, location) {
 			return
 		}
-		s.logger.Warn("recall did not reach playing, retrying", "attempt", attempt)
+		if busy {
+			s.logger.Warn("recall verify: box is playing a different stream than this recall pushed, re-issuing",
+				"attempt", attempt, "expected", expectedLocation, "playing", location)
+		} else {
+			s.logger.Warn("recall did not reach playing, retrying", "attempt", attempt)
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
 		retry(ctx, attempt == attempts)
 		cancel()
 	}
 	s.logger.Warn("recall still not playing after retries")
+}
+
+// recallLocationMatches reports whether the box's now-playing location is the
+// stream a recall pushed. Lenient on missing data: with no expectation or no
+// readable location it returns true, so a now_playing read hiccup can never
+// turn the verify into a retry storm. Only a POSITIVE "the box is on a
+// different URL" counts as a mismatch (#252).
+func recallLocationMatches(expected, nowLocation string) bool {
+	if expected == "" || nowLocation == "" {
+		return true
+	}
+	return nowLocation == expected
+}
+
+// xmlAttrUnescape decodes the predefined XML entities the box emits in
+// now_playing attribute values (location="...&amp;..."), so the recall verify
+// compares real URLs, not encodings.
+func xmlAttrUnescape(s string) string {
+	r := strings.NewReplacer("&amp;", "&", "&lt;", "<", "&gt;", ">", "&quot;", `"`, "&apos;", "'")
+	return r.Replace(s)
+}
+
+// boxPlayLocation reads now_playing once and reports the ContentItem location
+// the box is tuned to plus whether it is busy (playing, buffering or paused).
+// Best-effort: ("", false) when the box cannot be read; verifyRecall treats an
+// unreadable location as a match, so this can only ever ADD a justified retry,
+// never a spurious one.
+func (s *Server) boxPlayLocation() (location string, busy bool) {
+	if s.boxHost == "" {
+		return "", false
+	}
+	cl := &http.Client{Timeout: 5 * time.Second}
+	resp, err := cl.Get("http://" + s.boxHost + ":8090/now_playing")
+	if err != nil {
+		return "", false
+	}
+	b, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+	resp.Body.Close()
+	body := string(b)
+	if m := reNowPlayLocation.FindStringSubmatch(body); m != nil {
+		location = xmlAttrUnescape(m[1])
+	}
+	busy = strings.Contains(body, "PLAY_STATE") || strings.Contains(body, "BUFFERING_STATE") || strings.Contains(body, "PAUSE_STATE")
+	return location, busy
 }
 
 // setLastPlay records the box-facing stream + metadata for the auto-re-push. A
@@ -1786,7 +1849,7 @@ func (s *Server) ResumeLastPlay() {
 	}
 	lp.failed = false
 	lp.rePushes = 0
-	boxURL, title, art, mime := lp.boxURL, lp.title, lp.art, lp.mime
+	boxURL, title, art, mime, capturedTS := lp.boxURL, lp.title, lp.art, lp.mime, lp.ts
 	s.lastPlayMu.Unlock()
 
 	go func() {
@@ -1859,6 +1922,22 @@ func (s *Server) ResumeLastPlay() {
 		}
 		s.boxCmdMu.Lock()
 		defer s.boxCmdMu.Unlock()
+		// A play/recall that raced this resume may have been holding boxCmdMu
+		// while the checks above ran: it is the very request whose ensureBoxReady
+		// wake fired this DO_NOT_RESUME, and its stream had not started when the
+		// busy check above looked (so the check missed it). By the time we get
+		// the lock that recall has updated lastPlay, and pushing the target we
+		// captured at entry would replace the user's NEW station with the
+		// PREVIOUS one (#252: recall slot 5 right after a wake ended up back on
+		// slot 4). Re-read lastPlay under the lock and stand down when it moved.
+		s.lastPlayMu.Lock()
+		cur := s.lastPlay
+		s.lastPlayMu.Unlock()
+		if resumeIsStale(boxURL, capturedTS, cur) {
+			s.logger.Info("wake resume: a newer play started while this resume waited, standing down",
+				"captured", boxURL, "current", lastPlayURL(cur))
+			return
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		var err error
@@ -1873,6 +1952,30 @@ func (s *Server) ResumeLastPlay() {
 		}
 		s.logger.Info("wake resume: resumed last stream after power-on", "url", boxURL, "title", title)
 	}()
+}
+
+// resumeIsStale reports whether a resume target captured at the START of a
+// wake-resume / reconnect-recovery has been overtaken by a newer play by the
+// time the box command lock was finally acquired. Those paths capture lastPlay,
+// then wait (settle sleep, state probes, boxCmdMu); a user play/recall that
+// held the lock meanwhile has called setLastPlay, so the capture is the
+// PREVIOUS station and pushing it would clobber the one the user just started
+// (#252). A same-URL entry with a newer timestamp is stale too: the newer play
+// already (re)started that stream, and a second push only causes a
+// double-start hiccup.
+func resumeIsStale(capturedURL string, capturedTS time.Time, current *lastPlayInfo) bool {
+	if current == nil {
+		return true // nothing to resume anymore
+	}
+	return current.boxURL != capturedURL || !current.ts.Equal(capturedTS)
+}
+
+// lastPlayURL is a nil-safe accessor for the stand-down log line.
+func lastPlayURL(lp *lastPlayInfo) string {
+	if lp == nil {
+		return ""
+	}
+	return lp.boxURL
 }
 
 // RecoverAfterReconnect re-pushes the last stream when the gabbo WebSocket
@@ -1913,7 +2016,7 @@ func (s *Server) RecoverAfterReconnect() {
 		s.lastPlayMu.Unlock()
 		return
 	}
-	boxURL, title, art, mime := lp.boxURL, lp.title, lp.art, lp.mime
+	boxURL, title, art, mime, capturedTS := lp.boxURL, lp.title, lp.art, lp.mime, lp.ts
 	s.lastPlayMu.Unlock()
 
 	go func() {
@@ -1930,6 +2033,17 @@ func (s *Server) RecoverAfterReconnect() {
 		}
 		s.boxCmdMu.Lock()
 		defer s.boxCmdMu.Unlock()
+		// Same anti-clobber guard as the power-on resume (#252): a play/recall
+		// that held boxCmdMu while this recovery waited has updated lastPlay, and
+		// pushing the entry capture now would replace the user's new stream.
+		s.lastPlayMu.Lock()
+		cur := s.lastPlay
+		s.lastPlayMu.Unlock()
+		if resumeIsStale(boxURL, capturedTS, cur) {
+			s.logger.Info("reconnect recovery: a newer play started while this recovery waited, standing down",
+				"captured", boxURL, "current", lastPlayURL(cur))
+			return
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		var err error
@@ -4512,6 +4626,20 @@ func (s *Server) handleDebugState(w http.ResponseWriter, r *http.Request) {
 		// answer "is this box genuinely tighter or carrying foreign firmware
 		// leftovers" without needing SSH (#ST30 OTA no-space, 2026-06-24).
 		"disk_usage": nandInventory(),
+	}
+	// Preset store summary: one compact line per slot so a diagnostic bundle
+	// shows dead presets (empty/invalid stream URL) directly. Before this the
+	// store's content was invisible in bundles and a preset that saved wrong
+	// could only be diagnosed by asking the user to fetch presets.json (#252).
+	// Stream URLs are included in full; the app's exporter anonymizes bundles.
+	if s.presets != nil {
+		all := s.presets.All()
+		lines := make([]string, 0, len(all))
+		for _, p := range all {
+			lines = append(lines, fmt.Sprintf("slot %d: type=%s name=%q stream=%q uri=%q items=%d",
+				p.Slot, p.Type, p.Name, p.StreamURL, p.URI, len(p.Items)))
+		}
+		state["presets"] = lines
 	}
 	writeJSON(w, http.StatusOK, state)
 }


### PR DESCRIPTION
Fixes both halves of #252, root-caused from the reporter's diagnostic bundles.

## A: preset save stored the previous station (ST30 "assignment not accepted")
The recall's own wake triggered the power-on `ResumeLastPlay`, which captured the OLD `lastPlay` before the user's recall ran, passed its "already playing" check before taking `boxCmdMu`, and re-pushed the old stream right after the user's new play. The box then reported the old station, and the app's long-press save copied that old preset onto the target key. ST30-specific only because that box sits in standby.
- `ResumeLastPlay` (and `RecoverAfterReconnect`, same shape) now re-reads `lastPlay` after acquiring the lock and stands down when a user play happened meanwhile (`resumeIsStale`).
- `verifyRecall` now verifies the box is on the EXPECTED stream location instead of "any busy", and re-issues when it plays something else.
- The app's save prefers the station the app itself just started (<2 min) over the box-reported copy.
- Observability: WARN on radio-recall play failure, WARN on the streamproxy missing-preset 404, and the preset store (slot/type/name/codec/URL) in `/api/debug/state`.

## B: AAC/HE-AAC stations silent on the box, fine in the web player
Every radio play hardcoded DIDL protocolInfo `audio/mpeg`; the whole "Absolut" series (incl. the reporter's self-added station) is AAC, so the box got AAC bytes labeled MP3 and played silence with a healthy proxy — the failure fallback never fired.
- New `codec` hint through `/api/play`, the preset store, and both recall paths → `PlayURLMime("audio/aac")` for the AAC family (`upnp.MimeForCodec`, deliberately narrow, default unchanged).
- The app sends the radio-browser codec on play/save and prefers a same-name MP3 sibling from the loaded results for box playback.
- Save gate: empty `StreamURL` radio presets are rejected (422 `stream-url-missing`); a Spotify URI mis-typed as radio is healed to `type=spotify`.

## Tests
`internal/webui` suite executed under WSL (linux/amd64): PASS incl. new `TestResumeIsStale`, `TestRecallLocationMatches`, `TestPresetSave*`; `TestMimeForCodec` native. wailsjs bindings regenerated with the wails CLI.

Hardware verification still pending (AAC DIDL label + the sleep/recall race on a real box). Refs #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)