### PR TITLE
fix(radio): play legacy SHOUTcast stations that answer with "ICY 200 OK"

### DIFF
--- a/internal/streamproxy/icyconn_test.go
+++ b/internal/streamproxy/icyconn_test.go
@@ -1,0 +1,91 @@
+package streamproxy
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+)
+
+// serveOnce accepts one connection, discards the request, writes raw, closes.
+func serveOnce(t *testing.T, raw string) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		// Read (and drop) the request line so the client's write completes.
+		_, _ = bufio.NewReader(c).ReadString('\n')
+		_, _ = io.WriteString(c, raw)
+	}()
+	return ln
+}
+
+// TestICYConnRewritesShoutcastStatusLine is the regression guard for legacy
+// SHOUTcast stations (e.g. Radio Studio D) that answer with "ICY 200 OK" instead
+// of an HTTP status line: without the rewrite, http.ReadResponse rejects it and
+// the stream never plays.
+func TestICYConnRewritesShoutcastStatusLine(t *testing.T) {
+	ln := serveOnce(t, "ICY 200 OK\r\nContent-Type: audio/mpeg\r\nicy-br:128\r\n\r\nHELLOAUDIO")
+	defer ln.Close()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	_, _ = io.WriteString(conn, "GET /; HTTP/1.1\r\nHost: x\r\n\r\n")
+
+	ic := &icyConn{Conn: conn, br: bufio.NewReader(conn)}
+	resp, err := http.ReadResponse(bufio.NewReader(ic), nil)
+	if err != nil {
+		t.Fatalf("ReadResponse on an ICY response: %v (the rewrite did not take)", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "audio/mpeg" {
+		t.Fatalf("Content-Type = %q, want audio/mpeg (headers after the status line must survive)", ct)
+	}
+	if br := resp.Header.Get("icy-br"); br != "128" {
+		t.Fatalf("icy-br = %q, want 128", br)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "HELLOAUDIO" {
+		t.Fatalf("body = %q, want HELLOAUDIO (audio after the headers must survive)", string(body))
+	}
+}
+
+// TestICYConnLeavesHTTPUntouched confirms a normal HTTP response is passed
+// through byte-for-byte (the rewrite only triggers on a leading "ICY ").
+func TestICYConnLeavesHTTPUntouched(t *testing.T) {
+	ln := serveOnce(t, "HTTP/1.1 200 OK\r\nContent-Type: audio/aacp\r\n\r\nAACDATA")
+	defer ln.Close()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	_, _ = io.WriteString(conn, "GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+
+	ic := &icyConn{Conn: conn, br: bufio.NewReader(conn)}
+	resp, err := http.ReadResponse(bufio.NewReader(ic), nil)
+	if err != nil {
+		t.Fatalf("ReadResponse on plain HTTP: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || resp.Header.Get("Content-Type") != "audio/aacp" {
+		t.Fatalf("plain HTTP response was altered: status=%d ct=%q", resp.StatusCode, resp.Header.Get("Content-Type"))
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "AACDATA" {
+		t.Fatalf("body = %q, want AACDATA", string(body))
+	}
+}

--- a/internal/streamproxy/streamproxy.go
+++ b/internal/streamproxy/streamproxy.go
@@ -17,6 +17,7 @@
 package streamproxy
 
 import (
+	"bufio"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -394,6 +395,22 @@ func New(store *presets.Store, logger *slog.Logger) *Server {
 	// radio-browser URL cannot point the box at its own loopback services or
 	// cloud metadata.
 	baseDialer := &net.Dialer{Control: netutil.DialGuardSSRF}
+	// Legacy SHOUTcast v1 servers answer the stream request with an "ICY 200 OK"
+	// status line instead of "HTTP/1.0 200 OK". Go's net/http rejects that as a
+	// malformed response ("Received HTTP/0.9 when not allowed"), so those stations
+	// never play on STR even though media players (and other radio-browser apps)
+	// handle them fine - the whole class of old SHOUTcast stations was silently
+	// broken (field: "Radio Studio D" http://...:8018/;). This dialer wraps the
+	// plain-HTTP connection so the first response line's "ICY" prefix is rewritten
+	// to "HTTP/1.0" before Go parses it; everything else (headers, ICY metadata,
+	// audio) is untouched. HTTPS is left to dialTLS (SHOUTcast-over-TLS is rare).
+	icyDial := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		raw, err := baseDialer.DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		return &icyConn{Conn: raw, br: bufio.NewReader(raw)}, nil
+	}
 	// DialTLSContext handles HTTPS itself so the clock-tolerant verification has
 	// the real dial host (including a bare-IP host, for which the client sends
 	// no SNI and tls.ConnectionState.ServerName would be empty). It reuses the
@@ -427,7 +444,7 @@ func New(store *presets.Store, logger *slog.Logger) *Server {
 		client: &http.Client{
 			Transport: &http.Transport{
 				Proxy:                 http.ProxyFromEnvironment,
-				DialContext:           baseDialer.DialContext,
+				DialContext:           icyDial,
 				DialTLSContext:        dialTLS,
 				ForceAttemptHTTP2:     true,
 				MaxIdleConns:          100,
@@ -438,6 +455,42 @@ func New(store *presets.Store, logger *slog.Logger) *Server {
 		lastFail:   make(map[string]time.Time),
 		measuredBr: make(map[string]int),
 	}
+}
+
+// icyConn wraps a net.Conn so a legacy SHOUTcast "ICY 200 OK" response line is
+// rewritten to "HTTP/1.0 200 OK" on the first read, letting Go's net/http parse
+// the response instead of rejecting it. All bytes after the status line (headers,
+// the ICY-interleaved audio) pass through unchanged. Only the very first line is
+// inspected; a normal "HTTP/1.x ..." response is left exactly as received.
+type icyConn struct {
+	net.Conn
+	br        *bufio.Reader
+	inspected bool
+	prefix    []byte // rewritten status-line bytes not yet handed to the caller
+}
+
+func (c *icyConn) Read(p []byte) (int, error) {
+	if !c.inspected {
+		c.inspected = true
+		// Peek only as far as the protocol token; blocks until the response
+		// arrives, which is exactly when http.Transport issues its first read.
+		if head, err := c.br.Peek(4); err == nil && string(head[:3]) == "ICY" && (head[3] == ' ' || head[3] == '\t') {
+			if line, err := c.br.ReadString('\n'); err == nil {
+				// "ICY 200 OK\r\n" -> "HTTP/1.0 200 OK\r\n" (keep the rest verbatim).
+				c.prefix = append([]byte("HTTP/1.0"), line[3:]...)
+			} else {
+				// No full line yet: hand back what we consumed unchanged so we
+				// never lose bytes; the transport will keep reading.
+				c.prefix = []byte(line)
+			}
+		}
+	}
+	if len(c.prefix) > 0 {
+		n := copy(p, c.prefix)
+		c.prefix = c.prefix[n:]
+		return n, nil
+	}
+	return c.br.Read(p)
 }
 
 // minPlausibleClock is a lower bound on a trustworthy wall clock. STR shipped in


### PR DESCRIPTION
## Problem
Some radio-browser stations run legacy SHOUTcast v1 servers that reply to the stream request with `ICY 200 OK` instead of `HTTP/1.0 200 OK`. Go's `net/http` rejects that (`malformed HTTP version "ICY"`), so the stream proxy could never fetch them and the station played nothing - even though media players and other radio-browser apps handle them fine.

Reported station: **Radio Studio D** (`http://studiod.omerovic.info:8018/;`).

## Fix
The plain-HTTP dialer wraps the connection (`icyConn`) and rewrites a leading `ICY` status line to `HTTP/1.0` before net/http parses it. Headers, ICY metadata and audio pass through unchanged; a normal HTTP response is byte-for-byte untouched. SSRF guard and TLS path unaffected.

## Verified live against the reported station
```
[PLAIN net/http]  FEHLER: malformed HTTP version "ICY"   <- the user-facing failure
[WITH ICY FIX]    status=200 ct="audio/mpeg" icy-br="128" audio bytes flowing
```
Plus unit tests: ICY rewrite parses as HTTP 200 with headers+body intact, and a plain HTTP response is left unchanged. Fixes a whole class of legacy SHOUTcast stations. Targeted for 0.9.19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)