### PR TITLE
feat(remote): the phone remote is named after the speaker, shows the name in full, bass moves to the end

### DIFF
--- a/internal/webui/const.go
+++ b/internal/webui/const.go
@@ -14,25 +14,6 @@ const shutdownTimeout = 5 * time.Second
 //go:embed assets/icon.png
 var iconPNG []byte
 
-// webManifest is the PWA manifest served at /manifest.webmanifest. With it (plus
-// the apple-mobile-web-app meta in indexHTML) a phone can "Add to Home Screen"
-// and the page opens full-screen as a standalone STR app.
-const webManifest = `{
-  "name": "ST Reborn",
-  "short_name": "STR",
-  "description": "Control your Bose SoundTouch speaker",
-  "start_url": "/",
-  "scope": "/",
-  "display": "standalone",
-  "orientation": "portrait",
-  "background_color": "#1a1a1a",
-  "theme_color": "#1a1a1a",
-  "icons": [
-    { "src": "/icon.png", "sizes": "192x192", "type": "image/png", "purpose": "any" },
-    { "src": "/icon.png", "sizes": "192x192", "type": "image/png", "purpose": "maskable" }
-  ]
-}`
-
 // indexHTML is the self-contained controller page the agent serves on "/". It is
 // the phone remote: a mobile-first page (no desktop app needed) that drives the
 // box over the same REST API the desktop app uses. It is PWA-capable (save to
@@ -91,7 +72,10 @@ header { display:flex; align-items:center; gap:10px; margin-bottom:14px; }
 header img { width:30px; height:30px; border-radius:7px; }
 header .brand { font-size:18px; font-weight:700; letter-spacing:.2px; }
 header .brand span { color:var(--accent); }
