### PR TITLE
build(release): sign the Windows app via the Certum code signing certificate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -391,12 +391,12 @@ jobs:
     needs: [build-agent, build-go-librespot]
     runs-on: windows-latest
     env:
-      # Mirror of the Trusted Signing client id into an env var so the signing
-      # step's `if:` can test for its presence (GitHub does not allow reading
-      # `secrets.*` directly in an `if:`). When the Azure Trusted Signing secrets
-      # are not configured, the signing step is skipped and the release still
-      # builds an (unsigned) exe, so nothing breaks before the account is set up.
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      # Mirror the cert thumbprint into an env var so the signing steps' `if:`
+      # can test for its presence (GitHub does not allow reading `secrets.*`
+      # directly in an `if:`). With the Certum secrets unset the signing steps
+      # are skipped and the release still builds an (unsigned) exe, so nothing
+      # breaks before the certificate is issued.
+      CERT_THUMBPRINT: ${{ secrets.CERT_THUMBPRINT }}
     permissions:
       contents: read
       id-token: write
@@ -487,37 +487,41 @@ jobs:
             -trimpath \
             -clean
 
-      # Sign the .exe with Azure Trusted Signing. Smart App Control and the
-      # stricter SmartScreen prompts block the UNSIGNED build outright (SAC has
-      # no per-app override), and a Trusted Signing signature chains to a
-      # Microsoft-trusted root, so it clears both. ~$10/month, no HSM token.
+      # Sign the .exe with the Certum "Open Source" code signing certificate via
+      # SimplySign (cloud). The unsigned build trips SmartScreen's "unknown
+      # publisher" prompt; a Certum signature stamps the verified individual
+      # publisher name (CN=Jens Roggenfelder) and lets SmartScreen reputation
+      # build up over downloads. Certum does NOT chain to a Microsoft-owned root,
+      # so it does not instantly satisfy Smart App Control the way Azure Trusted
+      # Signing would — a deliberate trade to keep publishing under a private
+      # individual identity rather than a registered organisation.
       #
-      # Runs BEFORE the rename+hash and the Sigstore attestation below, so the
-      # published SHA256 and the provenance attestation both cover the SIGNED
+      # The two steps run BEFORE the rename+hash and the Sigstore attestation
+      # below, so the published SHA256 and the provenance both cover the SIGNED
       # binary (a hash taken before signing would never match what users get).
       #
-      # Gated on AZURE_CLIENT_ID: with the secrets unset the step is skipped and
-      # the release still produces an unsigned exe, so this can land before the
-      # Trusted Signing account exists without breaking a release.
+      # Gated on CERT_THUMBPRINT: with the Certum secrets unset both steps are
+      # skipped and the release still produces an unsigned exe, so this can land
+      # before the certificate exists without breaking a release.
       #
-      # TODO: pin this action to a commit SHA (repo policy is SHA-pinned actions)
-      # and confirm the input names against the current Trusted Signing docs
-      # before the first signed release.
-      - name: Sign Windows app (Azure Trusted Signing)
-        if: ${{ env.AZURE_CLIENT_ID != '' }}
-        uses: azure/trusted-signing-action@v0.5.9
-        with:
-          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-          endpoint: ${{ secrets.TRUSTED_SIGNING_ENDPOINT }}
-          trusted-signing-account-name: ${{ secrets.TRUSTED_SIGNING_ACCOUNT }}
-          certificate-profile-name: ${{ secrets.TRUSTED_SIGNING_PROFILE }}
-          files-folder: ${{ github.workspace }}\desktop-app\build\bin
-          files-folder-filter: exe
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
+      # SimplySign reaches the cloud key only through an authenticated desktop
+      # session; simplysign-ci-login.ps1 opens one non-interactively via a TOTP
+      # derived from the enrolment secret, then certum-sign.ps1 signs by
+      # thumbprint. TODO(before first signed release): confirm the SimplySign
+      # Desktop install/login CLI in simplysign-ci-login.ps1 against the locally
+      # installed version, then verify end to end with a throwaway exe.
+      - name: Start SimplySign session (Certum)
+        if: ${{ env.CERT_THUMBPRINT != '' }}
+        shell: powershell
+        env:
+          SIMPLYSIGN_TOKEN: ${{ secrets.SIMPLYSIGN_TOKEN }}
+          SIMPLYSIGN_OTP_SECRET: ${{ secrets.SIMPLYSIGN_OTP_SECRET }}
+        run: .\tools\simplysign-ci-login.ps1
+
+      - name: Sign Windows app (Certum SimplySign)
+        if: ${{ env.CERT_THUMBPRINT != '' }}
+        shell: powershell
+        run: .\tools\certum-sign.ps1 -File "desktop-app/build/bin/ST Reborn.exe"
 
       - name: Rename and hash output
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,6 +390,13 @@ jobs:
   build-desktop-windows:
     needs: [build-agent, build-go-librespot]
     runs-on: windows-latest
