### PR TITLE
fix(agent): keep presets alive after a standby or spontaneous source drop

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1942,13 +1942,43 @@ func (h *presetWsHandler) rePushAfterSourceReject(slot int, url, name, icon, mim
 	if h.userStoppedSince(recallStart) {
 		return
 	}
-	h.logger.Warn("hardware recall: box refused the stream (wrong state), pushing it again", "slot", slot)
+	h.logger.Warn("hardware recall: box refused the stream (wrong state), clearing the transport and pushing again", "slot", slot)
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
+	// The box refused the stream because its transport is stuck in the wrong
+	// state: it is still holding its own dead-cloud ContentItem active (the box
+	// answers with name=UNABLE_TO_PROCESS_NOT_LOGGED_IN detail=WrongState). Pushing
+	// the IDENTICAL SetURI onto that stuck state is what the box just rejected, so a
+	// blind re-push is rejected again and again until a power pull (bundle 55/56
+	// ST30, 59/60 Wave, all v0.9.15). Force the transport out of the wrong state
+	// first - Stop + ClearURI - then set the URI and Play from a clean slate. This
+	// mirrors the proven clean-slot recall that fixed the analogous hardware-skip
+	// INVALID_SOURCE wedge on Spotify (HardwareSkip, 59da772). The re-login
+	// self-heal fired in parallel from the boxws NOT_LOGGED_IN routing.
+	h.clearTransportForRePush(ctx, slot)
 	if mime != "" {
 		_ = h.renderer.PlayURLMime(ctx, url, name, icon, mime)
 	} else {
 		_ = h.renderer.PlayURL(ctx, url, name, icon)
+	}
+}
+
+// clearTransportForRePush forces the box's UPnP transport out of a stuck
+// wrong-state before a re-push: a Stop followed by an empty SetAVTransportURI
+// (ClearURI) so the firmware releases the dead ContentItem it keeps trying to
+// self-activate. Best-effort - both calls are advisory and a wedged renderer may
+// ACK them without acting - but starting the re-push from an emptied transport is
+// what turns the persistent 1036 loop into a recoverable one. Kept tiny and
+// side-effect-free on the happy path: it only runs on the wrong-state repair.
+func (h *presetWsHandler) clearTransportForRePush(ctx context.Context, slot int) {
+	if h.renderer == nil {
+		return
+	}
+	if err := h.renderer.Stop(ctx); err != nil {
+		h.logger.Debug("wrong-state repair: transport stop returned (expected if already stopped)", "slot", slot, "err", err)
+	}
+	if err := h.renderer.ClearURI(ctx); err != nil {
+		h.logger.Debug("wrong-state repair: clear transport URI returned", "slot", slot, "err", err)
 	}
 }
 

