### PR TITLE
feat(app): the selected speaker follows across the Music, Settings and Setup tabs

### DIFF
--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -301,9 +301,9 @@ initSpotifyView({
     .filter(b => b && b.kind !== 'stock' && b.deviceID && b.host)
     .map(b => ({ host: b.host, port: b.port, name: getBoxLabel(b) })),
 });
-initSettingsView({ switchView, updateFilterIndicators, discoverBoxes, renderBoxSelect, boxFetch, localizeLanguageName, doBoxUpdate, loadPresets, getRoomNames });
+initSettingsView({ switchView, updateFilterIndicators, discoverBoxes, renderBoxSelect, boxFetch, localizeLanguageName, doBoxUpdate, loadPresets, getRoomNames, speakerPicked: speakerPickedInTab });
 initLibraryView({ showSlotPicker, formatDuration });
-initSetupView({ switchView, discoverBoxes, doBoxUpdate, getRoomNames, boxFetch, celebrateProvision: inviteWorldMapAfterProvision });
+initSetupView({ switchView, discoverBoxes, doBoxUpdate, getRoomNames, boxFetch, celebrateProvision: inviteWorldMapAfterProvision, speakerPicked: speakerPickedInTab });
 initPodcastsView();
 
 // __nextLogoFallback walks a preset logo <img>'s data-fallbacks list (a
@@ -1700,6 +1700,19 @@ function renderBoxSelect() {
   updateBoxUiVisibility();
 }
 
+// speakerPickedInTab keeps the tabs in lock-step in the other direction: a
+// speaker picked in Settings or Setup becomes the music tab's active box too.
+// Stock boxes cannot be driven from the music tab, so they only preselect the
+// Settings/Setup pickers and leave the music selection alone.
+function speakerPickedInTab(box) {
+  if (!box) return;
+  state.settingsBox = box;
+  state.setupTarget = { kind: box.kind === 'stock' ? 'stock' : 'str', box };
+  if (box.kind !== 'stock' && (!state.currentBox || state.currentBox.host !== box.host)) {
+    selectBox(box);
+  }
+}
+
 function selectBox(box) {
   // Clear the cached now-playing line when actually switching to a different
   // speaker, so the status bar does not show the previous box's track until the
@@ -1708,6 +1721,14 @@ function selectBox(box) {
   const switched = !state.currentBox || state.currentBox.host !== (box && box.host);
   state.currentBox = box;
   if (box && box.deviceID) saveLastBox(box.deviceID);
+  // Tab-selection lock-step: the speaker picked here is preselected in the
+  // Settings and Setup tabs too (their pickers re-render on every tab entry),
+  // so switching tabs never lands on a different speaker than the one the
+  // user was just controlling.
+  if (box) {
+    state.settingsBox = box;
+    state.setupTarget = { kind: box.kind === 'stock' ? 'stock' : 'str', box };
+  }
   state.presetErrors = {};
   if (switched) { resetNowPlaying(); renderNowPlayingBar(); }
   renderBoxSelect();

--- a/desktop-app/frontend/src/views/settings.js
+++ b/desktop-app/frontend/src/views/settings.js
@@ -114,6 +114,8 @@ function mountSettingsShell() {
     if (box) {
       state.settingsBox = box;
       loadBoxSettings();
+      // Lock-step with the music tab (and the Setup target picker).
+      if (deps.speakerPicked) deps.speakerPicked(box);
     }
   };
   $('settingsRefreshBtn').onclick = async () => {

--- a/desktop-app/frontend/src/views/setup.js
+++ b/desktop-app/frontend/src/views/setup.js
@@ -634,6 +634,8 @@ export function renderSetupTargetPicker() {
         const box = list.find(b => b.host === host);
         if (!box) return;
         state.setupTarget = { kind, box };
+        // Lock-step with the music tab and the Settings picker.
+        if (deps.speakerPicked) deps.speakerPicked(box);
       }
       renderSetupTargetPicker();
       updateSetupGoButtonLabel();


### PR DESCRIPTION
Bidirectional lock-step of the three per-tab speaker pickers:

- `selectBox` (music tab) now also sets `state.settingsBox` and `state.setupTarget` - both pickers re-render on tab entry, so the speaker is already selected there.
- A new shared `speakerPickedInTab` handler (passed into the Settings and Setup views) syncs the other direction; STR speakers also become the music tab's active box, stock speakers only preselect Settings/Setup (the music tab cannot drive them).
- Factory-reset card picks deliberately do not touch the music selection.

vite build green; state-only propagation, no extra renders on hidden tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)