### PR TITLE
fix(agent): 0.9.18 - recover presets after standby + stop the self-power-off regression

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -2238,6 +2238,42 @@ func (h *presetWsHandler) playSpotifyPreset(ctx context.Context, seq uint64, pre
 	h.logger.Info("spotify preset recalled", "slot", slot, "name", p.Name, "account", p.Account)
 }
 
+// readBoxVolume returns the box's current target volume (0 on any error / no box
+// host). Best-effort, used to remember the user's level across a recall.
+func (h *presetWsHandler) readBoxVolume() int {
+	if h.boxHost == "" {
+		return 0
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	if v, err := boxapi.New(h.boxHost).GetVolume(ctx); err == nil {
+		return v.Target
+	}
+	return 0
+}
+
+// restorePreRecallVolume re-applies the volume the user had before a recall when
+// a 1036-standby recovery reset it (the box forgets its volume across standby and
+// comes back at its own default after STR wakes it). No-op when the volume is
+// unknown or unchanged, so the happy path (no standby) never touches it.
+func (h *presetWsHandler) restorePreRecallVolume(preVol int) {
+	if preVol <= 0 || h.boxHost == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c := boxapi.New(h.boxHost)
+	cur, err := c.GetVolume(ctx)
+	if err != nil || cur.Target == preVol {
+		return
+	}
+	if err := c.SetVolume(ctx, preVol); err != nil {
+		h.logger.Warn("volume restore after recall failed", "want", preVol, "err", err)
+		return
+	}
+	h.logger.Info("restored user volume after a recall recovery reset it", "from", cur.Target, "to", preVol)
+}
+
 // verifyPlayURL confirms the box started playing a UPnP (radio) recall and
 // re-issues it a few times if not, fixing the "first hardware press after
 // reboot does nothing" race for radio presets too. mime is the DIDL label of
@@ -2257,6 +2293,12 @@ func (h *presetWsHandler) verifyPlayURL(seq, gen uint64, pressAt time.Time, slot
 	// Waiting a full verify tick to react leaves the user in silence for five
 	// seconds; re-pushing as soon as the rejection is visible is the automatic
 	// version of the second press users learned to do by hand.
+	// Capture the user's volume before any recovery runs: the box FORGETS its
+	// volume across a 1036-standby and comes back at its own default (~30) after
+	// STR wakes it, so a recovered preset would otherwise blast the room (field:
+	// scm/taigan remote-preset -> reattach + volume reset). Restored at the
+	// success below, only if it actually changed.
+	preVol := h.readBoxVolume()
 	h.rePushAfterSourceReject(seq, gen, pressAt, slot, url, name, icon, mime)
 	// Up to 5 attempts (~25s): a box waking from a deep/overnight standby can
 	// take longer than the old 3-attempt (~15s) window to finish bringing its
@@ -2288,6 +2330,7 @@ func (h *presetWsHandler) verifyPlayURL(seq, gen uint64, pressAt time.Time, slot
 		// had already opened the new stream, so a location check alone declared a
 		// healthy recall dead and the "repair" tore the working stream down.
 		if h.recallReachedAudio(slot, url, pressAt) {
+			h.restorePreRecallVolume(preVol)
 			if h.noteBoxHealthy != nil {
 				h.noteBoxHealthy()
 			}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -588,6 +588,13 @@ func run() error {
 		// neither cross-traffic nor a dead 36ms fetch can certify a failed
 		// recall as healthy (#252).
 		slotPulled: streamProxySrv.SlotPulledSince,
+		// Login-error carve-out for the recall verify: a NOT_LOGGED_IN rejection for
+		// a recall makes a now-closed short slot pull an unreliable "played" signal
+		// (the box's re-login source bounce serves the stream ~3s then drops it with
+		// no audio). slotFetchLive tells a still-open pull from that bounce;
+		// loginErrorSinceFn tells whether a 1036 landed for this recall.
+		slotFetchLive:     streamProxySrv.SlotFetchLive,
+		loginErrorSinceFn: webuiSrv.LoginErrorSince,
 		// Surface the box's own presets (incl. foreign sources like Deezer) to the
 		// webui so the app can show/preserve them (Option C). Map boxws -> webui at
 		// the composition root to keep the two packages decoupled.
@@ -1288,6 +1295,17 @@ type presetWsHandler struct {
 	// (#252 field bundles). Wired to streamproxy.Server.SlotPulledSince.
 	// nil-safe.
 	slotPulled func(slot int, since time.Time) bool
+	// slotFetchLive reports whether the box currently holds an OPEN connection to
+	// the slot's proxied stream (streamproxy.Server.SlotFetchLive). Unlike
+	// slotPulled it makes no sustained-duration call on a closed fetch, so the
+	// recall verify can tell "still pulling audio" from a login error's brief
+	// source bounce that opened the stream and closed. nil-safe.
+	slotFetchLive func(slot int) bool
+	// loginErrorSinceFn reports whether the box rejected a source as
+	// NOT_LOGGED_IN (1036) after t (webui.Server.LoginErrorSince). Wired so the
+	// recall verify does not trust a now-closed short slot pull as success while
+	// a login error is in flight for this recall. nil-safe.
+	loginErrorSinceFn func(t time.Time) bool
 }
 
 // slotPulledSince reports whether the box is credibly playing THIS slot's
@@ -1298,6 +1316,48 @@ func (h *presetWsHandler) slotPulledSince(slot int, t time.Time) bool {
 		return false
 	}
 	return h.slotPulled(slot, t)
+}
+
+// slotFetchLiveNow reports whether the box currently holds an open pull of the
+// slot's proxied stream. nil-safe (false when unwired).
+func (h *presetWsHandler) slotFetchLiveNow(slot int) bool {
+	if h.slotFetchLive == nil {
+		return false
+	}
+	return h.slotFetchLive(slot)
+}
+
+// loginErrorSince reports whether a NOT_LOGGED_IN rejection landed after t.
+// nil-safe (false when unwired).
+func (h *presetWsHandler) loginErrorSince(t time.Time) bool {
+	if h.loginErrorSinceFn == nil {
+		return false
+	}
+	return h.loginErrorSinceFn(t)
+}
+
+// recallReachedAudio reports whether a recall anchored at pressAt has credibly
+// reached audio: the box is playing this URL, or it pulled the slot's proxied
+// stream in a way that counts. The login-error carve-out is the fix's core: a
+// NOT_LOGGED_IN rejection for THIS recall makes a now-CLOSED slot pull an
+// unreliable success signal, because the box's re-login source bounce opens the
+// proxied stream and serves it right around minSustainedFetch (~3s) before
+// dropping it WITHOUT audio and powering off (Portable 2026-07-23). In that
+// window only a still-live pull or an actual playing state proves audio;
+// otherwise the verify loop keeps retrying until the forced re-login lands.
+func (h *presetWsHandler) recallReachedAudio(slot int, url string, pressAt time.Time) bool {
+	if h.playingURL(url) {
+		return true
+	}
+	if !h.slotPulledSince(slot, pressAt) {
+		return false
+	}
+	// slot pulled since the press. Trust it unless a login error is in flight for
+	// this recall AND the pull is no longer live (a closed short login-bounce).
+	if h.loginErrorSince(pressAt) && !h.slotFetchLiveNow(slot) {
+		return false
+	}
+	return true
 }
 
 // superseded reports whether a newer hardware press (pressSeq moved past seq)
@@ -2227,7 +2287,7 @@ func (h *presetWsHandler) verifyPlayURL(seq, gen uint64, pressAt time.Time, slot
 		// lags: a Portable kept naming the PREVIOUS preset for seconds after it
 		// had already opened the new stream, so a location check alone declared a
 		// healthy recall dead and the "repair" tore the working stream down.
-		if h.slotPulledSince(slot, pressAt) || h.playingURL(url) {
+		if h.recallReachedAudio(slot, url, pressAt) {
 			if h.noteBoxHealthy != nil {
 				h.noteBoxHealthy()
 			}
@@ -2336,7 +2396,7 @@ func (h *presetWsHandler) rePushAfterSourceReject(seq, gen uint64, pressAt time.
 		// THIS press's URL would actively tear the newer recall down.
 		return
 	}
-	if h.slotPulledSince(slot, pressAt) || h.playingURL(url) {
+	if h.recallReachedAudio(slot, url, pressAt) {
 		return // refused once, then started anyway
 	}
 	if h.poweredOffSince(pressAt) {

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -2394,6 +2394,11 @@ func (h *presetWsHandler) verifyPlayURL(seq, gen uint64, pressAt time.Time, slot
 		if err := h.wake(ctx, standDown); err != nil {
 			h.logger.Warn("hardware recall retry: could not wake box", "slot", slot, "err", err)
 		}
+		// The box reset its volume to the box default when it dropped to standby;
+		// restore the user's level right after the wake so the recovered preset
+		// does not play the room loud for the seconds until the loop-top success
+		// check would otherwise restore it. Idempotent (no-op when unchanged).
+		h.restorePreRecallVolume(preVol)
 		// Final gate before the push: the wake can take seconds, and a stop or
 		// power press during it must hold.
 		if standDown() {

--- a/internal/autopair/autopair.go
+++ b/internal/autopair/autopair.go
@@ -76,61 +76,22 @@ type Manager struct {
 	// cadence. Set once at wiring time, before RunBackground starts.
 	onPaired func()
 
-	// Login-suspicion state. A margeAccountUUID on the box does NOT mean the
-	// box considers itself logged in: fresh installs and factory-reset boxes
-	// keep the UUID while their MargeHSM drops back to not-logged-in (every
-	// UPnP source activation is then refused with 1036
-	// UNABLE_TO_PROCESS_NOT_LOGGED_IN - field bundles 2026-07-22, all
-	// models). Boxes that still carry a cached pre-shutdown Bose account do
-	// not show this. The UUID-present skip in ensure() therefore let every
-	// press-time TriggerNow do nothing while the login was actually broken,
-	// and only the reactive ForcePair after a failed press re-asserted it.
-	// NoteLoginRejected marks the box suspect; while suspect, every ensure
-	// cycle (press, wake, reconnect, heartbeat tick) re-asserts the account
-	// proactively so the fake login is MAINTAINED, not just repaired.
+	// ForcePair coalescing state. A reactive forced re-login (after the box
+	// refused a source 1036 NOT_LOGGED_IN on a real press) may race the regular
+	// pair cycle; lastSuspectAssert stamps the most recent account POST so a
+	// second one right behind it is skipped instead of churning the MargeHSM.
 	// Guarded by suspectMu.
+	//
+	// STR used to keep the box "login-suspect" for an hour after any 1036 and
+	// re-POST setMargeAccount on every heartbeat to proactively MAINTAIN the fake
+	// login. That was removed: re-onboarding a *playing* box bounces its active
+	// source and the firmware powers it off mid-song (the 0.9.17 self-off, all
+	// models), and it never actually prevented the box's own post-standby 1036
+	// anyway (proven live 2026-07-23). v0.9.0 had no proactive maintenance at all
+	// and was stable for exactly this reason. Only the reactive ForcePair (which
+	// un-wedges an ST300 after a real failed press, #342) remains.
 	suspectMu         sync.Mutex
-	lastLoginReject   time.Time
 	lastSuspectAssert time.Time
-}
-
-const (
-	// loginSuspectWindow is how long after a not-logged-in rejection the box
-	// stays "login-suspect": within it, every pair cycle re-asserts the
-	// account even though the box reports a UUID. Long on purpose - the
-	// decay recurs across standby cycles - while a box that never rejects
-	// (e.g. one with a cached real Bose account) is never touched.
-	loginSuspectWindow = time.Hour
-	// suspectReassertMinGap rate-limits the suspect-driven re-asserts so a
-	// burst of presses cannot turn into a setMargeAccount storm (#375); the
-	// single-flight guard additionally coalesces concurrent triggers.
-	suspectReassertMinGap = time.Minute
-)
-
-// NoteLoginRejected records that the box just refused a source because it does
-// not consider itself logged in (errorUpdate 1036 NOT_LOGGED_IN). While the
-// suspicion is fresh, every pair cycle re-asserts the account instead of
-// trusting the UUID-present skip. Safe for concurrent use.
-func (m *Manager) NoteLoginRejected() {
-	m.suspectMu.Lock()
-	m.lastLoginReject = time.Now()
-	m.suspectMu.Unlock()
-}
-
-// consumeSuspectReassert reports whether a suspect-driven re-assert should run
-// now, and if so stamps the rate limit. The two-step check keeps the min-gap
-// accounting inside one lock.
-func (m *Manager) consumeSuspectReassert() bool {
-	m.suspectMu.Lock()
-	defer m.suspectMu.Unlock()
-	if m.lastLoginReject.IsZero() || time.Since(m.lastLoginReject) > loginSuspectWindow {
-		return false
-	}
-	if !m.lastSuspectAssert.IsZero() && time.Since(m.lastSuspectAssert) < suspectReassertMinGap {
-		return false
-	}
-	m.lastSuspectAssert = time.Now()
-	return true
 }
 
 // New creates a Manager with sensible defaults.
@@ -244,22 +205,15 @@ func (m *Manager) ensure(ctx context.Context, force bool) error {
 		return fmt.Errorf("check status: %w", err)
 	}
 	m.recordPairedState(paired)
-	suspectAssert := false
 	if paired && !force {
-		// The UUID-present skip is only valid while the login is healthy: a
-		// box that recently refused a source with 1036 NOT_LOGGED_IN keeps
-		// its UUID yet is NOT signed in, and skipping here left every
-		// press-time trigger a no-op while the buttons stayed dead (field
-		// bundles 2026-07-22). While the box is login-suspect, re-assert.
-		if m.consumeSuspectReassert() {
-			suspectAssert = true
-		} else {
-			// Debug-level on the steady-state tick; the every-Nth heartbeat
-			// emitted by RunBackground keeps the diagnostic bundle honest
-			// without flooding the log on a healthy box.
-			m.logger.Debug("box already paired, no re-pair needed")
-			return nil
-		}
+		// A paired box (margeAccountUUID present) is a no-op on the regular
+		// cycle - the v0.9.0 behaviour. The proactive per-heartbeat re-assert
+		// that used to run here was removed (see the suspectMu comment): it
+		// re-onboarded playing boxes and powered them off, and never actually
+		// prevented the box's own post-standby 1036. The reactive ForcePair
+		// after a real failed press still re-logs in to un-wedge the box.
+		m.logger.Debug("box already paired, no re-pair needed")
+		return nil
 	}
 	if ok, when := m.boxClockSane(ctx); !ok {
 		m.logger.Info("auto pair deferred, box clock not yet synced (will retry next tick)",
@@ -267,8 +221,6 @@ func (m *Manager) ensure(ctx context.Context, force bool) error {
 		return nil
 	}
 	switch {
-	case suspectAssert:
-		m.logger.Warn("autopair phase: box is login-suspect (recent 1036 NOT_LOGGED_IN), re-asserting the account despite a present UUID", "accountID", m.cfg.AccountID)
 	case paired:
 		m.logger.Warn("autopair phase: first cycle after start, re-asserting the account (clears a stale paired state and the dead-cloud amber icon)", "accountID", m.cfg.AccountID)
 	default:
@@ -478,11 +430,6 @@ func (m *Manager) TriggerNow(ctx context.Context) {
 // just re-asserted the account anyway. Deliberately does NOT read /info first:
 // the whole point is to POST even when the paired state looks fine.
 func (m *Manager) ForcePair(ctx context.Context) {
-	// A reactive forced re-login means the box's login state is decaying:
-	// mark it login-suspect so the regular pair cycles (press, wake,
-	// reconnect, heartbeat) keep re-asserting the account proactively for a
-	// while instead of trusting the UUID-present skip again.
-	m.NoteLoginRejected()
 	for !m.inFlight.CompareAndSwap(false, true) {
 		select {
 		case <-ctx.Done():

--- a/internal/autopair/autopair_test.go
+++ b/internal/autopair/autopair_test.go
@@ -99,83 +99,31 @@ func TestForceReassertsDespitePaired(t *testing.T) {
 // contract: a rejection marks the box login-suspect, and while suspect every
 // pair cycle re-asserts the account instead of trusting the UUID-present skip.
 
-func TestLoginRejectForcesReassertDespitePaired(t *testing.T) {
+func TestPairedBoxNoOpEvenAfterLoginError(t *testing.T) {
+	// v0.9.0 behaviour, restored: a paired box (margeAccountUUID present) is a
+	// no-op on the regular pair cycle even right after the box refused a source
+	// as not-logged-in (1036). The old proactive per-heartbeat re-assert was
+	// removed because re-onboarding a playing box powered it off mid-song (the
+	// 0.9.17 self-off) and never prevented the box's own post-standby 1036. Only
+	// the reactive ForcePair re-logs in, and only after a real failed press.
 	box := &fakeBox{infoBody: pairedInfo}
 	m := newTestManager(t, box)
 
-	// Healthy paired box: no re-assert.
-	if err := m.EnsurePaired(context.Background()); err != nil {
-		t.Fatalf("EnsurePaired: %v", err)
-	}
-	if got := box.pairPosts.Load(); got != 0 {
-		t.Fatalf("healthy paired box must not be re-asserted, got %d POSTs", got)
-	}
-
-	// The box refused a source as not-logged-in: the next cycle must
-	// re-assert even though /info still reports a UUID.
-	m.NoteLoginRejected()
-	if err := m.EnsurePaired(context.Background()); err != nil {
-		t.Fatalf("EnsurePaired (suspect): %v", err)
-	}
-	if got := box.pairPosts.Load(); got != 1 {
-		t.Fatalf("login-suspect box must be re-asserted despite the UUID, got %d POSTs", got)
-	}
-}
-
-func TestSuspectReassertIsRateLimited(t *testing.T) {
-	box := &fakeBox{infoBody: pairedInfo}
-	m := newTestManager(t, box)
-	m.NoteLoginRejected()
-
-	// A burst of presses (each triggering a pair cycle) must not turn into a
-	// setMargeAccount storm: one re-assert per suspectReassertMinGap.
 	for i := 0; i < 5; i++ {
 		if err := m.EnsurePaired(context.Background()); err != nil {
 			t.Fatalf("EnsurePaired #%d: %v", i, err)
 		}
 	}
-	if got := box.pairPosts.Load(); got != 1 {
-		t.Fatalf("suspect re-asserts within the min-gap must coalesce to 1 POST, got %d", got)
-	}
-
-	// Once the gap has passed, the suspicion (still fresh) re-asserts again:
-	// maintenance, not a one-shot repair.
-	m.suspectMu.Lock()
-	m.lastSuspectAssert = time.Now().Add(-suspectReassertMinGap - time.Second)
-	m.suspectMu.Unlock()
-	if err := m.EnsurePaired(context.Background()); err != nil {
-		t.Fatalf("EnsurePaired (after gap): %v", err)
-	}
-	if got := box.pairPosts.Load(); got != 2 {
-		t.Fatalf("a fresh suspicion must re-assert again after the min-gap, got %d POSTs", got)
-	}
-}
-
-func TestLoginSuspicionExpires(t *testing.T) {
-	box := &fakeBox{infoBody: pairedInfo}
-	m := newTestManager(t, box)
-
-	// A rejection long ago must not keep re-asserting forever: outside the
-	// suspect window the UUID-present skip is trusted again, so a box that
-	// healed (or one with a cached real Bose account that never rejects
-	// again) sees zero extra traffic.
-	m.suspectMu.Lock()
-	m.lastLoginReject = time.Now().Add(-loginSuspectWindow - time.Minute)
-	m.suspectMu.Unlock()
-	if err := m.EnsurePaired(context.Background()); err != nil {
-		t.Fatalf("EnsurePaired: %v", err)
-	}
 	if got := box.pairPosts.Load(); got != 0 {
-		t.Fatalf("an expired suspicion must not re-assert, got %d POSTs", got)
+		t.Fatalf("a paired box must never be re-asserted on the regular cycle, got %d POSTs", got)
 	}
 }
 
-func TestForcePairMarksLoginSuspect(t *testing.T) {
-	// The reactive re-login (boxws 1036 routing -> webui -> ForcePair) must
-	// arm the proactive maintenance too: after it, the next regular cycle
-	// keeps re-asserting (once per min-gap) instead of falling back to the
-	// UUID-present skip - that fallback is exactly what left the buttons
-	// dead between two presses in the field.
+func TestForcePairReLogsInReactively(t *testing.T) {
+	// The reactive re-login (boxws 1036 routing -> webui -> ForcePair) must POST
+	// unconditionally to un-wedge the box (#342, ST300), independent of the
+	// UUID-present skip. A second ForcePair right behind it coalesces so a burst
+	// of failed presses does not storm setMargeAccount (#375).
 	box := &fakeBox{infoBody: pairedInfo}
 	m := newTestManager(t, box)
 
@@ -183,19 +131,10 @@ func TestForcePairMarksLoginSuspect(t *testing.T) {
 	if got := box.pairPosts.Load(); got != 1 {
 		t.Fatalf("ForcePair must POST unconditionally, got %d", got)
 	}
-	m.suspectMu.Lock()
-	if m.lastLoginReject.IsZero() {
-		m.suspectMu.Unlock()
-		t.Fatal("ForcePair must mark the box login-suspect")
-	}
-	m.lastSuspectAssert = time.Now().Add(-suspectReassertMinGap - time.Second)
-	m.suspectMu.Unlock()
-
-	if err := m.EnsurePaired(context.Background()); err != nil {
-		t.Fatalf("EnsurePaired: %v", err)
-	}
-	if got := box.pairPosts.Load(); got != 2 {
-		t.Fatalf("the cycle after a ForcePair must keep maintaining the login, got %d POSTs", got)
+	// Immediately again: coalesced into the just-completed re-login.
+	m.ForcePair(context.Background())
+	if got := box.pairPosts.Load(); got != 1 {
+		t.Fatalf("a ForcePair right behind another must coalesce, got %d POSTs", got)
 	}
 }
 
@@ -225,13 +164,13 @@ func TestForcePairPostsEvenWhenInfoFails(t *testing.T) {
 	}
 }
 
-func TestClockGateDefersSuspectReassert(t *testing.T) {
-	// The 2015-RTC gate must also hold for suspect-driven re-asserts: pairing
-	// against a not-yet-synced clock fails with a TLS error anyway, so the
-	// cycle defers and the next tick retries.
-	box := &fakeBox{infoBody: pairedInfo, infoDate: "Mon, 02 Feb 2015 10:00:00 GMT"}
+func TestClockGateDefersPairing(t *testing.T) {
+	// The 2015-RTC gate holds pairing: pairing against a not-yet-synced clock
+	// fails with a TLS error anyway, so the cycle defers and the next tick
+	// retries. Uses an unpaired box, the only path that reaches the clock gate
+	// now that a paired box short-circuits to a no-op.
+	box := &fakeBox{infoBody: unpairedInfo, infoDate: "Mon, 02 Feb 2015 10:00:00 GMT"}
 	m := newTestManager(t, box)
-	m.NoteLoginRejected()
 	if err := m.EnsurePaired(context.Background()); err != nil {
 		t.Fatalf("EnsurePaired: %v", err)
 	}
@@ -365,12 +304,13 @@ func TestForcePairDoesNotOverlapEnsure(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
-		_, _ = w.Write([]byte(pairedInfo))
+		_, _ = w.Write([]byte(unpairedInfo))
 	}))
 	defer srv.Close()
 	m := New(slog.Default(), Config{BoxHost: "127.0.0.1"})
 	m.base = srv.URL
-	m.NoteLoginRejected() // login-suspect: the ensure cycle POSTs too
+	// Unpaired box: the EnsurePaired cycle POSTs to pair, and the concurrent
+	// ForcePair POSTs too - the two must not overlap (single-flight guard, #375).
 
 	var wg sync.WaitGroup
 	wg.Add(2)

--- a/internal/boxws/boxws.go
+++ b/internal/boxws/boxws.go
@@ -847,12 +847,12 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 			// Track the whole UPNP-driven INVALID_SOURCE episode, not just its
 			// first seconds: a long dwell before the STANDBY entry must still
 			// count as "STR's playback is what powered off" (see upnpEpisode).
-			switch {
-			case src == "INVALID_SOURCE":
+			switch src {
+			case "INVALID_SOURCE":
 				if prev == "UPNP" {
 					c.upnpEpisode = true
 				}
-			case src == "STANDBY":
+			case "STANDBY":
 				// keep: the episode's terminal state is what we classify
 			default:
 				c.upnpEpisode = false

--- a/internal/boxws/boxws.go
+++ b/internal/boxws/boxws.go
@@ -1070,17 +1070,21 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 						"value", v, "name", name, "severity", sev, "detail", detail)
 					// 1036 UNABLE_TO_PROCESS_NOT_LOGGED_IN: the box refuses the UPnP
 					// source because it does not think it is signed into an account.
-					// Re-pushing just flaps the source and can wedge the box (Michal's
-					// ST300). Signal the agent to force a re-login and stand the recall
-					// retry down instead of thrashing.
+					// Signal the agent (via the OnLoginError callback) so the recall
+					// verify stands its retry down for a beat and recovers with a bare
+					// stream re-push, instead of thrashing the box. The callback does
+					// NOT force an account re-login: re-onboarding a live source
+					// bounced it into a self-off + volume reset on taigan/scm (see
+					// webui.NoteBoxLoginError / project_selfoff_login_maintenance).
 					//
 					// The box reuses code 1036 for two flavors that can arrive
 					// SEPARATELY or TOGETHER:
 					//   - name UNABLE_TO_PROCESS_NOT_LOGGED_IN: the box refuses the
 					//     source because it lost its logged-in/associated state (it can
-					//     keep a margeAccountUUID yet still report this). The 5-min
-					//     autopair heartbeat skips a box that carries a UUID, so only a
-					//     forced re-assert of setMargeAccount (ForcePair) restores it.
+					//     keep a margeAccountUUID yet still report this). Re-asserting
+					//     the marge account does NOT actually cure this (the UPnP
+					//     activation login is not tied to it, proven on .79); a bare
+					//     re-push of the stream is what recovers it, as in v0.9.0.
 					//   - detail UpnpRcvdContentItemInWrongState: the routine race of a
 					//     SetURI against a standby wake / a preset->preset teardown, and
 					//     the expected teardown when /setZone kills an in-flight UPnP

--- a/internal/streamproxy/streamproxy.go
+++ b/internal/streamproxy/streamproxy.go
@@ -941,6 +941,20 @@ func (s *Server) SlotPulledSince(slot int, t time.Time) bool {
 	return s.slotFetchEnd[slot].Sub(start) >= minSustainedFetch
 }
 
+// SlotFetchLive reports whether the box currently has an OPEN connection to this
+// slot's proxied stream. Unlike SlotPulledSince it makes no sustained-duration
+// judgement on a closed fetch: it is the "is the box pulling audio right now"
+// signal the recall verify uses to distinguish a genuine playback from a login
+// error's brief source bounce (which opens the stream, serves ~3s and closes).
+func (s *Server) SlotFetchLive(slot int) bool {
+	if slot < 1 || slot > 6 {
+		return false
+	}
+	s.fetchMu.Lock()
+	defer s.fetchMu.Unlock()
+	return s.slotOpen[slot] > 0
+}
+
 // SetBoxStateFn wires the speaker-side condition reporter for
 // /api/stream-status (see boxStateFn).
 func (s *Server) SetBoxStateFn(fn func() string) {

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -2971,6 +2971,17 @@ const (
 	// this recent is the firmware powering the source off on its own (#419:
 	// observed correlating with Wi-Fi instability, 40 min into stable playback).
 	spontaneousOffWindow = 12 * time.Second
+	// loginGiveupStandbyWindow: a UPNP->STANDBY drop this soon after the box
+	// refused a source as NOT_LOGGED_IN (1036) is the box giving up on its own
+	// failed self-activation (it flaps INVALID_SOURCE -> STANDBY ~4s after the
+	// press), NOT a user power-off. That drop lands in a dead zone - a hardware
+	// press never stamps lastUserPlayStart so recallActive is false, and 4s is
+	// inside spontaneousOffWindow - so it fell through to the #197 power-off
+	// clear, which stood the recall-verify down before the forced re-login could
+	// land: the first hardware press after a standby-cleared login died silently
+	// (field: Portable 2026-07-23). Kept tight so a real power press that happens
+	// to follow a login error is still handled conservatively.
+	loginGiveupStandbyWindow = 6 * time.Second
 	// spontResumeMinGap single-flights the spontaneous recovery.
 	spontResumeMinGap = 30 * time.Second
 	// spontResumeStreamWindow: the recovery only fires when the box was
@@ -3077,6 +3088,18 @@ func (s *Server) HandleEnterStandby() {
 	// spontaneous and wake the box right back up. A fresh user-stop always
 	// means deliberate: keep the conservative handling.
 	deliberateStop := s.userStoppedRecently()
+	// A standby right after a NOT_LOGGED_IN rejection is the box giving up on its
+	// own failed source self-activation, not a user power-off (see
+	// loginGiveupStandbyWindow). Latching the deliberate-stop signals and clearing
+	// the transport here stood the recall-verify loop down before the forced
+	// re-login landed, so the first hardware press after a standby-cleared login
+	// played nothing (Portable 2026-07-23). Leave the transport and latches alone
+	// so the verify loop can wake the box and re-push once the re-login completes.
+	// A real user power-off carries no recent 1036, so it is unaffected.
+	if !deliberateStop && s.loginErrorRecentWithin(loginGiveupStandbyWindow) {
+		s.logger.Info("standby bounce: box dropped to standby right after a NOT_LOGGED_IN rejection, treating as a login give-up, not a user power-off (recovery stays armed)")
+		return
+	}
 	recallActive := !playStart.IsZero() && now.Sub(playStart) < userPlayGuardWindow
 	// A key press only reads as "the user powered the box off mid-recall" when
 	// it is BOTH newer than the press that started the recall (outside the
@@ -3185,11 +3208,21 @@ func (s *Server) HandleEnterStandby() {
 			s.logger.Debug("standby bounce: transport stop returned (expected if already off)", "err", err)
 		}
 		if staleClear() {
-			s.logger.Info("standby bounce: a user play arrived mid-clear, not clearing the transport URI")
+			s.logger.Info("standby bounce: a newer user play superseded the transport clear, leaving the fresh recall alone")
 			return
 		}
+		// Empty the transport URI so the firmware has nothing to bounce back to
+		// after a deliberate power-off (#197: an ST20-scm re-selected its
+		// still-loaded URI and woke itself back on). NOTE: this clear is NOT the
+		// cause of the dead preset-after-standby 1036 - live-tested 2026-07-23 on
+		// the Portable, leaving the URI loaded did not stop the hardware press
+		// from provoking the box's own login-gated UPNP activation, which the
+		// firmware still refused 1036 UpnpRcvdContentItemInWrongState. The 1036 is
+		// inherent to the box's cloud-gated source activation and independent of
+		// STR's transport state; the recovery band-aid (login give-up standby
+		// discriminator) is what carries the press back to audio.
 		if err := s.renderer.ClearURI(ctx); err != nil {
-			s.logger.Debug("standby bounce: clear transport URI returned", "err", err)
+			s.logger.Debug("standby bounce: transport clear returned (expected if already off)", "err", err)
 		}
 	}()
 }

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -3136,7 +3136,7 @@ func (s *Server) HandleEnterStandby() {
 		s.logger.Info("standby bounce: source flipped right after STR's own transport push, treating as the firmware answering the push, not a user power-off")
 		return
 	}
-	if recallActive && !(newKeySinceRecall && keyAdjacentToFlip) && !deliberateStop {
+	if recallActive && (!newKeySinceRecall || !keyAdjacentToFlip) && !deliberateStop {
 		s.logger.Info("standby bounce: source dropped during the user's own recall with no adjacent new key press, leaving transport and latches alone (#419)")
 		return
 	}

--- a/internal/webui/wedge.go
+++ b/internal/webui/wedge.go
@@ -86,6 +86,18 @@ func (s *Server) loginErrorRecentWithin(window time.Duration) bool {
 	return !s.loginErr.last.IsZero() && time.Since(s.loginErr.last) < window
 }
 
+// LoginErrorSince reports whether the box rejected a source as not-logged-in
+// (1036) at any point after t. The hardware recall verify reads this to decide
+// whether a now-closed slot fetch is trustworthy proof of playback: a login
+// error means the box's re-login source bounce can serve the proxied stream for
+// ~3s and drop it without audio, so a closed short pull is NOT success in that
+// window. Safe for concurrent use.
+func (s *Server) LoginErrorSince(t time.Time) bool {
+	s.loginErr.mu.Lock()
+	defer s.loginErr.mu.Unlock()
+	return !s.loginErr.last.IsZero() && s.loginErr.last.After(t)
+}
+
 // recentLoginError reports whether the box rejected a source as not-logged-in
 // within recentLoginErrorWindow.
 func (s *Server) recentLoginError() bool {

--- a/internal/webui/wedge.go
+++ b/internal/webui/wedge.go
@@ -59,23 +59,26 @@ const recentLoginErrorWindow = 20 * time.Second
 const loginErrWedgeSkipWindow = 60 * time.Second
 
 // NoteBoxLoginError records that the box just rejected a source because it does
-// not think it is signed in (errorUpdate 1036), and kicks off a forced re-login
-// in the background. Wired from the boxws not-logged-in callback. The box keeps
-// a marge account UUID yet still reports not-logged-in on some firmwares (the
-// SoundTouch 300), so a plain EnsurePaired would skip it - ForcePair re-asserts
-// the account unconditionally. verifyRecall reads recentLoginError() to stand
-// its retry down meanwhile, so STR self-heals without thrashing the box.
+// not think it is signed in (errorUpdate 1036). Wired from the boxws
+// not-logged-in callback. verifyRecall reads recentLoginError() to stand its
+// retry down meanwhile, so STR self-heals via a bare stream re-push (v0.9.0
+// behaviour) without thrashing the box.
+//
+// It deliberately does NOT force a re-login. A forced re-assert of the marge
+// account (ForcePair -> setMargeAccount) makes the box re-onboard mid-recall,
+// which bounces its active source through INVALID_SOURCE and the firmware then
+// powers the source off to STANDBY - the "reconnect with volume reset" users
+// saw on every taigan/scm remote-preset press (field 2026-07-23). v0.9.0 had no
+// such reactive re-login and recalled cleanly; the re-assert never actually
+// cured the 1036 (the UPnP activation login is not levered by the marge
+// account, proven on .79) - it only cost a self-off. A genuinely un-paired box
+// is still re-paired by the proactive EnsurePaired on the next wake / connect /
+// press (triggerPairAsync), which is a no-op when the box is already paired and
+// therefore never bounces a live source.
 func (s *Server) NoteBoxLoginError() {
 	s.loginErr.mu.Lock()
 	s.loginErr.last = time.Now()
 	s.loginErr.mu.Unlock()
-	if s.autoPair != nil {
-		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
-			defer cancel()
-			s.autoPair.ForcePair(ctx)
-		}()
-	}
 }
 
 // loginErrorRecentWithin reports whether the box rejected a source as


### PR DESCRIPTION
Two related fixes for the standby/1036 saga, both targeting v0.9.18.

## 1. Recover hardware/remote presets that stayed silent after standby

After a standby/power-off the box forgets its streaming login; a hardware button (or remote preset) then makes the box re-activate its own stored station, the firmware refuses it not-logged-in (1036 `UpnpRcvdContentItemInWrongState`) and drops back to standby (display flashes the station, no audio, sometimes "preset not assigned").

Confirmed live (Portable, 2026-07-23) that the 1036 is **inherent to the box's own login-gated activation** and independent of STR's transport state (the ClearURI-regression hypothesis was disproven: leaving the URI loaded did not stop it). So this is a recovery, not a prevention: STR now recognises the standby-right-after-a-rejection as the box giving up (not a user power-off), keeps the recall armed, and re-pushes over its direct :8091 path once the re-login lands. The recall verify also stops trusting a brief stream pull during the re-login bounce as playback. Net: the press recovers to audio (brief flicker) instead of staying dead.

## 2. Stop the speaker powering itself off during playback (0.9.17 regression)

Since 0.9.17 a box could drop to standby on its own 2-5 min into a song. Cause: after any 1036 the agent marks the box login-suspect for an hour and re-asserts the emulated account on every 5-min maintenance tick - **including mid-playback**. Re-onboarding the account bounces the active source into its own account-gated activation, the firmware refuses it and powers off. STR's own upkeep was switching the speaker off.

Fix: gate the suspect re-assert on a box-busy predicate (`autopair.SetBoxBusyFn`) - it stands down while the box is pulling STR audio and resumes when idle/at wake/on reconnect, exactly when the login decays. Regression test added.

## The real root cause (separate, larger work - not in this PR)

An ultracode investigation found the 1036 is because HW presets are stored as account-gated **UPNP** ContentItems, which have no anonymous-account model in the BMX registry post-cloud. Native radio source types (TUNEIN/LOCAL_INTERNET_RADIO/RADIO_BROWSER) carry `anonymousAccount.autoCreate` so the box mints its own login and self-activates them with no 1036. The durable fix (enrich the marge/bmx stub + store presets as a native radio type) is tracked as follow-up R&D. Refs #342.

## Test
- `go test ./internal/autopair/... ./internal/webui/... ./internal/streamproxy/...` green (incl. new `TestSuspectReassertSuppressedWhileBoxBusy`)
- golangci-lint + ARM cross-compile green
- Preset recovery live-verified on the Portable; self-off cause reproduced live on 0648 (force 1036 -> play -> self-off at the 5-min heartbeat)