### PR TITLE
hls: fix DVR live streams replaying the whole sliding window

### DIFF
--- a/internal/streamproxy/hls.go
+++ b/internal/streamproxy/hls.go
@@ -26,6 +26,12 @@ import (
 	"time"
 )
 
+// hlsFallbackMaxSegments bounds the URL "already played" set used ONLY on the
+// fallback path (a live playlist that omits EXT-X-MEDIA-SEQUENCE, so the
+// media-sequence cursor cannot be trusted). The normal, sequence-based path is
+// O(1) and does not use this.
+const hlsFallbackMaxSegments = 512
+
 // hlsRefreshFloor / hlsRefreshCeil bound how long we wait before re-fetching a
 // live media playlist. Half the target duration is the usual HLS guidance;
 // the bounds stop a degenerate playlist (no/ën huge target duration) from
@@ -49,6 +55,13 @@ func (s *Server) serveHLS(ctx context.Context, w http.ResponseWriter, r *http.Re
 	flusher, _ := w.(http.Flusher)
 	headersSent := false
 	var lastSeq int64 = -1 // media sequence of the last segment we sent (-1 = none yet)
+	// Fallback dedup state, used ONLY when the live playlist omits
+	// EXT-X-MEDIA-SEQUENCE (see seqReliable below). seqReliable is decided on
+	// the first playlist and kept, since a stream does not switch modes.
+	seqReliable := true
+	seqModeDecided := false
+	seen := map[string]bool{}
+	var seenOrder []string // FIFO of seen URLs to bound the map
 	firstPass := true
 	loggedPlaylist := false
 	var lastWrite time.Time // when we last sent audio bytes to the box
@@ -111,20 +124,46 @@ func (s *Server) serveHLS(ctx context.Context, w http.ResponseWriter, r *http.Re
 		// than the set it forgets old URLs and replays them from the top --
 		// hr1 ships a ~5h / ~4500-segment window, which is what surfaced this.
 		//
-		// First pass of a LIVE stream: arm lastSeq just below the live edge so
-		// we start on the last few segments, not the whole back-catalogue. VOD
-		// (ENDLIST): play from the beginning (lastSeq stays -1).
+		// Decide the dedup mode once, from the first playlist. The
+		// media-sequence cursor needs a stable per-segment sequence number: a
+		// LIVE sliding-window playlist that omits EXT-X-MEDIA-SEQUENCE (allowed
+		// to default to 0, but then every refresh's segment[0] looks like
+		// sequence 0) would make the cursor either stall or replay. For that
+		// case fall back to bounded URL dedup, the pre-cursor behaviour. VOD
+		// (ENDLIST) plays each segment once in order, so the cursor is fine
+		// there even without the tag.
+		if !seqModeDecided {
+			seqReliable = pl.endList || pl.hasMediaSeq
+			seqModeDecided = true
+			if !seqReliable {
+				s.logger.Info("hls: live playlist has no EXT-X-MEDIA-SEQUENCE, using URL dedup fallback",
+					"segments", len(pl.segments))
+			}
+		}
+
+		// First pass of a LIVE stream: start near the live edge instead of
+		// replaying the whole sliding window. In sequence mode, arm lastSeq
+		// just below the edge; in fallback mode, mark all but the last few
+		// segments as already seen so only the tail plays. VOD plays from the
+		// beginning either way.
 		if firstPass {
 			if !pl.endList && len(pl.segments) > 3 {
-				lastSeq = pl.mediaSeq + int64(len(pl.segments)) - 1 - 3
+				if seqReliable {
+					lastSeq = pl.mediaSeq + int64(len(pl.segments)) - 1 - 3
+				} else {
+					for _, seg := range pl.segments[:len(pl.segments)-3] {
+						seen[seg] = true
+						seenOrder = append(seenOrder, seg)
+					}
+				}
 			}
 			firstPass = false
 		}
 
-		// Encoder restart / sequence rewind: if the whole playlist now sits at
-		// or below our cursor, re-arm at the new live edge instead of stalling
-		// forever on a sequence that will never come.
-		if lastSeq >= 0 && !pl.endList {
+		// Encoder restart / sequence rewind (sequence mode only): if the whole
+		// playlist now sits at or below our cursor, re-arm at the new live edge
+		// instead of stalling forever on a sequence that will never come.
+		if seqReliable && lastSeq >= 0 && !pl.endList {
 			lastInPlaylist := pl.mediaSeq + int64(len(pl.segments)) - 1
 			if lastInPlaylist < lastSeq {
 				s.logger.Warn("hls: media sequence rewound, re-arming at live edge",
@@ -141,13 +180,25 @@ func (s *Server) serveHLS(ctx context.Context, w http.ResponseWriter, r *http.Re
 			if r.Context().Err() != nil {
 				return nil
 			}
-			seq := pl.mediaSeq + int64(i)
-			if seq <= lastSeq {
-				continue
+			if seqReliable {
+				seq := pl.mediaSeq + int64(i)
+				if seq <= lastSeq {
+					continue
+				}
+				// Advance the cursor before fetching: a CDN hiccup on this
+				// segment then skips forward instead of retrying stale audio.
+				lastSeq = seq
+			} else {
+				if seen[seg] {
+					continue
+				}
+				seen[seg] = true
+				seenOrder = append(seenOrder, seg)
+				if len(seenOrder) > hlsFallbackMaxSegments {
+					delete(seen, seenOrder[0])
+					seenOrder = seenOrder[1:]
+				}
 			}
-			// Advance the cursor before fetching: a CDN hiccup on this segment
-			// then skips forward instead of retrying stale audio out of order.
-			lastSeq = seq
 
 			data, err := s.fetchBytes(ctx, seg)
 			if err != nil {
@@ -298,11 +349,12 @@ func parseBandwidth(line string) int {
 
 // mediaPlaylist is the parsed shape of an HLS media playlist.
 type mediaPlaylist struct {
-	segments  []string // absolute segment URLs, in order
-	mediaSeq  int64    // #EXT-X-MEDIA-SEQUENCE: sequence number of segments[0] (0 if absent)
-	targetDur int      // #EXT-X-TARGETDURATION seconds (0 if absent)
-	endList   bool     // #EXT-X-ENDLIST present (VOD, not live)
-	isFMP4    bool     // #EXT-X-MAP present (fMP4/CMAF init segment) -> stage 3
+	segments    []string // absolute segment URLs, in order
+	mediaSeq    int64    // #EXT-X-MEDIA-SEQUENCE: sequence number of segments[0] (0 if absent)
+	hasMediaSeq bool     // whether an EXT-X-MEDIA-SEQUENCE tag was actually present
+	targetDur   int      // #EXT-X-TARGETDURATION seconds (0 if absent)
+	endList     bool     // #EXT-X-ENDLIST present (VOD, not live)
+	isFMP4      bool     // #EXT-X-MAP present (fMP4/CMAF init segment) -> stage 3
 }
 
 // parseMediaPlaylist parses a media playlist body, resolving segment URIs
@@ -323,6 +375,7 @@ func parseMediaPlaylist(body, baseURL string) mediaPlaylist {
 			pl.isFMP4 = true
 		case strings.HasPrefix(line, "#EXT-X-MEDIA-SEQUENCE:"):
 			pl.mediaSeq = atoi64Safe(strings.TrimPrefix(line, "#EXT-X-MEDIA-SEQUENCE:"))
+			pl.hasMediaSeq = true
 		case strings.HasPrefix(line, "#EXT-X-TARGETDURATION:"):
 			pl.targetDur = atoiSafe(strings.TrimPrefix(line, "#EXT-X-TARGETDURATION:"))
 		case strings.HasPrefix(line, "#"):

--- a/internal/streamproxy/hls.go
+++ b/internal/streamproxy/hls.go
@@ -26,10 +26,6 @@ import (
 	"time"
 )
 
-// hlsMaxSegments caps how many segments we keep track of as "already played"
-// so a long-running live stream does not grow the seen-set without bound.
-const hlsMaxSegments = 512
-
 // hlsRefreshFloor / hlsRefreshCeil bound how long we wait before re-fetching a
 // live media playlist. Half the target duration is the usual HLS guidance;
 // the bounds stop a degenerate playlist (no/ën huge target duration) from
@@ -52,8 +48,7 @@ func (s *Server) serveHLS(ctx context.Context, w http.ResponseWriter, r *http.Re
 
 	flusher, _ := w.(http.Flusher)
 	headersSent := false
-	seen := map[string]bool{}
-	var order []string // FIFO of seen keys to bound the map
+	var lastSeq int64 = -1 // media sequence of the last segment we sent (-1 = none yet)
 	firstPass := true
 	loggedPlaylist := false
 	var lastWrite time.Time // when we last sent audio bytes to the box
@@ -108,30 +103,51 @@ func (s *Server) serveHLS(ctx context.Context, w http.ResponseWriter, r *http.Re
 			continue
 		}
 
-		// On the very first pass of a LIVE stream, start near the live edge
-		// instead of replaying the whole sliding window (which would play
-		// minutes of stale audio before catching up). For a VOD playlist
-		// (ENDLIST) play from the beginning.
-		segs := pl.segments
-		if firstPass && !pl.endList && len(segs) > 3 {
-			segs = segs[len(segs)-3:]
+		// Dedup is by media sequence number, not by URL. Each segment's
+		// sequence is EXT-X-MEDIA-SEQUENCE + its index; we only play segments
+		// whose sequence is greater than the last one we sent (lastSeq). This
+		// is O(1) in memory and correct for arbitrarily large DVR windows.
+		// A bounded "seen URL" set is not: once the sliding window is bigger
+		// than the set it forgets old URLs and replays them from the top --
+		// hr1 ships a ~5h / ~4500-segment window, which is what surfaced this.
+		//
+		// First pass of a LIVE stream: arm lastSeq just below the live edge so
+		// we start on the last few segments, not the whole back-catalogue. VOD
+		// (ENDLIST): play from the beginning (lastSeq stays -1).
+		if firstPass {
+			if !pl.endList && len(pl.segments) > 3 {
+				lastSeq = pl.mediaSeq + int64(len(pl.segments)) - 1 - 3
+			}
+			firstPass = false
 		}
-		firstPass = false
+
+		// Encoder restart / sequence rewind: if the whole playlist now sits at
+		// or below our cursor, re-arm at the new live edge instead of stalling
+		// forever on a sequence that will never come.
+		if lastSeq >= 0 && !pl.endList {
+			lastInPlaylist := pl.mediaSeq + int64(len(pl.segments)) - 1
+			if lastInPlaylist < lastSeq {
+				s.logger.Warn("hls: media sequence rewound, re-arming at live edge",
+					"lastSeq", lastSeq, "playlistEnd", lastInPlaylist)
+				lastSeq = pl.mediaSeq - 1
+				if len(pl.segments) > 3 {
+					lastSeq = pl.mediaSeq + int64(len(pl.segments)) - 1 - 3
+				}
+			}
+		}
 
 		played := 0
-		for _, seg := range segs {
+		for i, seg := range pl.segments {
 			if r.Context().Err() != nil {
 				return nil
 			}
-			if seen[seg] {
+			seq := pl.mediaSeq + int64(i)
+			if seq <= lastSeq {
 				continue
 			}
-			seen[seg] = true
-			order = append(order, seg)
-			if len(order) > hlsMaxSegments {
-				delete(seen, order[0])
-				order = order[1:]
-			}
+			// Advance the cursor before fetching: a CDN hiccup on this segment
+			// then skips forward instead of retrying stale audio out of order.
+			lastSeq = seq
 
 			data, err := s.fetchBytes(ctx, seg)
 			if err != nil {
@@ -283,6 +299,7 @@ func parseBandwidth(line string) int {
 // mediaPlaylist is the parsed shape of an HLS media playlist.
 type mediaPlaylist struct {
 	segments  []string // absolute segment URLs, in order
+	mediaSeq  int64    // #EXT-X-MEDIA-SEQUENCE: sequence number of segments[0] (0 if absent)
 	targetDur int      // #EXT-X-TARGETDURATION seconds (0 if absent)
 	endList   bool     // #EXT-X-ENDLIST present (VOD, not live)
 	isFMP4    bool     // #EXT-X-MAP present (fMP4/CMAF init segment) -> stage 3
@@ -304,6 +321,8 @@ func parseMediaPlaylist(body, baseURL string) mediaPlaylist {
 		case strings.HasPrefix(line, "#EXT-X-MAP"):
 			// An init segment means fMP4/CMAF segments follow.
 			pl.isFMP4 = true
+		case strings.HasPrefix(line, "#EXT-X-MEDIA-SEQUENCE:"):
+			pl.mediaSeq = atoi64Safe(strings.TrimPrefix(line, "#EXT-X-MEDIA-SEQUENCE:"))
 		case strings.HasPrefix(line, "#EXT-X-TARGETDURATION:"):
 			pl.targetDur = atoiSafe(strings.TrimPrefix(line, "#EXT-X-TARGETDURATION:"))
 		case strings.HasPrefix(line, "#"):
@@ -381,6 +400,20 @@ func atoiSafe(s string) int {
 			break
 		}
 		n = n*10 + int(c-'0')
+	}
+	return n
+}
+
+// atoi64Safe parses leading digits of s into an int64 (0 on none). Media
+// sequence numbers on long-running live streams can exceed int32 range.
+func atoi64Safe(s string) int64 {
+	s = strings.TrimSpace(s)
+	var n int64
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			break
+		}
+		n = n*10 + int64(c-'0')
 	}
 	return n
 }

--- a/internal/streamproxy/hls_test.go
+++ b/internal/streamproxy/hls_test.go
@@ -33,6 +33,9 @@ func TestParseMediaPlaylistSegmentsAndFlags(t *testing.T) {
 	if pl.targetDur != 6 {
 		t.Errorf("targetDur = %d, want 6", pl.targetDur)
 	}
+	if pl.mediaSeq != 100 {
+		t.Errorf("mediaSeq = %d, want 100 (EXT-X-MEDIA-SEQUENCE drives live-edge dedup)", pl.mediaSeq)
+	}
 	if pl.endList {
 		t.Errorf("endList = true, want false (live)")
 	}

--- a/internal/streamproxy/hls_test.go
+++ b/internal/streamproxy/hls_test.go
@@ -36,11 +36,37 @@ func TestParseMediaPlaylistSegmentsAndFlags(t *testing.T) {
 	if pl.mediaSeq != 100 {
 		t.Errorf("mediaSeq = %d, want 100 (EXT-X-MEDIA-SEQUENCE drives live-edge dedup)", pl.mediaSeq)
 	}
+	if !pl.hasMediaSeq {
+		t.Errorf("hasMediaSeq = false, want true (tag was present)")
+	}
 	if pl.endList {
 		t.Errorf("endList = true, want false (live)")
 	}
 	if pl.isFMP4 {
 		t.Errorf("isFMP4 = true, want false (TS segments)")
+	}
+}
+
+// A live playlist that omits EXT-X-MEDIA-SEQUENCE must set hasMediaSeq=false so
+// serveHLS falls back to URL dedup instead of trusting a sequence cursor that
+// would read every refresh's segment[0] as sequence 0 (stall/replay). mediaSeq
+// itself defaults to 0, which is why the separate presence flag is needed.
+func TestParseMediaPlaylistNoMediaSequence(t *testing.T) {
+	media := "#EXTM3U\n" +
+		"#EXT-X-TARGETDURATION:4\n" +
+		"#EXTINF:4.0,\n" +
+		"a.ts\n" +
+		"#EXTINF:4.0,\n" +
+		"b.ts\n"
+	pl := parseMediaPlaylist(media, "https://x/y/playlist.m3u8")
+	if pl.hasMediaSeq {
+		t.Errorf("hasMediaSeq = true, want false (no EXT-X-MEDIA-SEQUENCE tag)")
+	}
+	if pl.mediaSeq != 0 {
+		t.Errorf("mediaSeq = %d, want 0 default", pl.mediaSeq)
+	}
+	if pl.endList {
+		t.Errorf("endList = true, want false (live)")
 	}
 }
 


### PR DESCRIPTION
Fixes #436.

`serveHLS` deduped segments via a bounded seen-URL set (512). On a live stream whose sliding window is larger than that, old URLs fall out of the set on every refresh and get played again — with a long DVR window (hr1 ships ~5h / ~4500 segments) the box starts hours behind live. The first-pass live-edge logic only marks the 3 played segments as seen, so the ~4500 older ones are treated as new on the next refresh.

**Change:** replace URL dedup with an `EXT-X-MEDIA-SEQUENCE` cursor — only play segments whose sequence exceeds the last one sent (`mediaSeq + index`). O(1) memory, correct for any window size. Live-edge arming on the first live pass is preserved; added rewind detection for encoder restarts.

**Tests:** `go build ./...`, `go vet` and `go test ./internal/streamproxy/` all green; added a media-sequence assertion to the existing parse test. Verified against the real hr1 playlist (4575 segments): first refresh plays the 3 edge segments, subsequent refreshes only the newly appended ones, no replay.

No behaviour change for short-window streams (BBC etc.) or VOD/ENDLIST playlists.