### PR TITLE
fix(update): updates succeed on write-protected or two-copies-too-small speaker storage

### DIFF
--- a/internal/webui/ota_lastresort.go
+++ b/internal/webui/ota_lastresort.go
@@ -1,0 +1,137 @@
+package webui
+
+// Last-resort OTA paths for a NAND that cannot take the update (#270).
+//
+// Tier 1 is the reclaim cascade in writeBinaryAtomic (drop stale temps, logs,
+// the regenerable Spotify engine). Field data showed two eventualities it
+// cannot handle:
+//
+//   - UBIFS flips the volume to READ-ONLY after an I/O error (its protective
+//     mode on aging NAND). Every delete in the cascade then fails silently,
+//     the engine survives, and the user sees an unexplainable "no space"
+//     (the #270 ST20: the inventory still carried the full engine after the
+//     reclaim). Tier 2 detects the write-protected state, tries a
+//     remount,rw, and retries once; if the volume stays read-only, the error
+//     says so and tells the user the one thing that helps (power-cycle).
+//
+//   - Even a successful reclaim cannot beat the DOUBLE-COPY requirement: the
+//     atomic .new+rename needs old + new agent side by side while the old
+//     binary's blocks are pinned by the running process. On a small volume
+//     (ST20: ~26 MB) that can be impossible no matter what is reclaimed.
+//     Tier 3 sidesteps it: stage the new binary in RAM (/dev/shm tmpfs,
+//     sized at half the box RAM), spawn a detached helper, exit the agent
+//     (releasing ETXTBSY and its pinned blocks), and let the helper copy
+//     RAM -> NAND, verify, sync and reboot. Peak NAND need drops to a single
+//     copy. run.sh starts the swapped binary at the next boot, so even a
+//     helper that dies leaves the box recoverable by a power-cycle.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+// ramStageDir is the tmpfs the last-resort swap stages into. /dev/shm is
+// mounted rw with no size cap (defaults to half the RAM) on every observed
+// SoundTouch firmware; the boxes have no dedicated /tmp (rootfs is ro).
+const ramStageDir = "/dev/shm"
+
+// ramStagePath is the staged new agent binary awaiting the swap.
+const ramStagePath = ramStageDir + "/streborn-ota.stage"
+
+// isReadOnlyFSErr reports whether err smells like EROFS. The syscall error is
+// matched directly and by message, because it usually arrives wrapped in
+// fs.PathError -> fmt.Errorf chains.
+func isReadOnlyFSErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, syscall.EROFS) ||
+		strings.Contains(err.Error(), "read-only file system")
+}
+
+// nandWritable probes whether the NAND volume actually accepts writes right
+// now. df/statfs stays happy on a read-only UBIFS, so a real write is the
+// only trustworthy probe.
+func nandWritable() bool {
+	p := nandRoot + "/.str-write-probe"
+	if err := os.WriteFile(p, []byte("w"), 0o600); err != nil {
+		return false
+	}
+	_ = os.Remove(p)
+	return true
+}
+
+// remountNANDRW asks the kernel to flip the NAND volume back to read-write
+// after UBIFS parked it read-only. Best-effort; the outcome is logged and
+// returned so the caller can retry or fail with a truthful message.
+func remountNANDRW(logger *slog.Logger) bool {
+	out, err := exec.Command("mount", "-o", "remount,rw", nandRoot).CombinedOutput()
+	if err != nil {
+		logger.Warn("NAND remount,rw failed", "err", err, "out", strings.TrimSpace(string(out)))
+		return false
+	}
+	ok := nandWritable()
+	logger.Info("NAND remount,rw attempted", "writableAfter", ok)
+	return ok
+}
+
+// errNANDReadOnly is returned when the NAND is write-protected and could not
+// be remounted read-write. The message is surfaced verbatim to the user.
+var errNANDReadOnly = errors.New(
+	"the speaker's storage is in a write-protected state and could not be re-enabled; " +
+		"unplug the speaker from power for a minute and run the update again")
+
+// swapHelperScript builds the BusyBox-sh script the detached helper runs:
+// wait for this agent process to exit (releasing the old binary), copy the
+// staged binary over it, verify by size (and SHA256 when the box has
+// sha256sum), sync and reboot. One retry on a bad copy; the staged file is
+// removed either way so RAM is not held across the reboot.
+func swapHelperScript(agentPID int, stage, dst string, size int, sha string) string {
+	return fmt.Sprintf(`i=0
+while [ -d /proc/%d ] && [ "$i" -lt 90 ]; do sleep 1; i=$((i+1)); done
+cp %q %q; sync
+ok=1
+[ "$(wc -c < %q 2>/dev/null | tr -d ' ')" = "%d" ] || ok=0
+if [ "$ok" = "1" ] && command -v sha256sum >/dev/null 2>&1; then
+  [ "$(sha256sum %q | cut -d' ' -f1)" = "%s" ] || ok=0
+fi
+if [ "$ok" != "1" ]; then cp %q %q; sync; fi
+rm -f %q
+sleep 1
+reboot`,
+		agentPID, stage, dst, dst, size, dst, sha, stage, dst, stage)
+}
+
+// stageAndSwapViaRAM implements tier 3: write body to the RAM stage, spawn
+// the detached swap helper, and return nil when the caller may answer the
+// client and exit the agent process. The caller MUST exit shortly after (the
+// helper waits for this PID, capped at 90 s).
+func (s *Server) stageAndSwapViaRAM(dst string, body []byte) error {
+	if _, avail, ok := diskFree(ramStageDir); ok && avail < int64(len(body))+(1<<20) {
+		return fmt.Errorf("RAM stage %s too small: need %d, avail %d", ramStageDir, len(body), avail)
+	}
+	if err := os.WriteFile(ramStagePath, body, 0o755); err != nil {
+		return fmt.Errorf("write RAM stage: %w", err)
+	}
+	sum := sha256.Sum256(body)
+	script := swapHelperScript(os.Getpid(), ramStagePath, dst, len(body), hex.EncodeToString(sum[:]))
+	cmd := exec.Command("sh", "-c", script)
+	// Own session: the helper must survive this agent's exit and any process-
+	// group teardown on the way down.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		_ = os.Remove(ramStagePath)
+		return fmt.Errorf("start swap helper: %w", err)
+	}
+	// Deliberately not Wait()ed: the helper outlives us by design.
+	s.logger.Warn("OTA: NAND cannot hold two agent copies; RAM-staged swap armed, agent will exit and the helper reboots the box",
+		"stage", ramStagePath, "bytes", len(body), "helperPID", cmd.Process.Pid)
+	return nil
+}

