### PR TITLE
Fix hardware preset buttons and IR remote failures (v0.9.16 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,11 @@ them back **without any Bose cloud dependency**.
 ```
 Client (Browser / Desktop App)
   -- REST API --> Stick Agent webui :8888
-     (sm2 boxes (ST10 rhino, ST30 mojo) reached directly; BCO/whitelisted
-      chassis (Portable/taigan, ST20 spotty/scm) reached via iptables
-      PREROUTING REDIRECT :17008 -> loopback :8888)
+     (sm2 boxes (ST10 rhino, sm2-ST30 mojo) reached directly; BCO/whitelisted
+      chassis (Portable/taigan, ST20 spotty/scm, scm-ST30 mojo, scm-Wave lisa)
+      reached via iptables PREROUTING REDIRECT :17008 -> loopback :8888;
+      the ST20/ST30/Wave each exist in BOTH chassis generations - see
+      docs/MODEL-VARIANTS.md before assuming the port path)
                             |
                             +--> /api/presets        preset store on NAND
                             +--> /api/play, /api/play/<slot>, /api/pause, /api/stop

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1250,6 +1250,15 @@ type presetWsHandler struct {
 	// earlier stop, #419) and anchors the standby-flip discriminator. Wired to
 	// webui.Server.NoteUserPlay. nil-safe.
 	noteUserPlay func()
+	// Test seams over the box CLI / now_playing probes. nil = the real
+	// implementations (boxcli.WakeAndWait, boxcli.PowerOn, boxPlayingURL,
+	// boxNowPlayingSource); the verify tests stub them so wake ordering and
+	// the stuck-source nudge are assertable without hardware.
+	wakeBox      func(ctx context.Context, host string) error
+	sysPowerFn   func(ctx context.Context, host string) error
+	boxPlayingFn func(url string) bool
+	boxSourceFn  func() string
+
 	// slotPulled reports whether the box is credibly playing THIS slot's
 	// proxied stream for a recall anchored at the given time. It is the recall
 	// verify's ground truth: the box pulling THIS slot's audio through the
@@ -1286,6 +1295,48 @@ func (h *presetWsHandler) superseded(seq, gen uint64) bool {
 		return true
 	}
 	return false
+}
+
+// wake brings the box out of standby (no-op without a configured box host or
+// when the box is already awake). Seam-aware for the verify tests.
+func (h *presetWsHandler) wake(ctx context.Context) error {
+	if h.boxHost == "" {
+		return nil
+	}
+	if h.wakeBox != nil {
+		return h.wakeBox(ctx, h.boxHost)
+	}
+	return boxcli.WakeAndWait(ctx, h.boxHost, 6*time.Second, h.logger)
+}
+
+// sysPowerToggle sends one `sys power` toggle over the TAP CLI (the stuck-
+// INVALID_SOURCE nudge). Seam-aware for the verify tests.
+func (h *presetWsHandler) sysPowerToggle(ctx context.Context) error {
+	if h.boxHost == "" {
+		return nil
+	}
+	if h.sysPowerFn != nil {
+		return h.sysPowerFn(ctx, h.boxHost)
+	}
+	return boxcli.PowerOn(ctx, h.boxHost)
+}
+
+// playingURL reports whether the box's now_playing points at url in a play
+// state. Seam-aware for the verify tests.
+func (h *presetWsHandler) playingURL(url string) bool {
+	if h.boxPlayingFn != nil {
+		return h.boxPlayingFn(url)
+	}
+	return boxPlayingURL(h.boxHost, url)
+}
+
+// currentBoxSource returns the box's now_playing source attribute ("" on any
+// error). Seam-aware for the verify tests.
+func (h *presetWsHandler) currentBoxSource() string {
+	if h.boxSourceFn != nil {
+		return h.boxSourceFn()
+	}
+	return boxNowPlayingSource(h.boxHost)
 }
 
 // poweredOffSince reports whether the user powered the box off after t,
@@ -2119,6 +2170,7 @@ func (h *presetWsHandler) verifyPlayURL(seq, gen uint64, pressAt time.Time, slot
 	// Up to 5 attempts (~25s): a box waking from a deep/overnight standby can
 	// take longer than the old 3-attempt (~15s) window to finish bringing its
 	// network and playback subsystem back up before it accepts the stream (#183).
+	nudged := false
 	for attempt := 1; attempt <= 5; attempt++ {
 		time.Sleep(5 * time.Second)
 		// A newer press or app recall owns the transport now: this loop's URL is
@@ -2144,7 +2196,7 @@ func (h *presetWsHandler) verifyPlayURL(seq, gen uint64, pressAt time.Time, slot
 		// lags: a Portable kept naming the PREVIOUS preset for seconds after it
 		// had already opened the new stream, so a location check alone declared a
 		// healthy recall dead and the "repair" tore the working stream down.
-		if h.slotPulledSince(slot, pressAt) || boxPlayingURL(h.boxHost, url) {
+		if h.slotPulledSince(slot, pressAt) || h.playingURL(url) {
 			if h.noteBoxHealthy != nil {
 				h.noteBoxHealthy()
 			}
@@ -2169,6 +2221,20 @@ func (h *presetWsHandler) verifyPlayURL(seq, gen uint64, pressAt time.Time, slot
 		}
 		h.logger.Warn("hardware recall not playing yet, retrying", "slot", slot, "attempt", attempt)
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		// A box stuck in INVALID_SOURCE ignores wake (WakeAndWait only toggles
+		// out of STANDBY) and inertly ACKs every SetURI+Play without ever
+		// fetching audio; in the mojo/ST30 field bundle the ONLY successful
+		// source activation of the day followed a real sys-power toggle. If the
+		// box still reports INVALID_SOURCE by the third attempt, send one
+		// bounded nudge before pushing again.
+		if nudgeStuckSource(attempt, nudged, h.currentBoxSource()) {
+			nudged = true
+			h.logger.Warn("hardware recall: box stuck in INVALID_SOURCE, sending one sys-power nudge", "slot", slot)
+			if err := h.sysPowerToggle(ctx); err != nil {
+				h.logger.Warn("hardware recall: sys-power nudge failed", "slot", slot, "err", err)
+			}
+			time.Sleep(1500 * time.Millisecond)
+		}
 		// Wake the box first: after the 1036 wrong-state rejection the firmware
 		// often gives up on its failed self-activation and powers the source off
 		// through INVALID_SOURCE -> STANDBY (field bundles 2026-07-22, all
@@ -2178,10 +2244,8 @@ func (h *presetWsHandler) verifyPlayURL(seq, gen uint64, pressAt time.Time, slot
 		// user power-off cannot reach this line (poweredOffSince stands the
 		// loop down above), so waking here only ever reverses the box's own
 		// give-up. No-op when the box is awake (a single now_playing read).
-		if h.boxHost != "" {
-			if err := boxcli.WakeAndWait(ctx, h.boxHost, 6*time.Second, h.logger); err != nil {
-				h.logger.Warn("hardware recall retry: could not wake box", "slot", slot, "err", err)
-			}
+		if err := h.wake(ctx); err != nil {
+			h.logger.Warn("hardware recall retry: could not wake box", "slot", slot, "err", err)
 		}
 		if mime != "" {
 			_ = h.renderer.PlayURLMime(ctx, url, name, icon, mime)
@@ -2221,7 +2285,7 @@ func (h *presetWsHandler) rePushAfterSourceReject(seq, gen uint64, pressAt time.
 		// THIS press's URL would actively tear the newer recall down.
 		return
 	}
-	if h.slotPulledSince(slot, pressAt) || boxPlayingURL(h.boxHost, url) {
+	if h.slotPulledSince(slot, pressAt) || h.playingURL(url) {
 		return // refused once, then started anyway
 	}
 	if h.poweredOffSince(pressAt) {
@@ -2238,10 +2302,8 @@ func (h *presetWsHandler) rePushAfterSourceReject(seq, gen uint64, pressAt time.
 	// re-pushing into that sleeping box did nothing. Wake it first - a no-op
 	// when it is awake, and a user power-off never reaches this line (checked
 	// above).
-	if h.boxHost != "" {
-		if err := boxcli.WakeAndWait(ctx, h.boxHost, 6*time.Second, h.logger); err != nil {
-			h.logger.Warn("wrong-state repair: could not wake box", "slot", slot, "err", err)
-		}
+	if err := h.wake(ctx); err != nil {
+		h.logger.Warn("wrong-state repair: could not wake box", "slot", slot, "err", err)
 	}
 	// The box refused the stream because its transport is stuck in the wrong
 	// state: it is still holding its own dead-cloud ContentItem active (the box
@@ -3493,6 +3555,14 @@ func boxIsPlaying(boxHost string) bool {
 	b, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
 	s := string(b)
 	return strings.Contains(s, "PLAY_STATE") || strings.Contains(s, "BUFFERING_STATE")
+}
+
+// nudgeStuckSource is the sys-power-nudge decision: the box still reports
+// INVALID_SOURCE at the third verify attempt and no nudge ran yet. Bounded to
+// exactly one nudge per recall; earlier attempts give the normal wake+re-push
+// a chance first.
+func nudgeStuckSource(attempt int, nudged bool, source string) bool {
+	return attempt == 3 && !nudged && source == "INVALID_SOURCE"
 }
 
 // boxPlayingURL reports whether the box is in a play/buffering state AND its

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -326,7 +326,41 @@ func run() error {
 	margeSrv := marge.New(logger.With("comp", "marge"),
 		marge.WithDeviceID(deviceID),
 		marge.WithReflectSourcesPath(boxsnapshot.ReflectPath()),
-		marge.WithReflectSourceFormatPath("/mnt/nv/streborn/reflect-format"))
+		marge.WithReflectSourceFormatPath("/mnt/nv/streborn/reflect-format"),
+		// The box re-reads its cloud presets from marge during every
+		// setMargeAccount re-onboarding. Answering with an empty <presets/>
+		// made the firmware WIPE its own hardware-key registrations after
+		// every forced re-login ("Preset noch nicht festgelegt" until the
+		// reconcile healed them minutes later). Serve the stick store live so
+		// the cloud view always matches the keys.
+		marge.WithPresetSource(func() []marge.Preset {
+			all := store.All()
+			out := make([]marge.Preset, 0, len(all))
+			for _, p := range all {
+				out = append(out, marge.Preset{
+					ID:            p.Slot,
+					Source:        "UPNP",
+					Type:          "audio",
+					Location:      boxPresetURL(p),
+					SourceAccount: "UPnPUserName",
+					ItemName:      margeXMLEscape(p.Name),
+					ContainerArt:  margeXMLEscape(firstArtURL(p.Art)),
+				})
+			}
+			return out
+		}))
+	// A configured account makes every legacy account/config probe answer
+	// "signed in": some firmwares poll marge account endpoints that fell into
+	// the UNCONFIGURED fallback, which reads as "not logged in" and feeds the
+	// 1036 rejections on fresh installs (boxes with a cached pre-shutdown Bose
+	// account never ask). Matches the ACTIVE account respondMargeAccountFull
+	// already reports on the /streaming paths.
+	margeSrv.SetAccount(&marge.AccountInfo{
+		AccountUUID:  "streborn-local-account",
+		AccountEmail: "stick@local",
+		AuthToken:    "local-token-v1",
+		CreatedAt:    "2026-01-01T00:00:00Z",
+	})
 	bmxSrv := bmx.New(logger.With("comp", "bmx"))
 	// The AutoPair manager is created up here so it can also be used in the
 	// WS and webui handlers.
@@ -543,12 +577,13 @@ func run() error {
 		// clears any deliberate-stop latch an earlier (or spontaneous, #419)
 		// power-off armed, so the recall is not suppressed by stale intent.
 		noteUserPlay: webuiSrv.NoteUserPlay,
-		// Ground truth for the recall verify: the box opening THIS slot's proxied
-		// stream proves it is playing what the recall pushed, where now_playing
-		// can still name the previous preset for seconds after the switch.
-		// Slot-scoped so cross-traffic (another slot, a zone follower) cannot
-		// certify a failed recall as healthy (#252).
-		slotStreamActivity: streamProxySrv.LastFetchForSlot,
+		// Ground truth for the recall verify: the box pulling THIS slot's proxied
+		// stream (still open, or served a sustained stretch) proves it is playing
+		// what the recall pushed, where now_playing can still name the previous
+		// preset for seconds after the switch. Slot-scoped and liveness-aware so
+		// neither cross-traffic nor a dead 36ms fetch can certify a failed
+		// recall as healthy (#252).
+		slotPulled: streamProxySrv.SlotPulledSince,
 		// Surface the box's own presets (incl. foreign sources like Deezer) to the
 		// webui so the app can show/preserve them (Option C). Map boxws -> webui at
 		// the composition root to keep the two packages decoupled.
@@ -599,6 +634,14 @@ func run() error {
 	// stamp the same classifier.
 	renderer.OnTransportCommand = wsClient.NoteOwnTransportCommand
 	webuiSrv.SetTransportCommandHook(wsClient.NoteOwnTransportCommand)
+	// The standby classifier reads the same stamp: a source flip right after
+	// STR's own push (a wake-resume/recall the firmware rejects) must not be
+	// classified as a user power-off.
+	webuiSrv.SetOwnTransportCmdFn(wsClient.LastOwnTransportCommand)
+	// A completed (re-)onboarding wipes the box's hardware-key preset
+	// registrations; re-register them right away instead of waiting for the
+	// reconcile cadence.
+	autoPair.SetOnPaired(func() { requestPresetKeyResyncUrgent(logger) })
 	// Let the WebUI fill the Wi-Fi signal from the gabbo stream on BCO
 	// boxes, whose /networkInfo reports no signal.
 	webuiSrv.SetWifiSignalFn(wsClient.LastWifiSignal)
@@ -1207,28 +1250,27 @@ type presetWsHandler struct {
 	// earlier stop, #419) and anchors the standby-flip discriminator. Wired to
 	// webui.Server.NoteUserPlay. nil-safe.
 	noteUserPlay func()
-	// slotStreamActivity reports when the box last OPENED the given slot's
-	// proxied stream. It is the recall verify's ground truth: the box pulling
-	// THIS slot's audio through the proxy proves it plays what this recall
-	// pushed, whereas now_playing lags and can still name the PREVIOUS preset
-	// seconds after the box switched. Slot-scoped on purpose: the old global
-	// stamp let any proxied fetch (another slot's reconnect, a zone follower,
-	// even a 404) certify a failed recall as healthy at the first tick, so no
-	// retry ran and the wedge counter was falsely cleared (#252). Wired to
-	// streamproxy.Server.LastFetchForSlot. nil-safe.
-	slotStreamActivity func(slot int) time.Time
+	// slotPulled reports whether the box is credibly playing THIS slot's
+	// proxied stream for a recall anchored at the given time. It is the recall
+	// verify's ground truth: the box pulling THIS slot's audio through the
+	// proxy proves it plays what this recall pushed, whereas now_playing lags
+	// and can still name the PREVIOUS preset seconds after the box switched.
+	// Slot-scoped AND liveness-aware on purpose: the old global stamp let any
+	// proxied fetch certify a failed recall, and even the slot stamp alone let
+	// a 36ms fetch that died in the box's re-login bounce count as success
+	// (#252 field bundles). Wired to streamproxy.Server.SlotPulledSince.
+	// nil-safe.
+	slotPulled func(slot int, since time.Time) bool
 }
 
-// slotPulledSince reports whether the box opened THIS slot's proxied stream
-// after t, i.e. it really is fetching what this recall pushed. A preset that
-// plays a direct (non-proxied) URL never stamps; the now_playing check decides
-// for it.
+// slotPulledSince reports whether the box is credibly playing THIS slot's
+// proxied stream for a recall anchored at t. A preset that plays a direct
+// (non-proxied) URL never stamps; the now_playing check decides for it.
 func (h *presetWsHandler) slotPulledSince(slot int, t time.Time) bool {
-	if h.slotStreamActivity == nil {
+	if h.slotPulled == nil {
 		return false
 	}
-	lf := h.slotStreamActivity(slot)
-	return !lf.IsZero() && lf.After(t)
+	return h.slotPulled(slot, t)
 }
 
 // superseded reports whether a newer hardware press (pressSeq moved past seq)
@@ -1727,6 +1769,12 @@ func (h *presetWsHandler) OnSourceRejected(_ context.Context) {
 	h.sourceRejectMu.Lock()
 	h.lastSourceReject = time.Now()
 	h.sourceRejectMu.Unlock()
+	// A 1036 rejection precedes the forced re-login, and the re-onboarding
+	// that follows is when the firmware wipes its hardware-key preset
+	// registrations (field bundles: "missing=5/6" healed right after every
+	// "forced re-login sent"). Schedule the heal proactively; own short
+	// budget, so a routine ask cannot starve it.
+	requestPresetKeyResyncUrgent(h.logger)
 }
 
 // lastSourceRejectTime returns when the box last rejected STR's source (zero if
@@ -1769,14 +1817,21 @@ func (h *presetWsHandler) OnThumbActivity(ctx context.Context) {
 
 // presetResyncAsk flags one forced full box-preset re-sync for the periodic
 // reconcile (the #342 dead-key self-heal). presetResyncLast rate-limits the
-// requests so repeated thumbs presses cannot cause a re-sync storm.
+// routine requests so repeated thumbs presses cannot cause a re-sync storm;
+// presetResyncUrgentLast is a SEPARATE, shorter budget for the deterministic
+// wipe moments (a 1036 source rejection precedes a forced re-login, and the
+// re-onboarding is when the firmware drops its key registrations) so a routine
+// ask consumed minutes earlier cannot starve the heal that is actually needed
+// now (field bundles 2026-07-22: five dead-key presses produced no resync
+// because the boot-time ask had eaten the 10-minute budget).
 var (
-	presetResyncAsk  atomic.Bool
-	presetResyncLast atomic.Int64 // unix seconds of the last accepted request
+	presetResyncAsk        atomic.Bool
+	presetResyncLast       atomic.Int64 // unix seconds of the last accepted routine request
+	presetResyncUrgentLast atomic.Int64 // unix seconds of the last accepted urgent request
 )
 
 func requestPresetKeyResync(logger *slog.Logger) {
-	const minGapSec = 10 * 60
+	const minGapSec = 2 * 60
 	now := time.Now().Unix()
 	last := presetResyncLast.Load()
 	if last != 0 && now-last < minGapSec {
@@ -1787,7 +1842,27 @@ func requestPresetKeyResync(logger *slog.Logger) {
 	}
 	presetResyncAsk.Store(true)
 	if logger != nil {
-		logger.Info("preset self-heal: lone key activity with no selection frame; scheduling a full box preset re-sync (#342)")
+		logger.Info("preset self-heal: scheduling a full box preset re-sync (#342)")
+	}
+}
+
+// requestPresetKeyResyncUrgent is requestPresetKeyResync for the moments where
+// a box-side key wipe is EXPECTED (a 1036 rejection / forced re-login, a fresh
+// pairing): it uses its own short budget so it cannot be starved by a routine
+// ask, and the reconcile's 10s wake bounds how often the forced pass can run.
+func requestPresetKeyResyncUrgent(logger *slog.Logger) {
+	const minGapSec = 60
+	now := time.Now().Unix()
+	last := presetResyncUrgentLast.Load()
+	if last != 0 && now-last < minGapSec {
+		return
+	}
+	if !presetResyncUrgentLast.CompareAndSwap(last, now) {
+		return
+	}
+	presetResyncAsk.Store(true)
+	if logger != nil {
+		logger.Info("preset self-heal: urgent full box preset re-sync scheduled (re-login/pairing wipes the key registrations)")
 	}
 }
 
@@ -2675,6 +2750,7 @@ func reconcileOnce(store *presets.Store, boxHost string, logger *slog.Logger, fo
 			})
 		}
 	}
+	syncFailed := false
 	if len(missing) > 0 {
 		if forceFull {
 			logger.Info("preset reconcile: full re-sync after box became ready (registers hardware buttons)", "slots", len(missing))
@@ -2688,6 +2764,7 @@ func reconcileOnce(store *presets.Store, boxHost string, logger *slog.Logger, fo
 		errs := boxcli.SyncAllPresets(context.Background(), boxHost, missing)
 		for _, spec := range missing {
 			if serr, failed := errs[spec.Slot]; failed {
+				syncFailed = true
 				logger.Warn("preset reconcile: AddPreset failed", "slot", spec.Slot, "err", serr)
 			} else {
 				logger.Info("preset reconcile healed", "slot", spec.Slot)
@@ -2715,6 +2792,16 @@ func reconcileOnce(store *presets.Store, boxHost string, logger *slog.Logger, fo
 			logger.Info("preset reconcile: removed a stale STR preset the store no longer backs (dead button after reinstall)", "slot", slot)
 		}
 		cancel()
+	}
+	// A pass with failed AddPresets is NOT done: returning true here dropped
+	// the loop to the 5-minute maintenance cadence while the box's key layer
+	// stayed empty, which is exactly the "hardware keys dead for ~6.5 minutes
+	// after every power cycle" window in the field bundles (a just-booted
+	// BoseApp accepts GET /presets but rejects AddPreset for a while). Report
+	// not-ready so the 10s fast cadence retries until every slot registered.
+	if syncFailed {
+		logger.Warn("preset reconcile: some AddPresets failed, keeping the fast retry cadence")
+		return false
 	}
 	return true
 }
@@ -2793,6 +2880,22 @@ var xmlEntityReplacer = strings.NewReplacer(
 	"&amp;", "&", "&lt;", "<", "&gt;", ">", "&quot;", `"`, "&apos;", "'")
 
 func xmlEntityUnescape(s string) string { return xmlEntityReplacer.Replace(s) }
+
+// margeXMLEscape escapes user-provided text (station names, art URLs) for the
+// marge preset template, which is a text/template and does not escape XML.
+var margeXMLEscaper = strings.NewReplacer(
+	"&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;", "'", "&apos;")
+
+func margeXMLEscape(s string) string { return margeXMLEscaper.Replace(s) }
+
+// firstArtURL returns the first entry of a pipe-separated art fallback chain
+// (how preset.Art is persisted); the box only ever gets one URL.
+func firstArtURL(art string) string {
+	if idx := strings.Index(art, "|"); idx >= 0 {
+		return art[:idx]
+	}
+	return art
+}
 
 // seedBoxPresetsAndRecoverStore runs once in the background at agent start.
 // Two jobs (#252, the ST20 whose presets showed "unassigned although they are

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -665,10 +665,15 @@ func run() error {
 	// the recently-played history can identify (#252: presets displayed as
 	// "unassigned although they are assigned" and every hardware press 404ed
 	// after a pre-v0.9.14 standby power-cut wiped presets.json and the OTA
-	// restart surfaced the loss).
+	// restart surfaced the loss). seedFirstRead closes once the first box
+	// preset read was attempted; autopair's start waits on it (bounded) so the
+	// first forced re-assert cannot re-onboard the box - and thereby wipe its
+	// preset list - before the recovery had its one chance to snapshot it.
+	seedFirstRead := make(chan struct{})
 	go seedBoxPresetsAndRecoverStore(store, recentStore, *boxHost,
 		func(bps []webui.BoxPreset) { webuiSrv.NoteBoxPresets(bps) },
-		logger.With("comp", "presetrecovery"))
+		logger.With("comp", "presetrecovery"),
+		func() { close(seedFirstRead) })
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
@@ -718,10 +723,19 @@ func run() error {
 	// Auto-pair background: pairs the box automatically on start. Re-pairs
 	// every 5 minutes in case the box is ever lost. Plus: the WS handler
 	// triggers TriggerNow on a preset press so pairing happens immediately
-	// after waking from standby.
+	// after waking from standby. Starts only after the preset recovery's
+	// first box read was attempted (bounded wait): the first pair cycle
+	// forces a re-assert, and the re-onboarding it triggers wipes the box
+	// preset list the recovery needs to read (#252 warm-restart race).
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		select {
+		case <-seedFirstRead:
+		case <-time.After(5 * time.Second):
+		case <-ctx.Done():
+			return
+		}
 		autoPair.RunBackground(ctx, 8*time.Second, 5*time.Minute)
 	}()
 
@@ -1303,14 +1317,50 @@ func (h *presetWsHandler) superseded(seq, gen uint64) bool {
 
 // wake brings the box out of standby (no-op without a configured box host or
 // when the box is already awake). Seam-aware for the verify tests.
-func (h *presetWsHandler) wake(ctx context.Context) error {
+//
+// abort (nil = never) is consulted by the wake helper immediately before it
+// would send the `sys power` toggle: the verify paths pass their stand-down
+// predicate so a user power press that lands AFTER the caller's loop-top check
+// but BEFORE the toggle still keeps the box off - the standby classifier
+// stamps the latch within milliseconds of the flip, while the wake's own
+// self-wake grace is 2.5s, so by toggle time the stamp is reliably visible.
+func (h *presetWsHandler) wake(ctx context.Context, abort func() bool) error {
 	if h.boxHost == "" {
 		return nil
 	}
 	if h.wakeBox != nil {
+		if abort != nil && abort() {
+			return nil
+		}
 		return h.wakeBox(ctx, h.boxHost)
 	}
-	return boxcli.WakeAndWait(ctx, h.boxHost, 6*time.Second, h.logger)
+	return boxcli.WakeAndWaitAbort(ctx, h.boxHost, 6*time.Second, h.logger, abort)
+}
+
+// triggerPairAsync fires one fire-and-forget pair cycle (9a9b0c7): the :8090
+// pair POST hangs for seconds on several firmwares, so it must never sit
+// between a button press and playback (#270). timeout bounds the cycle (press
+// paths use a short budget; wake/reconnect paths can afford a longer one).
+func (h *presetWsHandler) triggerPairAsync(timeout time.Duration) {
+	if h.autoPair == nil {
+		return
+	}
+	go func() {
+		pairCtx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		h.autoPair.TriggerNow(pairCtx)
+	}()
+}
+
+// recallStandDown reports whether an in-flight hardware recall must leave the
+// box alone: a newer press/play owns the transport, the user powered the box
+// off, or the user deliberately stopped playback since the press. Re-checked
+// not only at each verify tick but immediately before every escalation (wake,
+// sys-power nudge, re-push): those run seconds after the loop-top check, and a
+// power press inside that gap used to be reversed by the very wake that was
+// meant to recover the box's own give-up (#197).
+func (h *presetWsHandler) recallStandDown(seq, gen uint64, pressAt time.Time) bool {
+	return h.superseded(seq, gen) || h.poweredOffSince(pressAt) || h.userStoppedSince(pressAt)
 }
 
 // sysPowerToggle sends one `sys power` toggle over the TAP CLI (the stuck-
@@ -1345,6 +1395,10 @@ func (h *presetWsHandler) currentBoxSource() string {
 
 // poweredOffSince reports whether the user powered the box off after t,
 // preferring the absolute stamp over the rolling window (see standbyStopAfter).
+// The recentlyPoweredOff fallback is unreachable in production (main wires both
+// funcs from the same webui server); it exists so a partially-wired test - or a
+// future caller that only has the rolling window - still gets the conservative
+// answer instead of nil-func false.
 func (h *presetWsHandler) poweredOffSince(t time.Time) bool {
 	if h.standbyStopAfter != nil {
 		return h.standbyStopAfter(t)
@@ -1363,11 +1417,9 @@ func (h *presetWsHandler) OnPresetsChanged(_ context.Context, presets []boxws.Bo
 }
 
 func (h *presetWsHandler) OnPresetSelected(ctx context.Context, slot int, location, title string) {
-	// Sequence + press time are taken while still on the gabbo read loop, so
-	// rapid presses are ordered exactly as the user made them and every
+	// Press time is taken while still on the gabbo read loop, so every
 	// stand-down check anchors to when the user actually pressed, not to when
 	// STR got around to the recall.
-	seq := h.pressSeq.Add(1)
 	pressAt := time.Now()
 	// Per-key webhook (beta): fire the configured "preset<slot>" webhook on a
 	// hardware preset press (front panel or remote; app recalls take a different
@@ -1390,6 +1442,11 @@ func (h *presetWsHandler) OnPresetSelected(ctx context.Context, slot int, locati
 			return
 		}
 	}
+	// The press sequence orders rapid presses exactly as the user made them.
+	// Bumped only for presses that actually recall (i.e. after the replace-mode
+	// return above): a webhook-only press starts no recall of its own, so it
+	// must not read as "a newer press" to an unrelated in-flight verify.
+	seq := h.pressSeq.Add(1)
 	// The press is the user explicitly asking for playback: clear any stale
 	// deliberate-stop latch BEFORE the recall so a preceding (or spontaneous,
 	// #419) power-off cannot suppress it, and anchor the webui's standby-flip
@@ -1548,26 +1605,16 @@ func (h *presetWsHandler) recallPreset(ctx context.Context, seq uint64, pressAt 
 	}
 
 	// Wake from standby (fast on a hardware press, the box is already awake) AFTER
-	// the display push, so the SetURI is not delayed behind it.
-	if h.boxHost != "" {
-		wakeCtx, wcancel := context.WithTimeout(ctx, 8*time.Second)
-		if err := boxcli.WakeAndWait(wakeCtx, h.boxHost, 6*time.Second, h.logger); err != nil {
-			h.logger.Warn("could not bring box out of STANDBY", "err", err)
-		}
-		wcancel()
+	// the display push, so the SetURI is not delayed behind it. No abort: the
+	// press itself is the user's most recent intent.
+	wakeCtx, wcancel := context.WithTimeout(ctx, 8*time.Second)
+	if err := h.wake(wakeCtx, nil); err != nil {
+		h.logger.Warn("could not bring box out of STANDBY", "err", err)
 	}
-	if h.autoPair != nil {
-		// Fire-and-forget, mirroring the app-recall path (9a9b0c7): the
-		// :8090 pair POST hangs for seconds on several firmwares, and running
-		// it inline here kept the box's own "SERVICE NOT AVAILABLE" flash on
-		// screen for that whole gap on every hardware press (#270). Pairing
-		// is not a precondition for the UPnP push above.
-		go func() {
-			pairCtx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
-			defer cancel()
-			h.autoPair.TriggerNow(pairCtx)
-		}()
-	}
+	wcancel()
+	// Fire-and-forget, mirroring the app-recall path: pairing is not a
+	// precondition for the UPnP push above.
+	h.triggerPairAsync(6 * time.Second)
 	// Verify+retry in the background: the first hardware press after a cold
 	// boot can race the box/agent bringup so nothing plays until a second
 	// press. This re-issues until the box actually plays. Affects radio too.
@@ -1955,13 +2002,7 @@ func (h *presetWsHandler) OnPowerWake(_ context.Context) {
 	// pairing right at the wake. On a healthy box this is one /info read; on
 	// a login-suspect box (a recent 1036 NOT_LOGGED_IN) it re-asserts the
 	// account before the user's first press instead of after its failure.
-	if h.autoPair != nil {
-		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-			h.autoPair.TriggerNow(ctx)
-		}()
-	}
+	h.triggerPairAsync(10 * time.Second)
 	if h.onPowerWake != nil {
 		h.logger.Info("power-on detected, attempting last-station resume")
 		h.onPowerWake()
@@ -1984,13 +2025,7 @@ func (h *presetWsHandler) OnConnected(_ context.Context) {
 	requestPresetKeyResync(h.logger)
 	// Re-check the fake login too (see OnPowerWake): the reconnect moments
 	// are when the MargeHSM state decays on fresh-install boxes.
-	if h.autoPair != nil {
-		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-			h.autoPair.TriggerNow(ctx)
-		}()
-	}
+	h.triggerPairAsync(10 * time.Second)
 	if h.onBoxReconnect != nil {
 		h.onBoxReconnect()
 	}
@@ -2129,15 +2164,7 @@ func (h *presetWsHandler) playSpotifyPreset(ctx context.Context, seq uint64, pre
 		}
 		c()
 	}
-	if h.autoPair != nil {
-		// Fire-and-forget (9a9b0c7): never let a hanging :8090 pair POST sit
-		// between the button press and playback (#270).
-		go func() {
-			pairCtx, c := context.WithTimeout(context.Background(), 6*time.Second)
-			defer c()
-			h.autoPair.TriggerNow(pairCtx)
-		}()
-	}
+	h.triggerPairAsync(6 * time.Second)
 	// Load the playlist (audio): a default preset resumes where the user left off
 	// (shuffle off, in-order); a shuffle preset starts on a fresh random track.
 	if err := h.spotify.PlayAccount(playCtx, p.URI, p.Account, spotify.PlayOptions{Shuffle: p.Shuffle}); err != nil {
@@ -2225,14 +2252,27 @@ func (h *presetWsHandler) verifyPlayURL(seq, gen uint64, pressAt time.Time, slot
 		}
 		h.logger.Warn("hardware recall not playing yet, retrying", "slot", slot, "attempt", attempt)
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		// standDown re-checks the loop-top conditions right before every
+		// escalation below: the currentBoxSource probe, the nudge settle and
+		// the wake together stretch several seconds past the loop-top check,
+		// and a user power press inside that gap was correctly classified and
+		// stamped - but the already-running iteration then toggled the box
+		// straight back on (#197 check-then-act).
+		standDown := func() bool { return h.recallStandDown(seq, gen, pressAt) }
 		// A box stuck in INVALID_SOURCE ignores wake (WakeAndWait only toggles
 		// out of STANDBY) and inertly ACKs every SetURI+Play without ever
 		// fetching audio; in the mojo/ST30 field bundle the ONLY successful
 		// source activation of the day followed a real sys-power toggle. If the
 		// box still reports INVALID_SOURCE by the third attempt, send one
-		// bounded nudge before pushing again.
-		if nudgeStuckSource(attempt, nudged, h.currentBoxSource()) {
+		// bounded nudge before pushing again. The source probe (an up-to-4s
+		// :8090 read) only runs on the attempt that can consume it.
+		if attempt == 3 && !nudged && nudgeStuckSource(attempt, nudged, h.currentBoxSource()) {
 			nudged = true
+			if standDown() {
+				h.logger.Info("hardware recall: stand-down while preparing the sys-power nudge, leaving the box alone", "slot", slot)
+				cancel()
+				return
+			}
 			h.logger.Warn("hardware recall: box stuck in INVALID_SOURCE, sending one sys-power nudge", "slot", slot)
 			if err := h.sysPowerToggle(ctx); err != nil {
 				h.logger.Warn("hardware recall: sys-power nudge failed", "slot", slot, "err", err)
@@ -2245,11 +2285,18 @@ func (h *presetWsHandler) verifyPlayURL(seq, gen uint64, pressAt time.Time, slot
 		// models: the box "switches itself off" after the press). Every retry
 		// then pushed SetURI+Play into a sleeping box and the recall never
 		// converged, even though the forced re-login had already landed. A
-		// user power-off cannot reach this line (poweredOffSince stands the
-		// loop down above), so waking here only ever reverses the box's own
-		// give-up. No-op when the box is awake (a single now_playing read).
-		if err := h.wake(ctx); err != nil {
+		// user power-off stands the loop down above AND aborts the wake's
+		// toggle via the predicate, so waking here only ever reverses the
+		// box's own give-up. No-op when the box is awake.
+		if err := h.wake(ctx, standDown); err != nil {
 			h.logger.Warn("hardware recall retry: could not wake box", "slot", slot, "err", err)
+		}
+		// Final gate before the push: the wake can take seconds, and a stop or
+		// power press during it must hold.
+		if standDown() {
+			h.logger.Info("hardware recall: stand-down after wake, not re-pushing", "slot", slot)
+			cancel()
+			return
 		}
 		if mime != "" {
 			_ = h.renderer.PlayURLMime(ctx, url, name, icon, mime)
@@ -2304,10 +2351,16 @@ func (h *presetWsHandler) rePushAfterSourceReject(seq, gen uint64, pressAt time.
 	// The rejection's INVALID_SOURCE flap can end in STANDBY within ~1s of the
 	// press (the box gives up on its failed self-activation and powers off);
 	// re-pushing into that sleeping box did nothing. Wake it first - a no-op
-	// when it is awake, and a user power-off never reaches this line (checked
-	// above).
-	if err := h.wake(ctx); err != nil {
+	// when it is awake. The stand-down predicate covers the check-then-act
+	// gap: a user power press between the checks above and the wake's toggle
+	// must keep the box off (#197).
+	standDown := func() bool { return h.recallStandDown(seq, gen, pressAt) }
+	if err := h.wake(ctx, standDown); err != nil {
 		h.logger.Warn("wrong-state repair: could not wake box", "slot", slot, "err", err)
+	}
+	if standDown() {
+		h.logger.Info("wrong-state repair: stand-down after wake, not re-pushing", "slot", slot)
+		return
 	}
 	// The box refused the stream because its transport is stuck in the wrong
 	// state: it is still holding its own dead-cloud ContentItem active (the box
@@ -2979,18 +3032,39 @@ func firstArtURL(art string) string {
 //     layer works. Restore what the recently-played history can identify by
 //     exact station/playlist name, so the buttons come back without the user
 //     re-saving every slot.
-func seedBoxPresetsAndRecoverStore(store *presets.Store, recentStore *recent.Store, boxHost string, seed func([]webui.BoxPreset), logger *slog.Logger) {
+//
+// firstAttempt (nil = none) is called exactly once, right after the FIRST
+// :8090/presets read attempt returns, success or not. main gates autopair's
+// first forced re-assert on it: that re-assert makes the box re-read its cloud
+// presets from marge, and with an EMPTY stick store marge answers an empty
+// list, which wipe-prone firmwares translate into dropping their own preset
+// list within seconds - i.e. the re-onboarding at t=8s destroyed the very box
+// list this recovery wanted to read at t=20s, and the presets were lost for
+// good on exactly the warm-restart (#252/OTA) case the recovery targets.
+// Reading first, then pairing, closes the race.
+func seedBoxPresetsAndRecoverStore(store *presets.Store, recentStore *recent.Store, boxHost string, seed func([]webui.BoxPreset), logger *slog.Logger, firstAttempt func()) {
 	if boxHost == "" || store == nil {
+		if firstAttempt != nil {
+			firstAttempt()
+		}
 		return
 	}
-	// The box needs ~60s after a cold boot before :8090 answers; poll gently
-	// and give up quietly after ~10 minutes (the periodic reconcile keeps
-	// running regardless).
+	// First read attempt runs IMMEDIATELY: on a warm agent restart (OTA) the
+	// box answers right away, and the snapshot must be taken before autopair's
+	// first forced re-assert (see firstAttempt above). Only a cold boot - where
+	// :8090 needs ~60s to come up - falls back to the gentle 20s polling, which
+	// gives up quietly after ~10 minutes (the periodic reconcile keeps running
+	// regardless).
 	var entries []boxPresetEntry
 	for i := 0; i < 30; i++ {
-		time.Sleep(20 * time.Second)
+		if i > 0 {
+			time.Sleep(20 * time.Second)
+		}
 		var err error
 		entries, err = fetchBoxPresetsFull(boxHost)
+		if i == 0 && firstAttempt != nil {
+			firstAttempt()
+		}
 		if err == nil {
 			break
 		}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1821,6 +1821,17 @@ func (h *presetWsHandler) OnPowerWake(_ context.Context) {
 	// plays"). Ask for a full re-sync right at the wake so the keys work
 	// within seconds instead of minutes. Rate-limited internally.
 	requestPresetKeyResync(h.logger)
+	// The fake marge login decays across the same power cycles: re-check the
+	// pairing right at the wake. On a healthy box this is one /info read; on
+	// a login-suspect box (a recent 1036 NOT_LOGGED_IN) it re-asserts the
+	// account before the user's first press instead of after its failure.
+	if h.autoPair != nil {
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			h.autoPair.TriggerNow(ctx)
+		}()
+	}
 	if h.onPowerWake != nil {
 		h.logger.Info("power-on detected, attempting last-station resume")
 		h.onPowerWake()
@@ -1841,6 +1852,15 @@ func (h *presetWsHandler) OnConnected(_ context.Context) {
 	// hardware-key preset registrations (see OnPowerWake). Ask for a full
 	// re-sync so the keys are registered again within seconds.
 	requestPresetKeyResync(h.logger)
+	// Re-check the fake login too (see OnPowerWake): the reconnect moments
+	// are when the MargeHSM state decays on fresh-install boxes.
+	if h.autoPair != nil {
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			h.autoPair.TriggerNow(ctx)
+		}()
+	}
 	if h.onBoxReconnect != nil {
 		h.onBoxReconnect()
 	}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -515,6 +515,10 @@ func run() error {
 	// Wedge detection (see internal/webui/wedge.go): the proxy's last-fetch /
 	// last-failure timestamps tell a wedged box apart from a failing station.
 	webuiSrv.SetStreamActivityFn(streamProxySrv.LastActivity)
+	// Surface speaker-side failure states ("wedged", "login-error") in
+	// /api/stream-status, so the app can name the real cause instead of
+	// blaming the station and cycling radio-browser alternates.
+	streamProxySrv.SetBoxStateFn(webuiSrv.BoxStateHint)
 
 	// ICY radio text: the proxy parses the live StreamTitle out of the
 	// stream; push it to the box display by re-issuing the current stream URI

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -509,8 +509,12 @@ func run() error {
 		onRemoteSkip: webuiSrv.HardwareSkip,
 		webhooks:     webhooksStore,
 		// Record hardware-preset recalls so the wake-resume + auto-re-push know
-		// what to bring back.
+		// what to bring back. Returns the recall generation for supersession.
 		noteLastPlay: webuiSrv.NoteLastPlay,
+		// Supersession: a hardware verify stands down as soon as a newer play
+		// (hardware or app) bumps the shared recall generation, mirroring the
+		// soft path's verifyRecall guard ("pressed 2, got 1").
+		recallGenFn: webuiSrv.RecallGeneration,
 		// Wedge detection (power-cycle hint) fed from the hardware path too.
 		noteRecallExhausted: webuiSrv.NoteRecallExhausted,
 		noteBoxHealthy:      webuiSrv.NoteBoxHealthy,
@@ -531,15 +535,20 @@ func run() error {
 		onEnterStandby: webuiSrv.HandleEnterStandby,
 		// Let the hardware-recall verify stand down when the user powered the box
 		// off mid-recall, so it does not re-push the stream into a power-off (#197).
+		// The absolute variant is preferred: the rolling 6s window could expire
+		// between verify ticks and let a re-push wake the powered-off box.
 		recentlyPoweredOff: webuiSrv.RecentlyPoweredOff,
+		standbyStopAfter:   webuiSrv.StandbyStoppedAfter,
 		// A hardware preset press is the strongest possible "play" signal: it
 		// clears any deliberate-stop latch an earlier (or spontaneous, #419)
 		// power-off armed, so the recall is not suppressed by stale intent.
 		noteUserPlay: webuiSrv.NoteUserPlay,
-		// Ground truth for the recall verify: the box opening a proxied stream
-		// proves it is playing, where now_playing can still name the previous
-		// preset for seconds after the switch.
-		streamActivity: streamProxySrv.LastActivity,
+		// Ground truth for the recall verify: the box opening THIS slot's proxied
+		// stream proves it is playing what the recall pushed, where now_playing
+		// can still name the previous preset for seconds after the switch.
+		// Slot-scoped so cross-traffic (another slot, a zone follower) cannot
+		// certify a failed recall as healthy (#252).
+		slotStreamActivity: streamProxySrv.LastFetchForSlot,
 		// Surface the box's own presets (incl. foreign sources like Deezer) to the
 		// webui so the app can show/preserve them (Option C). Map boxws -> webui at
 		// the composition root to keep the two packages decoupled.
@@ -581,6 +590,15 @@ func run() error {
 		fmt.Sprintf("ws://%s:8080/", *boxHost),
 		wsHandler,
 	)
+	// Tell the gabbo classifier about STR's OWN transport commands: the box
+	// answers a SOAP Stop (and a SetURI flip) with a STOP_STATE frame that is
+	// indistinguishable from the user pressing stop, and reading it as a user
+	// stop latched a phantom stand-down that killed the very recall the command
+	// belonged to (#252 post-v0.9.16: the wrong-state repair's Stop+ClearURI
+	// aborted its own verify). Both renderer instances drive THIS box, so both
+	// stamp the same classifier.
+	renderer.OnTransportCommand = wsClient.NoteOwnTransportCommand
+	webuiSrv.SetTransportCommandHook(wsClient.NoteOwnTransportCommand)
 	// Let the WebUI fill the Wi-Fi signal from the gabbo stream on BCO
 	// boxes, whose /networkInfo reports no signal.
 	webuiSrv.SetWifiSignalFn(wsClient.LastWifiSignal)
@@ -594,6 +612,16 @@ func run() error {
 	// STR self-heals instead of thrashing the box into a wedge (rate-limited in
 	// boxws).
 	wsClient.SetOnLoginError(webuiSrv.NoteBoxLoginError)
+
+	// Seed the box-native preset snapshot once at start and, if the NAND preset
+	// store came up empty while the box still lists STR presets, restore what
+	// the recently-played history can identify (#252: presets displayed as
+	// "unassigned although they are assigned" and every hardware press 404ed
+	// after a pre-v0.9.14 standby power-cut wiped presets.json and the OTA
+	// restart surfaced the loss).
+	go seedBoxPresetsAndRecoverStore(store, recentStore, *boxHost,
+		func(bps []webui.BoxPreset) { webuiSrv.NoteBoxPresets(bps) },
+		logger.With("comp", "presetrecovery"))
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
@@ -1106,8 +1134,23 @@ type presetWsHandler struct {
 	// noteLastPlay records a hardware-preset recall as the webui's lastPlay so
 	// the auto-re-push and the wake-resume know what to resume (the hardware path
 	// plays straight through the renderer, bypassing the webui's own lastPlay).
+	// Returns the new recall generation for the supersession check below.
 	// Wired to webui.NoteLastPlay. nil-safe.
-	noteLastPlay func(boxURL, title, art, mime string)
+	noteLastPlay func(boxURL, title, art, mime string) uint64
+	// recallGenFn reads the webui's current recall generation. A hardware
+	// verify captures the generation its own noteLastPlay returned and stands
+	// down as soon as the live value moves on: a newer play (second hardware
+	// press or an app recall) supersedes the old loop, which otherwise kept
+	// re-pushing its stale URL over the user's newest choice for up to ~26s
+	// ("pressed 2, got 1"). The soft path has had exactly this guard
+	// (verifyRecall's recallGen) all along. Wired to webui.RecallGeneration.
+	// nil-safe.
+	recallGenFn func() uint64
+	// pressSeq orders the hardware presses themselves. It is bumped on the
+	// gabbo read loop (strictly in press order) before the slow recall work is
+	// handed to a goroutine, so a stale recall goroutine can recognise that a
+	// newer press exists even before either has reached noteLastPlay.
+	pressSeq atomic.Uint64
 	// Wedge detection hooks (webui.NoteRecallExhausted / NoteBoxHealthy): the
 	// hardware recall path reports exhausted/successful verifies so the
 	// power-cycle hint also fires when the user only uses the preset keys.
@@ -1141,6 +1184,13 @@ type presetWsHandler struct {
 	// firmware switched the speaker back on (#197). Wired to webui.RecentlyPoweredOff.
 	// nil-safe.
 	recentlyPoweredOff func() bool
+	// standbyStopAfter is the absolute variant of recentlyPoweredOff: it reports
+	// a power-off strictly AFTER the given time (the press). The rolling 6s
+	// window could expire between two verify ticks and let a re-push wake the
+	// powered-off box after all; the absolute stamp cannot. Preferred when
+	// wired; recentlyPoweredOff stays as the fallback. Wired to
+	// webui.StandbyStoppedAfter. nil-safe.
+	standbyStopAfter func(t time.Time) bool
 	// noteBoxPresets records the box's OWN preset list (gabbo presetsUpdated),
 	// including foreign sources like Deezer that STR did not set, into the webui
 	// so the app can show and preserve them (Option C). Wired to
@@ -1157,23 +1207,55 @@ type presetWsHandler struct {
 	// earlier stop, #419) and anchors the standby-flip discriminator. Wired to
 	// webui.Server.NoteUserPlay. nil-safe.
 	noteUserPlay func()
-	// streamActivity reports when the box last OPENED a proxied stream. It is
-	// the recall verify's ground truth: the box pulling audio through the proxy
-	// proves it is playing, whereas now_playing lags and can still name the
-	// PREVIOUS preset seconds after the box switched. Wired to
-	// streamproxy.Server.LastActivity. nil-safe.
-	streamActivity func() (lastFetch, lastFailure time.Time)
+	// slotStreamActivity reports when the box last OPENED the given slot's
+	// proxied stream. It is the recall verify's ground truth: the box pulling
+	// THIS slot's audio through the proxy proves it plays what this recall
+	// pushed, whereas now_playing lags and can still name the PREVIOUS preset
+	// seconds after the box switched. Slot-scoped on purpose: the old global
+	// stamp let any proxied fetch (another slot's reconnect, a zone follower,
+	// even a 404) certify a failed recall as healthy at the first tick, so no
+	// retry ran and the wedge counter was falsely cleared (#252). Wired to
+	// streamproxy.Server.LastFetchForSlot. nil-safe.
+	slotStreamActivity func(slot int) time.Time
 }
 
-// pulledStreamSince reports whether the box opened a proxied stream after t,
-// i.e. it really is fetching what this recall pushed. Used by the recall verify
-// as the authoritative success signal.
-func (h *presetWsHandler) pulledStreamSince(t time.Time) bool {
-	if h.streamActivity == nil {
+// slotPulledSince reports whether the box opened THIS slot's proxied stream
+// after t, i.e. it really is fetching what this recall pushed. A preset that
+// plays a direct (non-proxied) URL never stamps; the now_playing check decides
+// for it.
+func (h *presetWsHandler) slotPulledSince(slot int, t time.Time) bool {
+	if h.slotStreamActivity == nil {
 		return false
 	}
-	lastFetch, _ := h.streamActivity()
-	return !lastFetch.IsZero() && lastFetch.After(t)
+	lf := h.slotStreamActivity(slot)
+	return !lf.IsZero() && lf.After(t)
+}
+
+// superseded reports whether a newer hardware press (pressSeq moved past seq)
+// or a newer play of any kind (the webui recall generation moved past gen)
+// exists. Verify/re-push loops of an older recall stand down on it instead of
+// fighting the newest recall for the transport. gen==0 means the generation
+// was never captured (no webui wired); only the press sequence decides then.
+func (h *presetWsHandler) superseded(seq, gen uint64) bool {
+	if h.pressSeq.Load() != seq {
+		return true
+	}
+	if gen != 0 && h.recallGenFn != nil && h.recallGenFn() != gen {
+		return true
+	}
+	return false
+}
+
+// poweredOffSince reports whether the user powered the box off after t,
+// preferring the absolute stamp over the rolling window (see standbyStopAfter).
+func (h *presetWsHandler) poweredOffSince(t time.Time) bool {
+	if h.standbyStopAfter != nil {
+		return h.standbyStopAfter(t)
+	}
+	if h.recentlyPoweredOff != nil {
+		return h.recentlyPoweredOff()
+	}
+	return false
 }
 
 // OnPresetsChanged forwards the box's own preset list to the webui (Option C).
@@ -1184,17 +1266,28 @@ func (h *presetWsHandler) OnPresetsChanged(_ context.Context, presets []boxws.Bo
 }
 
 func (h *presetWsHandler) OnPresetSelected(ctx context.Context, slot int, location, title string) {
+	// Sequence + press time are taken while still on the gabbo read loop, so
+	// rapid presses are ordered exactly as the user made them and every
+	// stand-down check anchors to when the user actually pressed, not to when
+	// STR got around to the recall.
+	seq := h.pressSeq.Add(1)
+	pressAt := time.Now()
 	// Per-key webhook (beta): fire the configured "preset<slot>" webhook on a
 	// hardware preset press (front panel or remote; app recalls take a different
 	// path and never reach here). In replace mode, withhold the preset playback
 	// so only the webhook runs (the user has cleared the STR preset for this
-	// slot); in additional mode, the preset plays AND the webhook fires.
+	// slot); in additional mode, the preset plays AND the webhook fires. The
+	// replace decision is a config read and stays synchronous; the HTTP fire
+	// runs in a goroutine because a slow webhook target stalled the read loop
+	// for up to 8s per press, delaying every queued frame.
 	if h.webhooks != nil && slot >= 1 && slot <= 6 {
 		id := fmt.Sprintf("preset%d", slot)
 		replace := h.webhooks.ButtonReplaceEnabled(id)
-		if h.webhooks.FireButton(ctx, id) {
-			h.logger.Info("preset webhook fired", "slot", slot, "replace", replace)
-		}
+		go func() {
+			if h.webhooks.FireButton(ctx, id) {
+				h.logger.Info("preset webhook fired", "slot", slot, "replace", replace)
+			}
+		}()
 		if replace {
 			h.logger.Info("preset webhook replace mode: withholding preset playback", "slot", slot)
 			return
@@ -1208,6 +1301,27 @@ func (h *presetWsHandler) OnPresetSelected(ctx context.Context, slot int, locati
 	if h.noteUserPlay != nil {
 		h.noteUserPlay()
 	}
+	// Everything below talks to the box (SOAP, wake, pairing) and takes seconds
+	// on a cold or wedged box - exactly the boxes whose presses were failing.
+	// It used to run synchronously right here on the gabbo read loop, holding
+	// up every queued frame (the teardown STOP_STATE, the press's own trailing
+	// userActivityUpdate, 1036 errorUpdates, the user's next press) for up to
+	// ~18s. All the teardown windows in boxws and the #419 power-off
+	// discriminator in the webui measure at frame-PROCESSING time, so that
+	// delay made them read the box's routine teardown as user intent: a
+	// phantom user stop killed the verify, and the trailing key frame turned a
+	// mid-recall standby flap into a "user power-off" that cleared the
+	// transport - the ST20 that "switches itself off on every preset press"
+	// and the ST30 whose remote presses never play (#252). The read loop must
+	// keep draining; the recall runs beside it.
+	go h.recallPreset(ctx, seq, pressAt, slot, location, title)
+}
+
+// recallPreset is the slow half of a hardware preset press: the queue-preset
+// claim, the Spotify branch, URL selection, the UPnP push, wake, pairing and
+// the background verify. Runs OFF the gabbo read loop; seq/pressAt come from
+// the press event and drive supersession and the stand-down anchors.
+func (h *presetWsHandler) recallPreset(ctx context.Context, seq uint64, pressAt time.Time, slot int, location, title string) {
 	// A queue preset (a saved DLNA folder) is recalled by the webui's play-queue,
 	// not the single-track UPnP play below. Let it claim the press; it returns
 	// true (and starts the queue) only for a queue preset, so every other preset
@@ -1243,7 +1357,7 @@ func (h *presetWsHandler) OnPresetSelected(ctx context.Context, slot int, locati
 		// recalled by telling go-librespot to play the saved URI and then
 		// pointing the box's UPnP renderer at our live /spotify/stream.
 		if p.Type == "spotify" && p.URI != "" {
-			h.playSpotifyPreset(ctx, slot, p)
+			h.playSpotifyPreset(ctx, seq, pressAt, slot, p)
 			return
 		}
 		if p.Name != "" {
@@ -1300,6 +1414,23 @@ func (h *presetWsHandler) OnPresetSelected(ctx context.Context, slot int, locati
 		h.spotify.SwitchedAway(ctx)
 	}
 
+	// Record this hardware recall as the last play BEFORE the push: the returned
+	// recall generation is what stands every OLDER verify loop down, and bumping
+	// it first means a stale loop cannot clobber this recall while the SetURI is
+	// still in flight. The auto-re-push and the power-button wake-resume read
+	// the same record to know what to bring back (the webui only tracks its own
+	// soft plays otherwise); the mime rides along so re-pushes keep the AAC
+	// label too (#252).
+	var gen uint64
+	if h.noteLastPlay != nil {
+		if h.pressSeq.Load() != seq {
+			// A newer press exists before this recall even pushed: never let the
+			// older goroutine overwrite the newer press's lastPlay or URL.
+			h.logger.Info("hardware recall superseded before push, standing down", "slot", slot)
+			return
+		}
+		gen = h.noteLastPlay(url, name, icon, mime)
+	}
 	// Push the stream FIRST, before the wake and pairing, mirroring the Spotify
 	// path. On a hardware/remote press the box is already awake (it just emitted
 	// the gabbo frame) and briefly shows its own "Service Unavailable" flash from
@@ -1317,13 +1448,6 @@ func (h *presetWsHandler) OnPresetSelected(ctx context.Context, slot int, locati
 	}
 	if playErr != nil {
 		h.logger.Warn("upnp play (initial) failed, will verify+retry", "slot", slot, "err", playErr)
-	}
-	// Record this hardware recall as the last play so the auto-re-push and the
-	// power-button wake-resume know what to bring back (the webui only tracks its
-	// own soft plays otherwise). The mime rides along so those re-pushes keep
-	// the AAC label too.
-	if h.noteLastPlay != nil {
-		h.noteLastPlay(url, name, icon, mime)
 	}
 
 	// Wake from standby (fast on a hardware press, the box is already awake) AFTER
@@ -1350,15 +1474,28 @@ func (h *presetWsHandler) OnPresetSelected(ctx context.Context, slot int, locati
 	// Verify+retry in the background: the first hardware press after a cold
 	// boot can race the box/agent bringup so nothing plays until a second
 	// press. This re-issues until the box actually plays. Affects radio too.
-	go h.verifyPlayURL(slot, url, name, icon, mime)
+	go h.verifyPlayURL(seq, gen, pressAt, slot, url, name, icon, mime)
 	h.logger.Info("hardware preset mapped to upnp", "slot", slot, "name", name, "mime", mime)
 }
 
 // isSTRStreamURL reports whether u is one of STR's own stream URLs (the radio
 // stream proxy or the Spotify Ogg passthrough), as opposed to a stale Bose
-// ContentItem location that a re-sync has not yet replaced.
+// ContentItem location that a re-sync has not yet replaced. Deliberately loose
+// (substring): used only to PREFER the store URL over a box-provided location.
 func isSTRStreamURL(u string) bool {
 	return strings.Contains(u, "/stream/") || strings.Contains(u, "/spotify/")
+}
+
+// ownBoxPresetLocRe matches exactly the locations STR itself writes into the
+// box's preset slots (boxurl.Preset / boxurl.StreamSlot / boxurl.SpotifySlot).
+// The reconcile prune keys DELETION off this, so it must never match a foreign
+// station URL that merely contains "/stream/".
+var ownBoxPresetLocRe = regexp.MustCompile(`^http://127\.0\.0\.1:\d+/(?:stream/[1-6]|spotify/stream(?:-[1-6])?\.ogg)$`)
+
+// isOwnBoxPresetLocation reports whether loc is a box-preset location STR
+// itself wrote (strict match), the only shape the prune may remove.
+func isOwnBoxPresetLocation(loc string) bool {
+	return ownBoxPresetLocRe.MatchString(loc)
 }
 
 // isPlayableURL reports whether u is an absolute HTTP(S) URL the UPnP renderer can
@@ -1543,14 +1680,20 @@ func (h *presetWsHandler) OnRemoteSkip(ctx context.Context, forward bool) {
 	if h.onRemoteSkip == nil {
 		return
 	}
-	sctx, cancel := context.WithTimeout(ctx, 8*time.Second)
-	defer cancel()
-	src, err := h.onRemoteSkip(sctx, forward)
-	if err != nil {
-		h.logger.Warn("remote skip failed", "forward", forward, "source", src, "err", err)
-		return
-	}
-	h.logger.Info("remote skip", "forward", forward, "source", src)
+	// Off the gabbo read loop: a skip against a slow/wedged transport held the
+	// loop for up to 8s per press, delaying every queued frame and skewing the
+	// processing-time classification windows (#252). The webui skip serializes
+	// box commands internally, so concurrent presses do not interleave SOAP.
+	go func() {
+		sctx, cancel := context.WithTimeout(ctx, 8*time.Second)
+		defer cancel()
+		src, err := h.onRemoteSkip(sctx, forward)
+		if err != nil {
+			h.logger.Warn("remote skip failed", "forward", forward, "source", src, "err", err)
+			return
+		}
+		h.logger.Info("remote skip", "forward", forward, "source", src)
+	}()
 }
 
 // OnUserStop is fired when the box reports a deliberate playback stop over
@@ -1654,9 +1797,12 @@ func requestPresetKeyResync(logger *slog.Logger) {
 // the webhook does not false-fire on STR's own wake-for-recall.
 func (h *presetWsHandler) OnPowerKey(ctx context.Context) {
 	if h.webhooks != nil {
-		if h.webhooks.FireButton(ctx, "power") {
-			h.logger.Info("power webhook fired")
-		}
+		// Async: the webhook HTTP request must not stall the gabbo read loop.
+		go func() {
+			if h.webhooks.FireButton(ctx, "power") {
+				h.logger.Info("power webhook fired")
+			}
+		}()
 	}
 }
 
@@ -1702,9 +1848,12 @@ func (h *presetWsHandler) OnEnterStandby(_ context.Context) {
 // AUX input. Additional-only.
 func (h *presetWsHandler) OnSourceAux(ctx context.Context) {
 	if h.webhooks != nil {
-		if h.webhooks.FireButton(ctx, "aux") {
-			h.logger.Info("aux webhook fired")
-		}
+		// Async: the webhook HTTP request must not stall the gabbo read loop.
+		go func() {
+			if h.webhooks.FireButton(ctx, "aux") {
+				h.logger.Info("aux webhook fired")
+			}
+		}()
 	}
 }
 
@@ -1730,7 +1879,7 @@ var spotifyStreamURL = boxurl.SpotifyDefault()
 // playSpotifyPreset recalls a Spotify preset: wake + pair the box, tell
 // go-librespot to play the saved URI (autonomous, no app), then point the
 // box at the live /spotify/stream so it plays the audio over UPnP.
-func (h *presetWsHandler) playSpotifyPreset(ctx context.Context, slot int, p presets.Preset) {
+func (h *presetWsHandler) playSpotifyPreset(ctx context.Context, seq uint64, pressAt time.Time, slot int, p presets.Preset) {
 	// Log the inputs up front so a remote "recall does nothing" report (e.g.
 	// ST20 #45) shows immediately which precondition failed: no Spotify
 	// manager, no stored account/URI on the preset, or go-librespot not ready.
@@ -1798,9 +1947,15 @@ func (h *presetWsHandler) playSpotifyPreset(ctx context.Context, slot int, p pre
 		h.logger.Warn("spotify upnp play (display) failed, will verify+retry", "slot", slot, "err", err)
 	}
 	// Record this hardware recall as the last play so the power-button
-	// wake-resume can bring the Spotify stream back.
+	// wake-resume can bring the Spotify stream back. The returned recall
+	// generation feeds the verify's supersession check below.
+	var gen uint64
 	if h.noteLastPlay != nil {
-		h.noteLastPlay(slotURL, p.Name, p.Art, "audio/ogg")
+		if h.pressSeq.Load() != seq {
+			h.logger.Info("spotify recall superseded before push, standing down", "slot", slot)
+			return
+		}
+		gen = h.noteLastPlay(slotURL, p.Name, p.Art, "audio/ogg")
 	}
 	// Wake from standby + ensure pairing (the box is awake on a hardware press,
 	// so these return fast); kept AFTER the display push so the buffering state
@@ -1830,7 +1985,7 @@ func (h *presetWsHandler) playSpotifyPreset(ctx context.Context, slot int, p pre
 	// go-librespot's auth, so the box gets no audio and the user had to press
 	// twice. This retries until the box actually plays, with no latency on the
 	// happy path (the initial attempt above already played).
-	go h.verifySpotifyPlaying(slot, p)
+	go h.verifySpotifyPlaying(seq, gen, pressAt, slot, p)
 	h.logger.Info("spotify preset recalled", "slot", slot, "name", p.Name, "account", p.Account)
 }
 
@@ -1840,12 +1995,11 @@ func (h *presetWsHandler) playSpotifyPreset(ctx context.Context, slot int, p pre
 // the initial play ("" = audio/mpeg default); the retries must re-issue with
 // the SAME label or an AAC station recovered here would fall back to silence
 // (#252).
-func (h *presetWsHandler) verifyPlayURL(slot int, url, name, icon, mime string) {
-	// Anchor for the user-stop stand-down: only a STOP_STATE recorded after
-	// this point aborts the loop. Captured at verify start, i.e. after the
-	// initial play's SOAP round-trip, so the transient STOP_STATE that flip
-	// itself can emit has usually already been recorded and does not count.
-	recallStart := time.Now()
+func (h *presetWsHandler) verifyPlayURL(seq, gen uint64, pressAt time.Time, slot int, url, name, icon, mime string) {
+	// All stand-down checks anchor to pressAt, the moment the user pressed the
+	// key (stamped on the gabbo read loop). The old anchor - verify-start,
+	// i.e. after the initial SOAP push and wake - meant a user stop or a 1036
+	// rejection that landed DURING a slow push was invisible to the loop.
 	// Fast recovery for the wrong-state race, before the 5 s loop below: on a
 	// Wave the box answers every hardware press with 1036
 	// UpnpRcvdContentItemInWrongState about 0.8 s in, because it first tries to
@@ -1854,12 +2008,20 @@ func (h *presetWsHandler) verifyPlayURL(slot int, url, name, icon, mime string) 
 	// Waiting a full verify tick to react leaves the user in silence for five
 	// seconds; re-pushing as soon as the rejection is visible is the automatic
 	// version of the second press users learned to do by hand.
-	h.rePushAfterSourceReject(slot, url, name, icon, mime, recallStart)
+	h.rePushAfterSourceReject(seq, gen, pressAt, slot, url, name, icon, mime)
 	// Up to 5 attempts (~25s): a box waking from a deep/overnight standby can
 	// take longer than the old 3-attempt (~15s) window to finish bringing its
 	// network and playback subsystem back up before it accepts the stream (#183).
 	for attempt := 1; attempt <= 5; attempt++ {
 		time.Sleep(5 * time.Second)
+		// A newer press or app recall owns the transport now: this loop's URL is
+		// stale, and re-pushing it would flip the box back to the previous
+		// station ("pressed 2, got 1"). The soft path has had this guard all
+		// along (verifyRecall's recallGen); the hardware loop lacked it.
+		if h.superseded(seq, gen) {
+			h.logger.Info("hardware recall superseded by a newer play, standing down", "slot", slot)
+			return
+		}
 		// Success means the box is playing THIS recall, not merely "some play
 		// state". A bare play-state check silently passed the exact failure the
 		// verify exists for: on a Wave every hardware press is rejected with 1036
@@ -1870,12 +2032,12 @@ func (h *presetWsHandler) verifyPlayURL(slot int, url, name, icon, mime string) 
 		// showed the station, no audio ever came, no retry ran and no wedge strike
 		// was recorded. The Spotify verify already keys off the now_playing location
 		// for this very reason (see boxPlayingSpotify); radio now does too.
-		// The box pulling a proxied stream since this recall started is proof it
+		// The box pulling THIS SLOT's proxied stream since the press is proof it
 		// is playing what we pushed, and it is checked FIRST because now_playing
 		// lags: a Portable kept naming the PREVIOUS preset for seconds after it
 		// had already opened the new stream, so a location check alone declared a
 		// healthy recall dead and the "repair" tore the working stream down.
-		if h.pulledStreamSince(recallStart) || boxPlayingURL(h.boxHost, url) {
+		if h.slotPulledSince(slot, pressAt) || boxPlayingURL(h.boxHost, url) {
 			if h.noteBoxHealthy != nil {
 				h.noteBoxHealthy()
 			}
@@ -1887,14 +2049,14 @@ func (h *presetWsHandler) verifyPlayURL(slot int, url, name, icon, mime string) 
 		// speaker back on (#197, the "start via preset then power off" trigger). A
 		// genuine deep-standby wake (#183) carries no recent power-off, so the
 		// legitimate retry still runs.
-		if h.recentlyPoweredOff != nil && h.recentlyPoweredOff() {
+		if h.poweredOffSince(pressAt) {
 			h.logger.Info("hardware recall: box powered off mid-recall, not re-pushing (#197)", "slot", slot)
 			return
 		}
 		// The user deliberately stopped playback (gabbo STOP_STATE, e.g. the Bose
-		// remote's stop key) after this recall started: the stop must hold, like
-		// the webui side's stand-down, instead of being overridden by a re-push.
-		if h.userStoppedSince(recallStart) {
+		// remote's stop key) after this press: the stop must hold, like the webui
+		// side's stand-down, instead of being overridden by a re-push.
+		if h.userStoppedSince(pressAt) {
 			h.logger.Info("hardware recall: user stopped playback mid-recall, not re-pushing", "slot", slot)
 			return
 		}
@@ -1925,21 +2087,26 @@ const sourceRejectProbeDelay = 1500 * time.Millisecond
 // UpnpRcvdContentItemInWrongState, without waiting for the first 5 s verify
 // tick. The rejection means the box positively declined this stream, so
 // pushing it again is a repair rather than a guess; a recall that is already
-// playing, a box the user powered off, and a deliberate stop are all left
-// alone. Fires at most once per recall: the verify loop owns everything after
-// it.
-func (h *presetWsHandler) rePushAfterSourceReject(slot int, url, name, icon, mime string, recallStart time.Time) {
+// playing, a box the user powered off, a deliberate stop, and a recall a newer
+// press superseded are all left alone. Fires at most once per recall: the
+// verify loop owns everything after it.
+func (h *presetWsHandler) rePushAfterSourceReject(seq, gen uint64, pressAt time.Time, slot int, url, name, icon, mime string) {
 	time.Sleep(sourceRejectProbeDelay)
-	if !h.lastSourceRejectTime().After(recallStart) {
+	if !h.lastSourceRejectTime().After(pressAt) {
 		return // the box did not refuse this recall; the normal verify governs
 	}
-	if h.pulledStreamSince(recallStart) || boxPlayingURL(h.boxHost, url) {
+	if h.superseded(seq, gen) {
+		// A newer press/recall owns the transport: clearing it and re-pushing
+		// THIS press's URL would actively tear the newer recall down.
+		return
+	}
+	if h.slotPulledSince(slot, pressAt) || boxPlayingURL(h.boxHost, url) {
 		return // refused once, then started anyway
 	}
-	if h.recentlyPoweredOff != nil && h.recentlyPoweredOff() {
+	if h.poweredOffSince(pressAt) {
 		return // #197: never push into a box the user just switched off
 	}
-	if h.userStoppedSince(recallStart) {
+	if h.userStoppedSince(pressAt) {
 		return
 	}
 	h.logger.Warn("hardware recall: box refused the stream (wrong state), clearing the transport and pushing again", "slot", slot)
@@ -1985,15 +2152,22 @@ func (h *presetWsHandler) clearTransportForRePush(ctx context.Context, slot int)
 // verifySpotifyPlaying confirms the box reached a playing state after a Spotify
 // recall and re-issues the recall a few times if not, fixing the "first press
 // after reboot does nothing" race without needing a second press.
-func (h *presetWsHandler) verifySpotifyPlaying(slot int, p presets.Preset) {
-	// Anchor for the user-stop stand-down (see verifyPlayURL): only a
-	// STOP_STATE recorded after this point aborts the loop.
-	recallStart := time.Now()
+func (h *presetWsHandler) verifySpotifyPlaying(seq, gen uint64, pressAt time.Time, slot int, p presets.Preset) {
+	// Anchors mirror verifyPlayURL: pressAt (the moment of the key press) for
+	// the user-stop / power-off stand-downs, seq/gen for supersession.
 	// Track the box's 1036 wrong-state rejections so a fresh one within a verify
 	// tick forces a re-point instead of trusting the box's playing-looking state.
-	lastRejectSeen := recallStart
+	lastRejectSeen := pressAt
 	for attempt := 1; attempt <= 3; attempt++ {
 		time.Sleep(5 * time.Second)
+		// A newer press or app recall owns the transport: re-pointing at this
+		// Spotify slot now would yank the user's newest choice (e.g. a radio
+		// press made during this loop's 15s window used to bounce back to
+		// Spotify). Stand down.
+		if h.superseded(seq, gen) {
+			h.logger.Info("spotify recall superseded by a newer play, standing down", "slot", slot)
+			return
+		}
 		// A box that just rejected STR's source (1036 UpnpRcvdContentItemInWrongState,
 		// the preset->preset switch race) can report attached + BUFFERING on the
 		// Spotify location without ever reaching audio, then detach ~30s later with no
@@ -2026,13 +2200,13 @@ func (h *presetWsHandler) verifySpotifyPlaying(slot int, p presets.Preset) {
 		}
 		// Stand down if the user powered the box off mid-recall, so the re-point
 		// below does not re-wake a box the user just switched off (#197).
-		if h.recentlyPoweredOff != nil && h.recentlyPoweredOff() {
+		if h.poweredOffSince(pressAt) {
 			h.logger.Info("spotify recall: box powered off mid-recall, not re-pointing (#197)", "slot", slot)
 			return
 		}
-		// A deliberate stop (gabbo STOP_STATE) after this recall started must
-		// hold; do not re-point the box over the user's stop.
-		if h.userStoppedSince(recallStart) {
+		// A deliberate stop (gabbo STOP_STATE) after this press must hold; do
+		// not re-point the box over the user's stop.
+		if h.userStoppedSince(pressAt) {
 			h.logger.Info("spotify recall: user stopped playback mid-recall, not re-pointing", "slot", slot)
 			return
 		}
@@ -2469,11 +2643,13 @@ func reconcileOnce(store *presets.Store, boxHost string, logger *slog.Logger, fo
 	// firmware keeps its preset list across an STR reinstall, but STR's store is
 	// fresh, so those slots show a name yet cannot play (the store stream URL is
 	// gone) - the reporter saw old presets reappear after a reinstall and not
-	// work. Remove ONLY STR's own UPnP /stream/ or /spotify/ presets that the
-	// store lacks; a foreign preset (e.g. a box-cached Deezer entry) or any slot
-	// STR does have is left untouched.
+	// work. Remove ONLY locations STR itself wrote (strict boxurl shape, not the
+	// loose "/stream/" substring match, which could misread a foreign Icecast
+	// URL containing /stream/ as STR-owned and delete a working box preset); a
+	// foreign preset (e.g. a box-cached Deezer entry) or any slot STR does have
+	// is left untouched.
 	for slot, loc := range boxLocs {
-		if strSlots[slot] || !isSTRStreamURL(loc) {
+		if strSlots[slot] || !isOwnBoxPresetLocation(loc) {
 			continue
 		}
 		rctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
@@ -2493,6 +2669,32 @@ func reconcileOnce(store *presets.Store, boxHost string, logger *slog.Logger, fo
 // so the reconcile can prune only its own stale entries and never a box-native
 // preset.
 func fetchBoxPresets(boxHost string) (map[int]string, error) {
+	entries, err := fetchBoxPresetsFull(boxHost)
+	if err != nil {
+		return nil, err
+	}
+	out := map[int]string{}
+	for _, e := range entries {
+		out[e.Slot] = e.Location
+	}
+	return out, nil
+}
+
+// boxPresetEntry is one slot of the box's own :8090/presets list, with enough
+// ContentItem detail to seed the webui's box-native snapshot and to identify a
+// lost STR preset for the store recovery.
+type boxPresetEntry struct {
+	Slot     int
+	Location string
+	Name     string
+	Source   string
+	Type     string
+	Account  string
+}
+
+// fetchBoxPresetsFull reads GET /presets and returns each set slot's
+// ContentItem fields.
+func fetchBoxPresetsFull(boxHost string) ([]boxPresetEntry, error) {
 	client := http.Client{Timeout: 4 * time.Second}
 	resp, err := client.Get(fmt.Sprintf("http://%s:8090/presets", boxHost))
 	if err != nil {
@@ -2500,7 +2702,7 @@ func fetchBoxPresets(boxHost string) (map[int]string, error) {
 	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
-	out := map[int]string{}
+	var out []boxPresetEntry
 	// Bose format: <presets><preset id="1" ...><ContentItem location="..."/></preset></presets>
 	for _, blk := range presetBlockRegex.FindAllStringSubmatch(string(body), -1) {
 		slot := 0
@@ -2508,13 +2710,127 @@ func fetchBoxPresets(boxHost string) (map[int]string, error) {
 		if slot < 1 || slot > 6 {
 			continue
 		}
-		loc := ""
-		if lm := presetLocationRegex.FindStringSubmatch(blk[0]); lm != nil {
-			loc = lm[1]
+		e := boxPresetEntry{Slot: slot}
+		if m := presetLocationRegex.FindStringSubmatch(blk[0]); m != nil {
+			e.Location = m[1]
 		}
-		out[slot] = loc
+		if m := presetItemNameRegex.FindStringSubmatch(blk[0]); m != nil {
+			e.Name = xmlEntityUnescape(m[1])
+		}
+		if m := presetSourceRegex.FindStringSubmatch(blk[0]); m != nil {
+			e.Source = m[1]
+		}
+		if m := presetTypeRegex.FindStringSubmatch(blk[0]); m != nil {
+			e.Type = m[1]
+		}
+		if m := presetAccountRegex.FindStringSubmatch(blk[0]); m != nil {
+			e.Account = m[1]
+		}
+		out = append(out, e)
 	}
 	return out, nil
+}
+
+// xmlEntityUnescape reverses the five predefined XML entities in text content
+// (Bose escapes station names like "Pop & Rock" in /presets).
+var xmlEntityReplacer = strings.NewReplacer(
+	"&amp;", "&", "&lt;", "<", "&gt;", ">", "&quot;", `"`, "&apos;", "'")
+
+func xmlEntityUnescape(s string) string { return xmlEntityReplacer.Replace(s) }
+
+// seedBoxPresetsAndRecoverStore runs once in the background at agent start.
+// Two jobs (#252, the ST20 whose presets showed "unassigned although they are
+// assigned"):
+//
+//  1. Seed the webui's box-native preset snapshot from :8090/presets. The
+//     snapshot otherwise stays empty until the box happens to emit a gabbo
+//     presetsUpdated frame, so the app showed every slot as unassigned even
+//     though the box's own list still held them.
+//  2. If the NAND preset store came up EMPTY while the box still lists STR's
+//     own /stream/ presets, the store was lost (the pre-v0.9.14 non-durable
+//     save left presets.json at 0 bytes after a standby power-cut; the loss
+//     surfaced when the OTA restarted the agent). Every hardware press then
+//     404s at the stream proxy: the buttons are dead although the box's key
+//     layer works. Restore what the recently-played history can identify by
+//     exact station/playlist name, so the buttons come back without the user
+//     re-saving every slot.
+func seedBoxPresetsAndRecoverStore(store *presets.Store, recentStore *recent.Store, boxHost string, seed func([]webui.BoxPreset), logger *slog.Logger) {
+	if boxHost == "" || store == nil {
+		return
+	}
+	// The box needs ~60s after a cold boot before :8090 answers; poll gently
+	// and give up quietly after ~10 minutes (the periodic reconcile keeps
+	// running regardless).
+	var entries []boxPresetEntry
+	for i := 0; i < 30; i++ {
+		time.Sleep(20 * time.Second)
+		var err error
+		entries, err = fetchBoxPresetsFull(boxHost)
+		if err == nil {
+			break
+		}
+		entries = nil
+	}
+	if len(entries) == 0 {
+		return
+	}
+	if seed != nil {
+		bps := make([]webui.BoxPreset, 0, len(entries))
+		for _, e := range entries {
+			bps = append(bps, webui.BoxPreset{
+				Slot: e.Slot, Source: e.Source, Type: e.Type,
+				Location: e.Location, SourceAccount: e.Account, Name: e.Name,
+			})
+		}
+		seed(bps)
+		logger.Info("box preset snapshot seeded from :8090/presets", "slots", len(bps))
+	}
+	if recentStore == nil || len(store.All()) > 0 {
+		return
+	}
+	recovered := 0
+	recents := recentStore.All()
+	for _, e := range entries {
+		if !isOwnBoxPresetLocation(e.Location) || e.Name == "" {
+			continue
+		}
+		if _, exists := store.Get(e.Slot); exists {
+			continue
+		}
+		wantSpotify := strings.Contains(e.Location, "/spotify/")
+		// Newest matching history entry wins (the ring is oldest-first).
+		for i := len(recents) - 1; i >= 0; i-- {
+			r := recents[i]
+			if r.CardName != e.Name || r.CardURL == "" {
+				continue
+			}
+			if wantSpotify != (r.Source == "spotify") {
+				continue
+			}
+			p := presets.Preset{Slot: e.Slot, Name: e.Name, Art: r.CardArt, Homepage: r.Homepage}
+			if wantSpotify {
+				p.Type = "spotify"
+				p.URI = r.CardURL
+				p.Account = r.Account
+			} else {
+				p.Type = "radio"
+				p.StreamURL = r.CardURL
+			}
+			if err := store.SetSlot(p); err != nil {
+				logger.Warn("preset store recovery: could not save recovered slot", "slot", e.Slot, "err", err)
+			} else {
+				// Warn on purpose: this must be visible in a diagnostic bundle.
+				logger.Warn("preset store recovery: restored a lost preset from the recently-played history",
+					"slot", e.Slot, "name", e.Name, "type", p.Type)
+				recovered++
+			}
+			break
+		}
+	}
+	if recovered > 0 {
+		logger.Warn("preset store recovery: the preset store was empty while the box still lists STR presets (likely wiped by a pre-v0.9.14 standby power-cut); restored what the history could identify",
+			"recovered", recovered)
+	}
 }
 
 // presetBlockRegex captures one <preset id="N" ...> ... </preset> block; (?s)
@@ -2522,6 +2838,10 @@ func fetchBoxPresets(boxHost string) (map[int]string, error) {
 // pulls the ContentItem location out of that block.
 var presetBlockRegex = regexp.MustCompile(`(?s)<preset id="(\d+)".*?</preset>`)
 var presetLocationRegex = regexp.MustCompile(`location="([^"]*)"`)
+var presetItemNameRegex = regexp.MustCompile(`<itemName>([^<]*)</itemName>`)
+var presetSourceRegex = regexp.MustCompile(`source="([^"]*)"`)
+var presetTypeRegex = regexp.MustCompile(`type="([^"]*)"`)
+var presetAccountRegex = regexp.MustCompile(`sourceAccount="([^"]*)"`)
 
 // boxInSetupOOB reports whether BoseApp's /setup says the box is still
 // in out-of-box setup (SETUP_AP_OOB). Pushing presets in that state

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1814,6 +1814,13 @@ func (h *presetWsHandler) OnPowerKey(ctx context.Context) {
 // guard, so a stereo-pair self-wake (which looks identical on the wire) never
 // makes the box start playing on its own.
 func (h *presetWsHandler) OnPowerWake(_ context.Context) {
+	// The firmware loses hardware-key preset registrations across power
+	// cycles (field bundles 2026-07-22: the reconcile heals "missing=5/6"
+	// slots again and again; users see "preset not assigned" until the next
+	// 5-minute reconcile tick, and "after power-on only the first program
+	// plays"). Ask for a full re-sync right at the wake so the keys work
+	// within seconds instead of minutes. Rate-limited internally.
+	requestPresetKeyResync(h.logger)
 	if h.onPowerWake != nil {
 		h.logger.Info("power-on detected, attempting last-station resume")
 		h.onPowerWake()
@@ -1829,6 +1836,11 @@ func (h *presetWsHandler) OnPowerWake(_ context.Context) {
 // stream through the guarded resume (opt-out, zone, user-stop). A routine idle
 // reconnect (box in standby) or a box already playing is a no-op.
 func (h *presetWsHandler) OnConnected(_ context.Context) {
+	// A gabbo reconnect usually means the box just came back from a standby
+	// or reboot - exactly when the firmware tends to have dropped its
+	// hardware-key preset registrations (see OnPowerWake). Ask for a full
+	// re-sync so the keys are registered again within seconds.
+	requestPresetKeyResync(h.logger)
 	if h.onBoxReconnect != nil {
 		h.onBoxReconnect()
 	}
@@ -2062,6 +2074,20 @@ func (h *presetWsHandler) verifyPlayURL(seq, gen uint64, pressAt time.Time, slot
 		}
 		h.logger.Warn("hardware recall not playing yet, retrying", "slot", slot, "attempt", attempt)
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		// Wake the box first: after the 1036 wrong-state rejection the firmware
+		// often gives up on its failed self-activation and powers the source off
+		// through INVALID_SOURCE -> STANDBY (field bundles 2026-07-22, all
+		// models: the box "switches itself off" after the press). Every retry
+		// then pushed SetURI+Play into a sleeping box and the recall never
+		// converged, even though the forced re-login had already landed. A
+		// user power-off cannot reach this line (poweredOffSince stands the
+		// loop down above), so waking here only ever reverses the box's own
+		// give-up. No-op when the box is awake (a single now_playing read).
+		if h.boxHost != "" {
+			if err := boxcli.WakeAndWait(ctx, h.boxHost, 6*time.Second, h.logger); err != nil {
+				h.logger.Warn("hardware recall retry: could not wake box", "slot", slot, "err", err)
+			}
+		}
 		if mime != "" {
 			_ = h.renderer.PlayURLMime(ctx, url, name, icon, mime)
 		} else {
@@ -2112,6 +2138,16 @@ func (h *presetWsHandler) rePushAfterSourceReject(seq, gen uint64, pressAt time.
 	h.logger.Warn("hardware recall: box refused the stream (wrong state), clearing the transport and pushing again", "slot", slot)
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
+	// The rejection's INVALID_SOURCE flap can end in STANDBY within ~1s of the
+	// press (the box gives up on its failed self-activation and powers off);
+	// re-pushing into that sleeping box did nothing. Wake it first - a no-op
+	// when it is awake, and a user power-off never reaches this line (checked
+	// above).
+	if h.boxHost != "" {
+		if err := boxcli.WakeAndWait(ctx, h.boxHost, 6*time.Second, h.logger); err != nil {
+			h.logger.Warn("wrong-state repair: could not wake box", "slot", slot, "err", err)
+		}
+	}
 	// The box refused the stream because its transport is stuck in the wrong
 	// state: it is still holding its own dead-cloud ContentItem active (the box
 	// answers with name=UNABLE_TO_PROCESS_NOT_LOGGED_IN detail=WrongState). Pushing

--- a/cmd/agent/recall_supersede_test.go
+++ b/cmd/agent/recall_supersede_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSuperseded covers the hardware verify's stand-down on a newer play: a
+// newer hardware press (press sequence) or a newer play of any kind (the
+// webui recall generation) must stop an older verify loop from re-pushing its
+// stale URL over the user's newest choice ("pressed 2, got 1").
+func TestSuperseded(t *testing.T) {
+	h := &presetWsHandler{}
+	seq := h.pressSeq.Add(1)
+	if h.superseded(seq, 0) {
+		t.Fatal("the newest press must not read as superseded")
+	}
+	h.pressSeq.Add(1)
+	if !h.superseded(seq, 0) {
+		t.Fatal("a newer press must supersede the older verify")
+	}
+
+	cur := uint64(7)
+	h2 := &presetWsHandler{recallGenFn: func() uint64 { return cur }}
+	s2 := h2.pressSeq.Add(1)
+	if h2.superseded(s2, 7) {
+		t.Fatal("matching generation must not read as superseded")
+	}
+	cur = 8 // an app recall (or any newer play) bumped the shared generation
+	if !h2.superseded(s2, 7) {
+		t.Fatal("a newer recall generation must supersede the older verify")
+	}
+	if h2.superseded(s2, 0) {
+		t.Fatal("gen 0 means the generation was never captured; only the press sequence decides")
+	}
+}
+
+// TestSlotPulledSince covers the slot-scoped success signal: only THIS slot's
+// proxied fetch after the press counts, so cross-traffic (another slot's
+// reconnect, a zone follower) can no longer certify a failed recall as healthy.
+func TestSlotPulledSince(t *testing.T) {
+	h := &presetWsHandler{}
+	if h.slotPulledSince(3, time.Now().Add(-time.Minute)) {
+		t.Fatal("nil slotStreamActivity must read as not pulled")
+	}
+
+	stamp := time.Now()
+	h.slotStreamActivity = func(slot int) time.Time {
+		if slot == 3 {
+			return stamp
+		}
+		return time.Time{}
+	}
+	if !h.slotPulledSince(3, stamp.Add(-time.Second)) {
+		t.Fatal("this slot's fetch after the press must count as success")
+	}
+	if h.slotPulledSince(3, stamp.Add(time.Second)) {
+		t.Fatal("a fetch BEFORE the press must not count")
+	}
+	if h.slotPulledSince(2, stamp.Add(-time.Second)) {
+		t.Fatal("another slot's fetch must not certify this recall")
+	}
+}
+
+// TestIsOwnBoxPresetLocation pins the prune's deletion guard to exactly the
+// locations STR itself writes into box preset slots (boxurl shapes). The old
+// loose "/stream/" substring match could misread a foreign station URL as
+// STR-owned and delete a working box preset.
+func TestIsOwnBoxPresetLocation(t *testing.T) {
+	own := []string{
+		"http://127.0.0.1:8888/stream/1",
+		"http://127.0.0.1:8888/stream/6",
+		"http://127.0.0.1:8888/spotify/stream-4.ogg",
+		"http://127.0.0.1:8888/spotify/stream.ogg",
+	}
+	for _, u := range own {
+		if !isOwnBoxPresetLocation(u) {
+			t.Errorf("STR-written location not recognised: %s", u)
+		}
+	}
+	foreign := []string{
+		"http://icecast.example.com/stream/1",
+		"http://example.com/radio/stream/128.mp3",
+		"http://127.0.0.1:8888/stream/7",
+		"http://127.0.0.1:8888/stream/raw?u=abc",
+		"/v1/playback/station/s12345",
+		"123456789",
+		"",
+	}
+	for _, u := range foreign {
+		if isOwnBoxPresetLocation(u) {
+			t.Errorf("foreign location must never be prunable: %s", u)
+		}
+	}
+}

--- a/cmd/agent/recall_supersede_test.go
+++ b/cmd/agent/recall_supersede_test.go
@@ -35,30 +35,31 @@ func TestSuperseded(t *testing.T) {
 	}
 }
 
-// TestSlotPulledSince covers the slot-scoped success signal: only THIS slot's
-// proxied fetch after the press counts, so cross-traffic (another slot's
-// reconnect, a zone follower) can no longer certify a failed recall as healthy.
+// TestSlotPulledSince covers the handler's slot-scoped success pass-through:
+// the decision itself (liveness, sustained-fetch) lives in
+// streamproxy.SlotPulledSince and is tested there; here the wiring must be
+// nil-safe and forward slot + anchor untouched.
 func TestSlotPulledSince(t *testing.T) {
 	h := &presetWsHandler{}
 	if h.slotPulledSince(3, time.Now().Add(-time.Minute)) {
-		t.Fatal("nil slotStreamActivity must read as not pulled")
+		t.Fatal("nil slotPulled must read as not pulled")
 	}
 
-	stamp := time.Now()
-	h.slotStreamActivity = func(slot int) time.Time {
-		if slot == 3 {
-			return stamp
-		}
-		return time.Time{}
+	var gotSlot int
+	var gotSince time.Time
+	h.slotPulled = func(slot int, since time.Time) bool {
+		gotSlot, gotSince = slot, since
+		return slot == 3
 	}
-	if !h.slotPulledSince(3, stamp.Add(-time.Second)) {
-		t.Fatal("this slot's fetch after the press must count as success")
+	anchor := time.Now()
+	if !h.slotPulledSince(3, anchor) {
+		t.Fatal("wired signal must decide")
 	}
-	if h.slotPulledSince(3, stamp.Add(time.Second)) {
-		t.Fatal("a fetch BEFORE the press must not count")
+	if gotSlot != 3 || !gotSince.Equal(anchor) {
+		t.Fatalf("slot/anchor must pass through untouched, got slot=%d since=%v", gotSlot, gotSince)
 	}
-	if h.slotPulledSince(2, stamp.Add(-time.Second)) {
-		t.Fatal("another slot's fetch must not certify this recall")
+	if h.slotPulledSince(2, anchor) {
+		t.Fatal("another slot must not certify this recall")
 	}
 }
 
@@ -91,5 +92,37 @@ func TestIsOwnBoxPresetLocation(t *testing.T) {
 		if isOwnBoxPresetLocation(u) {
 			t.Errorf("foreign location must never be prunable: %s", u)
 		}
+	}
+}
+
+// TestUrgentResyncHasOwnBudget: the urgent re-sync (a 1036/re-login wipe is
+// imminent) must not be starved by a routine ask that consumed the normal
+// budget minutes earlier - the field bundles showed five dead-key presses
+// producing no heal because the boot-time ask had eaten the shared budget.
+func TestUrgentResyncHasOwnBudget(t *testing.T) {
+	presetResyncAsk.Store(false)
+	presetResyncLast.Store(time.Now().Unix()) // routine budget just consumed
+	presetResyncUrgentLast.Store(0)
+	t.Cleanup(func() {
+		presetResyncAsk.Store(false)
+		presetResyncLast.Store(0)
+		presetResyncUrgentLast.Store(0)
+	})
+
+	requestPresetKeyResync(nil)
+	if presetResyncAsk.Load() {
+		t.Fatal("routine ask inside its gap must be rate-limited")
+	}
+
+	requestPresetKeyResyncUrgent(nil)
+	if !presetResyncAsk.Load() {
+		t.Fatal("urgent ask must not be starved by the routine budget")
+	}
+
+	// The urgent budget itself still bounds a 1036 storm.
+	presetResyncAsk.Store(false)
+	requestPresetKeyResyncUrgent(nil)
+	if presetResyncAsk.Load() {
+		t.Fatal("urgent asks inside the urgent gap must coalesce")
 	}
 }

--- a/cmd/agent/recall_supersede_test.go
+++ b/cmd/agent/recall_supersede_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -243,5 +244,96 @@ func TestOnPresetSelectedReturnsBeforeSlowRecall(t *testing.T) {
 
 	if elapsed > time.Second {
 		t.Fatalf("OnPresetSelected blocked the gabbo dispatch for %v; the slow recall must run in the background", elapsed)
+	}
+}
+
+// TestRecallStandDown pins the shared stand-down decision the verify paths
+// re-check before every escalation (wake, sys-power nudge, re-push): those run
+// seconds after the loop-top check, and a power press inside that gap used to
+// be reversed by the very wake meant to recover the box's own give-up (#197).
+func TestRecallStandDown(t *testing.T) {
+	h := &presetWsHandler{}
+	seq := h.pressSeq.Add(1)
+	pressAt := time.Now()
+	if h.recallStandDown(seq, 0, pressAt) {
+		t.Fatal("a fresh recall with no events must not stand down")
+	}
+
+	h.standbyStopAfter = func(since time.Time) bool { return true }
+	if !h.recallStandDown(seq, 0, pressAt) {
+		t.Fatal("a power-off after the press must stand the recall down")
+	}
+	h.standbyStopAfter = nil
+
+	h.pressSeq.Add(1)
+	if !h.recallStandDown(seq, 0, pressAt) {
+		t.Fatal("a newer press must stand the older recall down")
+	}
+}
+
+// TestWakeSkipsWhenAbortSignalled: the wake helper consults the caller's abort
+// predicate so a stand-down that arrives after the caller decided to wake
+// still keeps the box off (#197 check-then-act).
+func TestWakeSkipsWhenAbortSignalled(t *testing.T) {
+	called := 0
+	h := &presetWsHandler{
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		boxHost: "192.0.2.9",
+		wakeBox: func(ctx context.Context, host string) error { called++; return nil },
+	}
+	if err := h.wake(context.Background(), func() bool { return true }); err != nil {
+		t.Fatalf("an aborted wake must be a quiet no-op, got %v", err)
+	}
+	if called != 0 {
+		t.Fatal("an abort that already holds must skip the wake entirely")
+	}
+	if err := h.wake(context.Background(), nil); err != nil {
+		t.Fatalf("wake: %v", err)
+	}
+	if called != 1 {
+		t.Fatal("nil abort must wake as before")
+	}
+}
+
+// TestVerifyPowerOffDuringWakeIsNotOverridden reproduces the #197
+// check-then-act window: the verify iteration passes its loop-top stand-downs,
+// then the user presses power while the wake helper is already running. The
+// re-check after the wake must catch the fresh stamp and no SOAP push may
+// follow - pre-fix the box was actively powered back on and the stale URL
+// re-armed.
+func TestVerifyPowerOffDuringWakeIsNotOverridden(t *testing.T) {
+	var mu sync.Mutex
+	pushes := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		pushes++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var poweredOff atomic.Bool
+	h := &presetWsHandler{
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		boxHost:  "192.0.2.9",
+		renderer: &upnp.Renderer{ControlURL: srv.URL, Client: srv.Client()},
+		wakeBox: func(ctx context.Context, host string) error {
+			// The user presses power while the wake helper runs; the standby
+			// classifier stamps the latch within milliseconds.
+			poweredOff.Store(true)
+			return nil
+		},
+		standbyStopAfter: func(since time.Time) bool { return poweredOff.Load() },
+		boxPlayingFn:     func(url string) bool { return false },
+		boxSourceFn:      func() string { return "STANDBY" },
+	}
+	seq := h.pressSeq.Add(1)
+
+	h.verifyPlayURL(seq, 0, time.Now(), 2, "http://127.0.0.1:8888/stream/2", "S", "", "")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if pushes != 0 {
+		t.Fatalf("a power press during the wake must hold: no SOAP push may follow, got %d", pushes)
 	}
 }

--- a/cmd/agent/recall_supersede_test.go
+++ b/cmd/agent/recall_supersede_test.go
@@ -1,8 +1,18 @@
 package main
 
 import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/JRpersonal/streborn/internal/presets"
+	"github.com/JRpersonal/streborn/internal/upnp"
 )
 
 // TestSuperseded covers the hardware verify's stand-down on a newer play: a
@@ -124,5 +134,114 @@ func TestUrgentResyncHasOwnBudget(t *testing.T) {
 	requestPresetKeyResyncUrgent(nil)
 	if presetResyncAsk.Load() {
 		t.Fatal("urgent asks inside the urgent gap must coalesce")
+	}
+}
+
+// TestNudgeStuckSource pins the sys-power-nudge decision: exactly one nudge
+// per recall, only at the third attempt, only while the box reports
+// INVALID_SOURCE (the mojo/ST30 wedge where the box inertly ACKs every push
+// and only a real sys-power toggle ever activated the source).
+func TestNudgeStuckSource(t *testing.T) {
+	cases := []struct {
+		attempt int
+		nudged  bool
+		source  string
+		want    bool
+	}{
+		{1, false, "INVALID_SOURCE", false}, // give the normal wake+re-push a chance first
+		{2, false, "INVALID_SOURCE", false},
+		{3, false, "INVALID_SOURCE", true},
+		{3, true, "INVALID_SOURCE", false}, // one nudge per recall
+		{3, false, "STANDBY", false},       // the wake path owns standby
+		{3, false, "UPNP", false},
+		{3, false, "", false}, // probe failed: do not toggle blind
+		{4, false, "INVALID_SOURCE", false},
+	}
+	for _, c := range cases {
+		if got := nudgeStuckSource(c.attempt, c.nudged, c.source); got != c.want {
+			t.Errorf("nudgeStuckSource(%d,%v,%q) = %v, want %v", c.attempt, c.nudged, c.source, got, c.want)
+		}
+	}
+}
+
+// TestRePushAfterSourceRejectWakesBeforePush asserts the wake ordering of the
+// wrong-state repair (bundle signature: box drops INVALID_SOURCE->STANDBY
+// within ~1s of the press; pushing without a wake did nothing): the repair
+// must wake the box BEFORE re-issuing SetURI+Play.
+func TestRePushAfterSourceRejectWakesBeforePush(t *testing.T) {
+	var mu sync.Mutex
+	var order []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		order = append(order, "soap")
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	h := &presetWsHandler{
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		boxHost:  "192.0.2.9",
+		renderer: &upnp.Renderer{ControlURL: srv.URL, Client: srv.Client()},
+		wakeBox: func(ctx context.Context, host string) error {
+			mu.Lock()
+			order = append(order, "wake")
+			mu.Unlock()
+			return nil
+		},
+		boxPlayingFn: func(url string) bool { return false },
+	}
+	seq := h.pressSeq.Add(1)
+	pressAt := time.Now().Add(-2 * time.Second)
+	h.OnSourceRejected(context.Background()) // 1036 stamped after pressAt
+
+	h.rePushAfterSourceReject(seq, 0, pressAt, 1, "http://127.0.0.1:8888/stream/1", "S", "", "")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(order) < 2 || order[0] != "wake" {
+		t.Fatalf("the repair must wake the box before pushing, got order %v", order)
+	}
+	if order[len(order)-1] != "soap" {
+		t.Fatalf("the repair must push after waking, got order %v", order)
+	}
+}
+
+// TestOnPresetSelectedReturnsBeforeSlowRecall pins the F1 contract directly:
+// the gabbo dispatch must not block behind slow box I/O (pre-fix, a press on a
+// cold box held the single read loop for up to ~18s and every queued frame -
+// including the teardown STOP_STATE the classification windows were tuned for -
+// was stamped late).
+func TestOnPresetSelectedReturnsBeforeSlowRecall(t *testing.T) {
+	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(3 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer slow.Close()
+
+	store, err := presets.Load(filepath.Join(t.TempDir(), "presets.json"))
+	if err != nil {
+		t.Fatalf("presets.Load: %v", err)
+	}
+	if err := store.SetSlot(presets.Preset{Slot: 1, Name: "S", StreamURL: "http://example.com/s.mp3", Type: "radio"}); err != nil {
+		t.Fatal(err)
+	}
+	h := &presetWsHandler{
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		store:        store,
+		renderer:     &upnp.Renderer{ControlURL: slow.URL, Client: slow.Client()},
+		wakeBox:      func(ctx context.Context, host string) error { return nil },
+		boxPlayingFn: func(url string) bool { return false },
+	}
+
+	start := time.Now()
+	h.OnPresetSelected(context.Background(), 1, "http://127.0.0.1:8888/stream/1", "S")
+	elapsed := time.Since(start)
+	// Supersede immediately so the background recall/verify goroutines stand
+	// down at their next check instead of retrying for ~30s.
+	h.pressSeq.Add(1)
+
+	if elapsed > time.Second {
+		t.Fatalf("OnPresetSelected blocked the gabbo dispatch for %v; the slow recall must run in the background", elapsed)
 	}
 }

--- a/cmd/agent/recall_verify_location_test.go
+++ b/cmd/agent/recall_verify_location_test.go
@@ -98,40 +98,9 @@ func TestNowPlayingIsURL_RawStreamMatches(t *testing.T) {
 	}
 }
 
-// TestPulledStreamSince covers the verify's authoritative success signal. A
-// Portable kept naming the PREVIOUS preset in now_playing for seconds after it
-// had already opened the new stream, so a location check alone called a healthy
-// recall dead and the "repair" tore the working stream down. The box opening a
-// proxied stream after the recall started settles it.
-func TestPulledStreamSince(t *testing.T) {
-	recallStart := time.Now()
-
-	none := &presetWsHandler{}
-	if none.pulledStreamSince(recallStart) {
-		t.Fatal("without a stream-activity source there is no proof of playback")
-	}
-
-	old := &presetWsHandler{streamActivity: func() (time.Time, time.Time) {
-		return recallStart.Add(-time.Minute), time.Time{}
-	}}
-	if old.pulledStreamSince(recallStart) {
-		t.Fatal("a stream opened BEFORE this recall proves nothing about it")
-	}
-
-	fresh := &presetWsHandler{streamActivity: func() (time.Time, time.Time) {
-		return recallStart.Add(2 * time.Second), time.Time{}
-	}}
-	if !fresh.pulledStreamSince(recallStart) {
-		t.Fatal("a stream opened after the recall started means the box is playing it")
-	}
-
-	never := &presetWsHandler{streamActivity: func() (time.Time, time.Time) {
-		return time.Time{}, time.Time{}
-	}}
-	if never.pulledStreamSince(recallStart) {
-		t.Fatal("a zero timestamp must not count as playback")
-	}
-}
+// The verify's authoritative success signal is now slot-scoped; see
+// TestSlotPulledSince in recall_supersede_test.go (the old global
+// pulledStreamSince let any proxied fetch certify a failed recall, #252).
 
 // TestStreamPath covers the comparison key, including the non-STR URL that
 // disables the comparison.

--- a/cmd/agent/seed_signal_test.go
+++ b/cmd/agent/seed_signal_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+)
+
+// TestSeedFirstAttemptSignalFiresOnEarlyReturn: autopair's start waits
+// (bounded) for the preset recovery's first box read, so the first forced
+// re-assert cannot wipe the box preset list before the recovery snapshots it
+// (#252 warm-restart race). The signal must fire even when the seed exits
+// early (no box host / no store), or every stickless start would sit out the
+// fallback timeout for nothing.
+func TestSeedFirstAttemptSignalFiresOnEarlyReturn(t *testing.T) {
+	fired := 0
+	seedBoxPresetsAndRecoverStore(nil, nil, "", nil,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		func() { fired++ })
+	if fired != 1 {
+		t.Fatalf("the first-attempt signal must fire exactly once on an early return, got %d", fired)
+	}
+}

--- a/desktop-app/logexport.go
+++ b/desktop-app/logexport.go
@@ -157,6 +157,13 @@ Privacy:
 	for i, host := range hosts {
 		snap := captureBoxSnapshot(host)
 		entry := boxIndexEntry{Index: i, Host: host}
+		if !snap.ReachableSSH && !snap.Reachable8090 && !snap.Reachable8888 && !snap.Reachable8091 {
+			entry.Offline = true
+			// WARN, not Info: an offline box means this bundle carries no
+			// on-box evidence for it, which support must see immediately.
+			a.logger.Warn("log export: box unreachable on every port, its snapshot carries no on-box data",
+				"host", entry.Host, "boxIndex", i)
+		}
 		if req.Anonymize {
 			entry.Host = maskIP(host)
 			snap = anonymizeSnapshot(snap)
@@ -300,6 +307,11 @@ func tailString(s string, cap int) string {
 type boxIndexEntry struct {
 	Index int    `json:"index"`
 	Host  string `json:"host"`
+	// Offline marks a snapshot captured while the box answered on NO port at
+	// all: its box-<n>.json is empty of on-box data. Without the marker such a
+	// bundle silently looked complete - a reporter exported four bundles of a
+	// flapping box and every one carried zero on-box evidence.
+	Offline bool `json:"offline,omitempty"`
 }
 
 type boxSnapshot struct {

--- a/desktop-app/true_factory_reset.go
+++ b/desktop-app/true_factory_reset.go
@@ -75,6 +75,10 @@ func (a *App) TrueFactoryReset(host string) TrueFactoryResetResult {
 	if helloErr != nil || !strings.Contains(hello, "STR_SSH_OK") {
 		res.Log = hello
 		res.Message = "SSH handshake to speaker failed: " + classifySSHError(hello, helloErr)
+		// Every failed step must land in the log: a field bundle showed only
+		// "starting" for a reset that never ran, so support could not tell a
+		// completed wipe from a dead SSH port.
+		a.logger.Warn("true_factory_reset: ssh handshake failed", "host", host, "err", helloErr, "message", res.Message)
 		return res
 	}
 
@@ -121,6 +125,7 @@ echo "TFR_WIPED:$WIPED"
 	res.Log = out
 	if err != nil {
 		res.Message = "wipe failed: " + classifySSHError(out, err)
+		a.logger.Warn("true_factory_reset: wipe failed", "host", host, "err", err, "message", res.Message)
 		return res
 	}
 	for _, line := range strings.Split(out, "\n") {
@@ -130,6 +135,7 @@ echo "TFR_WIPED:$WIPED"
 	}
 	if len(res.WipedFiles) == 0 {
 		res.Message = "wipe returned no file list — script may have failed silently. See log."
+		a.logger.Warn("true_factory_reset: wipe returned no file list", "host", host)
 		return res
 	}
 	a.logger.Info("true_factory_reset: persistence wiped",

--- a/docs/MODEL-VARIANTS.md
+++ b/docs/MODEL-VARIANTS.md
@@ -22,7 +22,7 @@ The final firmware Bose shipped before the cloud shutdown on 2026-02. Anything o
 | SoundTouch 10 | `27.0.6.46330.5043500 epdbuild.trunk.hepdswbld04.2022-08-04T11:20:29` | **2022-08-04** |
 | SoundTouch 20 | `27.0.6.46330.5043500 epdbuild.trunk.hepdswbld04.2022-08-04T11:20:29` | **2022-08-04** |
 | SoundTouch 30 | `27.0.6.46330.5043500 epdbuild.trunk.hepdswbld04.2022-08-04T11:20:29` | **2022-08-04** |
-| SoundTouch Portable | (to be confirmed from a diagnostic) | (to be confirmed) |
+| SoundTouch Portable | `27.0.6.46330.5043500 epdbuild.trunk.hepdswbld04.2022-08-04T11:20:29` | **2022-08-04** |
 
 ## SoundTouch 20
 
@@ -30,6 +30,16 @@ The final firmware Bose shipped before the cloud shutdown on 2026-02. Anything o
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `sm2` | `27.0.6.46330.5043500 epdbuild.trunk.hepdswbld04.2022-08-04T11:20:29` | 2022 | **yes** | `spotty` | `normal` | SCM, PackagedProduct | `wlan0`, `wlan1` | `GB` / `GB` |
 | `scm` | `27.0.6.46330.5043500 epdbuild.trunk.hepdswbld04.2022-08-04T11:20:29` | 2022 | **yes** | `spotty` | `normal` | SCM, PackagedProduct, **Lightswitch**, **SMSC** | varies (ethernet-only observed) | `EU` / `` (empty) |
+| `sm2` | `27.0.3.46298.4608935` | pre-2022 | **no (outdated)** | `spotty` | (unknown) | (unknown - box offline in every bundle) | (unknown) | (unknown) |
+
+- Row 3 (2026-07-22 mail bundle): the first live SM2-ST20 on a firmware
+  OLDER than the final 2022 build - the installer's `install_str` log
+  flagged it `outdated=true`. The box flapped offline in ~1-minute cycles
+  (established-TCP resets on `:8888` and `:17008`, SSH dead), so every
+  diagnostic export came back without on-box data and components/WLAN
+  remain unobserved. Treat reports from 27.0.3 boxes with care: this
+  firmware predates every behavior sample in this matrix, and the network
+  instability itself is unexplained (candidate confound: the old firmware).
 
 ### Critical differences (what actually changes STR's code path)
 
@@ -90,13 +100,30 @@ Confirmed from a diagnostic bundle (2026-06-10, #123 box-0):
 | `moduleType` | SCM `softwareVersion` | Build year | Latest official? | `variant` | `variantMode` | Components present | WLAN interfaces | `countryCode` / `regionCode` samples |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `sm2` | `27.0.6.46330.5043500 epdbuild.trunk.hepdswbld04.2022-08-04T11:20:29` | 2022 | **yes** | `mojo` | `normal` | SCM, PackagedProduct | `wlan0`, `wlan1` | `GB` / `GB` |
+| `scm` | `27.0.6.46330.5043500 epdbuild.trunk.hepdswbld04.2022-08-04T11:20:29` | 2022 | **yes** | `mojo` | `normal` | (per boseInfoXml; SMSC-class chassis) | (unrecorded) | (unrecorded) |
 
 - Kernel: `Linux mojo 3.14.43+ #137 Wed Oct 25 21:06:53 EDT 2017 armv7l` (same kernel as ST10/ST20).
-- `is_series_one=0`: like the ST10 (`rhino`), the ST30 (`mojo`) is **not** chipset-whitelisted. STR's `:8888` is reached directly once the iptables INPUT ACCEPT rule opens it; the LD_PRELOAD SoftwareUpdate shim is unnecessary and is skipped for `sm2` chassis (the `.so` cannot even load on `mojo`). See `usb-stick/run.sh` `shim_stage_wrapper`.
+- Row 1 (`sm2`): `is_series_one=0`: like the ST10 (`rhino`), this ST30 (`mojo`) is **not** chipset-whitelisted. STR's `:8888` is reached directly once the iptables INPUT ACCEPT rule opens it; the LD_PRELOAD SoftwareUpdate shim is unnecessary and is skipped for `sm2` chassis (the `.so` cannot even load on `mojo`). See `usb-stick/run.sh` `shim_stage_wrapper`.
+- Row 2 (`scm`, 2026-07-22 mail bundle): the ST30 ALSO ships as an `scm`
+  chassis - the agent installed the `:17008 -> :8888` PREROUTING REDIRECT
+  on it (rule packet counters confirmed live traffic), i.e. this variant
+  takes the whitelisted-chassis path like the `scm` ST20 and the Portable.
+  The architecture sketch's "ST30 = sm2, reached directly" grouping holds
+  only for row 1; always check `moduleType` before assuming the port path.
 
 ## SoundTouch Portable
 
-Not yet observed in a diagnostic bundle.
+Confirmed from a 2026-07-22 mail bundle:
+
+| `moduleType` | SCM `softwareVersion` | Build year | Latest official? | `variant` | `variantMode` | `countryCode` samples |
+| --- | --- | --- | --- | --- | --- | --- |
+| `scm` | `27.0.6.46330.5043500 epdbuild.trunk.hepdswbld04.2022-08-04T11:20:29` | 2022 | **yes** | `taigan` | `normal` | `US` |
+
+- Whitelisted chassis: reached via the `:17008 -> :8888` REDIRECT, matching
+  the long-standing `taigan` handling in `usb-stick/run.sh`.
+- This also settles the reference table above: the Portable's final Bose
+  firmware is the same 2022-08-04 `27.0.6.46330.5043500` build as the other
+  models.
 
 ## Wave SoundTouch IV
 
@@ -112,6 +139,28 @@ the maintainer and two independent #182 users installed end to end
 grouping working, and the IR remote's preset keys 1-6 recalling STR
 presets under the SoundTouch source. The Wave never reads a USB stick at
 boot, so the network install is the only path. See the `lisa` table below.
+
+A second Wave fingerprint (2026-07-22 mail bundle) reports
+`moduleType=scm`, `variant=lisa`, `variantMode=normal`, the same final SCM
+firmware 27.0.6.46330.5043500, `PackagedProduct` 04.04.08 and an SCM +
+SMSC dual `networkInfo` - i.e. the Wave, like the ST20 and ST30, exists in
+both an `sm2` and an `scm` chassis generation. The `scm` Wave takes the
+`:17008` REDIRECT path.
+
+## Lifestyle (SoundTouch console)
+
+First fingerprint from a 2026-07-22 mail bundle (STR was NOT installed on
+this box; observed via the stock probes only):
+
+| `type` | `moduleType` | SCM `softwareVersion` | `variant` | Components present | `networkInfo` entries | `countryCode` / `regionCode` |
+| --- | --- | --- | --- | --- | --- | --- |
+| `Lifestyle` | `sm2` | `27.0.6.46330.5043500 epdbuild.trunk.hepdswbld04.2022-08-04T11:20:29` | `bardeen` | SCM, PackagedProduct (`1.16.7.5043495`) | 2 (SCM + SMSC) | `GB` / `GB` |
+
+- The bundle also showed a stale `margeURL` pointing at a LAN host that no
+  longer exists (a previous STR/mod install on another machine), with an
+  empty `margeAccountUUID` - a setup probe against such a console should
+  expect leftover cloud config from earlier experiments.
+- STR has never run on a `bardeen`; no support claim is implied by this row.
 
 ## How to read a new bundle
 

--- a/internal/autopair/autopair.go
+++ b/internal/autopair/autopair.go
@@ -64,6 +64,13 @@ type Manager struct {
 	lastPaired *bool
 	tickCount  int
 
+	// onPaired fires when the box transitions from unpaired to paired (a
+	// completed (re-)onboarding). The firmware wipes its hardware-key preset
+	// registrations during exactly that onboarding, so the agent hooks this to
+	// schedule an immediate key re-sync instead of waiting for the reconcile
+	// cadence. Set once at wiring time, before RunBackground starts.
+	onPaired func()
+
 	// Login-suspicion state. A margeAccountUUID on the box does NOT mean the
 	// box considers itself logged in: fresh installs and factory-reset boxes
 	// keep the UUID while their MargeHSM drops back to not-logged-in (every
@@ -283,9 +290,25 @@ func (m *Manager) recordPairedState(paired bool) {
 	if *m.lastPaired != paired {
 		m.logger.Warn("autopair phase: paired state changed",
 			"from", *m.lastPaired, "to", paired)
+		wasUnpaired := !*m.lastPaired
 		v := paired
 		m.lastPaired = &v
+		// unpaired -> paired = a (re-)onboarding just completed; the firmware
+		// wipes its key-layer preset registrations in that transition, so let
+		// the agent re-register them right away. The initial observation is
+		// deliberately NOT a transition: an already-paired box at agent start
+		// went through no onboarding.
+		if paired && wasUnpaired && m.onPaired != nil {
+			m.onPaired()
+		}
 	}
+}
+
+// SetOnPaired registers the unpaired->paired transition hook. Call before
+// RunBackground starts; the callback must be fast (it runs inside the pair
+// cycle).
+func (m *Manager) SetOnPaired(fn func()) {
+	m.onPaired = fn
 }
 
 // boxClockSane returns true if the box's own clock — as reported by
@@ -351,6 +374,14 @@ func (m *Manager) RunBackground(ctx context.Context, startDelay, interval time.D
 	// interval.
 	const fastInterval = 20 * time.Second
 	const fastFor = 2 * time.Minute
+	// fastForUnpairedMax extends the fast window while the box has NOT yet
+	// been observed paired: on scm/mojo the post-boot clock sync and account
+	// clear can take ~5-8 minutes, and the old fixed 2-minute window left the
+	// box unpaired on the 5-minute steady cadence for most of that time (the
+	// field bundle showed an ~8-minute unpaired hole after a reboot, with the
+	// hardware keys dead throughout). Bounded so a permanently unreachable box
+	// still settles to the cheap steady interval eventually.
+	const fastForUnpairedMax = 10 * time.Minute
 	start := time.Now()
 	cur := fastInterval
 	if interval < fastInterval {
@@ -378,8 +409,10 @@ func (m *Manager) RunBackground(ctx context.Context, startDelay, interval time.D
 			m.logger.Warn("autopair phase: heartbeat",
 				"tick", m.tickCount, "state", state, "interval", cur.String())
 		}
-		// Settle to the steady interval once the fast post-boot window elapses.
-		if cur != interval && time.Since(start) >= fastFor {
+		// Settle to the steady interval once the fast post-boot window elapses;
+		// a box not yet observed paired holds the fast cadence longer (capped).
+		pairedObserved := m.lastPaired != nil && *m.lastPaired
+		if cur != interval && shouldSettleToSteady(time.Since(start), pairedObserved, fastFor, fastForUnpairedMax) {
 			cur = interval
 			tick.Reset(interval)
 		}
@@ -389,6 +422,16 @@ func (m *Manager) RunBackground(ctx context.Context, startDelay, interval time.D
 		case <-tick.C:
 		}
 	}
+}
+
+// shouldSettleToSteady decides when the post-boot fast poll drops to the
+// steady interval: after fastFor once the box has been observed paired, or
+// after the (longer) unpaired cap otherwise.
+func shouldSettleToSteady(elapsed time.Duration, pairedObserved bool, fastFor, fastForUnpairedMax time.Duration) bool {
+	if pairedObserved {
+		return elapsed >= fastFor
+	}
+	return elapsed >= fastForUnpairedMax
 }
 
 // TriggerNow forces a pair-check cycle, independent of the RunBackground

--- a/internal/autopair/autopair.go
+++ b/internal/autopair/autopair.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -62,6 +63,62 @@ type Manager struct {
 	// without the 5-min heartbeat drowning everything else.
 	lastPaired *bool
 	tickCount  int
+
+	// Login-suspicion state. A margeAccountUUID on the box does NOT mean the
+	// box considers itself logged in: fresh installs and factory-reset boxes
+	// keep the UUID while their MargeHSM drops back to not-logged-in (every
+	// UPnP source activation is then refused with 1036
+	// UNABLE_TO_PROCESS_NOT_LOGGED_IN - field bundles 2026-07-22, all
+	// models). Boxes that still carry a cached pre-shutdown Bose account do
+	// not show this. The UUID-present skip in ensure() therefore let every
+	// press-time TriggerNow do nothing while the login was actually broken,
+	// and only the reactive ForcePair after a failed press re-asserted it.
+	// NoteLoginRejected marks the box suspect; while suspect, every ensure
+	// cycle (press, wake, reconnect, heartbeat tick) re-asserts the account
+	// proactively so the fake login is MAINTAINED, not just repaired.
+	// Guarded by suspectMu.
+	suspectMu         sync.Mutex
+	lastLoginReject   time.Time
+	lastSuspectAssert time.Time
+}
+
+const (
+	// loginSuspectWindow is how long after a not-logged-in rejection the box
+	// stays "login-suspect": within it, every pair cycle re-asserts the
+	// account even though the box reports a UUID. Long on purpose - the
+	// decay recurs across standby cycles - while a box that never rejects
+	// (e.g. one with a cached real Bose account) is never touched.
+	loginSuspectWindow = time.Hour
+	// suspectReassertMinGap rate-limits the suspect-driven re-asserts so a
+	// burst of presses cannot turn into a setMargeAccount storm (#375); the
+	// single-flight guard additionally coalesces concurrent triggers.
+	suspectReassertMinGap = time.Minute
+)
+
+// NoteLoginRejected records that the box just refused a source because it does
+// not consider itself logged in (errorUpdate 1036 NOT_LOGGED_IN). While the
+// suspicion is fresh, every pair cycle re-asserts the account instead of
+// trusting the UUID-present skip. Safe for concurrent use.
+func (m *Manager) NoteLoginRejected() {
+	m.suspectMu.Lock()
+	m.lastLoginReject = time.Now()
+	m.suspectMu.Unlock()
+}
+
+// consumeSuspectReassert reports whether a suspect-driven re-assert should run
+// now, and if so stamps the rate limit. The two-step check keeps the min-gap
+// accounting inside one lock.
+func (m *Manager) consumeSuspectReassert() bool {
+	m.suspectMu.Lock()
+	defer m.suspectMu.Unlock()
+	if m.lastLoginReject.IsZero() || time.Since(m.lastLoginReject) > loginSuspectWindow {
+		return false
+	}
+	if !m.lastSuspectAssert.IsZero() && time.Since(m.lastSuspectAssert) < suspectReassertMinGap {
+		return false
+	}
+	m.lastSuspectAssert = time.Now()
+	return true
 }
 
 // New creates a Manager with sensible defaults.
@@ -175,21 +232,34 @@ func (m *Manager) ensure(ctx context.Context, force bool) error {
 		return fmt.Errorf("check status: %w", err)
 	}
 	m.recordPairedState(paired)
+	suspectAssert := false
 	if paired && !force {
-		// Debug-level on the steady-state tick; the every-Nth heartbeat
-		// emitted by RunBackground keeps the diagnostic bundle honest
-		// without flooding the log on a healthy box.
-		m.logger.Debug("box already paired, no re-pair needed")
-		return nil
+		// The UUID-present skip is only valid while the login is healthy: a
+		// box that recently refused a source with 1036 NOT_LOGGED_IN keeps
+		// its UUID yet is NOT signed in, and skipping here left every
+		// press-time trigger a no-op while the buttons stayed dead (field
+		// bundles 2026-07-22). While the box is login-suspect, re-assert.
+		if m.consumeSuspectReassert() {
+			suspectAssert = true
+		} else {
+			// Debug-level on the steady-state tick; the every-Nth heartbeat
+			// emitted by RunBackground keeps the diagnostic bundle honest
+			// without flooding the log on a healthy box.
+			m.logger.Debug("box already paired, no re-pair needed")
+			return nil
+		}
 	}
 	if ok, when := m.boxClockSane(ctx); !ok {
 		m.logger.Info("auto pair deferred, box clock not yet synced (will retry next tick)",
 			"boxDate", when)
 		return nil
 	}
-	if paired {
+	switch {
+	case suspectAssert:
+		m.logger.Warn("autopair phase: box is login-suspect (recent 1036 NOT_LOGGED_IN), re-asserting the account despite a present UUID", "accountID", m.cfg.AccountID)
+	case paired:
 		m.logger.Warn("autopair phase: first cycle after start, re-asserting the account (clears a stale paired state and the dead-cloud amber icon)", "accountID", m.cfg.AccountID)
-	} else {
+	default:
 		m.logger.Warn("autopair phase: box not paired, starting auto pair", "accountID", m.cfg.AccountID)
 	}
 	if err := m.Pair(ctx); err != nil {
@@ -336,6 +406,11 @@ func (m *Manager) TriggerNow(ctx context.Context) {
 // restore the login state that the UUID-present check would otherwise skip.
 // Best-effort: a failure is logged, not fatal.
 func (m *Manager) ForcePair(ctx context.Context) {
+	// A reactive forced re-login means the box's login state is decaying:
+	// mark it login-suspect so the regular pair cycles (press, wake,
+	// reconnect, heartbeat) keep re-asserting the account proactively for a
+	// while instead of trusting the UUID-present skip again.
+	m.NoteLoginRejected()
 	m.logger.Warn("autopair: forcing a re-login (box reported not-logged-in)")
 	if err := m.Pair(ctx); err != nil {
 		m.logger.Warn("autopair: forced re-login failed", "err", err)

--- a/internal/autopair/autopair.go
+++ b/internal/autopair/autopair.go
@@ -61,8 +61,13 @@ type Manager struct {
 	// for the last known state. Used to emit phase-marker logs only
 	// on transitions so a diagnostic bundle has a clean timeline
 	// without the 5-min heartbeat drowning everything else.
+	// Guarded by pairedMu: ensure cycles run on whichever goroutine
+	// triggered them (RunBackground tick, press-time TriggerNow, boxws
+	// reconnect), while RunBackground reads the state for its heartbeat.
+	pairedMu   sync.Mutex
 	lastPaired *bool
-	tickCount  int
+	// tickCount is only touched by RunBackground's own goroutine.
+	tickCount int
 
 	// onPaired fires when the box transitions from unpaired to paired (a
 	// completed (re-)onboarding). The firmware wipes its hardware-key preset
@@ -281,27 +286,42 @@ func (m *Manager) ensure(ctx context.Context, force bool) error {
 // so the diagnostic bundle always carries an explicit "initial state"
 // line right after agent start.
 func (m *Manager) recordPairedState(paired bool) {
+	m.pairedMu.Lock()
 	if m.lastPaired == nil {
-		m.logger.Warn("autopair phase: initial state observed", "paired", paired)
 		v := paired
 		m.lastPaired = &v
+		m.pairedMu.Unlock()
+		m.logger.Warn("autopair phase: initial state observed", "paired", paired)
 		return
 	}
-	if *m.lastPaired != paired {
-		m.logger.Warn("autopair phase: paired state changed",
-			"from", *m.lastPaired, "to", paired)
-		wasUnpaired := !*m.lastPaired
-		v := paired
-		m.lastPaired = &v
-		// unpaired -> paired = a (re-)onboarding just completed; the firmware
-		// wipes its key-layer preset registrations in that transition, so let
-		// the agent re-register them right away. The initial observation is
-		// deliberately NOT a transition: an already-paired box at agent start
-		// went through no onboarding.
-		if paired && wasUnpaired && m.onPaired != nil {
-			m.onPaired()
-		}
+	if *m.lastPaired == paired {
+		m.pairedMu.Unlock()
+		return
 	}
+	was := *m.lastPaired
+	v := paired
+	m.lastPaired = &v
+	m.pairedMu.Unlock()
+	m.logger.Warn("autopair phase: paired state changed", "from", was, "to", paired)
+	// unpaired -> paired = a (re-)onboarding just completed; the firmware
+	// wipes its key-layer preset registrations in that transition, so let
+	// the agent re-register them right away. The initial observation is
+	// deliberately NOT a transition: an already-paired box at agent start
+	// went through no onboarding.
+	if paired && !was && m.onPaired != nil {
+		m.onPaired()
+	}
+}
+
+// pairedState reports the last observed pair state: known=false means no
+// successful status read has happened yet. Safe for concurrent use.
+func (m *Manager) pairedState() (known, paired bool) {
+	m.pairedMu.Lock()
+	defer m.pairedMu.Unlock()
+	if m.lastPaired == nil {
+		return false, false
+	}
+	return true, *m.lastPaired
 }
 
 // SetOnPaired registers the unpaired->paired transition hook. Call before
@@ -399,8 +419,8 @@ func (m *Manager) RunBackground(ctx context.Context, startDelay, interval time.D
 			m.logger.Warn("auto pair failed, will retry next tick", "err", err)
 		} else if m.tickCount%heartbeatEvery == 0 {
 			state := "unknown"
-			if m.lastPaired != nil {
-				if *m.lastPaired {
+			if known, paired := m.pairedState(); known {
+				if paired {
 					state = "paired"
 				} else {
 					state = "not paired"
@@ -411,7 +431,7 @@ func (m *Manager) RunBackground(ctx context.Context, startDelay, interval time.D
 		}
 		// Settle to the steady interval once the fast post-boot window elapses;
 		// a box not yet observed paired holds the fast cadence longer (capped).
-		pairedObserved := m.lastPaired != nil && *m.lastPaired
+		_, pairedObserved := m.pairedState()
 		if cur != interval && shouldSettleToSteady(time.Since(start), pairedObserved, fastFor, fastForUnpairedMax) {
 			cur = interval
 			tick.Reset(interval)
@@ -448,17 +468,49 @@ func (m *Manager) TriggerNow(ctx context.Context) {
 // NOT_LOGGED_IN when handed a UPnP source; re-POSTing setMargeAccount can
 // restore the login state that the UUID-present check would otherwise skip.
 // Best-effort: a failure is logged, not fatal.
+//
+// Runs inside the same single-flight guard as ensure(): the press-time suspect
+// re-assert and the same press's 1036-driven ForcePair used to POST
+// setMargeAccount concurrently to a box whose POST handler can hang for
+// seconds, re-introducing exactly the stacked-POST pattern the guard exists
+// for (#375). ForcePair now waits (bounded by ctx) for a running cycle to
+// finish instead of overlapping it, and skips its own POST when that cycle
+// just re-asserted the account anyway. Deliberately does NOT read /info first:
+// the whole point is to POST even when the paired state looks fine.
 func (m *Manager) ForcePair(ctx context.Context) {
 	// A reactive forced re-login means the box's login state is decaying:
 	// mark it login-suspect so the regular pair cycles (press, wake,
 	// reconnect, heartbeat) keep re-asserting the account proactively for a
 	// while instead of trusting the UUID-present skip again.
 	m.NoteLoginRejected()
+	for !m.inFlight.CompareAndSwap(false, true) {
+		select {
+		case <-ctx.Done():
+			m.logger.Info("autopair: forced re-login skipped, another pair cycle ran for the whole window (it re-asserts too: the box is now login-suspect)")
+			return
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+	defer m.inFlight.Store(false)
+	// If a suspect-driven re-assert completed while we waited, the account was
+	// just POSTed; a second POST right behind it only churns the MargeHSM.
+	m.suspectMu.Lock()
+	justAsserted := !m.lastSuspectAssert.IsZero() && time.Since(m.lastSuspectAssert) < 5*time.Second
+	m.suspectMu.Unlock()
+	if justAsserted {
+		m.logger.Info("autopair: forced re-login coalesced into a just-completed suspect re-assert")
+		return
+	}
 	m.logger.Warn("autopair: forcing a re-login (box reported not-logged-in)")
 	if err := m.Pair(ctx); err != nil {
 		m.logger.Warn("autopair: forced re-login failed", "err", err)
 		return
 	}
+	// Stamp the suspect min-gap so the next ensure trigger (press, wake,
+	// reconnect, tick) does not immediately re-POST within seconds of this one.
+	m.suspectMu.Lock()
+	m.lastSuspectAssert = time.Now()
+	m.suspectMu.Unlock()
 	m.logger.Warn("autopair: forced re-login sent")
 }
 

--- a/internal/autopair/autopair_test.go
+++ b/internal/autopair/autopair_test.go
@@ -267,3 +267,76 @@ func TestEnsurePairedSingleFlight(t *testing.T) {
 		t.Fatalf("8 concurrent triggers must coalesce into 1 pair POST, got %d", got)
 	}
 }
+
+func TestOnPairedFiresOnlyOnUnpairedToPairedTransition(t *testing.T) {
+	box := &fakeBox{infoBody: unpairedInfo}
+	m := newTestManager(t, box)
+	fired := 0
+	m.SetOnPaired(func() { fired++ })
+
+	// Initial observation (unpaired) is not a transition.
+	if err := m.EnsurePaired(context.Background()); err != nil {
+		t.Fatalf("EnsurePaired: %v", err)
+	}
+	if fired != 0 {
+		t.Fatalf("initial unpaired observation must not fire, got %d", fired)
+	}
+
+	// The box completed its onboarding: unpaired -> paired must fire once
+	// (the firmware wipes its key registrations during the onboarding, and
+	// this hook is what schedules the immediate re-registration).
+	box.mu.Lock()
+	box.infoBody = pairedInfo
+	box.mu.Unlock()
+	if err := m.EnsurePaired(context.Background()); err != nil {
+		t.Fatalf("EnsurePaired: %v", err)
+	}
+	if fired != 1 {
+		t.Fatalf("unpaired->paired must fire the hook once, got %d", fired)
+	}
+
+	// Steady paired state: no more fires.
+	if err := m.EnsurePaired(context.Background()); err != nil {
+		t.Fatalf("EnsurePaired: %v", err)
+	}
+	if fired != 1 {
+		t.Fatalf("steady paired state must not re-fire, got %d", fired)
+	}
+}
+
+func TestOnPairedDoesNotFireOnInitialPairedObservation(t *testing.T) {
+	// A box that is already paired at agent start went through no onboarding:
+	// no wipe happened, so no forced re-sync is needed.
+	box := &fakeBox{infoBody: pairedInfo}
+	m := newTestManager(t, box)
+	fired := 0
+	m.SetOnPaired(func() { fired++ })
+	if err := m.EnsurePaired(context.Background()); err != nil {
+		t.Fatalf("EnsurePaired: %v", err)
+	}
+	if fired != 0 {
+		t.Fatalf("initial paired observation must not fire, got %d", fired)
+	}
+}
+
+func TestShouldSettleToSteady(t *testing.T) {
+	const fastFor = 2 * time.Minute
+	const unpairedMax = 10 * time.Minute
+	cases := []struct {
+		name    string
+		elapsed time.Duration
+		paired  bool
+		want    bool
+	}{
+		{"paired, inside fast window", time.Minute, true, false},
+		{"paired, fast window elapsed", 3 * time.Minute, true, true},
+		{"unpaired, would have settled before", 3 * time.Minute, false, false},
+		{"unpaired, holds the fast cadence long", 9 * time.Minute, false, false},
+		{"unpaired, capped eventually", 11 * time.Minute, false, true},
+	}
+	for _, c := range cases {
+		if got := shouldSettleToSteady(c.elapsed, c.paired, fastFor, unpairedMax); got != c.want {
+			t.Errorf("%s: shouldSettleToSteady = %v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/internal/autopair/autopair_test.go
+++ b/internal/autopair/autopair_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -18,6 +19,7 @@ const unpairedInfo = `<info><margeAccountUUID></margeAccountUUID></info>`
 type fakeBox struct {
 	mu        sync.Mutex
 	infoBody  string
+	infoDate  string // optional Date header (the RTC clock gate reads it)
 	infoDelay time.Duration
 	pairPosts atomic.Int64
 }
@@ -26,10 +28,13 @@ func (f *fakeBox) handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/info", func(w http.ResponseWriter, r *http.Request) {
 		f.mu.Lock()
-		body, delay := f.infoBody, f.infoDelay
+		body, date, delay := f.infoBody, f.infoDate, f.infoDelay
 		f.mu.Unlock()
 		if delay > 0 {
 			time.Sleep(delay)
+		}
+		if date != "" {
+			w.Header().Set("Date", date)
 		}
 		_, _ = w.Write([]byte(body))
 	})
@@ -81,6 +86,166 @@ func TestForceReassertsDespitePaired(t *testing.T) {
 	}
 	if got := box.pairPosts.Load(); got != 1 {
 		t.Fatalf("forced cycle must POST setMargeAccount once, got %d", got)
+	}
+}
+
+// --- Fake-login maintenance (the 1036 NOT_LOGGED_IN class) ---
+//
+// A margeAccountUUID on the box does not mean the box considers itself logged
+// in: fresh installs / factory-reset boxes keep the UUID while the MargeHSM
+// drops to not-logged-in, and every UPnP source activation is refused with
+// 1036 (field bundles 2026-07-22, all models). Boxes that still carry a cached
+// pre-shutdown Bose account never show this. These tests pin the maintenance
+// contract: a rejection marks the box login-suspect, and while suspect every
+// pair cycle re-asserts the account instead of trusting the UUID-present skip.
+
+func TestLoginRejectForcesReassertDespitePaired(t *testing.T) {
+	box := &fakeBox{infoBody: pairedInfo}
+	m := newTestManager(t, box)
+
+	// Healthy paired box: no re-assert.
+	if err := m.EnsurePaired(context.Background()); err != nil {
+		t.Fatalf("EnsurePaired: %v", err)
+	}
+	if got := box.pairPosts.Load(); got != 0 {
+		t.Fatalf("healthy paired box must not be re-asserted, got %d POSTs", got)
+	}
+
+	// The box refused a source as not-logged-in: the next cycle must
+	// re-assert even though /info still reports a UUID.
+	m.NoteLoginRejected()
+	if err := m.EnsurePaired(context.Background()); err != nil {
+		t.Fatalf("EnsurePaired (suspect): %v", err)
+	}
+	if got := box.pairPosts.Load(); got != 1 {
+		t.Fatalf("login-suspect box must be re-asserted despite the UUID, got %d POSTs", got)
+	}
+}
+
+func TestSuspectReassertIsRateLimited(t *testing.T) {
+	box := &fakeBox{infoBody: pairedInfo}
+	m := newTestManager(t, box)
+	m.NoteLoginRejected()
+
+	// A burst of presses (each triggering a pair cycle) must not turn into a
+	// setMargeAccount storm: one re-assert per suspectReassertMinGap.
+	for i := 0; i < 5; i++ {
+		if err := m.EnsurePaired(context.Background()); err != nil {
+			t.Fatalf("EnsurePaired #%d: %v", i, err)
+		}
+	}
+	if got := box.pairPosts.Load(); got != 1 {
+		t.Fatalf("suspect re-asserts within the min-gap must coalesce to 1 POST, got %d", got)
+	}
+
+	// Once the gap has passed, the suspicion (still fresh) re-asserts again:
+	// maintenance, not a one-shot repair.
+	m.suspectMu.Lock()
+	m.lastSuspectAssert = time.Now().Add(-suspectReassertMinGap - time.Second)
+	m.suspectMu.Unlock()
+	if err := m.EnsurePaired(context.Background()); err != nil {
+		t.Fatalf("EnsurePaired (after gap): %v", err)
+	}
+	if got := box.pairPosts.Load(); got != 2 {
+		t.Fatalf("a fresh suspicion must re-assert again after the min-gap, got %d POSTs", got)
+	}
+}
+
+func TestLoginSuspicionExpires(t *testing.T) {
+	box := &fakeBox{infoBody: pairedInfo}
+	m := newTestManager(t, box)
+
+	// A rejection long ago must not keep re-asserting forever: outside the
+	// suspect window the UUID-present skip is trusted again, so a box that
+	// healed (or one with a cached real Bose account that never rejects
+	// again) sees zero extra traffic.
+	m.suspectMu.Lock()
+	m.lastLoginReject = time.Now().Add(-loginSuspectWindow - time.Minute)
+	m.suspectMu.Unlock()
+	if err := m.EnsurePaired(context.Background()); err != nil {
+		t.Fatalf("EnsurePaired: %v", err)
+	}
+	if got := box.pairPosts.Load(); got != 0 {
+		t.Fatalf("an expired suspicion must not re-assert, got %d POSTs", got)
+	}
+}
+
+func TestForcePairMarksLoginSuspect(t *testing.T) {
+	// The reactive re-login (boxws 1036 routing -> webui -> ForcePair) must
+	// arm the proactive maintenance too: after it, the next regular cycle
+	// keeps re-asserting (once per min-gap) instead of falling back to the
+	// UUID-present skip - that fallback is exactly what left the buttons
+	// dead between two presses in the field.
+	box := &fakeBox{infoBody: pairedInfo}
+	m := newTestManager(t, box)
+
+	m.ForcePair(context.Background())
+	if got := box.pairPosts.Load(); got != 1 {
+		t.Fatalf("ForcePair must POST unconditionally, got %d", got)
+	}
+	m.suspectMu.Lock()
+	if m.lastLoginReject.IsZero() {
+		m.suspectMu.Unlock()
+		t.Fatal("ForcePair must mark the box login-suspect")
+	}
+	m.lastSuspectAssert = time.Now().Add(-suspectReassertMinGap - time.Second)
+	m.suspectMu.Unlock()
+
+	if err := m.EnsurePaired(context.Background()); err != nil {
+		t.Fatalf("EnsurePaired: %v", err)
+	}
+	if got := box.pairPosts.Load(); got != 2 {
+		t.Fatalf("the cycle after a ForcePair must keep maintaining the login, got %d POSTs", got)
+	}
+}
+
+func TestForcePairPostsEvenWhenInfoFails(t *testing.T) {
+	// ForcePair is the reactive last resort: it must not depend on /info
+	// being readable (a mid-flap box can refuse it) - it POSTs directly.
+	box := &fakeBox{infoBody: pairedInfo}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/info" {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		if r.URL.Path == "/setMargeAccount" {
+			box.pairPosts.Add(1)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	m := New(slog.Default(), Config{BoxHost: "127.0.0.1"})
+	m.base = srv.URL
+
+	m.ForcePair(context.Background())
+	if got := box.pairPosts.Load(); got != 1 {
+		t.Fatalf("ForcePair must POST even when /info fails, got %d", got)
+	}
+}
+
+func TestClockGateDefersSuspectReassert(t *testing.T) {
+	// The 2015-RTC gate must also hold for suspect-driven re-asserts: pairing
+	// against a not-yet-synced clock fails with a TLS error anyway, so the
+	// cycle defers and the next tick retries.
+	box := &fakeBox{infoBody: pairedInfo, infoDate: "Mon, 02 Feb 2015 10:00:00 GMT"}
+	m := newTestManager(t, box)
+	m.NoteLoginRejected()
+	if err := m.EnsurePaired(context.Background()); err != nil {
+		t.Fatalf("EnsurePaired: %v", err)
+	}
+	if got := box.pairPosts.Load(); got != 0 {
+		t.Fatalf("a box on the 2015 RTC must not be paired yet, got %d POSTs", got)
+	}
+}
+
+func TestPairXMLEscapesCredentials(t *testing.T) {
+	xml := buildPairXML(`a&b<c>"d`, "tok&", "e<f")
+	for _, want := range []string{"a&amp;b&lt;c&gt;&quot;d", "tok&amp;", "e&lt;f"} {
+		if !strings.Contains(xml, want) {
+			t.Fatalf("pair XML must escape credentials, missing %q in %s", want, xml)
+		}
 	}
 }
 

--- a/internal/autopair/autopair_test.go
+++ b/internal/autopair/autopair_test.go
@@ -340,3 +340,75 @@ func TestShouldSettleToSteady(t *testing.T) {
 		}
 	}
 }
+
+// TestForcePairDoesNotOverlapEnsure: the press-time suspect re-assert and the
+// same press's 1036-driven ForcePair used to POST setMargeAccount concurrently
+// - exactly the stacked-POST pattern the single-flight guard exists for
+// (#375). ForcePair now runs inside the same guard: with a slow POST handler
+// one of the two waits, and no two POSTs are ever in flight at once.
+func TestForcePairDoesNotOverlapEnsure(t *testing.T) {
+	var mu sync.Mutex
+	inFlight, maxInFlight, total := 0, 0, 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/setMargeAccount" {
+			mu.Lock()
+			inFlight++
+			total++
+			if inFlight > maxInFlight {
+				maxInFlight = inFlight
+			}
+			mu.Unlock()
+			time.Sleep(400 * time.Millisecond) // the slow box the guard exists for
+			mu.Lock()
+			inFlight--
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		_, _ = w.Write([]byte(pairedInfo))
+	}))
+	defer srv.Close()
+	m := New(slog.Default(), Config{BoxHost: "127.0.0.1"})
+	m.base = srv.URL
+	m.NoteLoginRejected() // login-suspect: the ensure cycle POSTs too
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); _ = m.EnsurePaired(context.Background()) }()
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		m.ForcePair(ctx)
+	}()
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if maxInFlight > 1 {
+		t.Fatalf("setMargeAccount POSTs overlapped (max %d in flight); the single-flight guard must cover ForcePair too (#375)", maxInFlight)
+	}
+	if total < 1 {
+		t.Fatal("at least one re-assert must have been sent")
+	}
+}
+
+// TestForcePairStampsSuspectAssert: the forced re-login IS a suspect
+// re-assert, so the next ensure trigger inside the min-gap must not POST a
+// second re-onboarding right behind it.
+func TestForcePairStampsSuspectAssert(t *testing.T) {
+	box := &fakeBox{infoBody: pairedInfo}
+	m := newTestManager(t, box)
+
+	m.ForcePair(context.Background())
+	if got := box.pairPosts.Load(); got != 1 {
+		t.Fatalf("ForcePair must POST, got %d", got)
+	}
+
+	if err := m.EnsurePaired(context.Background()); err != nil {
+		t.Fatalf("EnsurePaired: %v", err)
+	}
+	if got := box.pairPosts.Load(); got != 1 {
+		t.Fatalf("an ensure right after a forced re-login must coalesce into its min-gap, got %d POSTs", got)
+	}
+}

--- a/internal/boxcli/boxcli.go
+++ b/internal/boxcli/boxcli.go
@@ -80,6 +80,18 @@ const selfWakeGrace = 2500 * time.Millisecond
 // logger may be nil; when present, per-iteration phase markers are emitted
 // so a diagnostic bundle shows the standby-exit timeline (#60).
 func WakeAndWait(ctx context.Context, host string, maxWait time.Duration, logger *slog.Logger) error {
+	return WakeAndWaitAbort(ctx, host, maxWait, logger, nil)
+}
+
+// WakeAndWaitAbort is WakeAndWait with an abort predicate, consulted
+// immediately before EACH `sys power` toggle would be sent. Callers whose
+// wake decision can be invalidated while the wake is already running - the
+// recall verify, whose "the box's own give-up put it in standby" conclusion a
+// user power press can overtake at any moment - pass their stand-down check
+// here, so the toggle never re-powers a box the user just switched off
+// (#197). nil = never abort. Aborting returns nil: the box deliberately stays
+// as it is.
+func WakeAndWaitAbort(ctx context.Context, host string, maxWait time.Duration, logger *slog.Logger, abort func() bool) error {
 	if host == "" {
 		host = "127.0.0.1"
 	}
@@ -147,6 +159,10 @@ func WakeAndWait(ctx context.Context, host string, maxWait time.Duration, logger
 			logPhase("wake phase: pre-check read failed", "attempt", i, "err", err.Error())
 		} else {
 			logPhase("wake phase: STANDBY, sending sys power", "attempt", i, "source", state)
+		}
+		if abort != nil && abort() {
+			logPhase("wake phase: abort signalled (caller stood down), not toggling", "attempt", i)
+			return nil
 		}
 		if pwrErr := PowerOn(ctx, host); pwrErr != nil {
 			logPhase("wake phase: sys power write failed", "attempt", i, "err", pwrErr.Error())

--- a/internal/boxws/boxws.go
+++ b/internal/boxws/boxws.go
@@ -142,6 +142,19 @@ type Client struct {
 	lastInvalidSourceAt time.Time
 	lastPresetPressAt   time.Time
 
+	// lastOwnCmdAt is when STR itself last issued a transport-mutating SOAP
+	// command (SetURI/Play/Pause/Stop), stamped via NoteOwnTransportCommand from
+	// the upnp renderer's OnTransportCommand hook. The box answers a SOAP Stop
+	// (and a SetURI flip of an active transport) with a nowPlaying STOP_STATE
+	// that looks exactly like the user pressing stop; the v0.9.16 wrong-state
+	// repair (Stop+ClearURI ~1.5 s into a recall, after the press window
+	// expired) therefore latched a phantom user stop that aborted its OWN
+	// verify loop and stood every recovery down (#252 post-v0.9.16: "remote
+	// useless"). stopStateIsTeardown reads this stamp to excuse such an echo -
+	// unless a fresh physical key press accompanied it, which means the user
+	// really did stop. Guarded by mu.
+	lastOwnCmdAt time.Time
+
 	// lastStandbyFlapAt times the box's own UPNP<->STANDBY oscillation on a
 	// spontaneous firmware source power-off (#419). That drop is not a single
 	// transition: the box flips UPNP->STANDBY->UPNP within ~100 ms, and the
@@ -638,6 +651,18 @@ type ZoneMemberState struct {
 const (
 	presetTeardownWindow        = 4 * time.Second
 	invalidSourceTeardownWindow = 2 * time.Second
+	// ownCmdTeardownWindow bounds how soon after one of STR's OWN transport
+	// commands (SOAP Stop / SetURI / Play) a STOP_STATE still counts as the
+	// box's reaction to that command rather than a user stop. The echo arrives
+	// within a fraction of a second of the SOAP round-trip; kept short so a
+	// real stop the user makes a moment later is still honoured.
+	ownCmdTeardownWindow = 3 * time.Second
+	// ownCmdKeyVeto: a physical key press this close to the STOP_STATE means
+	// the stop came from the user (remote/box stop key), NOT from STR's own
+	// command, even inside ownCmdTeardownWindow. The firmware sends a
+	// userActivityUpdate alongside real key presses; STR's SOAP commands never
+	// produce one.
+	ownCmdKeyVeto = 1500 * time.Millisecond
 	// standbyFlapTeardownWindow bounds how soon after a UPNP<->STANDBY flap a
 	// STOP_STATE still counts as the spontaneous-off oscillation's teardown
 	// (#419) rather than a deliberate stop. The observed bounce completes in
@@ -668,9 +693,11 @@ func (c *Client) stopStateIsTeardown(np *wsNowPlaying) (bool, string) {
 	sincePress := time.Since(c.lastPresetPressAt)
 	sinceInvalid := time.Since(c.lastInvalidSourceAt)
 	sinceStandbyFlap := time.Since(c.lastStandbyFlapAt)
+	sinceOwnCmd := time.Since(c.lastOwnCmdAt)
 	pressSet := !c.lastPresetPressAt.IsZero()
 	invalidSet := !c.lastInvalidSourceAt.IsZero()
 	standbyFlapSet := !c.lastStandbyFlapAt.IsZero()
+	ownCmdSet := !c.lastOwnCmdAt.IsZero()
 	c.mu.Unlock()
 	if pressSet && sincePress < presetTeardownWindow {
 		return true, "hardware preset pressed " + sincePress.Round(time.Millisecond).String() + " ago"
@@ -690,7 +717,32 @@ func (c *Client) stopStateIsTeardown(np *wsNowPlaying) (bool, string) {
 	if standbyFlapSet && sinceStandbyFlap < standbyFlapTeardownWindow {
 		return true, "source flapped through STANDBY " + sinceStandbyFlap.Round(time.Millisecond).String() + " ago"
 	}
+	// STR itself just drove the transport (the wrong-state repair's Stop+ClearURI,
+	// a verify re-push's SetURI+Play, a re-push/resume from the webui): the box
+	// answers those with a STOP_STATE that is not a user stop. The veto: a
+	// physical key press right next to the frame means the user pressed stop on
+	// the remote/box even inside this window - the firmware accompanies real key
+	// presses with a userActivityUpdate, which STR's SOAP commands never cause.
+	if ownCmdSet && sinceOwnCmd < ownCmdTeardownWindow {
+		c.thumbMu.Lock()
+		sinceKey := time.Since(c.lastUserActivityAt)
+		keySet := !c.lastUserActivityAt.IsZero()
+		c.thumbMu.Unlock()
+		if !keySet || sinceKey > ownCmdKeyVeto {
+			return true, "STR's own transport command " + sinceOwnCmd.Round(time.Millisecond).String() + " ago"
+		}
+	}
 	return false, ""
+}
+
+// NoteOwnTransportCommand stamps that STR itself just issued a transport-
+// mutating SOAP command. Wired to upnp.Renderer.OnTransportCommand (for every
+// renderer that drives THIS box) so stopStateIsTeardown can excuse the box's
+// STOP_STATE reaction to STR's own commands. Safe for concurrent use.
+func (c *Client) NoteOwnTransportCommand() {
+	c.mu.Lock()
+	c.lastOwnCmdAt = time.Now()
+	c.mu.Unlock()
 }
 
 func (c *Client) handleMessage(ctx context.Context, data []byte) {

--- a/internal/boxws/boxws.go
+++ b/internal/boxws/boxws.go
@@ -745,6 +745,16 @@ func (c *Client) NoteOwnTransportCommand() {
 	c.mu.Unlock()
 }
 
+// LastOwnTransportCommand returns when STR last issued a transport-mutating
+// SOAP command (zero time if never). The webui's standby classifier reads it
+// to recognise a source flip that merely answers STR's OWN push (the firmware
+// rejecting a wake-resume/recall) instead of reading it as a user power-off.
+func (c *Client) LastOwnTransportCommand() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lastOwnCmdAt
+}
+
 func (c *Client) handleMessage(ctx context.Context, data []byte) {
 	c.logger.Debug("box ws frame", "bytes", len(data), "preview", preview(data, 400))
 

--- a/internal/boxws/boxws.go
+++ b/internal/boxws/boxws.go
@@ -155,6 +155,13 @@ type Client struct {
 	// really did stop. Guarded by mu.
 	lastOwnCmdAt time.Time
 
+	// lastUpnpActiveAt is when STR's own source (UPNP) last stopped being the
+	// active source. The firmware's give-up after a failed self-activation
+	// reaches STANDBY through INVALID_SOURCE (UPNP -> INVALID_SOURCE ->
+	// STANDBY), and the prev==UPNP gate alone made that route bypass the
+	// standby handling entirely. Guarded by mu.
+	lastUpnpActiveAt time.Time
+
 	// lastStandbyFlapAt times the box's own UPNP<->STANDBY oscillation on a
 	// spontaneous firmware source power-off (#419). That drop is not a single
 	// transition: the box flips UPNP->STANDBY->UPNP within ~100 ms, and the
@@ -657,6 +664,10 @@ const (
 	// within a fraction of a second of the SOAP round-trip; kept short so a
 	// real stop the user makes a moment later is still honoured.
 	ownCmdTeardownWindow = 3 * time.Second
+	// upnpFlapWindow bounds how long after UPNP stopped being the active
+	// source a STANDBY entry still counts as an STR-driven power-off (the
+	// UPNP -> INVALID_SOURCE -> STANDBY give-up completes within ~1-2s).
+	upnpFlapWindow = 5 * time.Second
 	// ownCmdKeyVeto: a physical key press this close to the STOP_STATE means
 	// the stop came from the user (remote/box stop key), NOT from STR's own
 	// command, even inside ownCmdTeardownWindow. The firmware sends a
@@ -811,6 +822,16 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 			if src == "STANDBY" || prev == "STANDBY" {
 				c.lastStandbyFlapAt = time.Now()
 			}
+			// Stamp when STR's own source (UPNP) STOPS being active: the box's
+			// give-up after a failed self-activation reaches STANDBY through
+			// INVALID_SOURCE (UPNP -> INVALID_SOURCE -> STANDBY), and the
+			// standby handling below must still recognise that STR-driven
+			// playback is what just powered off.
+			if prev == "UPNP" {
+				c.lastUpnpActiveAt = time.Now()
+			}
+			upnpRecently := prev == "UPNP" ||
+				(!c.lastUpnpActiveAt.IsZero() && time.Since(c.lastUpnpActiveAt) < upnpFlapWindow)
 			c.mu.Unlock()
 			if changed {
 				// Log every source transition at INFO (rare by construction: only
@@ -827,9 +848,15 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 				// itself back on. When STR's own source (UPNP) drops to STANDBY, give
 				// the handler a chance to clear the transport so the box has nothing to
 				// bounce back to. Optional interface so handlers that do not need it
-				// (tests) are unaffected. Gated to prev==UPNP so it only fires for
-				// STR-driven playback, never an AUX/Spotify power-off.
-				if src == "STANDBY" && prev == "UPNP" {
+				// (tests) are unaffected. Gated so it only fires for STR-driven
+				// playback, never an AUX/Spotify power-off: either a direct
+				// UPNP->STANDBY drop, or the give-up flap UPNP->INVALID_SOURCE->
+				// STANDBY the firmware performs after a failed self-activation -
+				// that flap used to bypass the entire standby machinery, so no
+				// classification/recovery ran while the box switched itself off
+				// (field bundles 2026-07-22, all standby entries on taigan/spotty/
+				// lisa took this route).
+				if src == "STANDBY" && upnpRecently {
 					if h, ok := c.handler.(interface{ OnEnterStandby(context.Context) }); ok {
 						h.OnEnterStandby(ctx)
 					}

--- a/internal/boxws/boxws.go
+++ b/internal/boxws/boxws.go
@@ -162,6 +162,18 @@ type Client struct {
 	// standby handling entirely. Guarded by mu.
 	lastUpnpActiveAt time.Time
 
+	// upnpEpisode is true while the box sits in the INVALID_SOURCE (or
+	// subsequent STANDBY) state it entered FROM STR's UPNP source. The
+	// rolling upnpFlapWindow only covers the fast give-up flap; a struggling
+	// box can dwell in INVALID_SOURCE for 16+ seconds (the state the
+	// sys-power nudge exists for), and a user power press at the end of that
+	// dwell produced INVALID_SOURCE->STANDBY with the window long expired -
+	// so no standby classification ran, nothing latched, and the recall
+	// verify's wake actively powered the just-switched-off box back on
+	// (#197). Set on UPNP->INVALID_SOURCE, cleared when the source becomes
+	// anything other than INVALID_SOURCE/STANDBY. Guarded by mu.
+	upnpEpisode bool
+
 	// lastStandbyFlapAt times the box's own UPNP<->STANDBY oscillation on a
 	// spontaneous firmware source power-off (#419). That drop is not a single
 	// transition: the box flips UPNP->STANDBY->UPNP within ~100 ms, and the
@@ -674,6 +686,16 @@ const (
 	// userActivityUpdate alongside real key presses; STR's SOAP commands never
 	// produce one.
 	ownCmdKeyVeto = 1500 * time.Millisecond
+	// ownCmdKeylessTeardownWindow replaces ownCmdTeardownWindow on firmware
+	// that has never emitted a userActivityUpdate: the key veto has no signal
+	// there, so the full 3s window would excuse EVERY stop within 3s of any of
+	// STR's own SOAP commands - and during a struggling recall STR pushes on a
+	// ~5s cadence, so a deliberate remote stop was near-guaranteed to be
+	// swallowed and the re-push overrode it. The box's echo to our own command
+	// arrives within a fraction of a second of the SOAP round-trip, so a tight
+	// window still excuses the genuine echo while a user stop a second later
+	// latches.
+	ownCmdKeylessTeardownWindow = 750 * time.Millisecond
 	// standbyFlapTeardownWindow bounds how soon after a UPNP<->STANDBY flap a
 	// STOP_STATE still counts as the spontaneous-off oscillation's teardown
 	// (#419) rather than a deliberate stop. The observed bounce completes in
@@ -734,12 +756,19 @@ func (c *Client) stopStateIsTeardown(np *wsNowPlaying) (bool, string) {
 	// physical key press right next to the frame means the user pressed stop on
 	// the remote/box even inside this window - the firmware accompanies real key
 	// presses with a userActivityUpdate, which STR's SOAP commands never cause.
-	if ownCmdSet && sinceOwnCmd < ownCmdTeardownWindow {
+	// Firmware that has NEVER emitted a userActivityUpdate gives the veto no
+	// signal, so only the much tighter keyless window applies there (see the
+	// constant): a real remote stop on such a box must still latch.
+	if ownCmdSet {
 		c.thumbMu.Lock()
 		sinceKey := time.Since(c.lastUserActivityAt)
 		keySet := !c.lastUserActivityAt.IsZero()
 		c.thumbMu.Unlock()
-		if !keySet || sinceKey > ownCmdKeyVeto {
+		window := ownCmdTeardownWindow
+		if !keySet {
+			window = ownCmdKeylessTeardownWindow
+		}
+		if sinceOwnCmd < window && (!keySet || sinceKey > ownCmdKeyVeto) {
 			return true, "STR's own transport command " + sinceOwnCmd.Round(time.Millisecond).String() + " ago"
 		}
 	}
@@ -815,6 +844,19 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 			if src == "INVALID_SOURCE" {
 				c.lastInvalidSourceAt = time.Now()
 			}
+			// Track the whole UPNP-driven INVALID_SOURCE episode, not just its
+			// first seconds: a long dwell before the STANDBY entry must still
+			// count as "STR's playback is what powered off" (see upnpEpisode).
+			switch {
+			case src == "INVALID_SOURCE":
+				if prev == "UPNP" {
+					c.upnpEpisode = true
+				}
+			case src == "STANDBY":
+				// keep: the episode's terminal state is what we classify
+			default:
+				c.upnpEpisode = false
+			}
 			// Stamp every flap to OR from STANDBY: the spontaneous-off oscillation
 			// (#419) carries a STOP_STATE on its STANDBY->UPNP leg whose source reads
 			// UPNP, so this is the only trace that the STOP_STATE belongs to the
@@ -831,7 +873,8 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 				c.lastUpnpActiveAt = time.Now()
 			}
 			upnpRecently := prev == "UPNP" ||
-				(!c.lastUpnpActiveAt.IsZero() && time.Since(c.lastUpnpActiveAt) < upnpFlapWindow)
+				(!c.lastUpnpActiveAt.IsZero() && time.Since(c.lastUpnpActiveAt) < upnpFlapWindow) ||
+				c.upnpEpisode
 			c.mu.Unlock()
 			if changed {
 				// Log every source transition at INFO (rare by construction: only

--- a/internal/boxws/boxws_test.go
+++ b/internal/boxws/boxws_test.go
@@ -432,3 +432,105 @@ func TestHandleMessage_EnterStandbyViaInvalidSourceFlap(t *testing.T) {
 		t.Fatalf("a standby entry with no recent UPNP activity must not fire OnEnterStandby, got %d", h2.enterStandby)
 	}
 }
+
+// TestHandleMessage_KeylessOwnCommandWindowIsTight: firmware that has never
+// emitted a userActivityUpdate gives the key veto no signal, so the full 3s
+// own-command window would excuse EVERY stop within 3s of any of STR's SOAP
+// commands - and during a struggling recall STR pushes on a ~5s cadence, so a
+// deliberate remote stop was near-guaranteed to be swallowed and the re-push
+// overrode it. On keyless firmware only the immediate echo of our own command
+// (the tight window) is excused; a stop a second and a half later must latch.
+func TestHandleMessage_KeylessOwnCommandWindowIsTight(t *testing.T) {
+	stop := `<updates><nowPlayingUpdated><nowPlaying source="UPNP"><playStatus>STOP_STATE</playStatus></nowPlaying></nowPlayingUpdated></updates>`
+
+	// (a) Keyless firmware, own command 1.5s ago (inside the old 3s window,
+	// outside the tight keyless window): a real remote stop, must latch.
+	h := &recHandler{}
+	c := newTestClient(h)
+	c.mu.Lock()
+	c.lastOwnCmdAt = time.Now().Add(-1500 * time.Millisecond)
+	c.mu.Unlock()
+	c.handleMessage(context.Background(), []byte(stop))
+	if h.userStops != 1 {
+		t.Fatalf("keyless firmware: a stop 1.5s after our own command is the user's, got %d OnUserStop", h.userStops)
+	}
+
+	// (b) Keyless firmware, immediate echo of our own command: still excused.
+	h2 := &recHandler{}
+	c2 := newTestClient(h2)
+	c2.NoteOwnTransportCommand()
+	c2.handleMessage(context.Background(), []byte(stop))
+	if h2.userStops != 0 {
+		t.Fatalf("keyless firmware: the immediate echo of our own command must stay excused, got %d", h2.userStops)
+	}
+
+	// (c) Key-emitting firmware (a key was seen earlier, not adjacent): the
+	// full window with the key veto keeps working as before.
+	h3 := &recHandler{}
+	c3 := newTestClient(h3)
+	c3.thumbMu.Lock()
+	c3.lastUserActivityAt = time.Now().Add(-10 * time.Second)
+	c3.thumbMu.Unlock()
+	c3.mu.Lock()
+	c3.lastOwnCmdAt = time.Now().Add(-1500 * time.Millisecond)
+	c3.mu.Unlock()
+	c3.handleMessage(context.Background(), []byte(stop))
+	if h3.userStops != 0 {
+		t.Fatalf("keyed firmware: a stop 1.5s after our own command with no adjacent key stays excused, got %d", h3.userStops)
+	}
+}
+
+// TestHandleMessage_EnterStandbyAfterLongInvalidSourceDwell covers the box
+// give-up route with a long dwell: UPNP -> INVALID_SOURCE, the box then SITS
+// in INVALID_SOURCE well past the 5s flap window (the state the sys-power
+// nudge exists for), and only then enters STANDBY (typically because the user
+// gave up and pressed power). That entry must still run the standby
+// classification: with the rolling window alone it bypassed the entire
+// machinery, nothing latched, and the recall verify's wake powered the
+// just-switched-off box back on (#197).
+func TestHandleMessage_EnterStandbyAfterLongInvalidSourceDwell(t *testing.T) {
+	standbyFrame := `<updates deviceID="x"><nowPlayingUpdated><nowPlaying source="STANDBY">` +
+		`<ContentItem source="STANDBY"/></nowPlaying></nowPlayingUpdated></updates>`
+	upnpFrame := `<updates><nowPlayingUpdated><nowPlaying source="UPNP"><playStatus>PLAY_STATE</playStatus></nowPlaying></nowPlayingUpdated></updates>`
+	invalidFrame := `<updates><nowPlayingUpdated><nowPlaying source="INVALID_SOURCE"/></nowPlayingUpdated></updates>`
+
+	// UPNP -> INVALID_SOURCE -> (long dwell) -> STANDBY fires the hook.
+	h := &recHandler{}
+	c := newTestClient(h)
+	c.handleMessage(context.Background(), []byte(upnpFrame))
+	c.handleMessage(context.Background(), []byte(invalidFrame))
+	c.mu.Lock()
+	c.lastUpnpActiveAt = time.Now().Add(-16 * time.Second) // dwell far past upnpFlapWindow
+	c.mu.Unlock()
+	c.handleMessage(context.Background(), []byte(standbyFrame))
+	if h.enterStandby != 1 {
+		t.Fatalf("a STANDBY entry ending a UPNP-driven INVALID_SOURCE episode must fire OnEnterStandby, got %d", h.enterStandby)
+	}
+
+	// Counter-leg: an INVALID_SOURCE episode NOT entered from UPNP (foreign
+	// source trouble) must still not fire it.
+	h2 := &recHandler{}
+	c2 := newTestClient(h2)
+	c2.handleMessage(context.Background(), []byte(`<updates><nowPlayingUpdated><nowPlaying source="AUX"/></nowPlayingUpdated></updates>`))
+	c2.handleMessage(context.Background(), []byte(invalidFrame))
+	c2.handleMessage(context.Background(), []byte(standbyFrame))
+	if h2.enterStandby != 0 {
+		t.Fatalf("an INVALID_SOURCE episode not entered from UPNP must not fire OnEnterStandby, got %d", h2.enterStandby)
+	}
+
+	// Recovery clears the episode: UPNP -> INVALID_SOURCE -> UPNP (healthy
+	// again) -> AUX -> (aged stamps) -> STANDBY is a foreign power-off.
+	h3 := &recHandler{}
+	c3 := newTestClient(h3)
+	c3.handleMessage(context.Background(), []byte(upnpFrame))
+	c3.handleMessage(context.Background(), []byte(invalidFrame))
+	c3.handleMessage(context.Background(), []byte(upnpFrame))
+	c3.handleMessage(context.Background(), []byte(`<updates><nowPlayingUpdated><nowPlaying source="AUX"/></nowPlayingUpdated></updates>`))
+	c3.mu.Lock()
+	c3.lastUpnpActiveAt = time.Now().Add(-16 * time.Second)
+	c3.mu.Unlock()
+	c3.handleMessage(context.Background(), []byte(standbyFrame))
+	if h3.enterStandby != 0 {
+		t.Fatalf("a recovered episode followed by a foreign-source power-off must not fire OnEnterStandby, got %d", h3.enterStandby)
+	}
+}

--- a/internal/boxws/boxws_test.go
+++ b/internal/boxws/boxws_test.go
@@ -159,6 +159,48 @@ func TestHandleMessage_TeardownStopStateIsNotUserStop(t *testing.T) {
 	}
 }
 
+// A STOP_STATE the box emits in reaction to one of STR's OWN transport
+// commands (the wrong-state repair's Stop+ClearURI, a verify re-push's
+// SetURI+Play) must not be read as a deliberate user stop: on a slow box the
+// repair's Stop landed outside the press window and the phantom stop aborted
+// the very verify the repair belonged to (#252 post-v0.9.16). A fresh physical
+// key press vetoes the excusal: the firmware accompanies real key presses with
+// a userActivityUpdate, which STR's SOAP commands never cause.
+func TestHandleMessage_OwnTransportCommandStopStateIsNotUserStop(t *testing.T) {
+	stop := `<updates><nowPlayingUpdated><nowPlaying source="UPNP"><playStatus>STOP_STATE</playStatus></nowPlaying></nowPlayingUpdated></updates>`
+
+	// (a) STOP_STATE right after STR's own SOAP command: excused.
+	h := &recHandler{}
+	c := newTestClient(h)
+	c.NoteOwnTransportCommand()
+	c.handleMessage(context.Background(), []byte(stop))
+	if h.userStops != 0 {
+		t.Fatalf("STOP_STATE right after STR's own transport command must not fire OnUserStop, got %d", h.userStops)
+	}
+
+	// (b) A fresh key press alongside it means the user really pressed stop on
+	// the remote/box: the veto keeps the real stop honoured.
+	h2 := &recHandler{}
+	c2 := newTestClient(h2)
+	c2.NoteOwnTransportCommand()
+	c2.handleMessage(context.Background(), []byte(`<userActivityUpdate deviceID="x"/>`))
+	c2.handleMessage(context.Background(), []byte(stop))
+	if h2.userStops != 1 {
+		t.Fatalf("a key press next to the STOP_STATE means a real user stop even inside the own-command window, got %d", h2.userStops)
+	}
+
+	// (c) An own-command older than the window does not excuse a stop.
+	h3 := &recHandler{}
+	c3 := newTestClient(h3)
+	c3.mu.Lock()
+	c3.lastOwnCmdAt = time.Now().Add(-10 * time.Second)
+	c3.mu.Unlock()
+	c3.handleMessage(context.Background(), []byte(stop))
+	if h3.userStops != 1 {
+		t.Fatalf("an own-command outside the window must not excuse a stop, got %d", h3.userStops)
+	}
+}
+
 func TestHandleMessage_PresetRecall(t *testing.T) {
 	h := &recHandler{}
 	c := newTestClient(h)

--- a/internal/boxws/boxws_test.go
+++ b/internal/boxws/boxws_test.go
@@ -402,3 +402,33 @@ func TestHandleMessage_QplaySkip(t *testing.T) {
 		t.Fatalf("expected [next, prev] skips, got %v", h.skips)
 	}
 }
+
+// TestHandleMessage_EnterStandbyViaInvalidSourceFlap: on taigan/spotty/lisa
+// firmware the box's give-up after a failed self-activation reaches STANDBY
+// through INVALID_SOURCE (UPNP -> INVALID_SOURCE -> STANDBY), never directly
+// from UPNP. The prev==UPNP gate made that route bypass the entire standby
+// machinery (no classification, no #197 clear, no recovery) while the box
+// switched itself off - every observed standby entry in the 2026-07-22 field
+// bundles took this route. The flap must fire OnEnterStandby; an AUX power-off
+// (no recent UPNP) still must not.
+func TestHandleMessage_EnterStandbyViaInvalidSourceFlap(t *testing.T) {
+	h := &recHandler{}
+	c := newTestClient(h)
+	c.handleMessage(context.Background(), []byte(`<updates><nowPlayingUpdated><nowPlaying source="UPNP"><playStatus>PLAY_STATE</playStatus></nowPlaying></nowPlayingUpdated></updates>`))
+	c.handleMessage(context.Background(), []byte(`<updates><nowPlayingUpdated><nowPlaying source="INVALID_SOURCE"/></nowPlayingUpdated></updates>`))
+	c.handleMessage(context.Background(), []byte(`<updates><nowPlayingUpdated><nowPlaying source="STANDBY"><ContentItem source="STANDBY"/></nowPlaying></nowPlayingUpdated></updates>`))
+	if h.enterStandby != 1 {
+		t.Fatalf("UPNP->INVALID_SOURCE->STANDBY must fire OnEnterStandby once, got %d", h.enterStandby)
+	}
+
+	// AUX -> INVALID_SOURCE -> STANDBY: STR's source was never active, the
+	// standby machinery must stay out of it.
+	h2 := &recHandler{}
+	c2 := newTestClient(h2)
+	c2.handleMessage(context.Background(), []byte(`<updates><nowPlayingUpdated><nowPlaying source="AUX"/></nowPlayingUpdated></updates>`))
+	c2.handleMessage(context.Background(), []byte(`<updates><nowPlayingUpdated><nowPlaying source="INVALID_SOURCE"/></nowPlayingUpdated></updates>`))
+	c2.handleMessage(context.Background(), []byte(`<updates><nowPlayingUpdated><nowPlaying source="STANDBY"><ContentItem source="STANDBY"/></nowPlaying></nowPlayingUpdated></updates>`))
+	if h2.enterStandby != 0 {
+		t.Fatalf("a standby entry with no recent UPNP activity must not fire OnEnterStandby, got %d", h2.enterStandby)
+	}
+}

--- a/internal/boxws/loginerror_test.go
+++ b/internal/boxws/loginerror_test.go
@@ -74,3 +74,34 @@ func TestLoginErrorFiresOnCombinedNotLoggedInWrongState(t *testing.T) {
 		t.Fatalf("combined 1036 must also signal OnSourceRejected for the verify re-point, got %d", h.sourceRejects)
 	}
 }
+
+// TestLoginErrorDedupWindow: a box that answers EVERY press with the 1036
+// NOT_LOGGED_IN frame (the fresh-install steady state seen in the field
+// bundles) must trigger at most one re-login per dedup window - the re-assert
+// cadence is owned by autopair's own rate limit, not by frame arrival.
+func TestLoginErrorDedupWindow(t *testing.T) {
+	h := &recHandler{}
+	c := newTestClient(h)
+	var fires atomic.Int64
+	c.SetOnLoginError(func() { fires.Add(1) })
+
+	frame := []byte(`<errorUpdate><error value="1036" name="UNABLE_TO_PROCESS_NOT_LOGGED_IN" severity="Unrecoverable">` +
+		`UpnpRcvdContentItemInWrongState</error></errorUpdate>`)
+	for i := 0; i < 4; i++ {
+		c.handleMessage(context.Background(), frame)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && fires.Load() == 0 {
+		time.Sleep(25 * time.Millisecond)
+	}
+	// Give a mistaken extra fire a moment to surface before asserting.
+	time.Sleep(150 * time.Millisecond)
+	if got := fires.Load(); got != 1 {
+		t.Fatalf("repeated 1036 frames within the dedup window must fire once, fired %d times", got)
+	}
+	// The verify re-point signal is per-frame, not deduped: every rejected
+	// press needs its re-point.
+	if h.sourceRejects != 4 {
+		t.Fatalf("every 1036 frame must signal OnSourceRejected, got %d of 4", h.sourceRejects)
+	}
+}

--- a/internal/marge/marge.go
+++ b/internal/marge/marge.go
@@ -40,6 +40,10 @@ type Server struct {
 	sources  []SourceItem
 	deviceID string
 
+	// presetSource, when set, provides the preset list live on every request
+	// (wired to the stick preset store). See WithPresetSource.
+	presetSource func() []Preset
+
 	// reflectPath points at the reflect-sources file (internal/boxsnapshot).
 	// Account-linked cloud sources listed there (e.g. Deezer) are re-advertised
 	// to the box in the source-provider + account responses so the box keeps
@@ -91,6 +95,18 @@ func WithSpyLogSize(n int) Option {
 // WithPresets initializes the preset list.
 func WithPresets(p []Preset) Option {
 	return func(s *Server) { s.presets = p }
+}
+
+// WithPresetSource wires a live preset provider, read fresh on every request.
+// This is what the box's post-setMargeAccount re-onboarding consumes: answering
+// it with an empty <presets/> made the firmware WIPE its own hardware-key
+// preset registrations after every forced re-login (field bundles 2026-07-22:
+// "preset reconcile: missing slots on box, syncing missing=5/6" right after
+// each "forced re-login sent", users saw "Preset noch nicht festgelegt"). A
+// live source keeps the cloud view identical to the stick store without any
+// refresh choreography.
+func WithPresetSource(fn func() []Preset) Option {
+	return func(s *Server) { s.presetSource = fn }
 }
 
 // WithSources initializes the source list.
@@ -795,7 +811,16 @@ func (s *Server) respondMargeAccountFull(w http.ResponseWriter, _ *http.Request)
 func (s *Server) respondPresets(w http.ResponseWriter) {
 	s.mu.RLock()
 	presets := s.presets
+	source := s.presetSource
 	s.mu.RUnlock()
+	// The live source (the stick preset store) wins over the static list: the
+	// box re-reads its cloud presets during every re-onboarding, and an empty
+	// answer makes the firmware wipe its own key registrations.
+	if source != nil {
+		if live := source(); len(live) > 0 {
+			presets = live
+		}
+	}
 
 	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
 	if len(presets) == 0 {

--- a/internal/marge/marge_test.go
+++ b/internal/marge/marge_test.go
@@ -372,3 +372,69 @@ func TestAddDeviceIdempotentAcrossForcedRelogins(t *testing.T) {
 		}
 	}
 }
+
+// TestPresetSourceServedDuringRelogin pins the anti-wipe contract: the box
+// re-reads its cloud presets during every setMargeAccount re-onboarding, and
+// an empty <presets/> makes the firmware wipe its own hardware-key
+// registrations. With a live preset source wired (the stick store), marge must
+// serve the real presets - on every read, so repeated re-logins stay safe -
+// with user text XML-escaped upstream.
+func TestPresetSourceServedDuringRelogin(t *testing.T) {
+	calls := 0
+	s := New(slog.New(slog.NewTextHandler(io.Discard, nil)), WithDeviceID("DEVICEID_PLACEHOLDER"),
+		WithPresetSource(func() []Preset {
+			calls++
+			return []Preset{
+				{ID: 1, Source: "UPNP", Type: "audio",
+					Location: "http://127.0.0.1:8888/stream/1", SourceAccount: "UPnPUserName",
+					ItemName: "Pop &amp; Rock"},
+				{ID: 4, Source: "UPNP", Type: "audio",
+					Location: "http://127.0.0.1:8888/spotify/stream-4.ogg", SourceAccount: "UPnPUserName",
+					ItemName: "Spotify"},
+			}
+		}))
+	h := s.Handler()
+	for round := 1; round <= 2; round++ {
+		req := httptest.NewRequest(http.MethodGet, "/preset/list", nil)
+		rw := httptest.NewRecorder()
+		h.ServeHTTP(rw, req)
+		body := rw.Body.String()
+		xmlWellFormed(t, body)
+		if strings.Contains(body, "<presets/>") {
+			t.Fatalf("round %d: live store must never answer an empty preset list (the firmware wipes its keys on it):\n%s", round, body)
+		}
+		for _, want := range []string{`id="1"`, `id="4"`, "Pop &amp; Rock", "/spotify/stream-4.ogg"} {
+			if !strings.Contains(body, want) {
+				t.Fatalf("round %d: preset response missing %q:\n%s", round, want, body)
+			}
+		}
+	}
+	if calls != 2 {
+		t.Fatalf("the source must be read live on every request, got %d reads", calls)
+	}
+}
+
+// TestConfiguredAccountAnswersLegacyProbes: some firmwares poll legacy account/
+// config endpoints; an UNCONFIGURED answer there reads as "not signed in" and
+// feeds the 1036 rejections. With an account set, both must report signed-in.
+func TestConfiguredAccountAnswersLegacyProbes(t *testing.T) {
+	s := newTestServer()
+	s.SetAccount(&AccountInfo{AccountUUID: "streborn-local-account",
+		AccountEmail: "stick@local", AuthToken: "local-token-v1",
+		CreatedAt: "2026-01-01T00:00:00Z"})
+	h := s.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/legacy/marge/account", nil)
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+	if strings.Contains(rw.Body.String(), "UNCONFIGURED") {
+		t.Fatalf("configured account must not answer UNCONFIGURED:\n%s", rw.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/legacy/config", nil)
+	rw = httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+	if !strings.Contains(rw.Body.String(), "SOUNDTOUCH_CONFIGURED") {
+		t.Fatalf("configured box must report SOUNDTOUCH_CONFIGURED:\n%s", rw.Body.String())
+	}
+}

--- a/internal/marge/marge_test.go
+++ b/internal/marge/marge_test.go
@@ -308,3 +308,67 @@ func TestHealthz(t *testing.T) {
 		t.Fatalf("body=%q", rec.Body.String())
 	}
 }
+
+// TestLoginFlowPathsNeverError pins the fake-login contract on the stub side:
+// every endpoint the box touches while establishing or re-validating its marge
+// login must answer with a success status. The firmware treats cloud errors
+// during onboarding as "not signed in" (MargeHSM falls back and every UPnP
+// source activation is then refused with 1036 NOT_LOGGED_IN), so a single
+// regression to a 4xx/5xx here silently kills the hardware preset buttons on
+// exactly the boxes that have no cached pre-shutdown Bose account left.
+func TestLoginFlowPathsNeverError(t *testing.T) {
+	s := newTestServer()
+	h := s.Handler()
+
+	paths := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/streaming/support/power_on"},
+		{http.MethodGet, "/streaming/support/anything"},
+		{http.MethodGet, "/streaming/sourceproviders"},
+		{http.MethodPost, "/streaming/account/stick@local/device/"},
+		{http.MethodGet, "/streaming/account/stick@local"},
+		{http.MethodGet, "/streaming/auth/token"},
+		{http.MethodGet, "/bmx/registry/v1/services"},
+		{http.MethodGet, "/bmx/anything/else"},
+		// Paths STR has not mapped explicitly must still succeed generically:
+		// an unknown firmware variant probing a new endpoint must never be
+		// told "error" mid-login.
+		{http.MethodGet, "/streaming/some/new/endpoint"},
+		{http.MethodPost, "/totally/unknown"},
+	}
+	for _, p := range paths {
+		req := httptest.NewRequest(p.method, p.path, strings.NewReader("<x/>"))
+		rw := httptest.NewRecorder()
+		h.ServeHTTP(rw, req)
+		if rw.Code >= 400 {
+			t.Errorf("%s %s: status %d - a login-flow path must never error", p.method, p.path, rw.Code)
+		}
+	}
+}
+
+// TestAddDeviceIdempotentAcrossForcedRelogins: the login maintenance re-asserts
+// setMargeAccount repeatedly on a login-suspect box, so the box re-runs its
+// addDevice call again and again. Every round must keep answering the full
+// adddeviceresponse (with a margetoken), or a later round would leave the
+// MargeHSM in a worse state than the first.
+func TestAddDeviceIdempotentAcrossForcedRelogins(t *testing.T) {
+	s := newTestServer()
+	h := s.Handler()
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/streaming/account/stick@local/device/",
+			strings.NewReader(`<adddevicerequest/>`))
+		rw := httptest.NewRecorder()
+		h.ServeHTTP(rw, req)
+		// wrap201 answers 201 Created, the format the firmware accepts.
+		if rw.Code < 200 || rw.Code > 299 {
+			t.Fatalf("addDevice round %d: status %d", i+1, rw.Code)
+		}
+		body := rw.Body.String()
+		xmlWellFormed(t, body)
+		if !strings.Contains(body, "margetoken") {
+			t.Fatalf("addDevice round %d: response carries no margetoken:\n%s", i+1, body)
+		}
+	}
+}

--- a/internal/marge/templates.go
+++ b/internal/marge/templates.go
@@ -100,6 +100,12 @@ type ServiceAvailability struct {
 }
 
 // Preset represents a single preset entry.
+//
+// Escaping contract: every string field is inserted VERBATIM into the presets
+// XML (see PresetsXML) - the caller must XML-escape user-controlled values
+// (station names, art URLs) before handing them over. The agent's preset
+// source does this via its margeXMLEscape helper; keep any new producer to the
+// same rule or a station name containing '&' breaks the box's preset parse.
 type Preset struct {
 	ID            int
 	CreatedOn     int64

--- a/internal/streamproxy/streamproxy.go
+++ b/internal/streamproxy/streamproxy.go
@@ -285,6 +285,12 @@ type Server struct {
 	slotFetchEnd [7]time.Time
 	slotOpen     [7]int
 
+	// boxStateFn reports a speaker-side condition that makes every station
+	// fail ("wedged", "login-error"; "" = fine). Wired to webui.BoxStateHint;
+	// surfaced in /api/stream-status so the app can distinguish a box problem
+	// from a station problem. nil-safe.
+	boxStateFn func() string
+
 	// netMu guards a briefly-cached verdict on whether the SPEAKER itself can
 	// reach the public internet. It lets /api/stream-status tell "this one
 	// station is unreachable" apart from "the speaker has no internet at all"
@@ -931,6 +937,12 @@ func (s *Server) SlotPulledSince(slot int, t time.Time) bool {
 	return s.slotFetchEnd[slot].Sub(start) >= minSustainedFetch
 }
 
+// SetBoxStateFn wires the speaker-side condition reporter for
+// /api/stream-status (see boxStateFn).
+func (s *Server) SetBoxStateFn(fn func() string) {
+	s.boxStateFn = fn
+}
+
 // LastActivity reports when the box last opened any proxied stream and when
 // the last terminal upstream failure happened (zero times = never). Consumed
 // by the webui's wedge detector.
@@ -963,10 +975,24 @@ func (s *Server) Register(mux *http.ServeMux) {
 // streamStatusTTL are reported so a long-past error never blocks a fresh play.
 func (s *Server) handleStreamStatus(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
+	// boxState surfaces a SPEAKER-side condition ("wedged", "login-error")
+	// that makes every station fail, so the app can say what is actually
+	// wrong instead of blaming the station and cycling radio-browser
+	// alternates ("Sender spielt nicht ... suche andere Quelle" while the box
+	// was rejecting sources as not-logged-in). Additive: absent when the box
+	// is fine, ignored by older frontends.
+	boxState := ""
+	if s.boxStateFn != nil {
+		boxState = s.boxStateFn()
+	}
 	s.errMu.Lock()
 	f := s.lastErr
 	s.errMu.Unlock()
 	if f.when.IsZero() || time.Since(f.when) > streamStatusTTL {
+		if boxState != "" {
+			fmt.Fprintf(w, `{"error":false,"boxState":%q}`, boxState)
+			return
+		}
 		fmt.Fprint(w, `{"error":false}`)
 		return
 	}
@@ -980,17 +1006,19 @@ func (s *Server) handleStreamStatus(w http.ResponseWriter, r *http.Request) {
 		f.reason = "offline"
 	}
 	body, err := json.Marshal(struct {
-		Error  bool   `json:"error"`
-		Status int    `json:"status"`
-		Reason string `json:"reason"`
-		URL    string `json:"url"`
-		AgeMs  int64  `json:"ageMs"`
+		Error    bool   `json:"error"`
+		Status   int    `json:"status"`
+		Reason   string `json:"reason"`
+		URL      string `json:"url"`
+		AgeMs    int64  `json:"ageMs"`
+		BoxState string `json:"boxState,omitempty"`
 	}{
-		Error:  true,
-		Status: f.code,
-		Reason: f.reason,
-		URL:    f.url,
-		AgeMs:  time.Since(f.when).Milliseconds(),
+		Error:    true,
+		Status:   f.code,
+		Reason:   f.reason,
+		URL:      f.url,
+		AgeMs:    time.Since(f.when).Milliseconds(),
+		BoxState: boxState,
 	})
 	if err != nil {
 		fmt.Fprint(w, `{"error":false}`)

--- a/internal/streamproxy/streamproxy.go
+++ b/internal/streamproxy/streamproxy.go
@@ -276,7 +276,14 @@ type Server struct {
 	// display, no audio, clean log).
 	fetchMu   sync.Mutex
 	lastFetch time.Time
-	slotFetch [7]time.Time // index 1..6
+	slotFetch [7]time.Time // index 1..6: when the box last OPENED the slot
+	// slotFetchEnd / slotOpen make the per-slot signal liveness-aware: a
+	// 36ms-2.4s fetch that dies in the box's re-login source bounce used to
+	// satisfy "opened since the press" and certified a dead recall as healthy
+	// (field bundles 2026-07-22). A recall counts as pulled only while a
+	// connection is OPEN or after it served a sustained stretch.
+	slotFetchEnd [7]time.Time
+	slotOpen     [7]int
 
 	// netMu guards a briefly-cached verdict on whether the SPEAKER itself can
 	// reach the public internet. It lets /api/stream-status tell "this one
@@ -860,20 +867,34 @@ func (s *Server) noteFetch() {
 
 // noteSlotFetch records that the box opened THIS slot's proxied stream. Called
 // only after the slot validated and the store had a playable preset, so a 404
-// or a foreign fetch can never stamp it.
+// or a foreign fetch can never stamp it. Paired with noteSlotFetchDone.
 func (s *Server) noteSlotFetch(slot int) {
 	if slot < 1 || slot > 6 {
 		return
 	}
 	s.fetchMu.Lock()
 	s.slotFetch[slot] = time.Now()
+	s.slotOpen[slot]++
+	s.fetchMu.Unlock()
+}
+
+// noteSlotFetchDone records that a slot connection closed, for the liveness
+// half of SlotPulledSince.
+func (s *Server) noteSlotFetchDone(slot int) {
+	if slot < 1 || slot > 6 {
+		return
+	}
+	s.fetchMu.Lock()
+	if s.slotOpen[slot] > 0 {
+		s.slotOpen[slot]--
+	}
+	s.slotFetchEnd[slot] = time.Now()
 	s.fetchMu.Unlock()
 }
 
 // LastFetchForSlot reports when the box last opened the given slot's proxied
-// stream (zero time = never, or slot out of range). The hardware recall verify
-// uses it as its slot-scoped success signal; the global LastActivity stamp
-// stays for the wedge detector, which deliberately counts any fetch.
+// stream (zero time = never, or slot out of range). The global LastActivity
+// stamp stays for the wedge detector, which deliberately counts any fetch.
 func (s *Server) LastFetchForSlot(slot int) time.Time {
 	if slot < 1 || slot > 6 {
 		return time.Time{}
@@ -881,6 +902,33 @@ func (s *Server) LastFetchForSlot(slot int) time.Time {
 	s.fetchMu.Lock()
 	defer s.fetchMu.Unlock()
 	return s.slotFetch[slot]
+}
+
+// minSustainedFetch is how long a now-closed slot fetch must have served to
+// still count as "the box played this recall". The box's re-login source
+// bounce opens the stream for 36ms-2.4s and drops it; a genuine playback
+// session either stays open or lasted well past this.
+const minSustainedFetch = 3 * time.Second
+
+// SlotPulledSince reports whether the box is credibly playing this slot's
+// proxied stream for a recall anchored at t: a connection opened after t that
+// is still OPEN, or one that served at least minSustainedFetch before closing.
+// This is the hardware recall verify's success signal; "opened once since t"
+// alone certified dead recalls as healthy (#252 field bundles).
+func (s *Server) SlotPulledSince(slot int, t time.Time) bool {
+	if slot < 1 || slot > 6 {
+		return false
+	}
+	s.fetchMu.Lock()
+	defer s.fetchMu.Unlock()
+	start := s.slotFetch[slot]
+	if start.IsZero() || !start.After(t) {
+		return false
+	}
+	if s.slotOpen[slot] > 0 {
+		return true
+	}
+	return s.slotFetchEnd[slot].Sub(start) >= minSustainedFetch
 }
 
 // LastActivity reports when the box last opened any proxied stream and when
@@ -1099,6 +1147,7 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 	}
 	p.StreamURL = s.resolvePresetURL(slot, p.StreamURL)
 	s.noteSlotFetch(slot)
+	defer s.noteSlotFetchDone(slot)
 	s.logger.Info("stream proxy start", "slot", slot, "name", p.Name)
 
 	if isDASHURL(p.StreamURL) {

--- a/internal/streamproxy/streamproxy.go
+++ b/internal/streamproxy/streamproxy.go
@@ -267,8 +267,16 @@ type Server struct {
 	// stream (slot or raw). The wedge detector uses it to tell "the box never
 	// even pulled the URL it accepted" (control stack wedged, needs a
 	// power-cycle) apart from "the box pulled it and the station failed".
+	// slotFetch records the same moment PER preset slot, stamped only after
+	// the slot validated and the store served a preset. The hardware recall
+	// verify keys its success signal off the slot it pushed: the global stamp
+	// let ANY proxied fetch (another slot's reconnect, a zone follower, even a
+	// 404) certify a failed recall as healthy at the first tick, so no retry
+	// ran and wedge strikes were falsely cleared (#252: station on the
+	// display, no audio, clean log).
 	fetchMu   sync.Mutex
 	lastFetch time.Time
+	slotFetch [7]time.Time // index 1..6
 
 	// netMu guards a briefly-cached verdict on whether the SPEAKER itself can
 	// reach the public internet. It lets /api/stream-status tell "this one
@@ -850,6 +858,31 @@ func (s *Server) noteFetch() {
 	s.fetchMu.Unlock()
 }
 
+// noteSlotFetch records that the box opened THIS slot's proxied stream. Called
+// only after the slot validated and the store had a playable preset, so a 404
+// or a foreign fetch can never stamp it.
+func (s *Server) noteSlotFetch(slot int) {
+	if slot < 1 || slot > 6 {
+		return
+	}
+	s.fetchMu.Lock()
+	s.slotFetch[slot] = time.Now()
+	s.fetchMu.Unlock()
+}
+
+// LastFetchForSlot reports when the box last opened the given slot's proxied
+// stream (zero time = never, or slot out of range). The hardware recall verify
+// uses it as its slot-scoped success signal; the global LastActivity stamp
+// stays for the wedge detector, which deliberately counts any fetch.
+func (s *Server) LastFetchForSlot(slot int) time.Time {
+	if slot < 1 || slot > 6 {
+		return time.Time{}
+	}
+	s.fetchMu.Lock()
+	defer s.fetchMu.Unlock()
+	return s.slotFetch[slot]
+}
+
 // LastActivity reports when the box last opened any proxied stream and when
 // the last terminal upstream failure happened (zero times = never). Consumed
 // by the webui's wedge detector.
@@ -1065,6 +1098,7 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	p.StreamURL = s.resolvePresetURL(slot, p.StreamURL)
+	s.noteSlotFetch(slot)
 	s.logger.Info("stream proxy start", "slot", slot, "name", p.Name)
 
 	if isDASHURL(p.StreamURL) {

--- a/internal/streamproxy/streamproxy.go
+++ b/internal/streamproxy/streamproxy.go
@@ -901,6 +901,10 @@ func (s *Server) noteSlotFetchDone(slot int) {
 // LastFetchForSlot reports when the box last opened the given slot's proxied
 // stream (zero time = never, or slot out of range). The global LastActivity
 // stamp stays for the wedge detector, which deliberately counts any fetch.
+// No production caller since the recall verify moved to the liveness-aware
+// SlotPulledSince (a bare open-stamp certified failed recalls); kept as the
+// low-level accessor its tests and future diagnostics read the raw stamp
+// through.
 func (s *Server) LastFetchForSlot(slot int) time.Time {
 	if slot < 1 || slot > 6 {
 		return time.Time{}

--- a/internal/streamproxy/streamproxy_test.go
+++ b/internal/streamproxy/streamproxy_test.go
@@ -3,7 +3,12 @@ package streamproxy
 import (
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/JRpersonal/streborn/internal/presets"
 )
 
 // silentLogger discards all log output so tests stay quiet.
@@ -50,5 +55,48 @@ func TestShouldLogFailResetsAfterSuccessfulReachClear(t *testing.T) {
 
 	if !s.shouldLogFail(url) {
 		t.Fatalf("after clear, the next failure must WARN again")
+	}
+}
+
+// TestSlotFetchStampsOnlyValidSlots covers the slot-scoped success signal for
+// the hardware recall verify: a fetch of an invalid slot or of a slot with no
+// playable preset must NOT stamp the per-slot time (it used to stamp the
+// global one before validation, which let a 404 certify a failed recall as
+// healthy, #252), while the global wedge-detector stamp keeps counting every
+// box contact.
+func TestSlotFetchStampsOnlyValidSlots(t *testing.T) {
+	s := New(presets.New(), silentLogger())
+
+	req := httptest.NewRequest(http.MethodGet, "/stream/2", nil)
+	rw := httptest.NewRecorder()
+	s.handle(rw, req)
+	if rw.Code != http.StatusNotFound {
+		t.Fatalf("slot with no preset must 404, got %d", rw.Code)
+	}
+	if !s.LastFetchForSlot(2).IsZero() {
+		t.Fatal("a 404 slot fetch must not stamp the per-slot time")
+	}
+	if lf, _ := s.LastActivity(); lf.IsZero() {
+		t.Fatal("the global wedge stamp must still record the box contact")
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/stream/9", nil)
+	rw = httptest.NewRecorder()
+	s.handle(rw, req)
+	if rw.Code != http.StatusBadRequest {
+		t.Fatalf("invalid slot must 400, got %d", rw.Code)
+	}
+	if !s.LastFetchForSlot(9).IsZero() || !s.LastFetchForSlot(0).IsZero() {
+		t.Fatal("out-of-range slots must never stamp")
+	}
+
+	// The direct stamp path used by handle() after validation.
+	before := time.Now()
+	s.noteSlotFetch(4)
+	if lf := s.LastFetchForSlot(4); lf.IsZero() || lf.Before(before) {
+		t.Fatal("a valid slot fetch must stamp the per-slot time")
+	}
+	if !s.LastFetchForSlot(3).IsZero() {
+		t.Fatal("other slots must stay unstamped")
 	}
 }

--- a/internal/streamproxy/streamproxy_test.go
+++ b/internal/streamproxy/streamproxy_test.go
@@ -100,3 +100,44 @@ func TestSlotFetchStampsOnlyValidSlots(t *testing.T) {
 		t.Fatal("other slots must stay unstamped")
 	}
 }
+
+// TestSlotPulledSinceLiveness pins the recall verify's success signal against
+// the field failure: the box's re-login source bounce opens the slot stream
+// for 36ms-2.4s and drops it, which must NOT count as playback, while a
+// still-open connection or a sustained (>= minSustainedFetch) session must.
+func TestSlotPulledSinceLiveness(t *testing.T) {
+	s := New(presets.New(), silentLogger())
+	anchor := time.Now().Add(-time.Minute)
+
+	if s.SlotPulledSince(2, anchor) {
+		t.Fatal("no fetch at all must not read as pulled")
+	}
+
+	// Dead fetch: opened and closed within the bounce (well under sustain).
+	s.noteSlotFetch(2)
+	s.noteSlotFetchDone(2)
+	if s.SlotPulledSince(2, anchor) {
+		t.Fatal("a fetch that died right after opening must not certify the recall")
+	}
+
+	// Open connection: playback in progress.
+	s.noteSlotFetch(3)
+	if !s.SlotPulledSince(3, anchor) {
+		t.Fatal("an open connection after the press must count as playback")
+	}
+	// Fetch opened BEFORE the press proves nothing about this recall.
+	if s.SlotPulledSince(3, time.Now().Add(time.Second)) {
+		t.Fatal("a fetch opened before the anchor must not count")
+	}
+	s.noteSlotFetchDone(3)
+
+	// Sustained session that already ended still counts (box played, then
+	// reconnect churn closed the socket moments before the verify tick).
+	s.fetchMu.Lock()
+	s.slotFetch[4] = time.Now().Add(-10 * time.Second)
+	s.slotFetchEnd[4] = time.Now()
+	s.fetchMu.Unlock()
+	if !s.SlotPulledSince(4, time.Now().Add(-time.Minute)) {
+		t.Fatal("a sustained finished session must count as playback")
+	}
+}

--- a/internal/upnp/upnp.go
+++ b/internal/upnp/upnp.go
@@ -24,6 +24,16 @@ type Renderer struct {
 
 	// Client is used for all SOAP requests. If nil, http.DefaultClient.
 	Client *http.Client
+
+	// OnTransportCommand, when set, is invoked at the start of every SOAP
+	// transport command (SetAVTransportURI, Play, Pause, Stop). The gabbo
+	// event classifier uses it to recognise the box's reaction to STR's OWN
+	// commands: a SOAP Stop (or a SetURI flip) makes the box emit a nowPlaying
+	// STOP_STATE that is indistinguishable on the wire from the user pressing
+	// stop, and reading it as a user stop latched a phantom stand-down that
+	// killed the very recall the command belonged to (#252 post-v0.9.16).
+	// Optional; must be safe for concurrent use.
+	OnTransportCommand func()
 }
 
 // NewBoseRenderer returns a Renderer for the typical Bose SoundTouch
@@ -215,6 +225,12 @@ func isStreamReachable(ctx context.Context, u string) bool {
 }
 
 func (r *Renderer) soapCall(ctx context.Context, action, body string) error {
+	// Every soapCall action mutates the transport (queries go through
+	// soapCallBody directly), so this is the one choke point where STR knows
+	// "the next transport-state frame on gabbo is our own doing".
+	if r.OnTransportCommand != nil {
+		r.OnTransportCommand()
+	}
 	_, err := r.soapCallBody(ctx, action, body)
 	return err
 }

--- a/internal/webui/queueplay.go
+++ b/internal/webui/queueplay.go
@@ -52,6 +52,11 @@ func (s *Server) RecallSlot(ctx context.Context, slot int) (handled bool) {
 	if len(items) == 0 {
 		return false
 	}
+	// Supersede any still-running hardware verify at claim time: startQueue's
+	// own setLastPlay only bumps the generation once the first push SUCCEEDS,
+	// and until then a stale verify loop from an earlier press would keep
+	// re-pushing its old URL over this queue start.
+	s.bumpRecallGen()
 	s.ensureBoxReady(ctx)
 	s.logger.Info("preset slot recall (hardware): queue", "slot", slot, "tracks", len(items), "shuffle", p.Shuffle)
 	// Record the saved folder as a Recently-played card (#220), keyed on the slot

--- a/internal/webui/repush_recall_collision_test.go
+++ b/internal/webui/repush_recall_collision_test.go
@@ -55,3 +55,54 @@ func TestRecallWindowOutlivesTheVerifyStorm(t *testing.T) {
 		t.Fatalf("window %v must span the verify's first two ticks (%v)", recallOwnsRetryWindow, twoVerifyTicks)
 	}
 }
+
+// TestMaybeRePushRearmsAfterRecallOwnsRetryWindow reproduces the orphaned-drop
+// field signature: a stream drop ~6s after a user play fell into the recall's
+// ownership window, the verify had already exited on its first success, and
+// maybeRePush returned permanently - the box sat silent with a clean log. The
+// re-push must wait out the window and then resume.
+func TestMaybeRePushRearmsAfterRecallOwnsRetryWindow(t *testing.T) {
+	s, rec := newPlayTestServer(t)
+	s.playStateFn = func() (bool, bool) { return false, false } // box on, idle
+	s.setLastPlay("http://127.0.0.1:8888/stream/6", "Antenne", "", "")
+	s.standbyStopMu.Lock()
+	s.lastUserPlayStart = time.Now().Add(-6 * time.Second) // drop 6s into the recall
+	s.standbyStopMu.Unlock()
+
+	done := make(chan struct{})
+	go func() { s.maybeRePush(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("maybeRePush did not return")
+	}
+	if !rec.has("SetAVTransportURI") {
+		t.Fatalf("an orphaned drop must be re-pushed once the ownership window ends, got %v", rec.list())
+	}
+}
+
+// TestMaybeRePushHonorsStopDuringOwnershipWait: a deliberate stop that arrives
+// WHILE maybeRePush waits out the ownership window must hold - compared via
+// absolute stamps, so it cannot expire out of the rolling 6s window during the
+// wait.
+func TestMaybeRePushHonorsStopDuringOwnershipWait(t *testing.T) {
+	s, rec := newPlayTestServer(t)
+	s.playStateFn = func() (bool, bool) { return false, false }
+	s.setLastPlay("http://127.0.0.1:8888/stream/2", "NDR", "", "")
+	s.standbyStopMu.Lock()
+	s.lastUserPlayStart = time.Now().Add(-6 * time.Second)
+	s.standbyStopMu.Unlock()
+	stopTimer := time.AfterFunc(3*time.Second, s.NoteUserStop)
+	defer stopTimer.Stop()
+
+	done := make(chan struct{})
+	go func() { s.maybeRePush(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("maybeRePush did not return")
+	}
+	if rec.has("SetAVTransportURI") {
+		t.Fatalf("a stop during the ownership wait must hold, got %v", rec.list())
+	}
+}

--- a/internal/webui/repush_recall_collision_test.go
+++ b/internal/webui/repush_recall_collision_test.go
@@ -106,3 +106,43 @@ func TestMaybeRePushHonorsStopDuringOwnershipWait(t *testing.T) {
 		t.Fatalf("a stop during the ownership wait must hold, got %v", rec.list())
 	}
 }
+
+// TestStreamDropCoalescingSurvivesNewPlay pins the drop-coalescing latch to the
+// Server, not the per-play struct: setLastPlay replaces the lastPlayInfo struct
+// on every fresh play, and a per-play latch let a drop of the NEW stream spawn
+// a second concurrent re-pusher while the first was still alive - the box got
+// double SetURI+Play (two audible re-buffers), and the first goroutine's
+// deferred release then cleared the latch the second one owned.
+func TestStreamDropCoalescingSurvivesNewPlay(t *testing.T) {
+	s, rec := newPlayTestServer(t)
+	s.playStateFn = func() (bool, bool) { return false, false } // box on, idle
+	s.setLastPlay("http://127.0.0.1:8888/stream/6", "First", "", "")
+
+	s.HandleStreamDisconnect(nil) // arms the latch, spawns re-pusher #1 (2s backoff)
+	s.setLastPlay("http://127.0.0.1:8888/stream/2", "Second", "", "")
+	s.HandleStreamDisconnect(nil) // drop of the NEW stream must coalesce, not stack
+
+	// #1 wakes after its backoff and re-pushes exactly once.
+	deadline := time.Now().Add(6 * time.Second)
+	for time.Now().Before(deadline) && !rec.has("SetAVTransportURI") {
+		time.Sleep(50 * time.Millisecond)
+	}
+	time.Sleep(500 * time.Millisecond) // let a mistaken second pusher surface
+	pushes := 0
+	for _, a := range rec.list() {
+		if a == "SetAVTransportURI" {
+			pushes++
+		}
+	}
+	if pushes != 1 {
+		t.Fatalf("one drop episode must produce exactly one re-push, got %d (%v)", pushes, rec.list())
+	}
+	// The deferred release must free the SERVER latch even though lastPlay was
+	// swapped mid-run, so a later genuine drop can re-arm.
+	s.lastPlayMu.Lock()
+	latched := s.rePushInFlight
+	s.lastPlayMu.Unlock()
+	if latched {
+		t.Fatal("the coalescing latch must be released after the re-pusher exits")
+	}
+}

--- a/internal/webui/standby_bounce_test.go
+++ b/internal/webui/standby_bounce_test.go
@@ -115,10 +115,26 @@ func TestHandleEnterStandby_DropDuringOwnRecall(t *testing.T) {
 	}
 }
 
+// waitForAction polls for an async transport action: HandleEnterStandby issues
+// its Stop+ClearURI in a goroutine so the SOAP round-trips cannot stall the
+// gabbo read loop (#252).
+func waitForAction(t *testing.T, rec *soapRecorder, action string) bool {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if rec.has(action) {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
 // TestHandleEnterStandby_PowerOffDuringRecallStillLatches guards #197: the user
 // starting a preset and then pressing power DURING the recall is a real
-// power-off (a NEW key press landed after the recall start). It must latch and
-// clear the transport exactly as before.
+// power-off (a NEW key press landed after the recall start, immediately
+// adjacent to the flip). It must latch and clear the transport exactly as
+// before.
 func TestHandleEnterStandby_PowerOffDuringRecallStillLatches(t *testing.T) {
 	s, rec := newPlayTestServer(t)
 	s.standbyStopMu.Lock()
@@ -134,8 +150,35 @@ func TestHandleEnterStandby_PowerOffDuringRecallStillLatches(t *testing.T) {
 	if !s.userStoppedRecently() {
 		t.Fatal("a power press during the recall must still arm the user-stop (#197)")
 	}
-	if !rec.has("Stop") {
+	if !waitForAction(t, rec, "Stop") {
 		t.Fatalf("a power press during the recall must still clear the transport (#197), got %v", rec.list())
+	}
+}
+
+// TestHandleEnterStandby_StaleKeyDuringRecallDoesNotLatch: a key press that is
+// merely SOMEWHERE in the recall window (a volume tweak seconds earlier) is not
+// a power press - the source flip does not follow it immediately. Latching on
+// it reclassified a routine firmware flap as a user power-off, cleared the
+// transport mid-recall and stood every recovery down: the ST20 that "switches
+// itself off on every preset press" (#252).
+func TestHandleEnterStandby_StaleKeyDuringRecallDoesNotLatch(t *testing.T) {
+	s, rec := newPlayTestServer(t)
+	s.standbyStopMu.Lock()
+	s.lastUserPlayStart = time.Now().Add(-20 * time.Second) // recall still active
+	s.standbyStopMu.Unlock()
+	// New key since the press (outside the trailing-frame epsilon) but NOT
+	// adjacent to the flip: a volume tweak ~8s ago, flip now.
+	s.SetUserActivityFn(func() time.Time { return time.Now().Add(-8 * time.Second) })
+
+	s.HandleEnterStandby()
+
+	if s.standbyStoppedRecently() || s.userStoppedRecently() {
+		t.Fatal("a non-adjacent key during the recall must not arm the stop latches (#252)")
+	}
+	// Give a mistaken async clear a moment to surface before asserting.
+	time.Sleep(150 * time.Millisecond)
+	if rec.count() != 0 {
+		t.Fatalf("a non-adjacent key during the recall must not clear the transport, got %v", rec.list())
 	}
 }
 
@@ -151,7 +194,7 @@ func TestHandleEnterStandby_NoActivitySignalStaysConservative(t *testing.T) {
 	if !s.standbyStoppedRecently() || !s.userStoppedRecently() {
 		t.Fatal("without an activity signal every drop must keep the conservative #197 latching")
 	}
-	if !rec.has("Stop") {
+	if !waitForAction(t, rec, "Stop") {
 		t.Fatalf("without an activity signal the transport must still be cleared (#197), got %v", rec.list())
 	}
 }
@@ -171,7 +214,7 @@ func TestHandleEnterStandby_AppStandbyStaysDeliberate(t *testing.T) {
 	if !s.standbyStoppedRecently() {
 		t.Fatal("an app-initiated standby must keep the deliberate power-off handling (#419)")
 	}
-	if !rec.has("Stop") {
+	if !waitForAction(t, rec, "Stop") {
 		t.Fatalf("an app-initiated standby must still clear the transport (#197), got %v", rec.list())
 	}
 }

--- a/internal/webui/standby_bounce_test.go
+++ b/internal/webui/standby_bounce_test.go
@@ -199,6 +199,28 @@ func TestHandleEnterStandby_NoActivitySignalStaysConservative(t *testing.T) {
 	}
 }
 
+// TestHandleEnterStandby_OwnPushWithNoKeySignalStaysConservative: on firmware
+// that never emits userActivityUpdate, lastKey is the zero time and the
+// own-push excusal's "push after key" comparison is vacuously true for EVERY
+// push - and during a struggling recall STR pushes on a ~5s cadence, so a real
+// power press was near-always within the flip window of some push. With no key
+// signal the excusal must not fire: the drop keeps the documented conservative
+// #197 handling (latch + clear), or the verify's wake powers the box back on.
+func TestHandleEnterStandby_OwnPushWithNoKeySignalStaysConservative(t *testing.T) {
+	s, rec := newPlayTestServer(t)
+	s.SetUserActivityFn(func() time.Time { return time.Time{} })
+	s.SetOwnTransportCmdFn(func() time.Time { return time.Now().Add(-2 * time.Second) })
+
+	s.HandleEnterStandby()
+
+	if !s.standbyStoppedRecently() || !s.userStoppedRecently() {
+		t.Fatal("without a key signal an own push must not excuse the drop; the conservative #197 latching must win")
+	}
+	if !waitForAction(t, rec, "Stop") {
+		t.Fatalf("without a key signal the transport must still be cleared (#197), got %v", rec.list())
+	}
+}
+
 // TestHandleEnterStandby_AppStandbyStaysDeliberate: a standby STR itself sent
 // (app / phone remote) produces no gabbo key frame, so the activity
 // discriminator alone would misread the resulting drop as spontaneous and wake

--- a/internal/webui/standby_bounce_test.go
+++ b/internal/webui/standby_bounce_test.go
@@ -240,3 +240,48 @@ func TestHandleEnterStandby_SpontaneousDropResumesActiveStream(t *testing.T) {
 	}
 	t.Fatalf("spontaneous-off recovery never re-pushed the interrupted stream, got %v", rec.list())
 }
+
+// TestHandleEnterStandby_FlipAfterOwnPushIsNotAPowerOff encodes the field
+// signature that survived F4: power-ON key press, STR's own wake-resume push
+// ~2s later, source flip 200ms after the push. The key press satisfied the
+// adjacency check, so the flip latched "user stopped deliberately" and the
+// very resume the key asked for was suppressed. A flip right after STR's own
+// transport command - with no key press since that command - answers OUR push
+// and must leave the latches and transport alone.
+func TestHandleEnterStandby_FlipAfterOwnPushIsNotAPowerOff(t *testing.T) {
+	s, rec := newPlayTestServer(t)
+	now := time.Now()
+	s.SetUserActivityFn(func() time.Time { return now.Add(-2400 * time.Millisecond) })
+	s.SetOwnTransportCmdFn(func() time.Time { return now.Add(-200 * time.Millisecond) })
+
+	s.HandleEnterStandby()
+
+	if s.standbyStoppedRecently() || s.userStoppedRecently() {
+		t.Fatal("a flip answering STR's own push must not arm the stop latches")
+	}
+	time.Sleep(150 * time.Millisecond)
+	if rec.count() != 0 {
+		t.Fatalf("a flip answering STR's own push must not clear the transport, got %v", rec.list())
+	}
+}
+
+// TestHandleEnterStandby_KeyAfterOwnPushStillLatches guards #197 against the
+// new excusal: a key press AFTER STR's last push is the user acting (the power
+// key), so the conservative power-off handling must win.
+func TestHandleEnterStandby_KeyAfterOwnPushStillLatches(t *testing.T) {
+	s, rec := newPlayTestServer(t)
+	s.standbyStopMu.Lock()
+	s.lastUserPlayStart = time.Now().Add(-10 * time.Second) // recall still active
+	s.standbyStopMu.Unlock()
+	s.SetOwnTransportCmdFn(func() time.Time { return time.Now().Add(-2 * time.Second) })
+	s.SetUserActivityFn(func() time.Time { return time.Now() }) // power press AFTER our push
+
+	s.HandleEnterStandby()
+
+	if !s.standbyStoppedRecently() || !s.userStoppedRecently() {
+		t.Fatal("a key press after STR's own push is a real power-off and must latch (#197)")
+	}
+	if !waitForAction(t, rec, "Stop") {
+		t.Fatalf("a real power-off must still clear the transport (#197), got %v", rec.list())
+	}
+}

--- a/internal/webui/standby_clear_stale_test.go
+++ b/internal/webui/standby_clear_stale_test.go
@@ -1,0 +1,68 @@
+package webui
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/JRpersonal/streborn/internal/presets"
+	"github.com/JRpersonal/streborn/internal/upnp"
+)
+
+// TestHandleEnterStandby_UserPlayDuringClearAbortsClearURI: moving the standby
+// transport clear off the gabbo read loop un-serialized it from the next
+// queued frame, so a preset press right after the power-off (the routine
+// power-on-via-preset flow) could have its fresh SetURI overtaken by the
+// straggling ClearURI - the Stop can block for seconds against a box that is
+// shutting down. A user play that arrives while the clear is in flight is
+// newer intent: the ClearURI must not be issued.
+func TestHandleEnterStandby_UserPlayDuringClearAbortsClearURI(t *testing.T) {
+	rec := &soapRecorder{}
+	stopStarted := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	box := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("SOAPACTION"), "#Stop") {
+			once.Do(func() { close(stopStarted) })
+			<-release
+		}
+		rec.ServeHTTP(w, r)
+	}))
+	t.Cleanup(box.Close)
+	store, err := presets.Load(filepath.Join(t.TempDir(), "presets.json"))
+	if err != nil {
+		t.Fatalf("presets.Load: %v", err)
+	}
+	s := &Server{
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		presets:  store,
+		queue:    newPlayQueue(),
+		renderer: &upnp.Renderer{ControlURL: box.URL, Client: box.Client()},
+	}
+	t.Cleanup(s.stopQueue)
+	// A real power-off: fresh adjacent key press, so the latch+clear route runs.
+	s.SetUserActivityFn(func() time.Time { return time.Now() })
+
+	s.HandleEnterStandby()
+
+	select {
+	case <-stopStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("the clear goroutine never issued its Stop")
+	}
+	// The user presses a preset while the Stop is still blocking.
+	s.NoteUserPlay()
+	close(release)
+
+	// Give the goroutine time to run its post-Stop staleness check.
+	time.Sleep(300 * time.Millisecond)
+	if rec.has("SetAVTransportURI") {
+		t.Fatalf("a user play during the clear must abort the ClearURI (it would wipe the fresh recall's transport), got %v", rec.list())
+	}
+}

--- a/internal/webui/verify_standdown_test.go
+++ b/internal/webui/verify_standdown_test.go
@@ -75,3 +75,30 @@ func TestSetLastPlayBumpsRecallGeneration(t *testing.T) {
 		t.Errorf("newest recall: stand-down reason %q, want none", reason)
 	}
 }
+
+// TestLoginErrorWindows pins the two windows hung off the same 1036 stamp: the
+// short retry stand-down (recentLoginError) and the wider wedge-attribution
+// skip that stops an exhausted, login-broken recall from counting as a wedge
+// strike (the field bundle latched boxHealth=wedged ~25s after a 1036 and told
+// the user to power-cycle a box that only needed the re-login to stick).
+func TestLoginErrorWindows(t *testing.T) {
+	s := &Server{}
+	if s.loginErrorRecentWithin(loginErrWedgeSkipWindow) {
+		t.Fatal("no login error recorded yet, want false")
+	}
+	s.loginErr.mu.Lock()
+	s.loginErr.last = time.Now().Add(-30 * time.Second)
+	s.loginErr.mu.Unlock()
+	if s.recentLoginError() {
+		t.Fatal("a 30s-old login error is outside the 20s retry stand-down window")
+	}
+	if !s.loginErrorRecentWithin(loginErrWedgeSkipWindow) {
+		t.Fatal("a 30s-old login error is inside the wedge-skip window: the exhaustion it caused must not count a strike")
+	}
+	s.loginErr.mu.Lock()
+	s.loginErr.last = time.Now().Add(-loginErrWedgeSkipWindow - time.Second)
+	s.loginErr.mu.Unlock()
+	if s.loginErrorRecentWithin(loginErrWedgeSkipWindow) {
+		t.Fatal("an old login error must not suppress wedge accounting")
+	}
+}

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -2043,13 +2043,58 @@ func (s *Server) loadLastPlay() {
 // (the hardware preset recall in cmd/agent goes straight to the renderer). It
 // lets the auto-re-push (#4) and the power-button wake-resume work for hardware
 // presses too, which otherwise left lastPlay unset and the box un-resumable.
-func (s *Server) NoteLastPlay(boxURL, title, art, mime string) {
+// It returns the new recall generation so the hardware verify can stand down
+// as soon as a later play (hardware or app) supersedes it, mirroring the soft
+// path's verifyRecall.
+func (s *Server) NoteLastPlay(boxURL, title, art, mime string) uint64 {
 	// A hardware recall is by definition a non-queue play (cmd/agent routes a
 	// queue preset through RecallSlot, which never reaches here): drop any
 	// active library queue so its watcher does not advance over the user's new
 	// choice minutes later.
 	s.stopQueue()
-	s.setLastPlay(boxURL, title, art, mime)
+	return s.setLastPlay(boxURL, title, art, mime)
+}
+
+// RecallGeneration returns the current recall generation (bumped by every
+// stream push recorded via setLastPlay, hardware and app alike). The hardware
+// recall verifies in cmd/agent compare it against the generation of their own
+// recall: a mismatch means a newer play started and the stale verify must
+// stand down instead of re-pushing its old URL over the user's newest choice
+// ("pressed 2, got 1").
+func (s *Server) RecallGeneration() uint64 {
+	s.lastPlayMu.Lock()
+	defer s.lastPlayMu.Unlock()
+	return s.recallGen
+}
+
+// bumpRecallGen advances the recall generation without recording a lastPlay.
+// Used by recall paths whose own setLastPlay only runs on success (the queue
+// preset start), so the claim itself already supersedes any older verify loop.
+func (s *Server) bumpRecallGen() {
+	s.lastPlayMu.Lock()
+	s.recallGen++
+	s.lastPlayMu.Unlock()
+}
+
+// StandbyStoppedAfter reports whether STR saw this box's UPnP source drop to
+// STANDBY (a power-off) strictly after t. The hardware recall verify anchors
+// this to its press time: unlike the rolling RecentlyPoweredOff window, the
+// stamp cannot expire between two verify ticks, so a power-off mid-recall
+// reliably stands the re-push down for the recall's whole lifetime (#197).
+func (s *Server) StandbyStoppedAfter(t time.Time) bool {
+	s.standbyStopMu.Lock()
+	defer s.standbyStopMu.Unlock()
+	return !s.lastStandbyStop.IsZero() && s.lastStandbyStop.After(t)
+}
+
+// SetTransportCommandHook wires the webui's own renderer into the gabbo
+// classifier's own-command excusal (boxws.NoteOwnTransportCommand): re-pushes,
+// resumes and the standby-bounce clear all make the box emit STOP_STATE frames
+// that must not latch a phantom user stop. No-op without a renderer.
+func (s *Server) SetTransportCommandHook(fn func()) {
+	if s.renderer != nil {
+		s.renderer.OnTransportCommand = fn
+	}
 }
 
 // --- Recently played (#135) ---
@@ -2885,6 +2930,14 @@ const (
 	// nowSelectionUpdated by a moment) from a genuinely NEW key press during
 	// the recall (e.g. the user pressing power to stop it, the original #197).
 	userPlayActivityEpsilon = 2 * time.Second
+	// powerKeyAdjacencyWindow: for a key press during a recall to count as the
+	// user powering the box off, the UPNP->STANDBY flip must follow the key
+	// within this window (a power press flips the source near-instantly). A key
+	// press that is merely SOMEWHERE in the recall window - a volume tweak, a
+	// thumbs key - used to reclassify a later firmware flap as a user power-off,
+	// which cleared the transport and latched every recovery off, so "press
+	// preset, touch volume, box dies" (#252: the ST20 switching itself off).
+	powerKeyAdjacencyWindow = 3 * time.Second
 	// spontaneousOffWindow: a UPNP->STANDBY drop with no physical key press
 	// this recent is the firmware powering the source off on its own (#419:
 	// observed correlating with Wi-Fi instability, 40 min into stable playback).
@@ -2985,9 +3038,17 @@ func (s *Server) HandleEnterStandby() {
 	// means deliberate: keep the conservative handling.
 	deliberateStop := s.userStoppedRecently()
 	recallActive := !playStart.IsZero() && now.Sub(playStart) < userPlayGuardWindow
+	// A key press only reads as "the user powered the box off mid-recall" when
+	// it is BOTH newer than the press that started the recall (outside the
+	// trailing-frame epsilon) AND immediately adjacent to the flip - a power
+	// press flips the source within a moment. Requiring only "any key since
+	// recall start" made a volume tweak seconds earlier reclassify a routine
+	// firmware flap as a power-off, clearing the transport and latching every
+	// recovery off mid-recall (#252).
 	newKeySinceRecall := lastKey.After(playStart.Add(userPlayActivityEpsilon))
-	if recallActive && !newKeySinceRecall && !deliberateStop {
-		s.logger.Info("standby bounce: source dropped during the user's own recall with no new key press, leaving transport and latches alone (#419)")
+	keyAdjacentToFlip := !lastKey.IsZero() && now.Sub(lastKey) <= powerKeyAdjacencyWindow
+	if recallActive && !(newKeySinceRecall && keyAdjacentToFlip) && !deliberateStop {
+		s.logger.Info("standby bounce: source dropped during the user's own recall with no adjacent new key press, leaving transport and latches alone (#419)")
 		return
 	}
 	if !recallActive && !deliberateStop && !lastKey.IsZero() && now.Sub(lastKey) > spontaneousOffWindow {
@@ -3025,16 +3086,23 @@ func (s *Server) HandleEnterStandby() {
 	// A power-off is a deliberate stop: drop any queue so it does not fight the
 	// standby, then Stop and EMPTY the transport URI so the firmware has nothing to
 	// bounce back to (Stop alone leaves the URI loaded and the box re-selects it).
+	// The SOAP calls run in a goroutine: HandleEnterStandby is invoked
+	// synchronously from the gabbo read loop, and up to ~5s of SOAP blocked
+	// every queued frame - which is exactly what skewed the processing-time
+	// stamps the teardown classification depends on (#252). The min-gap above
+	// already bounds how many of these can be in flight.
 	s.stopQueue()
 	s.logger.Info("standby bounce: box powered off STR's UPnP source, stopping + clearing the transport URI so it stays off (#197)")
-	ctx, cancel := context.WithTimeout(s.queueCtx(), 5*time.Second)
-	defer cancel()
-	if err := s.renderer.Stop(ctx); err != nil {
-		s.logger.Debug("standby bounce: transport stop returned (expected if already off)", "err", err)
-	}
-	if err := s.renderer.ClearURI(ctx); err != nil {
-		s.logger.Debug("standby bounce: clear transport URI returned", "err", err)
-	}
+	go func() {
+		ctx, cancel := context.WithTimeout(s.queueCtx(), 5*time.Second)
+		defer cancel()
+		if err := s.renderer.Stop(ctx); err != nil {
+			s.logger.Debug("standby bounce: transport stop returned (expected if already off)", "err", err)
+		}
+		if err := s.renderer.ClearURI(ctx); err != nil {
+			s.logger.Debug("standby bounce: clear transport URI returned", "err", err)
+		}
+	}()
 }
 
 // handleSpontaneousSourceOff handles a UPNP->STANDBY drop with no physical key

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -295,6 +295,9 @@ type Server struct {
 	// source flip that answers STR's own push. nil-safe.
 	ownTransportCmdFn func() time.Time
 
+	// playStateFn overrides boxPlayState for tests. nil = the real :8090 probe.
+	playStateFn func() (standby, busy bool)
+
 	// resumeOnPowerOnPath persists the per-box opt-out for "resume the last
 	// station when the speaker is switched on" (default on; file absent or "1").
 	// Empty falls back to defaultResumeOnPowerOnPath.
@@ -2864,6 +2867,14 @@ func (s *Server) userStoppedRecently() bool {
 	return !s.lastUserStop.IsZero() && time.Since(s.lastUserStop) < userStopWindow
 }
 
+// userStoppedAfter reports whether a deliberate stop happened strictly after t
+// (absolute, so a long wait cannot expire it out of the rolling window).
+func (s *Server) userStoppedAfter(t time.Time) bool {
+	s.lastUserStopMu.Lock()
+	defer s.lastUserStopMu.Unlock()
+	return !s.lastUserStop.IsZero() && s.lastUserStop.After(t)
+}
+
 // standbyBounceWakeWindow is how long after HandleEnterStandby cleared the
 // transport (a power-off STR saw as UPNP->STANDBY) a following DO_NOT_RESUME
 // "wake" is treated as the scm power-off BOUNCE rather than a genuine power-on.
@@ -3308,10 +3319,6 @@ func (s *Server) maybeRePush() {
 	// this function's 2 s backoff, because the drop being "recovered" was just
 	// the PREVIOUS preset being torn down by the new press. Stand down for that
 	// window and let the recall's verify do the work.
-	if s.userPlayedRecently() {
-		s.logger.Info("re-push: a preset/play the user just started owns the retry, not resuming on top of it")
-		return
-	}
 	// A deliberate user stop (STR Stop/Pause, or the box/remote stop button seen
 	// over gabbo) must hold. Genuine box-side drops carry no such stop and resume.
 	if s.userStoppedRecently() {
@@ -3324,6 +3331,38 @@ func (s *Server) maybeRePush() {
 	if s.standbyStoppedRecently() {
 		s.logger.Info("re-push: box just powered off (standby bounce), not resuming (#197)")
 		return
+	}
+	if s.userPlayedRecently() {
+		// The recall's verify owns the retry inside this window - but only
+		// while it is still alive. A stream drop 5-12s after a user play used
+		// to be orphaned: the verify had already exited on its first success,
+		// this path returned permanently, and the music stayed off with a
+		// clean log (field bundle: slot-6 drop at +5.5s, box off, zero
+		// recovery). Wait out the remainder of the window and re-evaluate. A
+		// NEWER play started while waiting hands ownership to that recall's
+		// verify; a stop or power-off that arrived while waiting is compared
+		// against absolute stamps so it cannot expire out of a rolling window
+		// during the wait.
+		s.logger.Info("re-push: a preset/play the user just started owns the retry; re-checking once the ownership window ends")
+		waitStart := time.Now()
+		s.standbyStopMu.Lock()
+		playStart := s.lastUserPlayStart
+		s.standbyStopMu.Unlock()
+		if remain := recallOwnsRetryWindow - time.Since(playStart) + time.Second; remain > 0 {
+			time.Sleep(remain)
+		}
+		if s.userPlayedRecently() {
+			s.logger.Info("re-push: a newer play started while waiting, standing down")
+			return
+		}
+		if s.userStoppedAfter(waitStart) {
+			s.logger.Info("re-push: user stopped while waiting out the ownership window, not resuming")
+			return
+		}
+		if s.StandbyStoppedAfter(waitStart) {
+			s.logger.Info("re-push: box powered off while waiting out the ownership window, not resuming (#197)")
+			return
+		}
 	}
 	standby, busy := s.boxPlayState()
 	if standby {
@@ -3521,6 +3560,9 @@ func (s *Server) pushDisplayDefault() {
 // and idle" and trigger a resume. One quick retry first so a single hiccup does
 // not abort a legitimate stream recovery (where the box really is awake+idle).
 func (s *Server) boxPlayState() (standby, busy bool) {
+	if s.playStateFn != nil {
+		return s.playStateFn()
+	}
 	if s.boxHost == "" {
 		return true, false
 	}

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -289,6 +289,12 @@ type Server struct {
 	// to the conservative power-off handling.
 	userActivityFn func() time.Time
 
+	// ownTransportCmdFn reports when STR itself last issued a transport-
+	// mutating SOAP command; zero = never. Wired to
+	// boxws.LastOwnTransportCommand. HandleEnterStandby uses it to excuse a
+	// source flip that answers STR's own push. nil-safe.
+	ownTransportCmdFn func() time.Time
+
 	// resumeOnPowerOnPath persists the per-box opt-out for "resume the last
 	// station when the speaker is switched on" (default on; file absent or "1").
 	// Empty falls back to defaultResumeOnPowerOnPath.
@@ -2930,6 +2936,11 @@ const (
 	// nowSelectionUpdated by a moment) from a genuinely NEW key press during
 	// the recall (e.g. the user pressing power to stop it, the original #197).
 	userPlayActivityEpsilon = 2 * time.Second
+	// ownPushFlipWindow: a UPNP->STANDBY flip this soon after one of STR's OWN
+	// transport commands (SetURI/Play of a wake-resume or recall) is the
+	// firmware answering that push, not a user power-off - provided no key
+	// press arrived after the push.
+	ownPushFlipWindow = 3 * time.Second
 	// powerKeyAdjacencyWindow: for a key press during a recall to count as the
 	// user powering the box off, the UPNP->STANDBY flip must follow the key
 	// within this window (a power press flips the source near-instantly). A key
@@ -2971,6 +2982,17 @@ func (s *Server) userPlayedRecently() bool {
 // a physical power-off from a spontaneous firmware source power-off (#419).
 func (s *Server) SetUserActivityFn(fn func() time.Time) {
 	s.userActivityFn = fn
+}
+
+// SetOwnTransportCmdFn wires boxws.LastOwnTransportCommand so HandleEnterStandby
+// can recognise a source flip that answers STR's OWN transport push (the
+// firmware rejecting a wake-resume or recall SetURI) instead of classifying it
+// as a user power-off. Field signature: power-on key press, STR's resume push
+// ~2s later, flip 200ms after the push - the key press satisfied the adjacency
+// check and the flip latched "user stopped deliberately", so the resume the
+// user asked for was suppressed.
+func (s *Server) SetOwnTransportCmdFn(fn func() time.Time) {
+	s.ownTransportCmdFn = fn
 }
 
 // NoteUserPlay records that the user explicitly asked for playback (hardware
@@ -3047,6 +3069,23 @@ func (s *Server) HandleEnterStandby() {
 	// recovery off mid-recall (#252).
 	newKeySinceRecall := lastKey.After(playStart.Add(userPlayActivityEpsilon))
 	keyAdjacentToFlip := !lastKey.IsZero() && now.Sub(lastKey) <= powerKeyAdjacencyWindow
+	// A flip right after STR's OWN transport push, with no key press SINCE that
+	// push, is the firmware rejecting/settling OUR command - not a user
+	// power-off, even when a key press sits just before the push (field case:
+	// power-ON key, STR's wake-resume push 2s later, flip 200ms after the
+	// push; the key satisfied the adjacency check and the flip latched "user
+	// stopped deliberately", suppressing the very resume the key asked for).
+	// A real power-off is unaffected: its key press comes AFTER our last push.
+	var lastOwnCmd time.Time
+	if s.ownTransportCmdFn != nil {
+		lastOwnCmd = s.ownTransportCmdFn()
+	}
+	ownPushAnswered := !lastOwnCmd.IsZero() && now.Sub(lastOwnCmd) <= ownPushFlipWindow &&
+		lastOwnCmd.After(lastKey)
+	if ownPushAnswered && !deliberateStop {
+		s.logger.Info("standby bounce: source flipped right after STR's own transport push, treating as the firmware answering the push, not a user power-off")
+		return
+	}
 	if recallActive && !(newKeySinceRecall && keyAdjacentToFlip) && !deliberateStop {
 		s.logger.Info("standby bounce: source dropped during the user's own recall with no adjacent new key press, leaving transport and latches alone (#419)")
 		return

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -211,6 +211,15 @@ type Server struct {
 	// stream on its own (reported: radio stops after ~11 min, no STR error).
 	lastPlayMu sync.Mutex
 	lastPlay   *lastPlayInfo
+	// rePushInFlight coalesces stream-drop resumes (see HandleStreamDisconnect).
+	// A SERVER-level latch on purpose, guarded by lastPlayMu: it used to live on
+	// lastPlayInfo, but setLastPlay replaces that struct on every fresh play, so
+	// a drop of the NEW stream while an older maybeRePush was still waiting out
+	// the recall-ownership window spawned a second concurrent re-pusher, and the
+	// first one's deferred release then cleared the latch the second one owned -
+	// the box got double SetURI+Play (two audible re-buffers) and a third
+	// goroutine could stack. One latch per Server survives the struct swap.
+	rePushInFlight bool
 	// recallGen counts every stream push recorded via setLastPlay. Each
 	// recall's verify loop captures the generation of its own play; any later
 	// play bumps it, telling the older verify it was superseded so it stands
@@ -403,16 +412,14 @@ type recentCardCtx struct{ key, name, art, url, account, homepage string }
 // re-push state. rePushes counts consecutive resume attempts on THIS stream and
 // drives an exponential backoff; once it hits maxRePushes the stream is marked
 // failed and never re-pushed again until a fresh play (setLastPlay) replaces it.
-// rePushInFlight coalesces drops: a dead stream fires a disconnect on every
-// failed resume, and without this each one spawned a new goroutine (reported
-// v0.7.5: a dead slot-3 URL produced dozens of resume attempts per second that
-// starved the control port :8888).
+// The drop-coalescing latch lives on the Server (rePushInFlight), NOT here: a
+// per-play latch died with every setLastPlay struct swap and let concurrent
+// re-pushers stack (see the Server field).
 type lastPlayInfo struct {
 	boxURL, title, art, mime string
 	ts                       time.Time
 	rePushes                 int
 	failed                   bool
-	rePushInFlight           bool
 }
 
 // resumeMaxAge bounds how stale the last station may be and still come back on a
@@ -3087,12 +3094,21 @@ func (s *Server) HandleEnterStandby() {
 	// push; the key satisfied the adjacency check and the flip latched "user
 	// stopped deliberately", suppressing the very resume the key asked for).
 	// A real power-off is unaffected: its key press comes AFTER our last push.
+	//
+	// The excusal requires an actual key signal (a nonzero lastKey): on
+	// firmware that never emits userActivityUpdate the "push after key"
+	// comparison is vacuously true for EVERY push, and STR pushes on a ~5s
+	// cadence while a recall struggles - so a genuine power press within 3s of
+	// any push would be excused, nothing would latch, and the verify's wake
+	// would power the box back on (#197). With no key signal we keep the
+	// documented conservative fall-through above; the field case that
+	// motivated the excusal had a real key press and still passes.
 	var lastOwnCmd time.Time
 	if s.ownTransportCmdFn != nil {
 		lastOwnCmd = s.ownTransportCmdFn()
 	}
 	ownPushAnswered := !lastOwnCmd.IsZero() && now.Sub(lastOwnCmd) <= ownPushFlipWindow &&
-		lastOwnCmd.After(lastKey)
+		!lastKey.IsZero() && lastOwnCmd.After(lastKey)
 	if ownPushAnswered && !deliberateStop {
 		s.logger.Info("standby bounce: source flipped right after STR's own transport push, treating as the firmware answering the push, not a user power-off")
 		return
@@ -3141,13 +3157,36 @@ func (s *Server) HandleEnterStandby() {
 	// every queued frame - which is exactly what skewed the processing-time
 	// stamps the teardown classification depends on (#252). The min-gap above
 	// already bounds how many of these can be in flight.
+	//
+	// The goroutine re-checks user intent before EACH SOAP call: moving the
+	// clear off the read loop also un-serialized it from the next queued frame,
+	// so a preset press right after the power-off (the routine power-on-via-
+	// preset flow) could have its fresh SetURI overtaken by this straggler's
+	// ClearURI - a Stop can block for seconds against a box that is shutting
+	// down, and the ClearURI then wiped the transport the new recall had just
+	// armed. A user play newer than this clear means the clear no longer
+	// represents current intent, so it stands down.
 	s.stopQueue()
 	s.logger.Info("standby bounce: box powered off STR's UPnP source, stopping + clearing the transport URI so it stays off (#197)")
+	clearArmedAt := time.Now()
 	go func() {
 		ctx, cancel := context.WithTimeout(s.queueCtx(), 5*time.Second)
 		defer cancel()
+		staleClear := func() bool {
+			s.standbyStopMu.Lock()
+			defer s.standbyStopMu.Unlock()
+			return s.lastUserPlayStart.After(clearArmedAt)
+		}
+		if staleClear() {
+			s.logger.Info("standby bounce: a newer user play superseded the transport clear, leaving the fresh recall alone")
+			return
+		}
 		if err := s.renderer.Stop(ctx); err != nil {
 			s.logger.Debug("standby bounce: transport stop returned (expected if already off)", "err", err)
+		}
+		if staleClear() {
+			s.logger.Info("standby bounce: a user play arrived mid-clear, not clearing the transport URI")
+			return
 		}
 		if err := s.renderer.ClearURI(ctx); err != nil {
 			s.logger.Debug("standby bounce: clear transport URI returned", "err", err)
@@ -3261,12 +3300,13 @@ func (s *Server) HandleStreamDisconnect(upstreamErr error) {
 	// declared dead, or a resume is already in flight. A dead/moved URL fires a
 	// disconnect on EVERY failed resume; without this latch each one spawned a
 	// fresh maybeRePush goroutine, producing the dozens-per-second runaway that
-	// starved :8888 (v0.7.5).
-	if lp == nil || time.Since(lp.ts) >= 6*time.Hour || lp.failed || lp.rePushInFlight {
+	// starved :8888 (v0.7.5). The latch is Server-level so it survives
+	// setLastPlay swapping the lastPlayInfo struct mid-wait.
+	if lp == nil || time.Since(lp.ts) >= 6*time.Hour || lp.failed || s.rePushInFlight {
 		s.lastPlayMu.Unlock()
 		return
 	}
-	lp.rePushInFlight = true
+	s.rePushInFlight = true
 	s.lastPlayMu.Unlock()
 	go s.maybeRePush()
 }
@@ -3280,11 +3320,11 @@ func (s *Server) HandleStreamDisconnect(upstreamErr error) {
 func (s *Server) maybeRePush() {
 	// Release the in-flight latch on exit so a later genuine drop can re-arm
 	// (HandleStreamDisconnect refuses to spawn a second goroutine until then).
+	// The latch is a Server field, so this release cannot land on the wrong
+	// struct after setLastPlay swapped lastPlay mid-run.
 	defer func() {
 		s.lastPlayMu.Lock()
-		if s.lastPlay != nil {
-			s.lastPlay.rePushInFlight = false
-		}
+		s.rePushInFlight = false
 		s.lastPlayMu.Unlock()
 	}()
 
@@ -3311,14 +3351,6 @@ func (s *Server) maybeRePush() {
 	}
 	time.Sleep(backoff)
 
-	// A recall the user just started owns its own retry: its verify re-pushes
-	// every 5 s until the box really plays that stream. Re-pushing here as well
-	// makes the two fight, and each push tears the other's stream down, which
-	// arms yet another disconnect. A Wave diagnostic caught the resulting storm:
-	// four stream starts and two re-pushes inside 1.7 s, 680 ms apart despite
-	// this function's 2 s backoff, because the drop being "recovered" was just
-	// the PREVIOUS preset being torn down by the new press. Stand down for that
-	// window and let the recall's verify do the work.
 	// A deliberate user stop (STR Stop/Pause, or the box/remote stop button seen
 	// over gabbo) must hold. Genuine box-side drops carry no such stop and resume.
 	if s.userStoppedRecently() {
@@ -3333,16 +3365,23 @@ func (s *Server) maybeRePush() {
 		return
 	}
 	if s.userPlayedRecently() {
-		// The recall's verify owns the retry inside this window - but only
-		// while it is still alive. A stream drop 5-12s after a user play used
-		// to be orphaned: the verify had already exited on its first success,
-		// this path returned permanently, and the music stayed off with a
-		// clean log (field bundle: slot-6 drop at +5.5s, box off, zero
-		// recovery). Wait out the remainder of the window and re-evaluate. A
-		// NEWER play started while waiting hands ownership to that recall's
-		// verify; a stop or power-off that arrived while waiting is compared
-		// against absolute stamps so it cannot expire out of a rolling window
-		// during the wait.
+		// A recall the user just started owns its own retry: its verify
+		// re-pushes every 5 s until the box really plays that stream.
+		// Re-pushing here as well makes the two fight, and each push tears the
+		// other's stream down, which arms yet another disconnect. A Wave
+		// diagnostic caught the resulting storm: four stream starts and two
+		// re-pushes inside 1.7 s, because the drop being "recovered" was just
+		// the PREVIOUS preset being torn down by the new press.
+		//
+		// But the verify is only alive for so long. A stream drop 5-12s after
+		// a user play used to be orphaned: the verify had already exited on
+		// its first success, this path returned permanently, and the music
+		// stayed off with a clean log (field bundle: slot-6 drop at +5.5s,
+		// box off, zero recovery). Wait out the remainder of the window and
+		// re-evaluate. A NEWER play started while waiting hands ownership to
+		// that recall's verify; a stop or power-off that arrived while
+		// waiting is compared against absolute stamps so it cannot expire out
+		// of a rolling window during the wait.
 		s.logger.Info("re-push: a preset/play the user just started owns the retry; re-checking once the ownership window ends")
 		waitStart := time.Now()
 		s.standbyStopMu.Lock()
@@ -3405,6 +3444,14 @@ func (s *Server) maybeRePush() {
 	s.logger.Info("re-push: box dropped the stream while idle, resuming", "url", boxURL, "attempt", n, "max", maxRePushes)
 	s.boxCmdMu.Lock()
 	defer s.boxCmdMu.Unlock()
+	// Re-check under the command mutex, mirroring the spontaneous-off path: a
+	// verify push or app play that held boxCmdMu while we waited may have
+	// started the box, and re-pushing over it would re-buffer a stream that is
+	// already playing.
+	if _, busy := s.boxPlayState(); busy {
+		s.logger.Info("re-push: box started playing while waiting for the command slot, standing down")
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
 	defer cancel()
 	var err error

--- a/internal/webui/wedge.go
+++ b/internal/webui/wedge.go
@@ -162,6 +162,22 @@ func (s *Server) NoteBoxHealthy() {
 	}
 }
 
+// BoxStateHint reports the speaker-side condition that would make streams fail
+// regardless of the station: "wedged" (transport accepted but the box never
+// pulls or plays; a power-cycle is required) or "login-error" (the box is
+// rejecting sources as not-logged-in while the re-login self-heal runs). "" =
+// no known box-side problem. Surfaced via /api/stream-status so the desktop
+// app can name the real cause instead of cycling station alternates.
+func (s *Server) BoxStateHint() string {
+	if status, _ := s.BoxHealth(); status == "wedged" {
+		return "wedged"
+	}
+	if s.loginErrorRecentWithin(loginErrWedgeSkipWindow) {
+		return "login-error"
+	}
+	return ""
+}
+
 // BoxHealth reports "ok" or "wedged" (plus the latch time for the latter).
 func (s *Server) BoxHealth() (status string, since time.Time) {
 	s.wedge.mu.Lock()

--- a/internal/webui/wedge.go
+++ b/internal/webui/wedge.go
@@ -52,6 +52,12 @@ type loginErrState struct {
 // STR does not immediately re-push the source the box just refused.
 const recentLoginErrorWindow = 20 * time.Second
 
+// loginErrWedgeSkipWindow is how long after a not-logged-in rejection an
+// exhausted recall verify is attributed to the login instead of a wedge. Wider
+// than recentLoginErrorWindow: the hardware verify exhausts ~26s after the
+// press that provoked the 1036.
+const loginErrWedgeSkipWindow = 60 * time.Second
+
 // NoteBoxLoginError records that the box just rejected a source because it does
 // not think it is signed in (errorUpdate 1036), and kicks off a forced re-login
 // in the background. Wired from the boxws not-logged-in callback. The box keeps
@@ -72,12 +78,18 @@ func (s *Server) NoteBoxLoginError() {
 	}
 }
 
+// loginErrorRecentWithin reports whether the box rejected a source as
+// not-logged-in within the given window.
+func (s *Server) loginErrorRecentWithin(window time.Duration) bool {
+	s.loginErr.mu.Lock()
+	defer s.loginErr.mu.Unlock()
+	return !s.loginErr.last.IsZero() && time.Since(s.loginErr.last) < window
+}
+
 // recentLoginError reports whether the box rejected a source as not-logged-in
 // within recentLoginErrorWindow.
 func (s *Server) recentLoginError() bool {
-	s.loginErr.mu.Lock()
-	defer s.loginErr.mu.Unlock()
-	return !s.loginErr.last.IsZero() && time.Since(s.loginErr.last) < recentLoginErrorWindow
+	return s.loginErrorRecentWithin(recentLoginErrorWindow)
 }
 
 // SetStreamActivityFn wires the stream proxy's LastActivity so the wedge
@@ -96,6 +108,16 @@ func (s *Server) NoteRecallExhausted() {
 	np := s.snapshotNowPlaying(npCtx)
 	cancel()
 	if np.Source == "STANDBY" || np.Source == "" {
+		return
+	}
+	// A recall that exhausted while the box was rejecting sources as
+	// not-logged-in failed on the LOGIN, not on a wedged transport: counting
+	// it latched boxHealth=wedged and told the user to power-cycle a box that
+	// only needed the re-login to stick (field bundle: strike at +25s after a
+	// 1036). The window is wider than recentLoginError's 20s because the
+	// verify exhausts ~26s after the press.
+	if s.loginErrorRecentWithin(loginErrWedgeSkipWindow) {
+		s.logger.Info("recall exhausted during a not-logged-in window; not counting a wedge strike (login failure, not a wedge)")
 		return
 	}
 	if s.streamActivityFn != nil {

--- a/usb-stick/install.sh
+++ b/usb-stick/install.sh
@@ -50,8 +50,9 @@ mkdir -p /mnt/nv/streborn/bin 2>/dev/null
 # ST300 2026-07-07). STR redirects only the STOCK hosts (streaming.bose.com,
 # content.api.bose.io) via /etc/hosts, so the box MUST carry the stock hostnames
 # for the redirect to catch them. Run this before the post-install reboot so the
-# SDK reads healed URLs on its very next boot. Idempotent: only rewrites tags whose
-# value actually contains the placeholder, leaves correct values untouched.
+# SDK reads healed URLs on its very next boot. Idempotent: a fully stock (or
+# empty) config is never touched, and re-running the heal reproduces the same
+# canonical stock values.
 heal_sdk_cloud_urls() {
     sdk_cfg="/mnt/nv/OverrideSdkPrivateCfg.xml"
     [ -f "$sdk_cfg" ] || return 0
@@ -60,9 +61,11 @@ heal_sdk_cloud_urls() {
     # same tags to their servers, and a box carrying such a host can never be
     # caught by STR's /etc/hosts redirect of the STOCK hostnames - the cloud
     # icon stays amber and the marge login never sticks, even after the user
-    # deleted the mod's files (live report 2026-07-22). Only non-empty values
-    # that do not already carry the stock host are rewritten; a stock or empty
-    # tag is left untouched, so the heal stays idempotent.
+    # deleted the mod's files (live report 2026-07-22). A non-empty, non-stock
+    # value in ANY of the three tags triggers the heal, and the sed then
+    # rewrites ALL non-empty tags to their canonical stock values (an
+    # already-stock tag is rewritten to the same value, so the heal stays
+    # idempotent; a fully stock or empty config is never touched at all).
     needs_heal=0
     if grep -q '<bmxRegistryUrl>[^<]' "$sdk_cfg" 2>/dev/null && \
        ! grep -q '<bmxRegistryUrl>https://content\.api\.bose\.io' "$sdk_cfg" 2>/dev/null; then

--- a/usb-stick/install.sh
+++ b/usb-stick/install.sh
@@ -55,12 +55,33 @@ mkdir -p /mnt/nv/streborn/bin 2>/dev/null
 heal_sdk_cloud_urls() {
     sdk_cfg="/mnt/nv/OverrideSdkPrivateCfg.xml"
     [ -f "$sdk_cfg" ] || return 0
-    grep -q 'str-setup\.invalid' "$sdk_cfg" 2>/dev/null || return 0
-    sed -e 's#\(<bmxRegistryUrl>\)[^<]*str-setup\.invalid[^<]*\(</bmxRegistryUrl>\)#\1https://content.api.bose.io/bmx/registry/v1/services\2#g' \
-        -e 's#\(<statsServerUrl>\)[^<]*str-setup\.invalid[^<]*\(</statsServerUrl>\)#\1https://events.api.bosecm.com\2#g' \
-        -e 's#\(<margeServerUrl>\)[^<]*str-setup\.invalid[^<]*\(</margeServerUrl>\)#\1https://streaming.bose.com\2#g' \
+    # Heal ANY non-stock host in the three cloud tags, not just STR's own
+    # str-setup.invalid placeholder: third-party mods (TechEndure) reroute the
+    # same tags to their servers, and a box carrying such a host can never be
+    # caught by STR's /etc/hosts redirect of the STOCK hostnames - the cloud
+    # icon stays amber and the marge login never sticks, even after the user
+    # deleted the mod's files (live report 2026-07-22). Only non-empty values
+    # that do not already carry the stock host are rewritten; a stock or empty
+    # tag is left untouched, so the heal stays idempotent.
+    needs_heal=0
+    if grep -q '<bmxRegistryUrl>[^<]' "$sdk_cfg" 2>/dev/null && \
+       ! grep -q '<bmxRegistryUrl>https://content\.api\.bose\.io' "$sdk_cfg" 2>/dev/null; then
+        needs_heal=1
+    fi
+    if grep -q '<statsServerUrl>[^<]' "$sdk_cfg" 2>/dev/null && \
+       ! grep -q '<statsServerUrl>https://events\.api\.bosecm\.com' "$sdk_cfg" 2>/dev/null; then
+        needs_heal=1
+    fi
+    if grep -q '<margeServerUrl>[^<]' "$sdk_cfg" 2>/dev/null && \
+       ! grep -q '<margeServerUrl>https://streaming\.bose\.com' "$sdk_cfg" 2>/dev/null; then
+        needs_heal=1
+    fi
+    [ "$needs_heal" = "1" ] || return 0
+    sed -e 's#<bmxRegistryUrl>[^<][^<]*</bmxRegistryUrl>#<bmxRegistryUrl>https://content.api.bose.io/bmx/registry/v1/services</bmxRegistryUrl>#g' \
+        -e 's#<statsServerUrl>[^<][^<]*</statsServerUrl>#<statsServerUrl>https://events.api.bosecm.com</statsServerUrl>#g' \
+        -e 's#<margeServerUrl>[^<][^<]*</margeServerUrl>#<margeServerUrl>https://streaming.bose.com</margeServerUrl>#g' \
         "$sdk_cfg" > "$sdk_cfg.new" 2>/dev/null && mv "$sdk_cfg.new" "$sdk_cfg" 2>/dev/null
-    echo "Healed str-setup.invalid cloud URLs in $sdk_cfg back to stock (redirect-catchable)"
+    echo "Healed non-stock cloud URLs in $sdk_cfg back to stock (redirect-catchable)"
 }
 
 phase1_install() {

--- a/usb-stick/run.sh
+++ b/usb-stick/run.sh
@@ -3085,11 +3085,11 @@ mount | grep -q '/etc/hosts' || {
 # tags back to the STOCK hostnames: STR only redirects the stock hosts
 # (streaming.bose.com, content.api.bose.io) via the /etc/hosts bind mount above,
 # so the box MUST carry the stock hostnames for that redirect to catch them.
-# Best-effort + idempotent: the grep gate means a config with no placeholder is
-# left untouched, and only tags whose value actually contains the placeholder
-# are rewritten. The SDK already read the (bad) value earlier this boot, so this
-# heal takes effect on the following boot; install.sh does the same before the
-# post-install reboot so the very first boot is clean.
+# Best-effort + idempotent: the grep gate means a config whose tags are all
+# stock (or empty) is left untouched entirely. The SDK already read the (bad)
+# value earlier this boot, so this heal takes effect on the following boot;
+# install.sh does the same before the post-install reboot so the very first
+# boot is clean.
 SDK_CFG="/mnt/nv/OverrideSdkPrivateCfg.xml"
 SDK_HEAL_NEEDED=0
 if [ -f "$SDK_CFG" ]; then
@@ -3098,7 +3098,10 @@ if [ -f "$SDK_CFG" ]; then
     # same tags to their servers, and such a host can never be caught by the
     # stock-hostname redirect above - the cloud icon stays amber and the marge
     # login never sticks, even after the user deleted the mod's files (live
-    # report 2026-07-22). Only non-empty, non-stock values trigger a rewrite.
+    # report 2026-07-22). A non-empty, non-stock value in ANY of the three
+    # tags triggers the heal, and the sed below then rewrites ALL non-empty
+    # tags to their canonical stock values (an already-stock tag is rewritten
+    # to the same value, so the result is idempotent either way).
     if grep -q '<bmxRegistryUrl>[^<]' "$SDK_CFG" 2>/dev/null && \
        ! grep -q '<bmxRegistryUrl>https://content\.api\.bose\.io' "$SDK_CFG" 2>/dev/null; then
         SDK_HEAL_NEEDED=1

--- a/usb-stick/run.sh
+++ b/usb-stick/run.sh
@@ -3091,12 +3091,33 @@ mount | grep -q '/etc/hosts' || {
 # heal takes effect on the following boot; install.sh does the same before the
 # post-install reboot so the very first boot is clean.
 SDK_CFG="/mnt/nv/OverrideSdkPrivateCfg.xml"
-if [ -f "$SDK_CFG" ] && grep -q 'str-setup\.invalid' "$SDK_CFG" 2>/dev/null; then
-    if sed -e 's#\(<bmxRegistryUrl>\)[^<]*str-setup\.invalid[^<]*\(</bmxRegistryUrl>\)#\1https://content.api.bose.io/bmx/registry/v1/services\2#g' \
-           -e 's#\(<statsServerUrl>\)[^<]*str-setup\.invalid[^<]*\(</statsServerUrl>\)#\1https://events.api.bosecm.com\2#g' \
-           -e 's#\(<margeServerUrl>\)[^<]*str-setup\.invalid[^<]*\(</margeServerUrl>\)#\1https://streaming.bose.com\2#g' \
+SDK_HEAL_NEEDED=0
+if [ -f "$SDK_CFG" ]; then
+    # Heal ANY non-stock host in the three cloud tags, not just STR's own
+    # str-setup.invalid placeholder: third-party mods (TechEndure) reroute the
+    # same tags to their servers, and such a host can never be caught by the
+    # stock-hostname redirect above - the cloud icon stays amber and the marge
+    # login never sticks, even after the user deleted the mod's files (live
+    # report 2026-07-22). Only non-empty, non-stock values trigger a rewrite.
+    if grep -q '<bmxRegistryUrl>[^<]' "$SDK_CFG" 2>/dev/null && \
+       ! grep -q '<bmxRegistryUrl>https://content\.api\.bose\.io' "$SDK_CFG" 2>/dev/null; then
+        SDK_HEAL_NEEDED=1
+    fi
+    if grep -q '<statsServerUrl>[^<]' "$SDK_CFG" 2>/dev/null && \
+       ! grep -q '<statsServerUrl>https://events\.api\.bosecm\.com' "$SDK_CFG" 2>/dev/null; then
+        SDK_HEAL_NEEDED=1
+    fi
+    if grep -q '<margeServerUrl>[^<]' "$SDK_CFG" 2>/dev/null && \
+       ! grep -q '<margeServerUrl>https://streaming\.bose\.com' "$SDK_CFG" 2>/dev/null; then
+        SDK_HEAL_NEEDED=1
+    fi
+fi
+if [ "$SDK_HEAL_NEEDED" = "1" ]; then
+    if sed -e 's#<bmxRegistryUrl>[^<][^<]*</bmxRegistryUrl>#<bmxRegistryUrl>https://content.api.bose.io/bmx/registry/v1/services</bmxRegistryUrl>#g' \
+           -e 's#<statsServerUrl>[^<][^<]*</statsServerUrl>#<statsServerUrl>https://events.api.bosecm.com</statsServerUrl>#g' \
+           -e 's#<margeServerUrl>[^<][^<]*</margeServerUrl>#<margeServerUrl>https://streaming.bose.com</margeServerUrl>#g' \
            "$SDK_CFG" > "$SDK_CFG.new" 2>/dev/null && mv "$SDK_CFG.new" "$SDK_CFG" 2>/dev/null; then
-        setup_log "healed str-setup.invalid SDK cloud URLs in $SDK_CFG back to stock (redirect-catchable); effective next boot"
+        setup_log "healed non-stock SDK cloud URLs in $SDK_CFG back to stock (redirect-catchable); effective next boot"
     else
         rm -f "$SDK_CFG.new" 2>/dev/null
         log "SDK cloud URL heal: sed/mv failed on $SDK_CFG (leaving it unchanged)"


### PR DESCRIPTION
## Summary

The v0.9.16 button/remote repair did not hold in the field. This series re-analyzes the GitHub issues plus eleven support-mail diagnostic bundles, fixes the root causes, and hardens the emulated Bose login so it is maintained rather than only repaired after a failed press.

Root causes fixed:

- **Blocked gabbo read loop skewed every classification window.** Synchronous handlers held the single WebSocket read loop for up to ~18s per press, so teardown frames were stamped late and misread as user intent (phantom stops, false power-off latches). The slow recall now runs beside the read loop, and stand-down checks anchor to the actual press time.
- **Verify loops fought newer presses.** A press sequence plus the shared recall generation supersede older verify/re-push loops ("pressed 2, got 1").
- **The v0.9.16 repair latched phantom user stops from its own Stop/ClearURI.** STR's own transport commands are now stamped and excused, with a key-press veto so real remote stops still latch.
- **`margeAccountUUID` present does not mean logged in.** Fresh installs and factory-reset boxes keep the UUID while the MargeHSM decays to not-logged-in (1036 on every press); boxes with a cached pre-shutdown Bose account never show this. The agent now marks a box login-suspect on rejection and proactively re-asserts the account (rate-limited, single-flight) so the fake login is maintained.
- **The re-login itself wiped the speaker's preset keys.** During re-onboarding the box re-reads its cloud presets from marge; marge now serves the live stick store instead of an empty list, and an urgent key re-sync runs right after each (re-)onboarding.
- **The box's give-up route (UPNP → INVALID_SOURCE → STANDBY) bypassed all standby machinery**, including after long INVALID_SOURCE dwells; the recall verify now wakes only a box whose standby has an attributable cause, re-checks its stand-downs before every escalation, and can nudge a stuck source once via sys-power.
- **A real power press stays off (#197).** The wake path takes an abort predicate consulted immediately before each `sys power` toggle, and the async standby clear stands down when a newer user play arrived.
- **Empty-store recovery raced the first forced re-login**; the first box preset read now runs before autopair may re-onboard the box.

Also included: box-state hints in the stream status (wedged / login-error), factory-reset failure logging, offline markers in diagnostic bundles, healing of third-party cloud URLs in `OverrideSdkPrivateCfg.xml`, and hardware fingerprints for SM2-ST20 fw 27.0.3, scm-ST30 (mojo), Portable (taigan), scm-Wave (lisa), and Lifestyle (bardeen) in `docs/MODEL-VARIANTS.md`.

The final commit implements all eight confirmed findings of an adversarial review of the series (concurrency, semantics, login/marge, quality dimensions), each with a regression test.

## Test plan

- ~35 new regression tests across `cmd/agent`, `internal/webui`, `internal/boxws`, `internal/autopair`, `internal/streamproxy`, `internal/marge`, derived from the field bundles (1036 storms, standby flaps, keyless firmware, wipe-on-relogin, wake abort, POST single-flight)
- Full suite green, `-race` green on all concurrency-touched packages
- ARM cross-compile (`GOOS=linux GOARCH=arm GOARM=5`) and desktop-app module build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6sFCeuzYjrMF5KNNo3YQK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6sFCeuzYjrMF5KNNo3YQK)_