--- a/internal/boxws/boxws.go
+++ b/internal/boxws/boxws.go
@@ -142,6 +142,18 @@ type Client struct {
 	lastInvalidSourceAt time.Time
 	lastPresetPressAt   time.Time
 
+	// lastStandbyFlapAt times the box's own UPNP<->STANDBY oscillation on a
+	// spontaneous firmware source power-off (#419). That drop is not a single
+	// transition: the box flips UPNP->STANDBY->UPNP within ~100 ms, and the
+	// STANDBY->UPNP leg carries a nowPlaying STOP_STATE whose source attribute
+	// reads UPNP (not INVALID_SOURCE/STANDBY), so stopStateIsTeardown missed it
+	// and fired OnUserStop. That latched a user-stop that then defeated the #419
+	// spontaneous-off exemption on the NEXT leg of the same oscillation, so #197
+	// tore the transport down and every recovery path stood down until a power
+	// pull (bundle 17, three sm2 boxes on v0.9.15). Stamping every flap to OR
+	// from STANDBY lets the STOP_STATE handler recognise the bounce. Guarded by mu.
+	lastStandbyFlapAt time.Time
+
 	// Thumb-trigger heuristic state. The remote thumbs keys surface only as a
 	// generic <userActivityUpdate/>; we treat a "lone" one (no volume / now
 	// playing / preset event around it) as a thumb press and fire
@@ -626,6 +638,12 @@ type ZoneMemberState struct {
 const (
 	presetTeardownWindow        = 4 * time.Second
 	invalidSourceTeardownWindow = 2 * time.Second
+	// standbyFlapTeardownWindow bounds how soon after a UPNP<->STANDBY flap a
+	// STOP_STATE still counts as the spontaneous-off oscillation's teardown
+	// (#419) rather than a deliberate stop. The observed bounce completes in
+	// ~100-150 ms; 3 s covers a slow flap without swallowing a real stop the user
+	// makes seconds after a genuine power event.
+	standbyFlapTeardownWindow = 3 * time.Second
 )
 
 // stopStateIsTeardown reports whether a STOP_STATE nowPlaying frame is the box's
@@ -649,14 +667,28 @@ func (c *Client) stopStateIsTeardown(np *wsNowPlaying) (bool, string) {
 	c.mu.Lock()
 	sincePress := time.Since(c.lastPresetPressAt)
 	sinceInvalid := time.Since(c.lastInvalidSourceAt)
+	sinceStandbyFlap := time.Since(c.lastStandbyFlapAt)
 	pressSet := !c.lastPresetPressAt.IsZero()
 	invalidSet := !c.lastInvalidSourceAt.IsZero()
+	standbyFlapSet := !c.lastStandbyFlapAt.IsZero()
 	c.mu.Unlock()
 	if pressSet && sincePress < presetTeardownWindow {
 		return true, "hardware preset pressed " + sincePress.Round(time.Millisecond).String() + " ago"
 	}
 	if invalidSet && sinceInvalid < invalidSourceTeardownWindow {
 		return true, "source flapped to INVALID_SOURCE " + sinceInvalid.Round(time.Millisecond).String() + " ago"
+	}
+	// The spontaneous-off oscillation (#419) flips UPNP->STANDBY->UPNP and emits a
+	// STOP_STATE on the way back up whose source reads UPNP, so the two checks
+	// above miss it. A STOP_STATE within a moment of a STANDBY flap is that
+	// bounce, not a deliberate stop: reading it as a user stop re-latched
+	// lastUserStop and defeated the #419 spontaneous-off exemption on the next leg
+	// of the same oscillation, so #197 cleared the transport and the box went
+	// silent until a power pull (bundle 17, three sm2 boxes on v0.9.15). A real
+	// power press is unaffected: on this firmware it emits a userActivityUpdate,
+	// so HandleEnterStandby still classifies and latches it via its own path.
+	if standbyFlapSet && sinceStandbyFlap < standbyFlapTeardownWindow {
+		return true, "source flapped through STANDBY " + sinceStandbyFlap.Round(time.Millisecond).String() + " ago"
 	}
 	return false, ""
 }
@@ -709,6 +741,13 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 			// teardown, not a user stop. See stopStateIsTeardown.
 			if src == "INVALID_SOURCE" {
 				c.lastInvalidSourceAt = time.Now()
+			}
+			// Stamp every flap to OR from STANDBY: the spontaneous-off oscillation
+			// (#419) carries a STOP_STATE on its STANDBY->UPNP leg whose source reads
+			// UPNP, so this is the only trace that the STOP_STATE belongs to the
+			// bounce and is not a deliberate user stop. See stopStateIsTeardown.
+			if src == "STANDBY" || prev == "STANDBY" {
+				c.lastStandbyFlapAt = time.Now()
 			}
 			c.mu.Unlock()
 			if changed {
@@ -903,27 +942,56 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 					// ST300). Signal the agent to force a re-login and stand the recall
 					// retry down instead of thrashing.
 					//
-					// The box reuses code 1036 for a second, unrelated flavor:
-					// UpnpRcvdContentItemInWrongState - the routine race of a SetURI
-					// against a standby wake, and the expected teardown when /setZone
-					// kills an in-flight UPnP session during group forming (#70). That
-					// flavor is NOT a login problem: firing the self-heal on it killed
-					// the recall retry and forced a pointless re-pair on every wake
-					// race, so it must never trigger here.
+					// The box reuses code 1036 for two flavors that can arrive
+					// SEPARATELY or TOGETHER:
+					//   - name UNABLE_TO_PROCESS_NOT_LOGGED_IN: the box refuses the
+					//     source because it lost its logged-in/associated state (it can
+					//     keep a margeAccountUUID yet still report this). The 5-min
+					//     autopair heartbeat skips a box that carries a UUID, so only a
+					//     forced re-assert of setMargeAccount (ForcePair) restores it.
+					//   - detail UpnpRcvdContentItemInWrongState: the routine race of a
+					//     SetURI against a standby wake / a preset->preset teardown, and
+					//     the expected teardown when /setZone kills an in-flight UPnP
+					//     session during group forming (#70). By itself NOT a login
+					//     problem: firing the self-heal on it killed the recall retry
+					//     and forced a pointless re-pair on every wake race.
+					//
+					// The decisive field is the NAME (the box's authoritative reason).
+					// Real hardware-preset rejections on the Portable/ST10/ST20/ST30
+					// carry BOTH markers at once -
+					// name=UNABLE_TO_PROCESS_NOT_LOGGED_IN detail=UpnpRcvdContentItemInWrongState
+					// (53/53 field log lines) - because the box could not activate its
+					// own stored ContentItem PRECISELY because it is not logged in. The
+					// previous detail-first check misread every one of those as a plain
+					// wake race and re-pushed the identical SetURI into a box that keeps
+					// answering 1036 until a power pull, never re-registering it. So
+					// classify by the name first: a not-logged-in name means re-login,
+					// even when the wrong-state teardown rides along in the detail.
+					notLoggedIn := strings.Contains(strings.ToUpper(name), "NOT_LOGGED_IN")
 					wrongState := strings.Contains(detail, "UpnpRcvdContentItemInWrongState")
-					if wrongState {
-						// The box rejected STR's SetURI as "wrong state": the routine race
-						// of a preset->preset switch (or a standby wake) where the box is
-						// still tearing down the previous source. It does NOT retry on its
-						// own and can hang attached-but-buffering on the Spotify stream
-						// without ever reaching audio, which needed a manual second preset
-						// press to clear (ST30 4->5 switch, 2026-07-14). Signal the recall so
-						// its verify re-points instead of trusting that stuck state. NOT a
-						// login problem, so it must not fire the re-login self-heal.
+					switch {
+					case notLoggedIn:
+						// Root cause: the box is not logged in. Re-assert the account so
+						// it accepts STR's source. Also nudge the recall's verify to
+						// re-point once the re-login lands (the box hangs
+						// attached-but-buffering otherwise); the self-heal is rate-limited
+						// and the verify re-push is a no-op once the box plays.
+						c.fireLoginError()
 						if h, ok := c.handler.(interface{ OnSourceRejected(context.Context) }); ok {
 							h.OnSourceRejected(ctx)
 						}
-					} else if v == "1036" || strings.Contains(strings.ToUpper(name), "NOT_LOGGED_IN") {
+					case wrongState:
+						// Pure wake/teardown race (name is a plain UNABLE_TO_PROCESS, no
+						// NOT_LOGGED_IN). It does NOT retry on its own and can hang
+						// attached-but-buffering on the Spotify stream without reaching
+						// audio, which needed a manual second preset press to clear (ST30
+						// 4->5 switch, 2026-07-14). Signal the recall so its verify
+						// re-points instead of trusting that stuck state. NOT a login
+						// problem, so it must not fire the re-login self-heal.
+						if h, ok := c.handler.(interface{ OnSourceRejected(context.Context) }); ok {
+							h.OnSourceRejected(ctx)
+						}
+					case v == "1036":
 						c.fireLoginError()
 					}
 					return

--- a/internal/boxws/boxws_test.go
+++ b/internal/boxws/boxws_test.go
@@ -14,18 +14,21 @@ import (
 // recHandler records which gabbo events the parser dispatched so tests can
 // assert that marker words in user-supplied text no longer mis-fire.
 type recHandler struct {
-	presets      []int
-	userStops    int
-	powerKeys    int
-	powerWakes   int
-	sourceAux    int
-	enterStandby int
-	skips        []bool
-	zones        []ZoneState
-	boxPresets   [][]BoxPreset
-	mu           sync.Mutex
-	thumbs       int // guarded by mu (fired from the debounce timer goroutine)
+	presets       []int
+	userStops     int
+	powerKeys     int
+	powerWakes    int
+	sourceAux     int
+	enterStandby  int
+	skips         []bool
+	zones         []ZoneState
+	boxPresets    [][]BoxPreset
+	sourceRejects int
+	mu            sync.Mutex
+	thumbs        int // guarded by mu (fired from the debounce timer goroutine)
 }
+
+func (h *recHandler) OnSourceRejected(context.Context) { h.sourceRejects++ }
 
 func (h *recHandler) thumbCount() int { h.mu.Lock(); defer h.mu.Unlock(); return h.thumbs }
 
@@ -138,6 +141,21 @@ func TestHandleMessage_TeardownStopStateIsNotUserStop(t *testing.T) {
 	c3.handleMessage(context.Background(), []byte(`<updates><nowPlayingUpdated><nowPlaying source="INVALID_SOURCE"><playStatus>STOP_STATE</playStatus></nowPlaying></nowPlayingUpdated></updates>`))
 	if h3.userStops != 0 {
 		t.Fatalf("STOP_STATE with source=INVALID_SOURCE must not fire OnUserStop, got %d", h3.userStops)
+	}
+
+	// (d) The #419 spontaneous-off oscillation: the box flips UPNP->STANDBY->UPNP
+	// and emits a STOP_STATE on the way back up whose OWN source reads UPNP (so
+	// the INVALID_SOURCE/STANDBY frame checks miss it). It must still be read as
+	// the bounce teardown, not a user stop - otherwise the latched user-stop
+	// defeats the #419 exemption on the next leg and the box goes silent until a
+	// power pull (bundle 17, three sm2 boxes on v0.9.15).
+	h4 := &recHandler{}
+	c4 := newTestClient(h4)
+	c4.handleMessage(context.Background(), []byte(`<updates><nowPlayingUpdated><nowPlaying source="UPNP"><playStatus>PLAY_STATE</playStatus></nowPlaying></nowPlayingUpdated></updates>`))
+	c4.handleMessage(context.Background(), []byte(`<updates><nowPlayingUpdated><nowPlaying source="STANDBY"><ContentItem source="STANDBY"/></nowPlaying></nowPlayingUpdated></updates>`))
+	c4.handleMessage(context.Background(), []byte(`<updates><nowPlayingUpdated><nowPlaying source="UPNP"><playStatus>STOP_STATE</playStatus></nowPlaying></nowPlayingUpdated></updates>`))
+	if h4.userStops != 0 {
+		t.Fatalf("STOP_STATE riding a UPNP<->STANDBY bounce must not fire OnUserStop, got %d", h4.userStops)
 	}
 }
 

--- a/internal/boxws/loginerror_test.go
+++ b/internal/boxws/loginerror_test.go
@@ -7,21 +7,22 @@ import (
 	"time"
 )
 
-// The box reuses errorUpdate value 1036 for two unrelated conditions:
-// UNABLE_TO_PROCESS_NOT_LOGGED_IN (a real login loss, must trigger the
-// self-heal) and UpnpRcvdContentItemInWrongState (the routine SetURI vs
-// standby-wake race, and the expected teardown when /setZone kills an
-// in-flight UPnP session during group forming, #70). Firing the self-heal on
-// the second flavor killed the recall retry and forced a pointless re-pair on
-// every wake race.
+// The box reuses errorUpdate value 1036 for two conditions that can arrive
+// separately OR together: UNABLE_TO_PROCESS_NOT_LOGGED_IN (a login loss, must
+// trigger the re-registration self-heal) and UpnpRcvdContentItemInWrongState
+// (the routine SetURI vs standby-wake race, and the expected teardown when
+// /setZone kills an in-flight UPnP session during group forming, #70). Firing
+// the self-heal on the PURE wrong-state flavor killed the recall retry and
+// forced a pointless re-pair on every wake race, so the name is the decisive
+// signal, not the detail.
 func TestLoginErrorFiresOnlyForNotLoggedIn1036(t *testing.T) {
 	h := &recHandler{}
 	c := newTestClient(h)
 	var fires atomic.Int64
 	c.SetOnLoginError(func() { fires.Add(1) })
 
-	// Wrong-state flavor first (it must not fire, and must not consume the
-	// dedup window either).
+	// Pure wrong-state flavor first (name is a plain UNABLE_TO_PROCESS): it must
+	// not fire, and must not consume the dedup window either.
 	c.handleMessage(context.Background(), []byte(
 		`<errorUpdate><error value="1036" name="UNABLE_TO_PROCESS" severity="Unknown">`+
 			`UpnpRcvdContentItemInWrongState</error></errorUpdate>`))
@@ -40,5 +41,36 @@ func TestLoginErrorFiresOnlyForNotLoggedIn1036(t *testing.T) {
 	}
 	if got := fires.Load(); got != 1 {
 		t.Fatalf("NOT_LOGGED_IN 1036 must trigger the login self-heal exactly once, fired %d times", got)
+	}
+}
+
+// TestLoginErrorFiresOnCombinedNotLoggedInWrongState is the field case: real
+// hardware-preset rejections on the Portable/ST10/ST20/ST30 carry BOTH markers
+// at once - name UNABLE_TO_PROCESS_NOT_LOGGED_IN AND detail
+// UpnpRcvdContentItemInWrongState (the box could not activate its own stored
+// ContentItem precisely because it is not logged in). The name must win: the
+// re-registration self-heal MUST fire (the old detail-first check swallowed
+// every one of these, so the box was re-pushed the identical SetURI forever and
+// only a power pull recovered it). The wrong-state re-point signal fires too.
+func TestLoginErrorFiresOnCombinedNotLoggedInWrongState(t *testing.T) {
+	h := &recHandler{}
+	c := newTestClient(h)
+	var fires atomic.Int64
+	c.SetOnLoginError(func() { fires.Add(1) })
+
+	c.handleMessage(context.Background(), []byte(
+		`<errorUpdate><error value="1036" name="UNABLE_TO_PROCESS_NOT_LOGGED_IN" severity="Unrecoverable">`+
+			`UpnpRcvdContentItemInWrongState</error></errorUpdate>`))
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && fires.Load() == 0 {
+		time.Sleep(25 * time.Millisecond)
+	}
+	if got := fires.Load(); got != 1 {
+		t.Fatalf("combined NOT_LOGGED_IN + wrong-state 1036 must trigger the re-login self-heal, fired %d times", got)
+	}
+	// The recall's verify re-point signal must also have fired so the box does
+	// not hang attached-but-buffering after the re-login lands.
+	if h.sourceRejects == 0 {
+		t.Fatalf("combined 1036 must also signal OnSourceRejected for the verify re-point, got %d", h.sourceRejects)
 	}
 }


### PR DESCRIPTION
## What

After a standby press or a spontaneous firmware UPnP source power-off, a following preset press could leave the box showing the station logo with no audio (`1036 UpnpRcvdContentItemInWrongState`), exhaust its retries and latch the "speaker not responding" banner until the user pulled the plug. This is the dominant current field complaint (9 mail/issue reports), still occurring on v0.9.15, i.e. on top of the v0.9.13 #419 fix.

Root-caused across 25 diagnostic bundles and the mail reports. Three distinct residual defects, all fixed here.

## Why it still failed on v0.9.13+

1. **The spontaneous-off oscillation re-latched a user stop.** The firmware drop is not a single transition: it flaps `UPNP -> STANDBY -> UPNP` within ~100 ms, and the `STANDBY -> UPNP` leg carries a `nowPlaying` `STOP_STATE` whose own source attribute reads `UPNP`. `stopStateIsTeardown` only recognised a teardown by `source == INVALID_SOURCE/STANDBY`, a preset press `< 4s`, or an `INVALID_SOURCE` flap `< 2s`, so it missed this frame and fired `OnUserStop`. That re-latched the deliberate-stop the #419 discriminator had just excused, so on the next leg of the same oscillation `#197` cleared the transport and every recovery path stood down.

2. **The re-registration self-heal never fired.** The box announces the refusal as `name=UNABLE_TO_PROCESS_NOT_LOGGED_IN` AND `detail=UpnpRcvdContentItemInWrongState` in the **same** frame (53/53 field log lines). The routing checked the detail first and sent every one of them to the routine wrong-state re-point, so `ForcePair` (re-assert the marge account) never ran. The old test only covered the two markers arriving separately, which the firmware never does.

3. **The wrong-state re-push was blind.** `rePushAfterSourceReject` and `verifyPlayURL` replayed the identical `SetAVTransportURI + Play` onto a transport still stuck on the box's dead-cloud ContentItem, so it was refused again until a power pull.

## Fix

1. `boxws` stamps `lastStandbyFlapAt` on every source change to/from `STANDBY`; `stopStateIsTeardown` gains a third clause (`standbyFlapTeardownWindow = 3s`). A real power press is unaffected because it carries a `userActivityUpdate` and is still latched via `HandleEnterStandby`.
2. Classify the 1036 by the box's authoritative **name**: a not-logged-in name fires the re-login self-heal even when the wrong-state teardown rides along in the detail. `OnSourceRejected` still fires too, so the verify re-point is unchanged.
3. `clearTransportForRePush` (`Stop` + `ClearURI`) precedes the wrong-state re-push, so it starts from an emptied transport instead of pushing onto the stuck state. Mirrors the proven HardwareSkip clean-slot recall (59da772). The existing `recentlyPoweredOff` / `userStoppedSince` guards still run first, so #197/#419 are unaffected.

## Test / verify

- New/updated tests in `internal/boxws`: the combined-marker 1036 routing, and the bounce `STOP_STATE` teardown. `go test ./internal/boxws/ ./internal/webui/ ./internal/autopair/ ./internal/upnp/` green, `go vet` clean.
- Live-verified on a Portable: a standby-then-recall that previously died now logs `STOP_STATE during a source teardown ... reason="source flapped through STANDBY 0s ago"` followed by `spontaneous-off recovery: resumed the stream`, and reaches `PLAY_STATE` with `boxHealth ok`.

Refs #419, #429, #428.
