### PR TITLE
fix(presets): recalling a saved station plays again instead of failing with 'context cancelled'

### DIFF
--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -4857,7 +4857,14 @@ func (s *Server) handleDebugState(w http.ResponseWriter, r *http.Request) {
 		"stick_listing":  listDir("/media/sda1"),
 		"media_listing":  listDir("/media"),
 		"nv_listing":     listDir("/mnt/nv/streborn"),
-		"proc_mounts":    readTail("/proc/mounts"),
+		// The /mnt/nv ROOT, not just STR's own subdir: a stock or STR-only box
+		// carries only Bose's persistent state and streborn/ here, so anything
+		// else (e.g. an aftertouch/ dir) is a leftover from another mod that can
+		// clash with STR's Wi-Fi/marge path. Surfacing it lets a bundle spot such
+		// remnants without SSH (do NOT blanket-wipe /mnt/nv: it holds the box's
+		// own Wi-Fi/AirPlay/account persistence).
+		"nv_root_listing": listDir("/mnt/nv"),
+		"proc_mounts":     readTail("/proc/mounts"),
 		// Writable-volume usage: df for /mnt/nv + / and the per-entry sizes that
 		// answer "is this box genuinely tighter or carrying foreign firmware
 		// leftovers" without needing SSH (#ST30 OTA no-space, 2026-06-24).

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -606,16 +606,30 @@ func WithRecent(r *recent.Store) Option {
 // Called before every play call.
 func (s *Server) ensureBoxReady(ctx context.Context) {
 	if s.boxHost != "" {
-		wakeCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
+		// Detach from the caller's request context: a slow wake must not be
+		// cancellable by the app giving up on the play POST, because the very
+		// same r.Context() then drives the SetURI that follows. When the wake
+		// (or the pair below) blocked past the app's request timeout, the app
+		// cancelled the request and the recall's own PlayURL then ran on an
+		// already-cancelled context and failed instantly with "context
+		// cancelled" - every preset recall dead on ST20/ST30 (bernd, #252).
+		wakeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 8*time.Second)
 		if err := boxcli.WakeAndWait(wakeCtx, s.boxHost, 6*time.Second, s.logger); err != nil {
 			s.logger.Warn("Box could not be woken from STANDBY", "err", err)
 		}
 		cancel()
 	}
 	if s.autoPair != nil {
-		pairCtx, cancel := context.WithTimeout(ctx, 6*time.Second)
-		s.autoPair.TriggerNow(pairCtx)
-		cancel()
+		// Fire-and-forget. The marge-account refresh is NOT needed for the
+		// UPnP playback that follows, yet the box's :8090 setMargeAccount POST
+		// can hang for seconds on some firmwares. Running it inline blocked the
+		// recall past the app's request timeout (see above), so run it in the
+		// background on its own context and never delay the play on it.
+		go func() {
+			pairCtx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+			defer cancel()
+			s.autoPair.TriggerNow(pairCtx)
+		}()
 	}
 }
 
@@ -1506,11 +1520,17 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 	// stream audio/aac in the DIDL so the box picks the right decoder. The
 	// fixed audio/mpeg label made those stations play silence (#252).
 	mime := upnp.MimeForCodec(p.Codec)
+	// Detach the play command from the request context: a preset recall should
+	// still reach the speaker if the app already gave up on the HTTP response,
+	// and it must never fail on a context the caller cancelled while the box was
+	// still being woken (the "context cancelled" recall regression, #252).
+	playCtx, playCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 12*time.Second)
+	defer playCancel()
 	var playErr error
 	if mime != "" {
-		playErr = s.renderer.PlayURLMime(r.Context(), playURL, p.Name, p.Art, mime)
+		playErr = s.renderer.PlayURLMime(playCtx, playURL, p.Name, p.Art, mime)
 	} else {
-		playErr = s.renderer.PlayURL(r.Context(), playURL, p.Name, p.Art)
+		playErr = s.renderer.PlayURL(playCtx, playURL, p.Name, p.Art)
 	}
 	if playErr != nil {
 		// Log the failed radio recall: this 502 used to be returned with no


### PR DESCRIPTION
## Critical regression (bernd, #252): every saved preset stopped playing on ST20/ST30

**Symptom:** recalling any saved station does nothing; the agent log shows `SetURI: Post ".../8091/AVTransport/Control": context cancelled` failing ~4 ms after the recall started, for every slot, on both boxes.

**Root cause:** `handlePlaySlot` calls `ensureBoxReady(r.Context())` before playing. That helper woke the box and then, **inline**, triggered an auto-pair `setMargeAccount` POST to the box's `:8090`. On several firmwares that POST hangs for seconds. It blocked the recall past the desktop app's request timeout, so the app cancelled the POST - and the recall's own `SetAVTransportURI`, which shares `r.Context()`, then ran on an already-cancelled context and failed instantly. Introduced when the auto-pair trigger was added to the recall path.

**Fix:**
- The auto-pair refresh runs in a **background goroutine** (it is not needed for the UPnP playback that follows).
- The wake runs on a context **detached** from the caller (`context.WithoutCancel`), so a client that gives up mid-wake cannot cancel it.
- The radio recall's `PlayURL` runs on a **detached, 12 s** context, so the play command reaches the speaker even if the app already gave up on the HTTP response.

## Verification
- Agent cross-builds (linux/arm, GOARM=5); webui recall tests pass.

Refs #252