### PR TITLE
ci: watch desktop-app module in Dependabot + guard go.mod drift

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,29 @@ updates:
       go-minor-patch:
         update-types: ["minor", "patch"]
 
+  # Desktop-app Go module. It is a SEPARATE module from the main one and shares
+  # transitive deps (golang.org/x/...) with it. Without watching it here, a
+  # Dependabot bump of the main module left the desktop-app go.mod stale and the
+  # build workflow's "go vet ./..." failed with "updates to go.mod needed"
+  # (2026-07-15). Watch it too so both modules move together.
+  - package-ecosystem: "gomod"
+    directory: "/desktop-app"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "go"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      go-minor-patch:
+        update-types: ["minor", "patch"]
+
   # Website npm dependencies have moved to a separate repository.
   # When the /website folder is removed from this repo, drop nothing
   # else here - this section already does not exist.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,20 @@ jobs:
           cache: true
           cache-dependency-path: desktop-app/go.sum
 
+      # Guard against the desktop-app module's go.mod/go.sum drifting out of tidy
+      # (e.g. a Dependabot bump of the main module that did not update this one):
+      # that made `go vet` fail with "updates to go.mod needed" and turned the
+      # whole workflow red while releases still shipped (2026-07-15). Fail early
+      # with an actionable message instead.
+      - name: go.mod tidy check
+        working-directory: desktop-app
+        run: |
+          go mod tidy
+          if ! git diff --exit-code go.mod go.sum; then
+            echo "::error::desktop-app go.mod/go.sum are not tidy. Run 'go mod tidy' in desktop-app and commit the result."
+            exit 1
+          fi
+
       - name: go vet
         working-directory: desktop-app
         run: go vet ./...


### PR DESCRIPTION
Prevents the red-build cause (#409) from recurring: a Dependabot entry for the /desktop-app Go module so its shared `golang.org/x` deps move with the main module, plus a `go mod tidy` drift check in the Desktop app build job that fails early and actionably instead of the opaque `go vet` "updates to go.mod needed".