### PR TITLE
fix(agent): stop the auto-resume colliding with a fresh recall, and keep codec-less AAC presets audible

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -536,6 +536,10 @@ func run() error {
 		// clears any deliberate-stop latch an earlier (or spontaneous, #419)
 		// power-off armed, so the recall is not suppressed by stale intent.
 		noteUserPlay: webuiSrv.NoteUserPlay,
+		// Ground truth for the recall verify: the box opening a proxied stream
+		// proves it is playing, where now_playing can still name the previous
+		// preset for seconds after the switch.
+		streamActivity: streamProxySrv.LastActivity,
 		// Surface the box's own presets (incl. foreign sources like Deezer) to the
 		// webui so the app can show/preserve them (Option C). Map boxws -> webui at
 		// the composition root to keep the two packages decoupled.
@@ -1153,6 +1157,23 @@ type presetWsHandler struct {
 	// earlier stop, #419) and anchors the standby-flip discriminator. Wired to
 	// webui.Server.NoteUserPlay. nil-safe.
 	noteUserPlay func()
+	// streamActivity reports when the box last OPENED a proxied stream. It is
+	// the recall verify's ground truth: the box pulling audio through the proxy
+	// proves it is playing, whereas now_playing lags and can still name the
+	// PREVIOUS preset seconds after the box switched. Wired to
+	// streamproxy.Server.LastActivity. nil-safe.
+	streamActivity func() (lastFetch, lastFailure time.Time)
+}
+
+// pulledStreamSince reports whether the box opened a proxied stream after t,
+// i.e. it really is fetching what this recall pushed. Used by the recall verify
+// as the authoritative success signal.
+func (h *presetWsHandler) pulledStreamSince(t time.Time) bool {
+	if h.streamActivity == nil {
+		return false
+	}
+	lastFetch, _ := h.streamActivity()
+	return !lastFetch.IsZero() && lastFetch.After(t)
 }
 
 // OnPresetsChanged forwards the box's own preset list to the webui (Option C).
@@ -1849,7 +1870,12 @@ func (h *presetWsHandler) verifyPlayURL(slot int, url, name, icon, mime string) 
 		// showed the station, no audio ever came, no retry ran and no wedge strike
 		// was recorded. The Spotify verify already keys off the now_playing location
 		// for this very reason (see boxPlayingSpotify); radio now does too.
-		if boxPlayingURL(h.boxHost, url) {
+		// The box pulling a proxied stream since this recall started is proof it
+		// is playing what we pushed, and it is checked FIRST because now_playing
+		// lags: a Portable kept naming the PREVIOUS preset for seconds after it
+		// had already opened the new stream, so a location check alone declared a
+		// healthy recall dead and the "repair" tore the working stream down.
+		if h.pulledStreamSince(recallStart) || boxPlayingURL(h.boxHost, url) {
 			if h.noteBoxHealthy != nil {
 				h.noteBoxHealthy()
 			}
@@ -1907,7 +1933,7 @@ func (h *presetWsHandler) rePushAfterSourceReject(slot int, url, name, icon, mim
 	if !h.lastSourceRejectTime().After(recallStart) {
 		return // the box did not refuse this recall; the normal verify governs
 	}
-	if boxPlayingURL(h.boxHost, url) {
+	if h.pulledStreamSince(recallStart) || boxPlayingURL(h.boxHost, url) {
 		return // refused once, then started anyway
 	}
 	if h.recentlyPoweredOff != nil && h.recentlyPoweredOff() {

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1229,7 +1229,10 @@ func (h *presetWsHandler) OnPresetSelected(ctx context.Context, slot int, locati
 			name = p.Name
 		}
 		icon = p.Art
-		mime = upnp.MimeForCodec(p.Codec)
+		// A preset stored before the codec was recorded has none, and an AAC
+		// station then got the audio/mpeg default and played silence (#252). Read
+		// the codec off the station URL in that case.
+		mime = upnp.MimeForCodecOrURL(p.Codec, p.StreamURL)
 		// Fallback: NetManager occasionally fires nowSelectionUpdated
 		// with an empty location — observed when Bose's preset cache
 		// was populated while BoseApp had not yet fully loaded the

--- a/cmd/agent/recall_verify_location_test.go
+++ b/cmd/agent/recall_verify_location_test.go
@@ -98,6 +98,41 @@ func TestNowPlayingIsURL_RawStreamMatches(t *testing.T) {
 	}
 }
 
+// TestPulledStreamSince covers the verify's authoritative success signal. A
+// Portable kept naming the PREVIOUS preset in now_playing for seconds after it
+// had already opened the new stream, so a location check alone called a healthy
+// recall dead and the "repair" tore the working stream down. The box opening a
+// proxied stream after the recall started settles it.
+func TestPulledStreamSince(t *testing.T) {
+	recallStart := time.Now()
+
+	none := &presetWsHandler{}
+	if none.pulledStreamSince(recallStart) {
+		t.Fatal("without a stream-activity source there is no proof of playback")
+	}
+
+	old := &presetWsHandler{streamActivity: func() (time.Time, time.Time) {
+		return recallStart.Add(-time.Minute), time.Time{}
+	}}
+	if old.pulledStreamSince(recallStart) {
+		t.Fatal("a stream opened BEFORE this recall proves nothing about it")
+	}
+
+	fresh := &presetWsHandler{streamActivity: func() (time.Time, time.Time) {
+		return recallStart.Add(2 * time.Second), time.Time{}
+	}}
+	if !fresh.pulledStreamSince(recallStart) {
+		t.Fatal("a stream opened after the recall started means the box is playing it")
+	}
+
+	never := &presetWsHandler{streamActivity: func() (time.Time, time.Time) {
+		return time.Time{}, time.Time{}
+	}}
+	if never.pulledStreamSince(recallStart) {
+		t.Fatal("a zero timestamp must not count as playback")
+	}
+}
+
 // TestStreamPath covers the comparison key, including the non-STR URL that
 // disables the comparison.
 func TestStreamPath(t *testing.T) {

--- a/internal/upnp/mime_codec_url_test.go
+++ b/internal/upnp/mime_codec_url_test.go
@@ -1,0 +1,44 @@
+package upnp
+
+import "testing"
+
+// A preset stored without a codec used to be labelled with the audio/mpeg
+// default, so an AAC station decoded as MPEG and played silence (#252). A field
+// diagnostic showed exactly that: an AAC station saved with an empty codec,
+// whose URL plainly reads "aac-64". MimeForCodecOrURL recovers those.
+func TestMimeForCodecOrURL(t *testing.T) {
+	cases := []struct {
+		name, codec, url, want string
+	}{
+		{"stated AAC wins", "AAC", "http://x/stream.mp3", "audio/aac"},
+		{"stated HE-AAC wins", "AAC+", "http://x/stream", "audio/aac"},
+		{"stated MP3 is trusted, URL ignored", "MP3", "http://x/aac-64/s", ""},
+		{"no codec, AAC in path", "", "http://streams.rsh.de/rsh-sylt/aac-64/streams.rsh.de/", "audio/aac"},
+		{"no codec, .aac suffix", "", "http://x/live.aac", "audio/aac"},
+		{"no codec, aacp token", "", "http://x/aacp/stream", "audio/aac"},
+		{"no codec, format query", "", "http://x/s?format=aac", "audio/aac"},
+		{"no codec, MP3 URL", "", "http://icecast.ndr.de/ndr/ndr2/mp3/128/stream.mp3", ""},
+		{"no codec, no hint", "", "http://stream.rtlradio.de/schlagerliebe/mp3-192/", ""},
+		{"must not match inside a word", "", "http://x/isaachome/stream", ""},
+		{"empty everything", "", "", ""},
+	}
+	for _, c := range cases {
+		if got := MimeForCodecOrURL(c.codec, c.url); got != c.want {
+			t.Errorf("%s: MimeForCodecOrURL(%q, %q) = %q, want %q", c.name, c.codec, c.url, got, c.want)
+		}
+	}
+}
+
+// MimeForCodec itself must be unchanged: it is the authoritative path when the
+// preset states a codec.
+func TestMimeForCodecUnchanged(t *testing.T) {
+	if MimeForCodec("AAC+") != "audio/aac" {
+		t.Fatal("AAC+ must map to audio/aac")
+	}
+	if MimeForCodec("MP3") != "" {
+		t.Fatal("MP3 must keep the audio/mpeg default (empty)")
+	}
+	if MimeForCodec("") != "" {
+		t.Fatal("an absent codec must not be guessed by MimeForCodec itself")
+	}
+}

--- a/internal/upnp/upnp.go
+++ b/internal/upnp/upnp.go
@@ -288,6 +288,61 @@ func MimeForCodec(codec string) string {
 	return ""
 }
 
+// MimeForCodecOrURL is MimeForCodec with a fallback that reads the codec off
+// the stream URL when the preset carries none.
+//
+// A preset saved before the codec was recorded (or by a client that did not
+// send one) has an empty codec, so an AAC station was labelled with the
+// audio/mpeg default and the box decoded it as MPEG and played silence (#252).
+// A field diagnostic showed exactly that: an AAC station stored with no codec,
+// its URL plainly containing "aac-64". Station URLs name their codec in the
+// path far more often than not, so this recovers the common case at no cost;
+// an unrecognisable URL keeps the previous behaviour.
+func MimeForCodecOrURL(codec, streamURL string) string {
+	if m := MimeForCodec(codec); m != "" {
+		return m
+	}
+	if codec != "" {
+		return "" // the preset states a codec and it is not AAC; trust it
+	}
+	u := strings.ToLower(streamURL)
+	// Match the codec as its own path/query token ("/aac", "aac-64", ".aac",
+	// "format=aac"), never as a substring of an unrelated word.
+	for _, tok := range []string{"aac", "aacp", "aac_", "he-aac"} {
+		if containsToken(u, tok) {
+			return "audio/aac"
+		}
+	}
+	return ""
+}
+
+// containsToken reports whether s contains tok delimited by non-alphanumeric
+// characters (or the string bounds), so "aac" matches "/aac-64/" but not
+// "isaachome".
+func containsToken(s, tok string) bool {
+	for i := 0; ; {
+		j := strings.Index(s[i:], tok)
+		if j < 0 {
+			return false
+		}
+		start := i + j
+		end := start + len(tok)
+		beforeOK := start == 0 || !isAlnum(s[start-1])
+		afterOK := end == len(s) || !isAlnum(s[end])
+		if beforeOK && afterOK {
+			return true
+		}
+		i = start + 1
+		if i >= len(s) {
+			return false
+		}
+	}
+}
+
+func isAlnum(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+}
+
 // buildDIDL builds the CurrentURIMetaData XML for an audio stream.
 // DLNA renderers often want DIDL-Lite with upnp:class and res protocolInfo
 // to detect the stream codec. If iconURL is set it is embedded as

--- a/internal/webui/repush_recall_collision_test.go
+++ b/internal/webui/repush_recall_collision_test.go
@@ -1,0 +1,57 @@
+package webui
+
+import (
+	"testing"
+	"time"
+)
+
+// The auto-re-push (box-dropped-the-stream recovery) and a recall's own verify
+// used to push at the same time. A Wave diagnostic showed the result: switching
+// preset tore down the previous stream, the disconnect armed the re-push, and
+// four stream starts plus two re-pushes landed inside 1.7 s, 680 ms apart
+// despite the 2 s backoff, because each push tore down the other's stream.
+
+// TestUserPlayedRecently_OwnsRetryAfterAPress: right after a preset press or an
+// app play, the recall owns the retry and the re-push must stand down.
+func TestUserPlayedRecently_OwnsRetryAfterAPress(t *testing.T) {
+	s := &Server{}
+	if s.userPlayedRecently() {
+		t.Fatal("no play recorded yet, want false")
+	}
+
+	s.NoteUserPlay()
+	if !s.userPlayedRecently() {
+		t.Fatal("a play the user just started must own the retry")
+	}
+}
+
+// TestUserPlayedRecently_ExpiresSoTheDropRecoveryResumes: once the recall's
+// verify has run its course, an ordinary mid-playback dropout must be resumed
+// by the re-push again.
+func TestUserPlayedRecently_ExpiresSoTheDropRecoveryResumes(t *testing.T) {
+	s := &Server{}
+	s.standbyStopMu.Lock()
+	s.lastUserPlayStart = time.Now().Add(-(recallOwnsRetryWindow + time.Second))
+	s.standbyStopMu.Unlock()
+
+	if s.userPlayedRecently() {
+		t.Fatal("past the window the drop recovery must take over again")
+	}
+}
+
+// TestRecallWindowOutlivesTheVerifyStorm pins the window against the two things
+// it has to span: the wrong-state re-push and the first verify ticks. If the
+// verify's early pushes fell outside it, the collision this guard exists for
+// would come straight back.
+func TestRecallWindowOutlivesTheVerifyStorm(t *testing.T) {
+	// cmd/agent: the wrong-state re-push fires at 1.5 s and the verify ticks
+	// every 5 s. Two ticks plus the fast re-push must fit inside the window.
+	const fastRePush = 1500 * time.Millisecond
+	const twoVerifyTicks = 10 * time.Second
+	if recallOwnsRetryWindow < fastRePush+time.Second {
+		t.Fatalf("window %v must outlast the wrong-state re-push at %v", recallOwnsRetryWindow, fastRePush)
+	}
+	if recallOwnsRetryWindow < twoVerifyTicks {
+		t.Fatalf("window %v must span the verify's first two ticks (%v)", recallOwnsRetryWindow, twoVerifyTicks)
+	}
+}

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -1734,8 +1734,9 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 	playURL := boxurl.StreamSlot(slot)
 	// A preset saved from an AAC/HE-AAC station carries its codec: label the
 	// stream audio/aac in the DIDL so the box picks the right decoder. The
-	// fixed audio/mpeg label made those stations play silence (#252).
-	mime := upnp.MimeForCodec(p.Codec)
+	// fixed audio/mpeg label made those stations play silence (#252). A preset
+	// stored without a codec falls back to reading it off the station URL.
+	mime := upnp.MimeForCodecOrURL(p.Codec, p.StreamURL)
 	var playErr error
 	if mime != "" {
 		playErr = s.renderer.PlayURLMime(playCtx, playURL, p.Name, p.Art, mime)
@@ -2896,6 +2897,23 @@ const (
 	spontResumeStreamWindow = 60 * time.Second
 )
 
+// recallOwnsRetryWindow is how long after a user-started play the recall's own
+// verify owns the retry, so maybeRePush does not push on top of it. It spans
+// the press, the wrong-state re-push and the first verify ticks, which is where
+// the two used to collide; after it the verify's own pacing is 5 s apart, far
+// from a storm.
+const recallOwnsRetryWindow = 12 * time.Second
+
+// userPlayedRecently reports whether the user started a play (hardware preset
+// press or app play) within recallOwnsRetryWindow. A stream drop inside that
+// window is almost always the PREVIOUS stream being torn down by the new
+// selection, not a box-side dropout worth resuming.
+func (s *Server) userPlayedRecently() bool {
+	s.standbyStopMu.Lock()
+	defer s.standbyStopMu.Unlock()
+	return !s.lastUserPlayStart.IsZero() && time.Since(s.lastUserPlayStart) < recallOwnsRetryWindow
+}
+
 // SetUserActivityFn wires boxws.LastUserActivity so HandleEnterStandby can tell
 // a physical power-off from a spontaneous firmware source power-off (#419).
 func (s *Server) SetUserActivityFn(fn func() time.Time) {
@@ -3175,6 +3193,18 @@ func (s *Server) maybeRePush() {
 	}
 	time.Sleep(backoff)
 
+	// A recall the user just started owns its own retry: its verify re-pushes
+	// every 5 s until the box really plays that stream. Re-pushing here as well
+	// makes the two fight, and each push tears the other's stream down, which
+	// arms yet another disconnect. A Wave diagnostic caught the resulting storm:
+	// four stream starts and two re-pushes inside 1.7 s, 680 ms apart despite
+	// this function's 2 s backoff, because the drop being "recovered" was just
+	// the PREVIOUS preset being torn down by the new press. Stand down for that
+	// window and let the recall's verify do the work.
+	if s.userPlayedRecently() {
+		s.logger.Info("re-push: a preset/play the user just started owns the retry, not resuming on top of it")
+		return
+	}
 	// A deliberate user stop (STR Stop/Pause, or the box/remote stop button seen
 	// over gabbo) must hold. Genuine box-side drops carry no such stop and resume.
 	if s.userStoppedRecently() {


### PR DESCRIPTION
## Summary

Two further defects found while re-reading a Wave owner's full mail thread (six diagnostic bundles, 2026-07-16 and 07-19). Both are visible in his logs and neither is Wave-specific.

### 1. The auto-resume and a recall push on top of each other

Switching preset tears down the previous stream. That disconnect arms `maybeRePush` ("box dropped the stream while idle"), which then pushes while the new preset is still starting, so the recall verify and the drop recovery fight over the renderer and each push tears down the other's stream, arming yet another disconnect. From the 07-19 bundle:

```
09:46:06.177  re-push: box dropped the stream while idle, resuming  attempt=1
09:46:06.855  re-push: box dropped the stream while idle, resuming  attempt=2
```

Two recoveries 680 ms apart despite the documented 2 s backoff, and four `stream proxy start` lines inside 1.7 s. On this firmware every push also produces a fresh 1036, so the storm feeds itself.

A play the user just started now owns the retry for `recallOwnsRetryWindow` (12 s): its own verify already re-issues every 5 s until the box really plays it, so coverage is unchanged while the two no longer collide. An ordinary mid-stream dropout after that window is resumed exactly as before.

### 2. AAC stations play silence when the preset carries no codec

`MimeForCodec("")` returns "", so the DIDL falls back to audio/mpeg and the box decodes an AAC stream as MPEG: silence (#252). His 07-16 bundle has slot 5 `RSH Sylt` with `codec=""` and the URL `.../rsh-sylt/aac-64/...`, i.e. an AAC station stored without a codec. Presets saved by older clients are all in that state.

`MimeForCodecOrURL` now reads the codec off the station URL when the preset states none, matched as a delimited token so `aac-64`, `.aac`, `aacp` and `format=aac` hit while `isaachome` does not. A preset that does state a codec is trusted unchanged, so nothing that works today changes.

## Verification

- New tests for both: the collision window (including a guard pinning it against the verify's own timings) and a table for the codec fallback.
- `go test ./cmd/... ./internal/...` green, gofmt clean, ARM (`GOARM=5`) cross-compile green, deployed to a Portable.

## Not covered

The Wave's 1036 refusal itself, and the wedge-after-idle in his 07-16 evening bundle (`health=wedged`, zero stream fetches, only a power cycle clears it) which is the #402 family. Both are firmware states STR can only work around.

Refs #419, refs #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)