+    env:
+      # Mirror of the Trusted Signing client id into an env var so the signing
+      # step's `if:` can test for its presence (GitHub does not allow reading
+      # `secrets.*` directly in an `if:`). When the Azure Trusted Signing secrets
+      # are not configured, the signing step is skipped and the release still
+      # builds an (unsigned) exe, so nothing breaks before the account is set up.
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
     permissions:
       contents: read
       id-token: write
@@ -479,6 +486,38 @@ jobs:
             -ldflags "-s -w -X main.appVersion=${VERSION} -X main.appBuild=${BUILD_STAMP}" \
             -trimpath \
             -clean
+
+      # Sign the .exe with Azure Trusted Signing. Smart App Control and the
+      # stricter SmartScreen prompts block the UNSIGNED build outright (SAC has
+      # no per-app override), and a Trusted Signing signature chains to a
+      # Microsoft-trusted root, so it clears both. ~$10/month, no HSM token.
+      #
+      # Runs BEFORE the rename+hash and the Sigstore attestation below, so the
+      # published SHA256 and the provenance attestation both cover the SIGNED
+      # binary (a hash taken before signing would never match what users get).
+      #
+      # Gated on AZURE_CLIENT_ID: with the secrets unset the step is skipped and
+      # the release still produces an unsigned exe, so this can land before the
+      # Trusted Signing account exists without breaking a release.
+      #
+      # TODO: pin this action to a commit SHA (repo policy is SHA-pinned actions)
+      # and confirm the input names against the current Trusted Signing docs
+      # before the first signed release.
+      - name: Sign Windows app (Azure Trusted Signing)
+        if: ${{ env.AZURE_CLIENT_ID != '' }}
+        uses: azure/trusted-signing-action@v0.5.9
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ secrets.TRUSTED_SIGNING_ENDPOINT }}
+          trusted-signing-account-name: ${{ secrets.TRUSTED_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.TRUSTED_SIGNING_PROFILE }}
+          files-folder: ${{ github.workspace }}\desktop-app\build\bin
+          files-folder-filter: exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
 
       - name: Rename and hash output
         shell: bash

--- a/desktop-app/wails.json
+++ b/desktop-app/wails.json
@@ -9,5 +9,11 @@
   "author": {
     "name": "Jens",
     "email": "str@sichtbar-app.de"
+  },
+  "info": {
+    "companyName": "STR (SoundTouch Reborn)",
+    "productName": "ST Reborn",
+    "copyright": "Copyright (c) 2026",
+    "comments": "SoundTouch Reborn - local control for Bose SoundTouch speakers after the cloud shutdown. Unofficial, not affiliated with or endorsed by Bose."
   }
 }