-header .dev { margin-left:auto; min-width:0; font-size:12px; color:var(--muted); text-align:right; max-width:42%; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+/* The speaker name is the page's identity (one saved app per speaker), so it
+   reads as a headline: bright, semi-bold, and it WRAPS instead of getting cut
+   off - multi-word room names were ellipsized before. */
+header .dev { margin-left:auto; min-width:0; font-size:15px; font-weight:600; color:var(--fg); text-align:right; overflow-wrap:anywhere; line-height:1.25; }
 .card { background:var(--card); border:1px solid var(--line); border-radius:10px; padding:12px; margin:12px 0; }
 .nowcard { padding:14px 16px; background:linear-gradient(180deg,var(--nowgrad1),var(--nowgrad2)); }
 .nowcard .now { display:block; color:var(--accent); font-weight:600; font-size:18px; line-height:1.25; }
@@ -107,9 +91,6 @@ button.btn.active, a.btn.active { border-color:var(--accent); color:var(--accent
 button.btn:active { background:var(--press); }
 @media (hover:hover) { button.btn:hover, a.btn:hover { background:var(--hover); } .preset:hover { background:var(--hover); } }
 .vol { display:flex; align-items:center; gap:12px; }
-/* Second slider label in the same card (Bass under Volume): needs its own
-   top gap; both stay hidden until /api/box/settings confirms bass support. */
-.bass-label { margin-top:14px; }
 .vol input[type=range] { flex:1; accent-color:var(--accent); height:44px; }
 .vol input[type=range]::-webkit-slider-thumb { -webkit-appearance:none; width:24px; height:24px; border-radius:50%; background:var(--accent); }
 .vol input[type=range]::-moz-range-thumb { width:24px; height:24px; border:0; border-radius:50%; background:var(--accent); }
@@ -243,8 +224,6 @@ footer .hint { display:block; margin-top:6px; color:var(--muted); opacity:.7; }
 <div class="card">
 <div class="label" id="lblVol">Volume</div>
 <div class="vol"><input type="range" id="vol" min="0" max="100" value="0" aria-label="Volume" oninput="onVol(this.value)"><span class="val" id="volval">0</span></div>
-<div class="label bass-label" id="lblBass" style="display:none">Bass</div>
-<div class="vol" id="bassRow" style="display:none"><input type="range" id="bass" min="-9" max="0" value="0" aria-label="Bass" oninput="onBass(this.value)"><span class="val" id="bassval">0</span></div>
 </div>
 
 <div class="card">
@@ -273,6 +252,11 @@ footer .hint { display:block; margin-top:6px; color:var(--muted); opacity:.7; }
 <div class="card" id="peersCard">
 <div class="label" id="lblPeers">Other speakers</div>
 <div class="row" id="peers"></div>
+</div>
+
+<div class="card" id="bassCard" style="display:none">
+<div class="label" id="lblBass">Bass</div>
+<div class="vol"><input type="range" id="bass" min="-9" max="0" value="0" aria-label="Bass" oninput="onBass(this.value)"><span class="val" id="bassval">0</span></div>
 </div>
 </main>
 
@@ -448,8 +432,7 @@ async function loadSettings() {
     bassLast = s.bass.actual;
     b.value = s.bass.actual;
     document.getElementById('bassval').textContent = s.bass.actual;
-    document.getElementById('lblBass').style.display = '';
-    document.getElementById('bassRow').style.display = '';
+    document.getElementById('bassCard').style.display = '';
   }
 }
 

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"log/slog"
 	"net"
@@ -6021,9 +6022,34 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 
 // ---- Index Page (minimal HTML for direct browser use) ----
 
+// remoteDisplayName is the speaker's friendly name for the phone remote's
+// identity (page title, iOS home-screen label, PWA manifest). Empty when the
+// box has not told us a name (yet).
+func (s *Server) remoteDisplayName() string {
+	if s.boxNameFn == nil {
+		return ""
+	}
+	name, _ := s.boxNameFn()
+	return strings.TrimSpace(name)
+}
+
 func (s *Server) handleIndex(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, _ = fmt.Fprint(w, indexHTML)
+	page := indexHTML
+	// Stamp the speaker's name into the page identity so "Add to Home Screen"
+	// saves one distinguishable app PER SPEAKER: iOS takes its label from the
+	// apple-mobile-web-app-title meta (and the title tag) at save time; each
+	// speaker is its own origin, so the phone keeps them apart as separate
+	// apps. The generic "ST Reborn" is only the fallback for a box whose name
+	// is not known yet.
+	if name := s.remoteDisplayName(); name != "" {
+		esc := html.EscapeString(name)
+		page = strings.Replace(page, "<title>ST Reborn</title>", "<title>"+esc+"</title>", 1)
+		page = strings.Replace(page,
+			`<meta name="apple-mobile-web-app-title" content="ST Reborn">`,
+			`<meta name="apple-mobile-web-app-title" content="`+esc+`">`, 1)
+	}
+	_, _ = fmt.Fprint(w, page)
 }
 
 // handlePeers lists the other STR speakers on the LAN so the page can offer
@@ -6041,11 +6067,39 @@ func (s *Server) handlePeers(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleManifest serves the PWA manifest so a phone can install the controller
-// page as a standalone home-screen app.
+// page as a standalone home-screen app. The app name is the SPEAKER's name, so
+// a user with several speakers saves several distinguishable apps (one per
+// origin); the generic branding is only the fallback while the box name is
+// unknown. Cache short: a rename should reach the next home-screen save.
 func (s *Server) handleManifest(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	name, short := "ST Reborn", "STR"
+	if n := s.remoteDisplayName(); n != "" {
+		name = n
+		// short_name shows under the icon; Android truncates around 12-15
+		// characters itself, but a deliberate cap keeps the label readable.
+		short = n
+		if r := []rune(short); len(r) > 14 {
+			short = string(r[:14])
+		}
+	}
 	w.Header().Set("Content-Type", "application/manifest+json")
-	w.Header().Set("Cache-Control", "public, max-age=86400")
-	_, _ = fmt.Fprint(w, webManifest)
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"name":             name,
+		"short_name":       short,
+		"description":      "Control your Bose SoundTouch speaker",
+		"start_url":        "/",
+		"scope":            "/",
+		"display":          "standalone",
+		"orientation":      "portrait",
+		"background_color": "#1a1a1a",
+		"theme_color":      "#1a1a1a",
+		"icons": []map[string]string{
+			{"src": "/icon.png", "sizes": "192x192", "type": "image/png", "purpose": "any"},
+			{"src": "/icon.png", "sizes": "192x192", "type": "image/png", "purpose": "maskable"},
+		},
+	})
 }
 
 // handleIcon serves the embedded STR app icon (favicon, iOS apple-touch-icon and


### PR DESCRIPTION
Three phone-remote refinements:

1. **One home-screen app per speaker**: `/` and `/manifest.webmanifest` now stamp the speaker's friendly name into the page title, the `apple-mobile-web-app-title` meta (iOS reads it at add-to-home-screen time) and the manifest `name`/`short_name` (Android). Each speaker is its own origin, so a user can save several distinguishable remotes. Manifest cache dropped to 300 s so renames propagate; the static manifest const is gone (built dynamically, JSON-encoded so names cannot break it).
2. **Speaker name prominent and never truncated**: brighter, semi-bold, wraps instead of ellipsizing (multi-word room names were cut off).
3. **Bass control moved to its own card at the end of the page** (was under the volume slider), still shown only when the box reports a bass stage.

Live-verified on a SoundTouch Portable (title/meta/manifest = "ArbeitszimmerPortable", bass card last, no ellipsis CSS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)