### PR TITLE
v0.9.11: presets no longer vanish after standby (durable writes + backup recovery)

### DIFF
--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -1,0 +1,65 @@
+// Package atomicfile writes a file durably, so an unclean shutdown cannot leave
+// it empty or torn.
+//
+// A plain os.WriteFile followed by os.Rename is ATOMIC for a concurrent reader
+// (it sees either the old file or the whole new one) but it is NOT DURABLE: the
+// rename's metadata can reach stable storage while the file's data blocks are
+// still sitting in the page cache. If power is lost at that moment, the renamed
+// file is present but its data is gone, so it comes back as ZERO BYTES.
+//
+// On the SoundTouch speakers this is not a corner case. They cut power at
+// standby, so a file written shortly before an overnight standby routinely came
+// back empty the next morning: presets.json and last-play.json were found at 0
+// bytes on users' boxes, which wiped every preset (2026-07-15). WriteFile fixes
+// that by fsyncing the data to flash BEFORE the rename and fsyncing the directory
+// AFTER, so both the data and the rename survive a power-cut.
+package atomicfile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// WriteFile durably writes data to path. It writes a sibling temp file (same
+// directory, so the rename stays on one filesystem and is itself atomic),
+// fsyncs its data, renames it over path, then fsyncs the directory. On any
+// failure the temp file is removed and the original path is left untouched.
+func WriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp := path + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
+	if err != nil {
+		return fmt.Errorf("open temp: %w", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("write temp: %w", err)
+	}
+	// fsync the DATA to flash before the rename. This is the step that makes the
+	// write survive a power-cut: without it the rename can land while the data is
+	// still buffered, leaving a 0-byte file after the next unclean boot.
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("fsync temp: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename: %w", err)
+	}
+	// fsync the DIRECTORY so the rename itself is durable; otherwise a power loss
+	// just after the rename could revert path to its old entry. Best-effort: some
+	// filesystems do not allow opening a directory for sync, and the data fsync
+	// above is the part that prevents the 0-byte loss.
+	if d, derr := os.Open(dir); derr == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
+	return nil
+}

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -1,0 +1,57 @@
+package atomicfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteFileCreatesAndReadsBack(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "presets.json")
+	want := []byte(`{"presets":[{"slot":1}]}`)
+	if err := WriteFile(p, want, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("content = %q, want %q", got, want)
+	}
+	// The temp sibling must not survive a successful write.
+	if _, err := os.Stat(p + ".tmp"); !os.IsNotExist(err) {
+		t.Fatalf("temp file left behind: %v", err)
+	}
+}
+
+func TestWriteFileOverwritesAtomically(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "last-play.json")
+	if err := WriteFile(p, []byte("old-and-longer-content"), 0o644); err != nil {
+		t.Fatalf("first WriteFile: %v", err)
+	}
+	if err := WriteFile(p, []byte("new"), 0o644); err != nil {
+		t.Fatalf("second WriteFile: %v", err)
+	}
+	got, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("content = %q, want %q (no truncation leftover)", got, "new")
+	}
+}
+
+// A directory in place of the target must fail cleanly, leaving nothing torn.
+func TestWriteFileTargetIsDir(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "adir")
+	if err := os.Mkdir(p, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteFile(p, []byte("x"), 0o644); err == nil {
+		t.Fatal("expected error writing over a directory, got nil")
+	}
+}

--- a/internal/presets/presets.go
+++ b/internal/presets/presets.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"os"
 	"sync"
+
+	"github.com/JRpersonal/streborn/internal/atomicfile"
 )
 
 // Preset describes a single preset slot.
@@ -250,9 +252,10 @@ func (s *Store) Save() error {
 	if err != nil {
 		return fmt.Errorf("serialize presets: %w", err)
 	}
-	tmp := s.path + ".tmp"
-	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+	// Durable write (fsync + rename): a plain write+rename left presets.json at 0
+	// bytes after a speaker's overnight standby power-cut, wiping every preset.
+	if err := atomicfile.WriteFile(s.path, b, 0o644); err != nil {
 		return fmt.Errorf("write presets: %w", err)
 	}
-	return os.Rename(tmp, s.path)
+	return nil
 }

