### PR TITLE
feat(update): the app re-checks for its own updates every 12 hours while it runs

### DIFF
--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -818,6 +818,11 @@ async function renderFooter() {
   // so even if it ever misbehaved it cannot abort startup. checkAppUpdate
   // is itself fully guarded (try/catch + Go-side recover).
   setTimeout(() => { try { checkAppUpdate(); } catch {} }, 8000);
+  // Long-running apps re-check every 12 hours (#71): STR often stays open for
+  // days on a media PC, and the startup-only check meant such installs never
+  // learned about a new release (and its security fixes) until a restart. The
+  // banner render is idempotent, so a repeat check just refreshes it.
+  setInterval(() => { try { checkAppUpdate(); } catch {} }, 12 * 3600 * 1000);
   // appInfo may have arrived after the first discovery completed; the
   // badge function defers until both are known. Re-render the box list
   // too so the per-speaker update dot (boxNeedsUpdate) appears once the


### PR DESCRIPTION
Completes #71: the online check now runs at startup AND every 12 hours while the app stays open (the banner render is idempotent). The rest of the #71 scope (download the matching asset, verify SHA256 against the release manifest, per-OS install handoff: Windows/Linux self-replace + relaunch, macOS download+open) already shipped in update_app.go.

Closes #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)