### PR TITLE
fix(agent): recover a preset the speaker accepts but never plays (Wave wrong-state race)

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1822,6 +1822,15 @@ func (h *presetWsHandler) verifyPlayURL(slot int, url, name, icon, mime string) 
 	// initial play's SOAP round-trip, so the transient STOP_STATE that flip
 	// itself can emit has usually already been recorded and does not count.
 	recallStart := time.Now()
+	// Fast recovery for the wrong-state race, before the 5 s loop below: on a
+	// Wave the box answers every hardware press with 1036
+	// UpnpRcvdContentItemInWrongState about 0.8 s in, because it first tries to
+	// activate its OWN stored ContentItem (which no longer works without the
+	// Bose cloud) and STR's push lands while that teardown is still running.
+	// Waiting a full verify tick to react leaves the user in silence for five
+	// seconds; re-pushing as soon as the rejection is visible is the automatic
+	// version of the second press users learned to do by hand.
+	h.rePushAfterSourceReject(slot, url, name, icon, mime, recallStart)
 	// Up to 5 attempts (~25s): a box waking from a deep/overnight standby can
 	// take longer than the old 3-attempt (~15s) window to finish bringing its
 	// network and playback subsystem back up before it accepts the stream (#183).
@@ -1872,6 +1881,45 @@ func (h *presetWsHandler) verifyPlayURL(slot int, url, name, icon, mime string) 
 	h.logger.Warn("hardware recall still not playing after retries", "slot", slot)
 	if h.noteRecallExhausted != nil {
 		h.noteRecallExhausted()
+	}
+}
+
+// sourceRejectProbeDelay is how long verifyPlayURL waits before looking for a
+// wrong-state rejection of the recall it just pushed. The box reports the 1036
+// about 0.8 s after a hardware press and its source flap settles within ~50 ms
+// of that, so this both catches the rejection and lets the teardown finish; a
+// recall that simply started normally is already playing by now and is left
+// alone.
+const sourceRejectProbeDelay = 1500 * time.Millisecond
+
+// rePushAfterSourceReject re-issues a recall the box refused with 1036
+// UpnpRcvdContentItemInWrongState, without waiting for the first 5 s verify
+// tick. The rejection means the box positively declined this stream, so
+// pushing it again is a repair rather than a guess; a recall that is already
+// playing, a box the user powered off, and a deliberate stop are all left
+// alone. Fires at most once per recall: the verify loop owns everything after
+// it.
+func (h *presetWsHandler) rePushAfterSourceReject(slot int, url, name, icon, mime string, recallStart time.Time) {
+	time.Sleep(sourceRejectProbeDelay)
+	if !h.lastSourceRejectTime().After(recallStart) {
+		return // the box did not refuse this recall; the normal verify governs
+	}
+	if boxPlayingURL(h.boxHost, url) {
+		return // refused once, then started anyway
+	}
+	if h.recentlyPoweredOff != nil && h.recentlyPoweredOff() {
+		return // #197: never push into a box the user just switched off
+	}
+	if h.userStoppedSince(recallStart) {
+		return
+	}
+	h.logger.Warn("hardware recall: box refused the stream (wrong state), pushing it again", "slot", slot)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if mime != "" {
+		_ = h.renderer.PlayURLMime(ctx, url, name, icon, mime)
+	} else {
+		_ = h.renderer.PlayURL(ctx, url, name, icon)
 	}
 }
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1827,7 +1827,17 @@ func (h *presetWsHandler) verifyPlayURL(slot int, url, name, icon, mime string) 
 	// network and playback subsystem back up before it accepts the stream (#183).
 	for attempt := 1; attempt <= 5; attempt++ {
 		time.Sleep(5 * time.Second)
-		if boxIsPlaying(h.boxHost) {
+		// Success means the box is playing THIS recall, not merely "some play
+		// state". A bare play-state check silently passed the exact failure the
+		// verify exists for: on a Wave every hardware press is rejected with 1036
+		// UpnpRcvdContentItemInWrongState, the box then flips UPNP -> INVALID_SOURCE
+		// -> UPNP while still reporting a stale PLAY/BUFFERING state from the
+		// previous stream, and it never fetches the new URL. boxIsPlaying read that
+		// as success at the first tick, so the recall returned silently: the display
+		// showed the station, no audio ever came, no retry ran and no wedge strike
+		// was recorded. The Spotify verify already keys off the now_playing location
+		// for this very reason (see boxPlayingSpotify); radio now does too.
+		if boxPlayingURL(h.boxHost, url) {
 			if h.noteBoxHealthy != nil {
 				h.noteBoxHealthy()
 			}
@@ -2897,6 +2907,62 @@ func boxIsPlaying(boxHost string) bool {
 	b, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
 	s := string(b)
 	return strings.Contains(s, "PLAY_STATE") || strings.Contains(s, "BUFFERING_STATE")
+}
+
+// boxPlayingURL reports whether the box is in a play/buffering state AND its
+// now_playing actually points at wantURL, the URL this recall pushed. It is the
+// success signal for the radio recall verify.
+//
+// The location check is what a bare play-state check misses: a box that rejects
+// the recall (1036 UpnpRcvdContentItemInWrongState, chronic on the Wave) keeps
+// reporting the PREVIOUS stream's play state while never fetching the new one,
+// so the verify passed at its first tick and the user was left with a display
+// that shows the station and no audio at all.
+//
+// Deliberately forgiving in one direction: firmware whose now_playing carries NO
+// location at all falls back to the plain play-state verdict, so a model that
+// simply does not report a location does not end up in an endless re-push loop.
+func boxPlayingURL(boxHost, wantURL string) bool {
+	if boxHost == "" {
+		boxHost = "127.0.0.1"
+	}
+	cl := &http.Client{Timeout: 4 * time.Second}
+	resp, err := cl.Get("http://" + boxHost + ":8090/now_playing")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+	return nowPlayingIsURL(string(b), wantURL)
+}
+
+// nowPlayingIsURL is boxPlayingURL's verdict over an already-fetched
+// now_playing document; split out so the discriminator is testable without
+// hardware or a fixed :8090 listener.
+func nowPlayingIsURL(doc, wantURL string) bool {
+	if !strings.Contains(doc, "PLAY_STATE") && !strings.Contains(doc, "BUFFERING_STATE") {
+		return false
+	}
+	// Compare on the path (e.g. "/stream/5"), not the whole URL: the box echoes
+	// the location it was given, but host spellings differ across the paths that
+	// build these URLs (loopback vs the box's LAN address).
+	want := streamPath(wantURL)
+	if want == "" || !strings.Contains(doc, `location="`) {
+		return true // nothing to compare against; keep the old play-state verdict
+	}
+	return strings.Contains(doc, want)
+}
+
+// streamPath reduces an STR stream URL to the path+query the box echoes back in
+// now_playing ("http://127.0.0.1:8888/stream/5" -> "/stream/5"), so a location
+// comparison does not depend on which host spelling built the URL. Returns ""
+// for anything that is not an STR stream URL, which disables the comparison.
+func streamPath(u string) string {
+	i := strings.Index(u, "/stream/")
+	if i < 0 {
+		return ""
+	}
+	return u[i:]
 }
 
 // boxPlayingSpotify reports whether the box's now_playing is STR's Spotify

--- a/cmd/agent/recall_verify_location_test.go
+++ b/cmd/agent/recall_verify_location_test.go
@@ -1,6 +1,32 @@
 package main
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
+
+// TestSourceRejectIsScopedToThisRecall covers the trigger of the fast re-push:
+// only a wrong-state rejection recorded AFTER this recall started may cause it.
+// An older rejection (e.g. from the previous preset press) must not, or every
+// recall following one rejection would be pushed twice.
+func TestSourceRejectIsScopedToThisRecall(t *testing.T) {
+	h := &presetWsHandler{}
+
+	// The box reports the rejection ~0.8 s after the press; a couple of
+	// milliseconds is enough to establish the same ordering here.
+	recallStart := time.Now()
+	time.Sleep(2 * time.Millisecond)
+	h.OnSourceRejected(nil)
+	if !h.lastSourceRejectTime().After(recallStart) {
+		t.Fatal("a rejection during this recall must be visible to the verify")
+	}
+
+	// A rejection that predates the recall must not count.
+	later := time.Now().Add(time.Second)
+	if h.lastSourceRejectTime().After(later) {
+		t.Fatal("a rejection older than the recall must not trigger the re-push")
+	}
+}
 
 // The radio recall verify decides success from the box's now_playing document.
 // These cover nowPlayingIsURL, the discriminator behind boxPlayingURL.

--- a/cmd/agent/recall_verify_location_test.go
+++ b/cmd/agent/recall_verify_location_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -16,7 +17,7 @@ func TestSourceRejectIsScopedToThisRecall(t *testing.T) {
 	// milliseconds is enough to establish the same ordering here.
 	recallStart := time.Now()
 	time.Sleep(2 * time.Millisecond)
-	h.OnSourceRejected(nil)
+	h.OnSourceRejected(context.Background())
 	if !h.lastSourceRejectTime().After(recallStart) {
 		t.Fatal("a rejection during this recall must be visible to the verify")
 	}

--- a/cmd/agent/recall_verify_location_test.go
+++ b/cmd/agent/recall_verify_location_test.go
@@ -1,0 +1,88 @@
+package main
+
+import "testing"
+
+// The radio recall verify decides success from the box's now_playing document.
+// These cover nowPlayingIsURL, the discriminator behind boxPlayingURL.
+
+// TestNowPlayingIsURL_StalePlayStateOnOtherStream is the field failure the
+// verify used to pass silently: a Wave rejects the recall (1036
+// UpnpRcvdContentItemInWrongState), never fetches the new slot, but keeps
+// reporting the PREVIOUS stream in a play state. Counting that as success made
+// the verify return at its first tick, so no retry ran and the user was left
+// with a display that shows the station and no audio at all.
+func TestNowPlayingIsURL_StalePlayStateOnOtherStream(t *testing.T) {
+	doc := `<?xml version="1.0" encoding="UTF-8" ?><nowPlaying deviceID="x" source="UPNP">` +
+		`<ContentItem source="UPNP" location="http://127.0.0.1:8888/stream/4"><itemName>RSH Live</itemName></ContentItem>` +
+		`<playStatus>PLAY_STATE</playStatus></nowPlaying>`
+
+	if nowPlayingIsURL(doc, "http://127.0.0.1:8888/stream/1") {
+		t.Fatal("a play state on a DIFFERENT stream must not count as this recall playing")
+	}
+}
+
+// TestNowPlayingIsURL_MatchingStreamPlays: the ordinary success case still
+// passes, including when the box echoes the location with a different host
+// spelling than the one that built the URL.
+func TestNowPlayingIsURL_MatchingStreamPlays(t *testing.T) {
+	doc := `<?xml version="1.0" encoding="UTF-8" ?><nowPlaying deviceID="x" source="UPNP">` +
+		`<ContentItem source="UPNP" location="http://192.168.1.50:8888/stream/5"><itemName>RSH Sylt</itemName></ContentItem>` +
+		`<playStatus>BUFFERING_STATE</playStatus></nowPlaying>`
+
+	if !nowPlayingIsURL(doc, "http://127.0.0.1:8888/stream/5") {
+		t.Fatal("the box playing this recall's slot must count as success regardless of host spelling")
+	}
+}
+
+// TestNowPlayingIsURL_NoLocationKeepsPlayStateVerdict: firmware whose
+// now_playing carries no location must keep the old play-state behaviour, so it
+// cannot fall into an endless re-push loop.
+func TestNowPlayingIsURL_NoLocationKeepsPlayStateVerdict(t *testing.T) {
+	doc := `<?xml version="1.0" encoding="UTF-8" ?><nowPlaying deviceID="x" source="UPNP">` +
+		`<playStatus>PLAY_STATE</playStatus></nowPlaying>`
+
+	if !nowPlayingIsURL(doc, "http://127.0.0.1:8888/stream/2") {
+		t.Fatal("without a reported location the plain play-state verdict must stand")
+	}
+}
+
+// TestNowPlayingIsURL_StandbyIsNotPlaying guards the obvious negative.
+func TestNowPlayingIsURL_StandbyIsNotPlaying(t *testing.T) {
+	doc := `<?xml version="1.0" encoding="UTF-8" ?><nowPlaying deviceID="x" source="STANDBY">` +
+		`<ContentItem source="STANDBY" /></nowPlaying>`
+
+	if nowPlayingIsURL(doc, "http://127.0.0.1:8888/stream/3") {
+		t.Fatal("a box in standby is not playing this recall")
+	}
+}
+
+// TestNowPlayingIsURL_RawStreamMatches covers the app-driven play path, whose
+// URL carries a query string.
+func TestNowPlayingIsURL_RawStreamMatches(t *testing.T) {
+	raw := "http://127.0.0.1:8888/stream/raw?u=aHR0cDovL2V4YW1wbGU"
+	doc := `<?xml version="1.0" encoding="UTF-8" ?><nowPlaying source="UPNP">` +
+		`<ContentItem source="UPNP" location="` + raw + `" /><playStatus>PLAY_STATE</playStatus></nowPlaying>`
+
+	if !nowPlayingIsURL(doc, raw) {
+		t.Fatal("an app-driven raw-stream play must verify against its own URL")
+	}
+	if nowPlayingIsURL(doc, "http://127.0.0.1:8888/stream/2") {
+		t.Fatal("a raw-stream play must not satisfy a slot recall's verify")
+	}
+}
+
+// TestStreamPath covers the comparison key, including the non-STR URL that
+// disables the comparison.
+func TestStreamPath(t *testing.T) {
+	cases := map[string]string{
+		"http://127.0.0.1:8888/stream/5":        "/stream/5",
+		"http://127.0.0.1:8888/stream/raw?u=aB": "/stream/raw?u=aB",
+		"https://example.com/live.mp3":          "",
+		"":                                      "",
+	}
+	for in, want := range cases {
+		if got := streamPath(in); got != want {
+			t.Errorf("streamPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Root-cause fix for a Wave owner's report (mailed diagnostics, three bundles, 2026-07-19; same failure still present on v0.9.13).

**What the speaker does.** On a Wave every hardware preset press is answered with `1036 UNABLE_TO_PROCESS_NOT_LOGGED_IN / UpnpRcvdContentItemInWrongState`, followed by a `UPNP -> INVALID_SOURCE -> UPNP` flap: the box first tries to activate its OWN stored ContentItem, which no longer works post-cloud, and STR's push lands mid-teardown. App-driven playback never triggers it (0 occurrences in the app-play bundle vs 3 and 4 in the press bundles), because nothing tries to self-activate there. Whoever wins that race decides the symptom the user sees:

- STR's push wins -> audio plays, display shows a bare "UPnP" instead of the station name.
- The box's own activation wins -> display shows the station name, the box never fetches the stream, silence.

Both of the reporter's complaints are the two outcomes of that one race. It also matches the independent Wave report in discussion #182 ("randomly either UPNP or the station name").

**The STR bug.** The silent case was invisible to STR. For the failing press there is no `stream proxy start` at all, yet all three bundles contain **zero** retry lines, no wedge strike, `boxHealth: "ok"`. `verifyPlayURL` has exactly one silent exit (`boxIsPlaying == true`); every other path logs. So the Wave reported the PREVIOUS stream as playing and the verify passed on its first tick. `boxIsPlaying` is a bare substring test for `PLAY_STATE`/`BUFFERING_STATE` with no location check, while the Spotify verify has keyed off the location since #22 for precisely this reason.

## Changes

1. **Location-aware radio verify.** Success now means the box is on THIS recall's stream, not merely in some play state. Firmware that reports no location keeps the old play-state verdict, so no model can be pushed into a re-push loop.
2. **Fast repair on refusal.** When the box refuses the recall with the wrong-state error, STR pushes it again ~1.5 s later instead of waiting a full 5 s verify tick: the automatic form of the second press users learned to do by hand. Scoped to a rejection recorded after this recall started, and it stands down for an already-playing recall, a powered-off box (#197) and a deliberate stop.

## Verification

- New tests cover the exact field signature (stale play state on a different stream), the success case across host spellings, the no-location fallback, standby, the raw-stream form, and the rejection scoping.
- `go test ./cmd/... ./internal/...` green, gofmt clean, ARM (`GOARM=5`) cross-compile green, deployed to a Portable.
- **Not verifiable on my hardware:** I have no Wave. The reporter is the only test rig for the Wave-specific path; the fixes are written to be no-ops wherever the refusal does not occur.

## Not fixed here

The 1036 itself. These changes work around the refusal, they do not remove it. Open questions went back to the reporter.

Refs #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)