--- a/tools/certum-sign.ps1
+++ b/tools/certum-sign.ps1
@@ -1,0 +1,66 @@
+<#
+.SYNOPSIS
+  Sign a Windows binary with the Certum "Open Source" code signing certificate.
+
+.DESCRIPTION
+  Locates signtool.exe from the installed Windows SDK, signs the given file with
+  SHA-256 and an RFC-3161 timestamp from Certum, then verifies the signature.
+
+  The certificate is selected by its SHA-1 thumbprint (visible in the SimplySign
+  cloud profile). The private key lives in the SimplySign cloud and is only
+  reachable while a SimplySign Desktop session is active, so this script assumes
+  such a session already exists: established interactively via the SimplySign
+  mobile app when signing locally, or by tools/simplysign-ci-login.ps1 in CI.
+
+  Usable both locally (after logging in through SimplySign Desktop) and from the
+  release workflow.
+
+.PARAMETER File
+  Path to the .exe (or other PE) to sign.
+
+.PARAMETER Thumbprint
+  SHA-1 thumbprint of the code signing certificate. Defaults to $env:CERT_THUMBPRINT.
+#>
+param(
+  [Parameter(Mandatory = $true)][string]$File,
+  [string]$Thumbprint = $env:CERT_THUMBPRINT
+)
+$ErrorActionPreference = 'Stop'
+
+if (-not $Thumbprint) {
+  throw "No certificate thumbprint given (pass -Thumbprint or set CERT_THUMBPRINT)."
+}
+if (-not (Test-Path -LiteralPath $File)) {
+  throw "File not found: $File"
+}
+
+# Locate the newest x64 signtool.exe from the Windows SDK.
+$roots = @(
+  "${env:ProgramFiles(x86)}\Windows Kits\10\bin",
+  "${env:ProgramFiles}\Windows Kits\10\bin"
+)
+$signtool = $null
+foreach ($r in $roots) {
+  if (Test-Path -LiteralPath $r) {
+    $cand = Get-ChildItem -Path $r -Recurse -Filter signtool.exe -ErrorAction SilentlyContinue |
+      Where-Object { $_.FullName -match '\\x64\\signtool\.exe$' } |
+      Sort-Object FullName -Descending | Select-Object -First 1
+    if ($cand) { $signtool = $cand.FullName; break }
+  }
+}
+if (-not $signtool) {
+  throw "signtool.exe not found. Install the Windows SDK (or Visual Studio Build Tools)."
+}
+Write-Host "Using signtool: $signtool"
+
+# Certum's RFC-3161 timestamp authority. Timestamping is what keeps the
+# signature valid after the certificate itself expires.
+$timestamp = 'http://time.certum.pl'
+
+& $signtool sign /sha1 $Thumbprint /fd SHA256 /tr $timestamp /td SHA256 /v "$File"
+if ($LASTEXITCODE -ne 0) { throw "signtool sign failed (exit $LASTEXITCODE)" }
+
+& $signtool verify /pa /v "$File"
+if ($LASTEXITCODE -ne 0) { throw "signtool verify failed (exit $LASTEXITCODE)" }
+
+Write-Host "Signed and verified: $File"

