### PR TITLE
fix(app): avoid redundant per-second DOM writes during the OTA countdown

### DIFF
--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -2769,7 +2769,14 @@ async function doBoxUpdate(targetBox) {
   // "Update running on <name>" label there.
   const setStatus = (text) => {
     if (!state.currentBox || state.currentBox.host !== state.otaTargetHost) return;
-    buttons().forEach(b => { b.textContent = text; b.disabled = true; });
+    // Idempotent: only touch the DOM when a value actually changes. The 1 s
+    // countdown tick called this every second during the post-update wait, and
+    // re-setting `disabled` each time re-triggered the button's CSS transition,
+    // which read as a per-second flicker through the whole 2nd (Spotify) upload.
+    buttons().forEach(b => {
+      if (b.textContent !== text) b.textContent = text;
+      if (!b.disabled) b.disabled = true;
+    });
   };
   const reset = () => {
     if (!state.currentBox || state.currentBox.host !== state.otaTargetHost) return;


### PR DESCRIPTION
## What

During the post-update wait, a 1 s countdown tick called `setStatus` every second, which unconditionally rewrote the update button's text AND re-set `disabled=true` even when nothing had changed. Make `setStatus` idempotent so it only touches the DOM on a real change.

## Why

A user reported a per-second flicker during the second (Spotify engine) upload phase and traced it to the 1 s status tick.

## Honesty note

I could not reproduce this locally: there is no Go/Wails toolchain on the dev machine to run the desktop app, so this change targets the clearly-redundant per-tick writes rather than a confirmed repaint cause. The countdown text itself still changes every second (M:SS), so if the flicker persists on-device, the next step is to isolate the countdown number into its own element so the surrounding sentence node is not rebuilt each tick. Needs on-device confirmation at the next update.