--- a/internal/presets/presets.go
+++ b/internal/presets/presets.go
@@ -15,6 +15,7 @@
 package presets
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -114,38 +115,69 @@ type Store struct {
 // New creates an empty Store without a persistence path.
 func New() *Store { return &Store{} }
 
-// Load reads the presets.json from the given path.
-// If the file does not exist or is empty, an empty Store is returned.
-// On parse error an empty Store is also returned plus the error so the
-// caller decides whether it crashes or continues.
+// Load reads presets.json from path. A primary that is MISSING, ZERO BYTES, or
+// unparseable is recovered from the durable backup (presets.json.bak, written on
+// every non-empty save), and the primary is rewritten from it: this brings back a
+// preset store that a power-cut truncated to 0 bytes (the overnight-standby data
+// loss) instead of coming up empty. A genuinely empty preset set (an explicit
+// clear, stored as {"presets":null}) is honored, NOT treated as loss. With no
+// usable primary and no backup, an empty Store is returned (first boot). A parse
+// error with no backup returns an empty Store plus the error so the caller
+// decides whether to crash or continue.
 func Load(path string) (*Store, error) {
 	s := &Store{path: path}
 	b, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return s, nil
-		}
+	if err != nil && !os.IsNotExist(err) {
 		return s, fmt.Errorf("read presets: %w", err)
 	}
-	if len(b) == 0 {
-		return s, nil
+	// A non-empty, parseable primary is authoritative (an explicit empty set
+	// parses fine and is kept as-is).
+	if len(b) > 0 {
+		if data, perr := parse(b); perr == nil {
+			s.data = data
+			return s, nil
+		}
+		// Primary present but corrupt: fall through to the backup.
 	}
-
-	// First try the array format
-	var arr []rawPreset
-	if err := json.Unmarshal(b, &arr); err == nil {
-		s.data = normalize(arr)
-		return s, nil
+	// Primary missing / 0 bytes / corrupt: recover from the durable backup.
+	if bb, berr := os.ReadFile(path + ".bak"); berr == nil && len(bb) > 0 {
+		if data, perr := parse(bb); perr == nil && len(data) > 0 {
+			s.data = data
+			// Restore the primary durably so the box is whole again and
+			// GET /api/presets stops returning empty. Best-effort.
+			_ = atomicfile.WriteFile(path, bb, 0o644)
+			return s, nil
+		}
 	}
-
-	// Then the object format with "presets" wrapper
-	var wrap rawWrapper
-	if err := json.Unmarshal(b, &wrap); err == nil && wrap.Presets != nil {
-		s.data = normalize(wrap.Presets)
-		return s, nil
+	if len(b) > 0 {
+		return s, fmt.Errorf("parse presets: unknown format in %s", path)
 	}
+	return s, nil
+}
 
-	return s, fmt.Errorf("parse presets: unknown format in %s", path)
+// parse decodes presets in either supported layout. A bare array [ ... ] and the
+// wrapper object {"presets":[ ... ]} are both accepted; {"presets":null} and []
+// decode to an empty (but valid) set. Malformed JSON returns an error.
+func parse(b []byte) ([]Preset, error) {
+	trimmed := bytes.TrimSpace(b)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	switch trimmed[0] {
+	case '[':
+		var arr []rawPreset
+		if err := json.Unmarshal(b, &arr); err != nil {
+			return nil, err
+		}
+		return normalize(arr), nil
+	case '{':
+		var wrap rawWrapper
+		if err := json.Unmarshal(b, &wrap); err != nil {
+			return nil, err
+		}
+		return normalize(wrap.Presets), nil
+	}
+	return nil, fmt.Errorf("unknown format")
 }
 
 // normalize converts rawPreset into Preset, with alias resolution.
@@ -256,6 +288,12 @@ func (s *Store) Save() error {
 	// bytes after a speaker's overnight standby power-cut, wiping every preset.
 	if err := atomicfile.WriteFile(s.path, b, 0o644); err != nil {
 		return fmt.Errorf("write presets: %w", err)
+	}
+	// Keep a durable backup of the last NON-EMPTY preset set so a primary that is
+	// ever lost can be recovered on the next load (see Load). Never back up an
+	// empty set: a stray empty save must not erase the safety net.
+	if len(s.data) > 0 {
+		_ = atomicfile.WriteFile(s.path+".bak", b, 0o644)
 	}
 	return nil
 }

--- a/internal/presets/presets_test.go
+++ b/internal/presets/presets_test.go
@@ -1,10 +1,67 @@
 package presets
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
 )
+
+// A primary presets.json truncated to 0 bytes (the overnight-standby power-cut
+// loss) must be recovered from the durable backup on the next Load, and the
+// primary rewritten from it.
+func TestBackupRecoversZeroedPrimary(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "presets.json")
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load(new): %v", err)
+	}
+	if err := s.SetSlot(Preset{Slot: 1, Name: "NDR2", Type: "radio", StreamURL: "http://example/ndr2.mp3"}); err != nil {
+		t.Fatalf("SetSlot: %v", err)
+	}
+	// The save must have produced a durable backup.
+	if _, err := os.Stat(path + ".bak"); err != nil {
+		t.Fatalf("backup not written: %v", err)
+	}
+	// Simulate the power-cut loss: primary is now 0 bytes.
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reloaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load(after zeroing): %v", err)
+	}
+	got, ok := reloaded.Get(1)
+	if !ok || got.Name != "NDR2" || got.StreamURL != "http://example/ndr2.mp3" {
+		t.Fatalf("preset not recovered from backup: %+v ok=%v", got, ok)
+	}
+	// The primary must have been rewritten (non-empty) so the box is whole again.
+	if b, _ := os.ReadFile(path); len(b) == 0 {
+		t.Fatal("primary was not restored from backup")
+	}
+}
+
+// An explicit empty preset set ({"presets":null}) is a valid state and must NOT
+// be overridden by the backup, or clearing presets would be impossible.
+func TestExplicitEmptyNotRecovered(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "presets.json")
+	// A backup exists with content...
+	if err := os.WriteFile(path+".bak", []byte(`{"presets":[{"slot":1,"name":"Old"}]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// ...but the primary is a deliberate empty set, not a 0-byte loss.
+	if err := os.WriteFile(path, []byte(`{"presets":null}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if n := len(s.All()); n != 0 {
+		t.Fatalf("explicit empty set was overridden by backup: %d presets", n)
+	}
+}
 
 // normalize must carry the Spotify fields (Type/URI/Account) through, and
 // keep defaulting Type to "radio" for legacy entries that omit it.

--- a/internal/recent/recent.go
+++ b/internal/recent/recent.go
@@ -28,6 +28,8 @@ import (
 	"os"
 	"sync"
 	"time"
+
+	"github.com/JRpersonal/streborn/internal/atomicfile"
 )
 
 // maxEntries caps the ring. #135 specifies "last 30 tracks across all sources".
@@ -43,14 +45,14 @@ const flushDelay = 90 * time.Second
 // for the same card repeat the card fields; that redundancy keeps the box logic
 // trivial and the file self-contained.
 type Entry struct {
-	TS       string `json:"ts"`                // RFC3339, when this play/track started
-	Source   string `json:"source"`            // "radio" | "spotify" | "upnp" | "airplay" | ...
-	CardKey  string `json:"cardKey"`           // stable group key (replay target identity)
-	CardName string `json:"cardName"`          // station / playlist / folder name
-	CardArt  string `json:"cardArt,omitempty"` // logo / cover URL
-	CardURL  string `json:"cardURL,omitempty"` // replay target: stream URL / spotify URI / NAS location
-	Track    string `json:"track,omitempty"`   // song / track title; empty for stations without ICY
-	Account  string `json:"account,omitempty"` // sourceAccount (e.g. which Spotify account)
+	TS       string `json:"ts"`                 // RFC3339, when this play/track started
+	Source   string `json:"source"`             // "radio" | "spotify" | "upnp" | "airplay" | ...
+	CardKey  string `json:"cardKey"`            // stable group key (replay target identity)
+	CardName string `json:"cardName"`           // station / playlist / folder name
+	CardArt  string `json:"cardArt,omitempty"`  // logo / cover URL
+	CardURL  string `json:"cardURL,omitempty"`  // replay target: stream URL / spotify URI / NAS location
+	Track    string `json:"track,omitempty"`    // song / track title; empty for stations without ICY
+	Account  string `json:"account,omitempty"`  // sourceAccount (e.g. which Spotify account)
 	Homepage string `json:"homepage,omitempty"` // station website, for the "website" link (radio)
 }
 
@@ -285,12 +287,13 @@ func (s *Store) Flush() error {
 	s.dirty = false
 	s.mu.Unlock()
 
-	tmp := s.path + ".tmp"
-	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+	// Durable write (fsync + rename): a plain write+rename can leave the file at
+	// 0 bytes after a speaker's standby power-cut.
+	if err := atomicfile.WriteFile(s.path, b, 0o644); err != nil {
 		s.mu.Lock()
 		s.dirty = true // write failed; re-arm on the next Add
 		s.mu.Unlock()
 		return fmt.Errorf("recent write: %w", err)
 	}
-	return os.Rename(tmp, s.path)
+	return nil
 }

--- a/internal/spotify/resume.go
+++ b/internal/spotify/resume.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/JRpersonal/streborn/internal/atomicfile"
 )
 
 // resumeStore remembers, per Spotify context (a playlist or album URI), the