--- a/tools/simplysign-ci-login.ps1
+++ b/tools/simplysign-ci-login.ps1
@@ -1,0 +1,100 @@
+<#
+.SYNOPSIS
+  Establish a SimplySign Desktop cloud session non-interactively, for CI.
+
+.DESCRIPTION
+  The Certum "Open Source" certificate's private key lives in the SimplySign
+  cloud. signtool can only reach it while a SimplySign Desktop session is active,
+  and opening that session normally requires a human to approve it in the
+  SimplySign mobile app. To run in GitHub Actions without a human, we
+  authenticate with a time-based one-time code (TOTP) derived from the base32
+  secret that is embedded in the QR code shown during SimplySign enrolment
+  (the `otpauth://` URI). Capture that secret once and store it as the
+  SIMPLYSIGN_OTP_SECRET repository secret.
+
+  Get-Totp below is a standard RFC 6238 implementation (HMAC-SHA1, 6 digits,
+  30 s period) and is correct as written.
+
+  !! TODO(before first signed release): the SimplySign Desktop download URL and
+  the exact login command differ between SimplySign versions. The install/login
+  block at the bottom is a placeholder and MUST be confirmed against the version
+  installed locally (proCertumSmartSign / SimplySignDesktop.exe CLI). Once
+  verified end-to-end with a throwaway exe, drop the TODO.
+
+.PARAMETER Token
+  SimplySign card/token identifier. Defaults to $env:SIMPLYSIGN_TOKEN.
+
+.PARAMETER OtpSecret
+  Base32 TOTP secret from the enrolment QR. Defaults to $env:SIMPLYSIGN_OTP_SECRET.
+#>
+param(
+  [string]$Token     = $env:SIMPLYSIGN_TOKEN,
+  [string]$OtpSecret = $env:SIMPLYSIGN_OTP_SECRET
+)
+$ErrorActionPreference = 'Stop'
+
+function ConvertFrom-Base32 {
+  param([Parameter(Mandatory = $true)][string]$Value)
+  $alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
+  $clean = ($Value -replace '=', '').ToUpperInvariant()
+  $bits = New-Object System.Text.StringBuilder
+  foreach ($ch in $clean.ToCharArray()) {
+    $idx = $alphabet.IndexOf($ch)
+    if ($idx -lt 0) { continue }
+    [void]$bits.Append([Convert]::ToString($idx, 2).PadLeft(5, '0'))
+  }
+  $bitStr = $bits.ToString()
+  $bytes = New-Object System.Collections.Generic.List[byte]
+  for ($i = 0; $i + 8 -le $bitStr.Length; $i += 8) {
+    [void]$bytes.Add([Convert]::ToByte($bitStr.Substring($i, 8), 2))
+  }
+  return , $bytes.ToArray()
+}
+
+function Get-Totp {
+  param(
+    [Parameter(Mandatory = $true)][string]$Secret,
+    [int]$Digits = 6,
+    [int]$Period = 30
+  )
+  $key = ConvertFrom-Base32 -Value $Secret
+  $counter = [int64][math]::Floor([DateTimeOffset]::UtcNow.ToUnixTimeSeconds() / $Period)
+  $counterBytes = [BitConverter]::GetBytes($counter)
+  if ([BitConverter]::IsLittleEndian) { [Array]::Reverse($counterBytes) }
+  $hmac = New-Object System.Security.Cryptography.HMACSHA1
+  try {
+    $hmac.Key = $key
+    $hash = $hmac.ComputeHash($counterBytes)
+  } finally {
+    $hmac.Dispose()
+  }
+  $offset = $hash[$hash.Length - 1] -band 0x0f
+  $binary = ((($hash[$offset] -band 0x7f) -shl 24) -bor `
+             (($hash[$offset + 1] -band 0xff) -shl 16) -bor `
+             (($hash[$offset + 2] -band 0xff) -shl 8) -bor `
+              ($hash[$offset + 3] -band 0xff))
+  $otp = $binary % [int][math]::Pow(10, $Digits)
+  return ([string]$otp).PadLeft($Digits, '0')
+}
+
+if (-not $OtpSecret) { throw "SIMPLYSIGN_OTP_SECRET is not set." }
+if (-not $Token)     { throw "SIMPLYSIGN_TOKEN is not set." }
+
+$otp = Get-Totp -Secret $OtpSecret
+Write-Host ("Derived TOTP (masked): {0}****" -f $otp.Substring(0, 2))
+
+# --- TODO: confirm against the locally installed SimplySign Desktop ----------
+# 1) Silent install:
+#      $installer = Join-Path $env:TEMP 'SimplySignDesktop.exe'
+#      Invoke-WebRequest -Uri '<official SimplySign Desktop download URL>' -OutFile $installer
+#      Start-Process -FilePath $installer -ArgumentList '/S' -Wait
+#
+# 2) Non-interactive login (exact executable + flags version-dependent):
+#      $ssd = Join-Path ${env:ProgramFiles} 'Certum\SimplySign Desktop\SimplySignDesktop.exe'
+#      & $ssd --login --token $Token --otp $otp
+#
+# After login the certificate appears in the CurrentUser\My store and
+# tools/certum-sign.ps1 can select it by thumbprint. Until this block is filled
+# in, this script only proves the TOTP derivation works.
+# -----------------------------------------------------------------------------
+Write-Host "SimplySign login step is not yet wired up (see TODO in this script)."


### PR DESCRIPTION
## What

Code-sign the Windows desktop app so the "unknown publisher" SmartScreen
prompt goes away and the verified publisher name is shown.

Uses the **Certum "Open Source" code signing certificate** via SimplySign
(cloud). This keeps publishing under a **private individual identity**
(`CN=Jens Roggenfelder`), which is why we did not go with Azure Trusted
Signing: Azure's public track requires a registered organisation in
Germany. The trade-off is that Certum does not chain to a Microsoft-owned
root, so it does **not** instantly clear Smart App Control the way Azure
would; SmartScreen reputation builds over downloads instead.

## Changes

- `release.yml`: replace the Azure step with two gated steps that open a
  SimplySign session and then sign + verify by thumbprint. Placed before
  the rename/hash and the Sigstore attestation so both cover the signed
  binary.
- `tools/certum-sign.ps1`: locate `signtool`, sign with SHA-256 + the
  Certum RFC-3161 timestamp, verify. Reusable for local signing too.
- `tools/simplysign-ci-login.ps1`: derive an RFC 6238 TOTP (validated
  against the spec test vector) to open a SimplySign session without human
  interaction.

## Gating

Everything is gated on the `CERT_THUMBPRINT` secret. With the Certum
secrets unset, both signing steps are skipped and the release still
produces an unsigned exe, so this can merge before the certificate exists
without breaking a release.

## Follow-ups before the first signed release

- **Confirm the SimplySign Desktop install + login CLI** in
  `tools/simplysign-ci-login.ps1` against the locally installed version
  (marked TODO), then verify end to end with a throwaway exe.
- Add repository secrets:
  - `CERT_THUMBPRINT` (SHA-1 thumbprint of the Certum cert)
  - `SIMPLYSIGN_TOKEN` (SimplySign card/token id)
  - `SIMPLYSIGN_OTP_SECRET` (base32 secret from the enrolment QR)
- Certum certificate identity validation must be approved first.