--- a/internal/webui/ota_lastresort_test.go
+++ b/internal/webui/ota_lastresort_test.go
@@ -1,0 +1,62 @@
+package webui
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// EROFS must be recognized both as a wrapped syscall errno and by message,
+// because it usually arrives buried in fs.PathError -> fmt.Errorf chains.
+func TestIsReadOnlyFSErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain EROFS", syscall.EROFS, true},
+		{"wrapped EROFS", fmt.Errorf("write tmp: %w", syscall.EROFS), true},
+		{"message only", errors.New("open /mnt/nv/x: read-only file system"), true},
+		{"ENOSPC is not it", syscall.ENOSPC, false},
+		{"unrelated", errors.New("connection refused"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isReadOnlyFSErr(tc.err); got != tc.want {
+				t.Errorf("isReadOnlyFSErr(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// The swap helper must wait for the agent PID, copy stage->dst, verify by
+// size and (when available) SHA256 with one retry, clean the stage, and
+// reboot. Guard the script's load-bearing pieces so a refactor cannot
+// silently drop one.
+func TestSwapHelperScript(t *testing.T) {
+	script := swapHelperScript(4242, "/dev/shm/streborn-ota.stage",
+		"/mnt/nv/streborn/bin/streborn-armv7l", 12345678, "abc123")
+	for _, want := range []string{
+		"/proc/4242",
+		`cp "/dev/shm/streborn-ota.stage" "/mnt/nv/streborn/bin/streborn-armv7l"`,
+		`wc -c < "/mnt/nv/streborn/bin/streborn-armv7l"`,
+		"12345678",
+		"sha256sum",
+		"abc123",
+		`rm -f "/dev/shm/streborn-ota.stage"`,
+		"reboot",
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("helper script is missing %q:\n%s", want, script)
+		}
+	}
+	// BusyBox sh only: no bashisms.
+	for _, forbidden := range []string{"[[", "function ", "$((i++))"} {
+		if strings.Contains(script, forbidden) {
+			t.Errorf("helper script contains non-POSIX construct %q", forbidden)
+		}
+	}
+}

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -3026,7 +3026,44 @@ func (s *Server) handleAgentUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	const dst = "/mnt/nv/streborn/bin/streborn-armv7l"
-	if err := writeBinaryAtomic(dst, body); err != nil {
+	err := writeBinaryAtomic(dst, body)
+	// Tier 2 (#270): a NAND that UBIFS parked read-only fails the write (or,
+	// sneakier, fails every reclaim delete so the write path reports "no
+	// space"). Probe, remount rw, retry once; if the volume stays protected,
+	// the truthful error beats another opaque 507.
+	if err != nil && (isReadOnlyFSErr(err) || !nandWritable()) {
+		if remountNANDRW(s.logger) {
+			err = writeBinaryAtomic(dst, body)
+		} else {
+			http.Error(w, errNANDReadOnly.Error(), http.StatusInsufficientStorage)
+			return
+		}
+	}
+	// Tier 3 (#270): the volume writes fine but cannot hold OLD + NEW agent
+	// side by side even after the reclaim (small ST20 volumes). Stage the new
+	// binary in RAM and let a detached helper swap it in after this process
+	// exits, then reboot — peak NAND need drops to a single copy.
+	if errors.Is(err, errInsufficientNAND) {
+		if serr := s.stageAndSwapViaRAM(dst, body); serr == nil {
+			writeJSON(w, http.StatusOK, map[string]string{
+				"status": "ok",
+				"action": "reboot",
+				"mode":   "ram-staged",
+			})
+			go func() {
+				// Give the 200 OK time to flush, then exit: the helper waits
+				// for this PID before copying (the running binary is ETXTBSY
+				// and its blocks are pinned until we are gone).
+				time.Sleep(1500 * time.Millisecond)
+				s.logger.Info("exiting for the RAM-staged binary swap; the helper reboots the box")
+				os.Exit(0)
+			}()
+			return
+		} else {
+			s.logger.Warn("RAM-staged swap unavailable, reporting the space failure", "err", serr)
+		}
+	}
+	if err != nil {
 		http.Error(w, err.Error(), nandWriteHTTPStatus(err))
 		return
 	}


### PR DESCRIPTION
The real #270 fix (follow-up to the visibility pass in #345), after root-causing the ST20 field failure: the engine survived the reclaim because its deletes failed silently - the signature of UBIFS parking the volume read-only after an I/O error. Separately, a small volume can be unable to hold OLD+NEW agent side by side no matter what is reclaimed (the atomic .new+rename requirement, with the old binary's blocks pinned by the running process).

**Tier 2 - read-only NAND**: real-write probe, `mount -o remount,rw`, one retry; if it stays protected the user gets a truthful "storage is write-protected, power-cycle and retry" instead of an opaque 507.

**Tier 3 - RAM-staged swap**: stage the new binary in `/dev/shm` (tmpfs on all observed firmware; there is no /tmp - verified against a live box's /proc/mounts), answer the app, exit the agent; a detached `Setsid` BusyBox helper waits for the PID, copies RAM->NAND, verifies size + SHA256 (one retry), syncs, reboots. Peak NAND requirement drops to a single copy. Failure mode is safe: a dead helper just means the old binary boots again after a power-cycle.

Tests: `TestIsReadOnlyFSErr` (wrapped errno + message matching), `TestSwapHelperScript` (load-bearing script pieces + POSIX-only guard) - executed green under WSL (linux/amd64).

Hardware verification tracked in #349. Refs #270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)