@@ -146,13 +148,9 @@ func (s *resumeStore) flush() {
 	if err != nil || s.path == "" {
 		return
 	}
-	tmp := s.path + ".tmp"
-	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+	// Durable write (fsync + rename): a plain write+rename can leave the file at
+	// 0 bytes after a speaker's standby power-cut.
+	if err := atomicfile.WriteFile(s.path, b, 0o644); err != nil {
 		s.logger.Debug("spotify: resume store write failed", "err", err)
-		return
-	}
-	if err := os.Rename(tmp, s.path); err != nil {
-		s.logger.Debug("spotify: resume store rename failed", "err", err)
-		_ = os.Remove(tmp) // don't orphan the temp file on NAND
 	}
 }

--- a/internal/webhooks/webhooks.go
+++ b/internal/webhooks/webhooks.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/JRpersonal/streborn/internal/atomicfile"
 )
 
 // Action is one configured trigger action. Type selects the transport: an HTTP
@@ -172,12 +174,9 @@ func (s *Store) save(c Config) error {
 	if err != nil {
 		return err
 	}
-	tmp := s.path + ".new"
-	if err := os.WriteFile(tmp, b, 0o644); err != nil {
-		return err
-	}
-	if err := os.Rename(tmp, s.path); err != nil {
-		_ = os.Remove(tmp)
+	// Durable write (fsync + rename): a plain write+rename can leave the file at
+	// 0 bytes after a speaker's standby power-cut.
+	if err := atomicfile.WriteFile(s.path, b, 0o644); err != nil {
 		return err
 	}
 	return nil

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -29,6 +29,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/JRpersonal/streborn/internal/atomicfile"
 	"github.com/JRpersonal/streborn/internal/autopair"
 	"github.com/JRpersonal/streborn/internal/boxapi"
 	"github.com/JRpersonal/streborn/internal/boxcli"
@@ -1964,9 +1965,11 @@ type persistedLastPlay struct {
 	LastResumeAt   time.Time `json:"lastResumeAt,omitzero"`
 }
 
-// persistLastPlay writes the resume target to NAND atomically (temp + rename),
-// so a power loss mid-write cannot leave a torn file. Best-effort, no-op without
-// a configured path.
+// persistLastPlay writes the resume target to NAND durably (fsync + rename), so
+// a power loss mid-write cannot leave a torn OR zero-byte file. A plain
+// write+rename left last-play.json at 0 bytes after an overnight standby
+// power-cut (the same loss that wiped presets.json, 2026-07-15). Best-effort,
+// no-op without a configured path.
 func (s *Server) persistLastPlay(boxURL, title, art, mime string, ts time.Time, resumeAttempts int, lastResumeAt time.Time) {
 	if s.lastPlayPath == "" {
 		return
@@ -1976,17 +1979,11 @@ func (s *Server) persistLastPlay(boxURL, title, art, mime string, ts time.Time, 
 	if err != nil {
 		return
 	}
-	tmp := s.lastPlayPath + ".tmp"
 	// Warn, not Debug: on a full NAND this is the ONLY trace of why the
 	// power-on resume has no station to bring back after the next standby
 	// (#119, ST30 with a full /mnt/nv).
-	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+	if err := atomicfile.WriteFile(s.lastPlayPath, b, 0o644); err != nil {
 		s.logger.Warn("last-play persist failed", "err", err)
-		return
-	}
-	if err := os.Rename(tmp, s.lastPlayPath); err != nil {
-		s.logger.Warn("last-play rename failed", "err", err)
-		_ = os.Remove(tmp)
 	}
 }
 

--- a/internal/zones/zones.go
+++ b/internal/zones/zones.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"os"
 	"sync"
+
+	"github.com/JRpersonal/streborn/internal/atomicfile"
 )
 
 // Member is one speaker in a zone: its stable deviceID plus a last-known IP
@@ -134,9 +136,10 @@ func (s *Store) Save() error {
 	} else if b, err = json.MarshalIndent(s.zone, "", "  "); err != nil {
 		return fmt.Errorf("marshal zones: %w", err)
 	}
-	tmp := s.path + ".tmp"
-	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+	// Durable write (fsync + rename): a plain write+rename can leave the file at
+	// 0 bytes after a speaker's standby power-cut.
+	if err := atomicfile.WriteFile(s.path, b, 0o644); err != nil {
 		return fmt.Errorf("write zones: %w", err)
 	}
-	return os.Rename(tmp, s.path)
+	return nil
 }


### PR DESCRIPTION
Fixes a critical data-loss bug: after an overnight standby, speakers came up with **all presets gone** ("service unavailable" on every preset). Reported by several users on v0.9.9/v0.9.10; confirmed in a diagnostic (presets.json and last-play.json both **0 bytes**, everything else intact).

## Cause
The on-box JSON stores wrote a temp file and renamed it into place, which is atomic for a reader but **not durable**. On the speaker's flash the rename's metadata can reach storage while the data is still buffered, and the speakers **cut power at standby** — so a file written shortly before standby came back empty.

## Fix
- **`internal/atomicfile.WriteFile`**: fsync the data to flash before the rename, fsync the directory after. Routed through every on-box store: presets, last-play, recently-played, zones, Spotify resume, webhooks.
- **Preset backup + recovery**: every non-empty save also writes a durable `presets.json.bak`; a primary that is missing, zero-byte, or corrupt is recovered from it on load and the primary rewritten. A deliberately empty set (`{"presets":null}`) is honored, not overridden.

## Verified
- Build deployed to an ST10 over the air: presets load intact (no regression on the load path).
- Unit tests cover durable write, atomic overwrite, backup recovery of a zeroed primary, and the explicit-empty case.

A box already wiped before this ships has no backup yet, so it needs its presets added once, after which they are protected permanently.