### PR TITLE
fix(update): recover a storage-full speaker over the network instead of dead-ending

### DIFF
--- a/desktop-app/ota.go
+++ b/desktop-app/ota.go
@@ -184,6 +184,14 @@ func (a *App) UpdateBoxAgent(host string, port int) (err error) {
 				a.logger.Info("update agent: HTTP connection dropped (agent restarting) and SSH raced the reboot; deferring to the post-OTA version poll", "host", host, "httpErr", err, "sshErr", sshErr)
 				return nil
 			}
+			// A 507 means the speaker's storage is full and its (old) agent
+			// cannot free space by itself, and the SSH recovery could not open
+			// SSH either (no :17000, or the unlock failed). Tell the user the
+			// one thing that always works — a one-time USB-stick update — rather
+			// than a raw "status 507".
+			if strings.Contains(err.Error(), "507") || strings.Contains(strings.ToLower(err.Error()), "insufficient nand") {
+				return fmt.Errorf("the speaker's storage is full and it is on an older STR version that cannot free space over the network. Update this speaker once from a USB stick (that cleans up the storage and installs the current version); after that, updates manage the space themselves. Details: %v", err)
+			}
 			return fmt.Errorf("HTTP OTA failed (%v) and the SSH fallback also failed: %w", err, sshErr)
 		}
 		a.logger.Info("update agent: SSH-OTA succeeded after HTTP failure", "host", host, "bytes", len(bin))
@@ -776,7 +784,42 @@ func (a *App) updateAgentViaSSH(host string, bin []byte) error {
 	// 4 spaced attempts (sshHandshake): the OTA path runs when the box is
 	// busiest, exactly where the one-shot 8 s attempt used to flake (#114).
 	if hello, err := sshHandshake(host, 4); err != nil || !strings.Contains(hello, "STR_SSH_OK") {
-		return fmt.Errorf("ssh handshake failed: %v (%s)", err, strings.TrimSpace(hello))
+		// SSH is closed (opt-in since v0.8.1). Before giving up, open it
+		// stick-free via the box's :17000 setup port — the same unlock the
+		// install path uses. This is the ONLY remote rescue for a box stuck
+		// on a pre-reclaim agent (< v0.8.34, e.g. v0.8.32) whose NAND is full:
+		// that old agent cannot free space during an HTTP update and SSH is
+		// off, so the update otherwise dead-ends at "ssh handshake failed"
+		// (Peter's ST10, 2026-07-09). Once SSH is open, the SSH upload command
+		// below frees the NAND (drops the ~16 MB engine when tight) and pushes
+		// the fresh agent, after which the box self-manages space. Only when
+		// :17000 answers.
+		opened := false
+		if tcpReachable(host, 17000, 2*time.Second) {
+			a.logger.Info("SSH-OTA: plain SSH closed, opening it stick-free via :17000 to recover a full/old box", "host", host)
+			var tlog string
+			opened, tlog = a.enableSSHViaTelnet(host, "")
+			if opened {
+				// Restore stock cloud URLs while :17000 is still plain Bose TAP,
+				// so the injected str-setup.invalid does not leave the box
+				// marge-checking a dead host (the light-bar sweep). Best-effort.
+				if rerr := a.resetBoseURLsViaTelnet(host); rerr != nil {
+					a.logger.Warn("SSH-OTA: could not restore cloud URLs after stick-free unlock", "host", host, "err", rerr)
+				}
+				a.logger.Info("SSH-OTA: SSH opened stick-free via :17000; continuing the update over SSH", "host", host)
+			} else {
+				// The unlock may have written a dead .invalid URL; restore stock
+				// URLs + reboot so the box is never left marge-checking a dead
+				// host (also protects a later stick install's interception).
+				a.restoreStockBoseURLsAndReboot(host)
+				a.logger.Warn("SSH-OTA: stick-free :17000 unlock did not open SSH", "host", host, "log", lastN(tlog, 200))
+			}
+		}
+		if !opened {
+			if hello, err := sshHandshake(host, 2); err != nil || !strings.Contains(hello, "STR_SSH_OK") {
+				return fmt.Errorf("ssh handshake failed: %v (%s)", err, strings.TrimSpace(hello))
+			}
+		}
 	}
 	// mkdir + cat in one ssh-with-stdin session so a missing parent dir on
 	// a freshly-installed box does not need a separate round-trip. The


### PR DESCRIPTION
Root-caused from a field diagnostic (ST10 on agent v0.8.32, 2026-07-09): the speaker is stuck on an STR version older than the storage-reclaim fix and its NAND is full (agent ~12 MB + go-librespot engine ~16 MB fill the 32 MB volume). The old on-box agent handles the incoming write and has no engine-reclaim (`reclaimSpotifyEngine` shipped v0.8.34, the engine-stop v0.8.35), so the atomic write does not fit and it returns 507. The desktop app fell back to SSH, but SSH is opt-in/off since v0.8.1, so the fallback dead-ended at `ssh handshake failed: exit status 255` — the box was unrecoverable over the network. (The same owner's ST20s on v0.9.1 self-reclaim and update fine.)

Key gap found: `updateAgentViaSSH` only tried plain SSH (:22) and gave up; it never used the `:17000` stick-free unlock (`enableSSHViaTelnet`) that the install and uninstall paths use.

Fix:
- On a failed SSH handshake, if `:17000` answers, open SSH stick-free via `enableSSHViaTelnet`, restore the stock cloud URLs (`resetBoseURLsViaTelnet`, so the injected `str-setup.invalid` never strands the box), then continue over SSH. The existing SSH upload command already frees the NAND (drops the regenerable engine when `df` says tight) before pushing the fresh agent — so a full old-agent box is recovered fully over the network, and self-manages storage afterward.
- If SSH cannot be opened (no :17000), the 507 failure now returns a clear "update this speaker once from a USB stick" message instead of a raw `status 507`.

Note: boxes on v0.9.x already self-reclaim (verified: the current `writeBinaryAtomic` drops the running engine after stopping it); this fix is for boxes STUCK on a pre-reclaim agent. Refs #270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)