### PR TITLE
feat(app): reliable update + engine delivery, self-identifying diagnostics, standby volume fix

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -660,6 +660,10 @@ func run() error {
 	// userActivityUpdate key frame) from the firmware spontaneously powering
 	// off STR's UPnP source (#419).
 	webuiSrv.SetUserActivityFn(wsClient.LastUserActivity)
+	// The volume restore consults the same signal so a hand-adjusted level
+	// during a recall recovery is never clamped back to the pre-recall
+	// snapshot (which after a deep standby is the box's own wake default).
+	wsHandler.lastUserActivity = wsClient.LastUserActivity
 
 	// When the box rejects a source as not-logged-in (errorUpdate 1036, seen on
 	// the SoundTouch 300), force a re-login and stand the recall retry down so
@@ -1175,6 +1179,12 @@ type presetWsHandler struct {
 	// over gabbo (STOP_STATE). Wired to webui.NoteUserStop so the auto-re-push
 	// does not fight a wanted stop. nil-safe.
 	onUserStop func()
+	// lastUserActivity reports when the box last emitted a userActivityUpdate
+	// (any physical key on the box or IR remote). Wired to
+	// boxws.Client.LastUserActivity; nil-safe. The volume restore consults it
+	// so a level the user chose BY HAND during a recall recovery is never
+	// overridden.
+	lastUserActivity func() time.Time
 	// lastUserStop is when OnUserStop last fired (guarded by lastUserStopMu).
 	// The hardware recall verifies (verifyPlayURL / verifySpotifyPlaying)
 	// compare it against their recall start so a deliberate stop DURING the
@@ -2292,6 +2302,18 @@ func (h *presetWsHandler) playSpotifyPreset(ctx context.Context, seq uint64, pre
 	h.logger.Info("spotify preset recalled", "slot", slot, "name", p.Name, "account", p.Account)
 }
 
+// userAdjustedSince reports whether the box saw a physical key press (any
+// userActivityUpdate) after anchor plus a small epsilon. The epsilon exists
+// because the anchoring press ITSELF emits a userActivityUpdate; anything
+// later means the user interacted with the box again. nil-safe: without the
+// boxws wiring (tests, exotic firmware) it reads as "no interaction".
+func (h *presetWsHandler) userAdjustedSince(anchor time.Time) bool {
+	if h.lastUserActivity == nil {
+		return false
+	}
+	return h.lastUserActivity().After(anchor.Add(2 * time.Second))
+}
+
 // readBoxVolume returns the box's current target volume (0 on any error / no box
 // host). Best-effort, used to remember the user's level across a recall.
 func (h *presetWsHandler) readBoxVolume() int {
@@ -2306,12 +2328,25 @@ func (h *presetWsHandler) readBoxVolume() int {
 	return 0
 }
 
-// restorePreRecallVolume re-applies the volume the user had before a recall when
+// restorePreRecallVolume re-applies the volume the box had before a recall when
 // a 1036-standby recovery reset it (the box forgets its volume across standby and
 // comes back at its own default after STR wakes it). No-op when the volume is
 // unknown or unchanged, so the happy path (no standby) never touches it.
-func (h *presetWsHandler) restorePreRecallVolume(preVol int) {
+//
+// The pre-recall snapshot is NOT always the user's chosen level: a press right
+// after a deep standby reads the box's own low wake default (10 on a spotty
+// ST20), and blindly re-applying that forced the level back DOWN over the
+// user's manual correction during the ~25 s recovery window (#435 bundle,
+// "from=34 to=10", twice). A physical volume change emits a
+// userActivityUpdate, so any user activity after the press (plus a small
+// epsilon, since the press itself emits one) means the CURRENT level is the
+// user's choice and the restore stands down.
+func (h *presetWsHandler) restorePreRecallVolume(pressAt time.Time, preVol int) {
 	if preVol <= 0 || h.boxHost == "" {
+		return
+	}
+	if h.userAdjustedSince(pressAt) {
+		h.logger.Info("volume restore stood down: user adjusted the box during the recovery", "preVol", preVol)
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -2384,7 +2419,7 @@ func (h *presetWsHandler) verifyPlayURL(seq, gen uint64, pressAt time.Time, slot
 		// had already opened the new stream, so a location check alone declared a
 		// healthy recall dead and the "repair" tore the working stream down.
 		if h.recallReachedAudio(slot, url, pressAt) {
-			h.restorePreRecallVolume(preVol)
+			h.restorePreRecallVolume(pressAt, preVol)
 			if h.noteBoxHealthy != nil {
 				h.noteBoxHealthy()
 			}
@@ -2452,7 +2487,7 @@ func (h *presetWsHandler) verifyPlayURL(seq, gen uint64, pressAt time.Time, slot
 		// restore the user's level right after the wake so the recovered preset
 		// does not play the room loud for the seconds until the loop-top success
 		// check would otherwise restore it. Idempotent (no-op when unchanged).
-		h.restorePreRecallVolume(preVol)
+		h.restorePreRecallVolume(pressAt, preVol)
 		// Final gate before the push: the wake can take seconds, and a stop or
 		// power press during it must hold.
 		if standDown() {

--- a/cmd/agent/recall_verify_stop_test.go
+++ b/cmd/agent/recall_verify_stop_test.go
@@ -77,3 +77,29 @@ func TestPresetWsHandlerOnUserStopNilHook(t *testing.T) {
 		t.Fatal("stop must be recorded even without the webui hook")
 	}
 }
+
+// The volume restore after a 1036-standby recovery must stand down when the
+// user physically adjusted the box after the press: the pre-recall snapshot
+// taken right after a deep standby is the box's own wake default (10 on a
+// spotty ST20), and re-applying it clamped a hand-raised level back down
+// (#435 bundle, "restored user volume ... from=34 to=10").
+func TestUserAdjustedSince(t *testing.T) {
+	h := &presetWsHandler{}
+	pressAt := time.Now().Add(-30 * time.Second)
+	if h.userAdjustedSince(pressAt) {
+		t.Fatal("without boxws wiring the gate must read as no interaction")
+	}
+
+	// The press's own userActivityUpdate lands within the epsilon: no veto.
+	act := pressAt.Add(500 * time.Millisecond)
+	h.lastUserActivity = func() time.Time { return act }
+	if h.userAdjustedSince(pressAt) {
+		t.Fatal("the press's own activity frame must not read as an adjustment")
+	}
+
+	// A later key press (volume keys mid-recovery) must veto the restore.
+	act = pressAt.Add(10 * time.Second)
+	if !h.userAdjustedSince(pressAt) {
+		t.Fatal("a key press after the epsilon must veto the volume restore")
+	}
+}

--- a/desktop-app/frontend/package-lock.json
+++ b/desktop-app/frontend/package-lock.json
@@ -871,9 +871,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -931,9 +931,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -951,7 +951,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/desktop-app/frontend/src/i18n/bundles/ar.json
+++ b/desktop-app/frontend/src/i18n/bundles/ar.json
@@ -1177,5 +1177,13 @@
   "group.addedToast": "تمت إضافة {{name}} إلى المجموعة",
   "group.removedToast": "تمت إزالة {{name}} من المجموعة",
   "settingsView.copyPresetsProgress": "جارٍ نقل الإعدادات المسبقة وتسجيل دخول Spotify إلى السمّاعة...",
-  "settingsView.copyPresetsBusyBtn": "جارٍ النقل..."
+  "settingsView.copyPresetsBusyBtn": "جارٍ النقل...",
+  "spotify.engineMissingTitle": "Spotify engine not installed on {{name}}",
+  "spotify.engineMissingLine": "Spotify presets need a small engine on the speaker. Install it to play Spotify from the preset buttons.",
+  "spotify.engineInstallBtn": "Install Spotify engine",
+  "spotify.engineInstalling": "Installing...",
+  "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
+  "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
+  "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
 }

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -1186,5 +1186,13 @@
   "group.addedToast": "{{name}} zur Gruppe hinzugefügt",
   "group.removedToast": "{{name}} aus der Gruppe entfernt",
   "settingsView.copyPresetsProgress": "Übertrage Presets und Spotify-Login auf den Lautsprecher...",
-  "settingsView.copyPresetsBusyBtn": "Übertrage..."
+  "settingsView.copyPresetsBusyBtn": "Übertrage...",
+  "spotify.engineMissingTitle": "Spotify-Engine auf {{name}} nicht installiert",
+  "spotify.engineMissingLine": "Spotify-Presets brauchen eine kleine Engine auf dem Lautsprecher. Installiere sie, um Spotify über die Preset-Tasten abzuspielen.",
+  "spotify.engineInstallBtn": "Spotify-Engine installieren",
+  "spotify.engineInstalling": "Installiere...",
+  "spotify.engineTooFull": "Nicht genug freier Speicher auf dem Lautsprecher für die Spotify-Engine. Entferne andere SoundTouch-Zusatzsoftware davon, um Platz zu schaffen, und versuche es erneut.",
+  "spotify.engineTooFullNamed": "Nicht genug freier Speicher für die Spotify-Engine. Entferne zuerst diese andere SoundTouch-Software vom Lautsprecher: {{software}}. Danach erneut versuchen.",
+  "spotify.engineInstallFailed": "Die Spotify-Engine konnte nicht installiert werden. Bitte erneut versuchen.",
+  "spotify.engineDeferredVisible": "Lautsprecher aktualisiert. Die Spotify-Engine ist noch nicht installiert - du kannst sie auf dem Lautsprecher-Bildschirm installieren."
 }

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -1186,5 +1186,13 @@
   "group.addedToast": "{{name}} added to the group",
   "group.removedToast": "{{name}} removed from the group",
   "settingsView.copyPresetsProgress": "Transferring presets and Spotify login to the speaker...",
-  "settingsView.copyPresetsBusyBtn": "Transferring..."
+  "settingsView.copyPresetsBusyBtn": "Transferring...",
+  "spotify.engineMissingTitle": "Spotify engine not installed on {{name}}",
+  "spotify.engineMissingLine": "Spotify presets need a small engine on the speaker. Install it to play Spotify from the preset buttons.",
+  "spotify.engineInstallBtn": "Install Spotify engine",
+  "spotify.engineInstalling": "Installing...",
+  "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
+  "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
+  "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
 }

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -1177,5 +1177,13 @@
   "group.addedToast": "{{name}} añadido al grupo",
   "group.removedToast": "{{name}} quitado del grupo",
   "settingsView.copyPresetsProgress": "Transfiriendo presintonías e inicio de sesión de Spotify al altavoz...",
-  "settingsView.copyPresetsBusyBtn": "Transfiriendo..."
+  "settingsView.copyPresetsBusyBtn": "Transfiriendo...",
+  "spotify.engineMissingTitle": "Spotify engine not installed on {{name}}",
+  "spotify.engineMissingLine": "Spotify presets need a small engine on the speaker. Install it to play Spotify from the preset buttons.",
+  "spotify.engineInstallBtn": "Install Spotify engine",
+  "spotify.engineInstalling": "Installing...",
+  "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
+  "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
+  "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
 }

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -1177,5 +1177,13 @@
   "group.addedToast": "{{name}} ajouté au groupe",
   "group.removedToast": "{{name}} retiré du groupe",
   "settingsView.copyPresetsProgress": "Transfert des préréglages et de la connexion Spotify vers l'enceinte...",
-  "settingsView.copyPresetsBusyBtn": "Transfert..."
+  "settingsView.copyPresetsBusyBtn": "Transfert...",
+  "spotify.engineMissingTitle": "Spotify engine not installed on {{name}}",
+  "spotify.engineMissingLine": "Spotify presets need a small engine on the speaker. Install it to play Spotify from the preset buttons.",
+  "spotify.engineInstallBtn": "Install Spotify engine",
+  "spotify.engineInstalling": "Installing...",
+  "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
+  "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
+  "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
 }

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -1177,5 +1177,13 @@
   "group.addedToast": "{{name}} をグループに追加しました",
   "group.removedToast": "{{name}} をグループから外しました",
   "settingsView.copyPresetsProgress": "プリセットとSpotifyログインをスピーカーに転送しています...",
-  "settingsView.copyPresetsBusyBtn": "転送中..."
+  "settingsView.copyPresetsBusyBtn": "転送中...",
+  "spotify.engineMissingTitle": "Spotify engine not installed on {{name}}",
+  "spotify.engineMissingLine": "Spotify presets need a small engine on the speaker. Install it to play Spotify from the preset buttons.",
+  "spotify.engineInstallBtn": "Install Spotify engine",
+  "spotify.engineInstalling": "Installing...",
+  "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
+  "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
+  "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
 }

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -1177,5 +1177,13 @@
   "group.addedToast": "{{name}} pridėta į grupę",
   "group.removedToast": "{{name}} pašalinta iš grupės",
   "settingsView.copyPresetsProgress": "Išankstiniai nustatymai ir Spotify prisijungimas perkeliami į garsiakalbį...",
-  "settingsView.copyPresetsBusyBtn": "Perkeliama..."
+  "settingsView.copyPresetsBusyBtn": "Perkeliama...",
+  "spotify.engineMissingTitle": "Spotify engine not installed on {{name}}",
+  "spotify.engineMissingLine": "Spotify presets need a small engine on the speaker. Install it to play Spotify from the preset buttons.",
+  "spotify.engineInstallBtn": "Install Spotify engine",
+  "spotify.engineInstalling": "Installing...",
+  "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
+  "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
+  "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
 }

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -1177,5 +1177,13 @@
   "group.addedToast": "{{name}} pievienots grupai",
   "group.removedToast": "{{name}} noņemts no grupas",
   "settingsView.copyPresetsProgress": "Notiek priekšiestatījumu un Spotify pieteikšanās pārsūtīšana uz skaļruni...",
-  "settingsView.copyPresetsBusyBtn": "Notiek pārsūtīšana..."
+  "settingsView.copyPresetsBusyBtn": "Notiek pārsūtīšana...",
+  "spotify.engineMissingTitle": "Spotify engine not installed on {{name}}",
+  "spotify.engineMissingLine": "Spotify presets need a small engine on the speaker. Install it to play Spotify from the preset buttons.",
+  "spotify.engineInstallBtn": "Install Spotify engine",
+  "spotify.engineInstalling": "Installing...",
+  "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
+  "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
+  "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
 }

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -1177,5 +1177,13 @@
   "group.addedToast": "{{name}} aan de groep toegevoegd",
   "group.removedToast": "{{name}} uit de groep verwijderd",
   "settingsView.copyPresetsProgress": "Presets en Spotify-login worden naar de speaker overgezet...",
-  "settingsView.copyPresetsBusyBtn": "Bezig met overzetten..."
+  "settingsView.copyPresetsBusyBtn": "Bezig met overzetten...",
+  "spotify.engineMissingTitle": "Spotify engine not installed on {{name}}",
+  "spotify.engineMissingLine": "Spotify presets need a small engine on the speaker. Install it to play Spotify from the preset buttons.",
+  "spotify.engineInstallBtn": "Install Spotify engine",
+  "spotify.engineInstalling": "Installing...",
+  "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
+  "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
+  "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
 }

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -1177,5 +1177,13 @@
   "group.addedToast": "Dodano {{name}} do grupy",
   "group.removedToast": "Usunięto {{name}} z grupy",
   "settingsView.copyPresetsProgress": "Przenoszenie presetów i logowania Spotify do głośnika...",
-  "settingsView.copyPresetsBusyBtn": "Przenoszenie..."
+  "settingsView.copyPresetsBusyBtn": "Przenoszenie...",
+  "spotify.engineMissingTitle": "Spotify engine not installed on {{name}}",
+  "spotify.engineMissingLine": "Spotify presets need a small engine on the speaker. Install it to play Spotify from the preset buttons.",
+  "spotify.engineInstallBtn": "Install Spotify engine",
+  "spotify.engineInstalling": "Installing...",
+  "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
+  "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
+  "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
 }

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -1177,5 +1177,13 @@
   "group.addedToast": "{{name}} gruba eklendi",
   "group.removedToast": "{{name}} gruptan çıkarıldı",
   "settingsView.copyPresetsProgress": "Ön ayarlar ve Spotify oturumu hoparlöre aktarılıyor...",
-  "settingsView.copyPresetsBusyBtn": "Aktarılıyor..."
+  "settingsView.copyPresetsBusyBtn": "Aktarılıyor...",
+  "spotify.engineMissingTitle": "Spotify engine not installed on {{name}}",
+  "spotify.engineMissingLine": "Spotify presets need a small engine on the speaker. Install it to play Spotify from the preset buttons.",
+  "spotify.engineInstallBtn": "Install Spotify engine",
+  "spotify.engineInstalling": "Installing...",
+  "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
+  "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
+  "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
 }

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -1177,5 +1177,13 @@
   "group.addedToast": "{{name}} додано до групи",
   "group.removedToast": "{{name}} вилучено з групи",
   "settingsView.copyPresetsProgress": "Перенесення пресетів і входу Spotify на динамік...",
-  "settingsView.copyPresetsBusyBtn": "Перенесення..."
+  "settingsView.copyPresetsBusyBtn": "Перенесення...",
+  "spotify.engineMissingTitle": "Spotify engine not installed on {{name}}",
+  "spotify.engineMissingLine": "Spotify presets need a small engine on the speaker. Install it to play Spotify from the preset buttons.",
+  "spotify.engineInstallBtn": "Install Spotify engine",
+  "spotify.engineInstalling": "Installing...",
+  "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
+  "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
+  "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
 }

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -2765,8 +2765,20 @@ async function runBoxUpdate(box, onPhase) {
     // Journal the real verdict and classify why (unreachable / not landed /
     // landed-but-not-running), feeding the loop breaker so an update that
     // cannot stick is not re-offered as a fresh one-click push forever.
-    try { noteOTAFailure(box, await ClassifyOTAResult(box.host, box.port)); } catch {}
-    return { outcome: 'timeout', version: null };
+    let cls = '';
+    try { cls = await ClassifyOTAResult(box.host, box.port); } catch {}
+    // "confirmed" = the box IS on the new build, it just crossed the verify
+    // window late (slow boot / late reachability). Treating that as a timeout
+    // made update-all report a perfectly updated ST10 as stuck (live
+    // 2026-07-25, "confirmed late" at +6 min). Count it as updated and fall
+    // through to the engine step like any confirmed box.
+    if (cls === 'confirmed') {
+      try { confirmedVer = await BoxAgentVersion(box.host, box.port); } catch {}
+    }
+    if (!confirmedVer) {
+      try { noteOTAFailure(box, cls); } catch {}
+      return { outcome: 'timeout', version: null };
+    }
   }
   clearOTAStuck(box);
   try { RecordOTAOutcome(box.host, `confirmed: box is on build ${confirmedVer.build || '?'} (stability window passed)`); } catch {}

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -2383,32 +2383,62 @@ function updateSettingsTabBadge() {
   btn.classList.toggle('has-update', needsUpdate);
 }
 
-// engineHealAt debounces the #406 Spotify-engine self-heal per box (host ->
-// last-attempt ms) so a discovery/selection refresh loop never re-streams the
-// ~16 MB engine repeatedly.
-const engineHealAt = {};
+// foreignMod maps a leftover /mnt/nv directory name (as the agent reports it in
+// foreignDirs / conflictingMod) to a human-readable name of the OTHER SoundTouch
+// tool it belongs to, so the app can tell the user exactly what to remove to
+// free NAND for the Spotify engine. Unknown names are shown verbatim.
+const foreignMod = {
+  aftertouch: 'AfterTouch',
+  opentouchcloud: 'OpenTouchCloud',
+  opentouch: 'OpenTouchCloud',
+  bosman: 'Bosman',
+  betterst: 'BetterST',
+  sixback: 'SixBack',
+  soundploy: 'SoundPloy',
+};
 
-// healMissingEngine re-delivers go-librespot to a box that reports it missing,
-// in the background. A box whose post-update engine delivery was interrupted was
-// left with goLibrespot "missing" forever, because EnsureSpotifyEngine only ran
-// as part of an OTA and the app otherwise saw "version current" and never
-// re-delivered (#406). Now, whenever we read a box's version and the engine is
-// gone, we heal it, so it recovers the next time the speaker is opened, with no
-// re-update. Debounced, best-effort, and a no-op on a dev build with no embedded
-// engine (EnsureSpotifyEngine returns that itself).
-async function healMissingEngine(box) {
+// foreignSoftwareLabel turns a box version's foreignDirs/conflictingMod into a
+// readable, de-duplicated list ("AfterTouch, OpenTouchCloud") for the
+// "not enough space" message. Empty when the box carries no foreign leftovers.
+function foreignSoftwareLabel(v) {
+  const names = [];
+  const push = (raw) => {
+    if (!raw) return;
+    String(raw).split(',').forEach((n) => {
+      const key = n.trim().toLowerCase();
+      if (!key) return;
+      const label = foreignMod[key] || n.trim();
+      if (!names.includes(label)) names.push(label);
+    });
+  };
+  if (v) { push(v.conflictingMod); push(v.foreignDirs); }
+  return names.join(', ');
+}
+
+// installSpotifyEngineVisible delivers the Spotify engine (go-librespot) to a box
+// ON DEMAND, from a visible button, with honest feedback. It replaces the old
+// silent background self-heal: a box does not free NAND on its own, so a silent
+// retry was pointless and hid the real cause. If the box is too full, we name
+// the OTHER SoundTouch software eating the space so the user knows what to
+// remove; otherwise we confirm success. Re-renders the banner afterwards.
+async function installSpotifyEngineVisible(box) {
   if (!box || !box.host) return;
-  const now = Date.now();
-  if (now - (engineHealAt[box.host] || 0) < 120000) return; // at most once / 2 min per box
-  engineHealAt[box.host] = now;
+  const btn = $('boxInstallEngineBtn');
+  if (btn) { btn.disabled = true; btn.textContent = t('spotify.engineInstalling'); }
   try {
     const res = await EnsureSpotifyEngine(box.host, box.port);
-    if (res && res !== 'current' && !/no embedded engine/i.test(res)) {
-      showToast(t('update.spotifyDoneToast'));
-    }
+    if (res && !/no embedded engine/i.test(res)) showToast(t('update.spotifyDoneToast'));
   } catch (e) {
-    try { console.warn('spotify engine self-heal failed (will retry later)', e); } catch {}
-    engineHealAt[box.host] = now - 90000; // let a still-settling box retry sooner
+    const m = String((e && e.message) || e || '');
+    if (/insufficient nand|no space|507/i.test(m)) {
+      let foreign = '';
+      try { foreign = foreignSoftwareLabel(await BoxAgentVersion(box.host, box.port)); } catch {}
+      showToast(foreign ? t('spotify.engineTooFullNamed', { software: foreign }) : t('spotify.engineTooFull'));
+    } else {
+      showToast(t('spotify.engineInstallFailed'));
+    }
+  } finally {
+    try { await checkBoxUpdate(); } catch {}
   }
 }
 
@@ -2466,17 +2496,33 @@ async function checkBoxUpdate() {
     const boxBuild = v.build || '';
     const appVer = state.appInfo.version;
     const appBuild = state.appInfo.build || '';
-    // #406 self-heal: re-deliver a missing Spotify engine even when the box is
-    // already on the current version (the case that never recovered before, since
-    // the version comparison below returns early for a same-version box).
-    if (v && v.goLibrespot === 'missing') healMissingEngine(state.currentBox);
+    // Spotify engine state. We no longer silently re-push a missing engine in the
+    // background: a box gains no NAND on its own, so a silent retry is pointless
+    // and hides the cause. If the box is otherwise up to date but the engine is
+    // missing, show a visible, actionable "install" banner below; a box that is
+    // BEHIND delivers the engine as a visible step of the normal update flow.
+    const engineMissing = !!(v && v.goLibrespot === 'missing');
     // Direction matters. The speaker update pushes THIS app's embedded agent, so
     // it only makes sense when the app is newer than the box. The old code fired
     // on any difference and so offered "Aktualisieren" even when the box was
     // newer than the app, which would have downgraded the box and confused the
     // user (#105: an old app v0.6.22 next to a box on v0.7.32).
     const cmp = compareVerBuild(appVer, appBuild, boxVer, boxBuild);
-    if (cmp === 0) return;
+    if (cmp === 0) {
+      if (engineMissing) {
+        banner.innerHTML = `
+          <div class="update-msg">
+            <b>${escapeHtml(t('spotify.engineMissingTitle', { name: boxName }))}</b><br>
+            <small>${escapeHtml(t('spotify.engineMissingLine'))}</small>
+          </div>
+          <button class="btn btn-primary btn-mini" id="boxInstallEngineBtn"${otaElsewhere ? ' disabled' : ''}>${escapeHtml(t('spotify.engineInstallBtn'))}</button>
+        `;
+        banner.classList.remove('hidden');
+        const eb = $('boxInstallEngineBtn');
+        if (eb && !otaElsewhere) eb.onclick = () => installSpotifyEngineVisible(state.currentBox);
+      }
+      return;
+    }
     // When only the build stamp differs (same version string), show the build on
     // both sides so the line is not the confusing "v0.8.1 -> v0.8.1" (Jens,
     // 2026-06-17). A real release bumps the version, so production never hits the
@@ -3031,15 +3077,18 @@ async function doBoxUpdate(targetBox) {
         } else if (engDone) {
           // Engine was already current: nothing to announce.
         } else if (engTooFull) {
-          // Agent updated fine, but the box is out of room for the engine.
-          // Retrying is pointless until the user frees space, so say so plainly
-          // instead of the "will be delivered next time" copy.
-          showToast(t('update.spotifyTooFullToast'));
+          // Agent updated fine, but the box is out of room for the engine. Name
+          // the OTHER SoundTouch software eating the NAND so the user knows what
+          // to remove; retrying is pointless until they free space.
+          const foreign = foreignSoftwareLabel(confirmedVer);
+          showToast(foreign
+            ? t('spotify.engineTooFullNamed', { software: foreign })
+            : t('spotify.engineTooFull'));
         } else {
           // Could not land within the window; the engine is still missing but the
-          // agent update itself succeeded. Tell the user it will be retried next
-          // time they open this speaker (EnsureSpotifyEngine runs again then).
-          showToast(t('update.spotifyDeferredToast'));
+          // agent update itself succeeded. No silent retry - the speaker screen
+          // now shows a visible "Install Spotify engine" action.
+          showToast(t('spotify.engineDeferredVisible'));
         }
       }
     } else {

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -2656,15 +2656,31 @@ function isEngineStreamDrop(msg) {
 // waitForStableAgent waits (bounded by deadlineMs) until the box's agent
 // answers again and KEEPS answering for stableMs, so the next engine attempt
 // streams at a settled box instead of one mid-reboot.
-async function waitForStableAgent(box, deadlineMs, stableMs = 15_000) {
+//
+// Agents that report their box uptime (uptimeSec, v0.9.20+) get two extra
+// gates, learned from the #466 bundles where the FIRST post-confirm 16 MB push
+// reliably died with a connection reset ~107 s in while a retry minutes later
+// sailed through in ~15 s: the box must be past the reboot-prone post-OTA
+// settling window (uptime >= minUptimeSec), and an uptime DROP between two
+// probes is a reboot that plain reachability polling misses entirely (the box
+// can be back up before the next probe) - it resets the stability clock.
+// Older agents without uptimeSec keep the reachability-only behavior.
+async function waitForStableAgent(box, deadlineMs, stableMs = 30_000, minUptimeSec = 150) {
   let up = 0;
+  let lastUptime = -1;
   while (Date.now() < deadlineMs) {
     await sleep(3_000);
     try {
-      await BoxAgentVersion(box.host, box.port);
+      const v = await BoxAgentVersion(box.host, box.port);
+      const uptime = v && v.uptimeSec ? parseInt(v.uptimeSec, 10) : NaN;
+      if (!Number.isNaN(uptime)) {
+        if (uptime < lastUptime) up = 0; // rebooted between probes
+        lastUptime = uptime;
+        if (uptime < minUptimeSec) continue; // still in the settling window
+      }
       if (!up) up = Date.now();
       if (Date.now() - up >= stableMs) return true;
-    } catch { up = 0; }
+    } catch { up = 0; lastUptime = -1; }
   }
   return false;
 }
@@ -2760,11 +2776,18 @@ async function runBoxUpdate(box, onPhase) {
   // reclaimable only after the reboot). EnsureSpotifyEngine is cheap when the
   // engine is already current (one version GET, returns "current").
   if (confirmedVer.goLibrespot) {
-    const engDeadlineMs = Date.now() + 240_000;
+    // 10 min window, and every push attempt is gated on a settled box. The
+    // old 240 s window with an ungated first push burned itself on exactly
+    // two doomed ~107 s streams per OTA (#466): the box reliably reboots or
+    // resets large uploads in its first post-OTA minutes, while a push at a
+    // genuinely settled box completes in ~15 s. Waiting out the settling
+    // window first costs a minute in the good case and wins the bad ones.
+    const engDeadlineMs = Date.now() + 600_000;
     let attempt = 0;
     while (Date.now() < engDeadlineMs) {
       attempt++;
       phase('spotify', { attempt, remainingMs: engDeadlineMs - Date.now() });
+      await waitForStableAgent(box, engDeadlineMs);
       try {
         await EnsureSpotifyEngine(box.host, box.port);
         return { outcome: 'done', version: confirmedVer };
@@ -2774,12 +2797,10 @@ async function runBoxUpdate(box, onPhase) {
         // help, only freeing space can. The agent update itself succeeded.
         if (/insufficient nand|no space|507/i.test(m)) break;
         try { console.warn(`spotify engine delivery attempt ${attempt} failed (will retry)`, engErr); } catch {}
-        // Mid-stream drop: the box is likely rebooting. Wait until its agent
-        // answers steadily before streaming 16 MB at it again.
-        if (isEngineStreamDrop(m)) {
-          await waitForStableAgent(box, engDeadlineMs);
-          continue;
-        }
+        // Mid-stream drop: the box rebooted or reset the stream. Loop straight
+        // back: the top-of-loop settle gate does the waiting (reachable,
+        // uptime past the settling window, stable for 30 s).
+        if (isEngineStreamDrop(m)) continue;
       }
       // Exponential backoff (2s -> 30s cap): each failed attempt costs the
       // box a probe, and during a slow agent start hammering it every 2s
@@ -3026,7 +3047,11 @@ async function doBoxUpdate(targetBox) {
       // reboot. Best-effort: it must never turn a successful agent update into an
       // error.
       if (confirmedVer && confirmedVer.goLibrespot) {
-        const engDeadlineMs = Date.now() + 240_000;
+        // 10 min window with a settle gate before every push, mirroring
+        // runBoxUpdate (#466): the box reliably reboots or resets large
+        // uploads in its first post-OTA minutes, so the old 240 s window
+        // spent itself on two doomed ~107 s streams and gave up.
+        const engDeadlineMs = Date.now() + 600_000;
         let engDone = false;
         let engDelivered = false;
         let engTooFull = false;
@@ -3040,6 +3065,8 @@ async function doBoxUpdate(targetBox) {
         try {
           while (Date.now() < engDeadlineMs) {
             engAttempt++;
+            await waitForStableAgent(targetBox, engDeadlineMs);
+            renderEng();
             try {
               const engRes = await EnsureSpotifyEngine(targetBox.host, targetBox.port);
               engDone = true;
@@ -3056,13 +3083,9 @@ async function doBoxUpdate(targetBox) {
               // (#119). Anything else is the box still settling: keep retrying.
               if (/insufficient nand|no space|507/i.test(m)) { engTooFull = true; break; }
               try { console.warn(`post-update Spotify engine delivery attempt ${engAttempt} failed (will retry)`, engErr); } catch {}
-              // Mid-stream drop: the box is likely rebooting. Wait until its
-              // agent answers steadily before streaming 16 MB at it again.
-              if (isEngineStreamDrop(m)) {
-                await waitForStableAgent(targetBox, engDeadlineMs);
-                renderEng();
-                continue;
-              }
+              // Mid-stream drop: the box rebooted or reset the stream. Loop
+              // straight back; the top-of-loop settle gate does the waiting.
+              if (isEngineStreamDrop(m)) continue;
             }
             // Exponential backoff (2s -> 30s cap, #270): a box that is still
             // settling after the reboot gains nothing from a 2s hammer.

--- a/desktop-app/logexport.go
+++ b/desktop-app/logexport.go
@@ -34,6 +34,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
@@ -69,6 +70,48 @@ func (a *App) ExportDiagnosticLogs(req LogExportRequest) (LogExportResult, error
 		return LogExportResult{}, fmt.Errorf("savePath is required")
 	}
 
+	// Capture every box snapshot up front so the README and manifest can
+	// name each box's model and agent version in the first lines of the
+	// bundle. Reporters rename their uploads by hand to carry exactly this
+	// (issue #435: "st20--0.9.18--str-diagnostic-...zip") because neither
+	// the filename nor the README said which box, which STR version, when.
+	hosts := append([]string{}, req.BoxHosts...)
+	sort.Strings(hosts) // stable ordering so subsequent runs diff cleanly
+	snaps := make([]boxSnapshot, len(hosts))
+	entries := make([]boxIndexEntry, len(hosts))
+	var boxSummary strings.Builder
+	for i, host := range hosts {
+		snap := captureBoxSnapshot(host)
+		entry := boxIndexEntry{Index: i, Host: host}
+		if !snap.ReachableSSH && !snap.Reachable8090 && !snap.Reachable8888 && !snap.Reachable8091 {
+			entry.Offline = true
+			// WARN, not Info: an offline box means this bundle carries no
+			// on-box evidence for it, which support must see immediately.
+			a.logger.Warn("log export: box unreachable on every port, its snapshot carries no on-box data",
+				"host", entry.Host, "boxIndex", i)
+		}
+		if m, ok := snap.STRAgentVer["model"].(string); ok {
+			entry.Model = strings.TrimSpace(m)
+		}
+		if v, ok := snap.STRAgentVer["version"].(string); ok {
+			entry.AgentVersion = strings.TrimSpace(v)
+		}
+		if req.Anonymize {
+			entry.Host = maskIP(host)
+			snap = anonymizeSnapshot(snap)
+		}
+		snaps[i] = snap
+		entries[i] = entry
+		switch {
+		case entry.Offline:
+			fmt.Fprintf(&boxSummary, "  box-%d  %-15s  unreachable at export time\n", i, entry.Host)
+		case entry.AgentVersion == "":
+			fmt.Fprintf(&boxSummary, "  box-%d  %-15s  no STR agent detected\n", i, entry.Host)
+		default:
+			fmt.Fprintf(&boxSummary, "  box-%d  %-15s  %s  STR %s\n", i, entry.Host, entry.Model, entry.AgentVersion)
+		}
+	}
+
 	f, err := os.Create(req.SavePath)
 	if err != nil {
 		return LogExportResult{}, fmt.Errorf("create zip: %w", err)
@@ -84,7 +127,7 @@ OS:          %s/%s
 App version: %s
 Anonymized:  %v
 Boxes asked: %d
-
+%s
 Contents:
   README.txt            this file
   app.log               desktop app log (rolling, up to 2 MB)
@@ -99,7 +142,7 @@ Privacy:
   hashed (first 8 chars of SHA256), and SSID-looking strings in the
   app log are scrubbed. Even so, please skim the files before
   attaching to a public issue.
-`, time.Now().UTC().Format(time.RFC3339), runtime.GOOS, runtime.GOARCH, appVersion, req.Anonymize, len(req.BoxHosts))
+`, time.Now().UTC().Format(time.RFC3339), runtime.GOOS, runtime.GOARCH, appVersion, req.Anonymize, len(req.BoxHosts), boxSummary.String())
 	if err := writeZipEntry(zw, "README.txt", []byte(readme)); err != nil {
 		return LogExportResult{}, err
 	}
@@ -137,7 +180,7 @@ Privacy:
 		_ = writeZipEntry(zw, "ota-history.log", oj)
 	}
 
-	// 3. Per-box snapshots.
+	// 3. Per-box snapshots (captured up front, before the README).
 	manifest := struct {
 		Timestamp string          `json:"timestamp"`
 		OS        string          `json:"os"`
@@ -149,29 +192,11 @@ Privacy:
 		OS:        runtime.GOOS,
 		Arch:      runtime.GOARCH,
 		Anonymize: req.Anonymize,
+		Boxes:     entries,
 	}
-
-	// Stable ordering so subsequent runs diff cleanly.
-	hosts := append([]string{}, req.BoxHosts...)
-	sort.Strings(hosts)
-	for i, host := range hosts {
-		snap := captureBoxSnapshot(host)
-		entry := boxIndexEntry{Index: i, Host: host}
-		if !snap.ReachableSSH && !snap.Reachable8090 && !snap.Reachable8888 && !snap.Reachable8091 {
-			entry.Offline = true
-			// WARN, not Info: an offline box means this bundle carries no
-			// on-box evidence for it, which support must see immediately.
-			a.logger.Warn("log export: box unreachable on every port, its snapshot carries no on-box data",
-				"host", entry.Host, "boxIndex", i)
-		}
-		if req.Anonymize {
-			entry.Host = maskIP(host)
-			snap = anonymizeSnapshot(snap)
-		}
-		manifest.Boxes = append(manifest.Boxes, entry)
-		name := fmt.Sprintf("box-%d.json", i)
-		b, _ := json.MarshalIndent(snap, "", "  ")
-		if err := writeZipEntry(zw, name, b); err != nil {
+	for i := range snaps {
+		b, _ := json.MarshalIndent(snaps[i], "", "  ")
+		if err := writeZipEntry(zw, fmt.Sprintf("box-%d.json", i), b); err != nil {
 			return LogExportResult{}, err
 		}
 	}
@@ -312,6 +337,12 @@ type boxIndexEntry struct {
 	// bundle silently looked complete - a reporter exported four bundles of a
 	// flapping box and every one carried zero on-box evidence.
 	Offline bool `json:"offline,omitempty"`
+	// Model / AgentVersion are copied out of /api/agent/version so the
+	// manifest (and the README box list built from the same entries)
+	// identifies each box without opening its box-<n>.json. Model and
+	// version are not personal identifiers, so they survive anonymize.
+	Model        string `json:"model,omitempty"`
+	AgentVersion string `json:"agentVersion,omitempty"`
 }
 
 type boxSnapshot struct {
@@ -801,12 +832,124 @@ func writeZipEntry(zw *zip.Writer, name string, data []byte) error {
 	return err
 }
 
+// probeBoxIdentity fetches just model + agent version from one box, on
+// whichever external STR port answers. Deliberately tiny and short-lived:
+// it runs BEFORE the save dialog opens, so the user must not wait behind
+// the full snapshot capture (that runs after they pick a path).
+func probeBoxIdentity(host string) (model, version string) {
+	strPort := 0
+	if portOpen(host, 8888, 800) {
+		strPort = 8888
+	} else if portOpen(host, 17008, 800) {
+		strPort = 17008
+	}
+	if strPort == 0 {
+		return "", ""
+	}
+	raw := httpGetTextTimeout(fmt.Sprintf("http://%s:%d/api/agent/version", host, strPort), 1024, 2*time.Second)
+	if raw == "" {
+		return "", ""
+	}
+	var m map[string]any
+	if json.Unmarshal([]byte(raw), &m) != nil {
+		return "", ""
+	}
+	mo, _ := m["model"].(string)
+	ve, _ := m["version"].(string)
+	return strings.TrimSpace(mo), strings.TrimSpace(ve)
+}
+
+// shortModel compresses a Bose model string into a filename token:
+// "SoundTouch 20" -> "ST20", "SoundTouch Portable" -> "Portable",
+// "Bose Wave SoundTouch" -> "WaveSoundTouch". Empty when unknown.
+func shortModel(model string) string {
+	m := strings.TrimSpace(model)
+	m = strings.TrimPrefix(m, "Bose ")
+	if rest, ok := strings.CutPrefix(m, "SoundTouch"); ok {
+		rest = strings.TrimSpace(rest)
+		if rest != "" {
+			if _, err := strconv.Atoi(rest); err == nil {
+				return "ST" + rest
+			}
+			m = rest
+		}
+	}
+	return filenameToken(strings.ReplaceAll(m, " ", ""))
+}
+
+// filenameToken keeps a string safe for a cross-platform filename:
+// alphanumerics, dot, plus, underscore, hyphen; everything else becomes
+// a hyphen. Capped so a weird model string cannot blow the name up.
+func filenameToken(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9',
+			r == '.', r == '+', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	out := b.String()
+	if len(out) > 24 {
+		out = out[:24]
+	}
+	return out
+}
+
+// diagnosticDefaultName builds the save-dialog default filename with the
+// box model(s), STR agent version(s), and timestamp embedded, so the
+// uploaded file self-identifies in a GitHub issue thread. Reporters were
+// renaming bundles by hand to exactly this shape (issue #435). Boxes
+// without a reachable STR agent contribute nothing; with no identified
+// box at all the name falls back to the plain timestamp form.
+func diagnosticDefaultName(hosts []string, now time.Time) string {
+	// Probe all boxes concurrently: an offline box costs two 800 ms port
+	// timeouts, and the dialog must not wait for them back to back.
+	type identity struct{ model, version string }
+	ids := make([]identity, len(hosts))
+	var wg sync.WaitGroup
+	for i, host := range hosts {
+		wg.Add(1)
+		go func(i int, host string) {
+			defer wg.Done()
+			mo, ve := probeBoxIdentity(host)
+			ids[i] = identity{model: mo, version: ve}
+		}(i, host)
+	}
+	wg.Wait()
+
+	var models, versions []string
+	seenM, seenV := map[string]bool{}, map[string]bool{}
+	for _, id := range ids {
+		mo, ve := id.model, id.version
+		if t := shortModel(mo); t != "" && !seenM[t] && len(models) < 3 {
+			seenM[t] = true
+			models = append(models, t)
+		}
+		if t := filenameToken(ve); t != "" && !seenV[t] && len(versions) < 3 {
+			seenV[t] = true
+			versions = append(versions, t)
+		}
+	}
+	parts := []string{"str-diagnostic"}
+	if len(models) > 0 {
+		parts = append(parts, strings.Join(models, "+"))
+	}
+	if len(versions) > 0 {
+		parts = append(parts, strings.Join(versions, "+"))
+	}
+	parts = append(parts, now.Format("20060102-150405"))
+	return strings.Join(parts, "-") + ".zip"
+}
+
 // SaveDiagnosticBundle is the one-call frontend entry point: pops
 // the OS save-file dialog with a sensible default filename, then
 // writes the zip there. Returns the resulting path or empty string
 // if the user cancelled. Anonymize defaults to true.
 func (a *App) SaveDiagnosticBundle(boxHosts []string, anonymize bool) (LogExportResult, error) {
-	defaultName := fmt.Sprintf("str-diagnostic-%s.zip", time.Now().UTC().Format("20060102-150405"))
+	defaultName := diagnosticDefaultName(boxHosts, time.Now().UTC())
 	path, err := wailsruntime.SaveFileDialog(a.ctx, wailsruntime.SaveDialogOptions{
 		DefaultFilename: defaultName,
 		Title:           "Save STR diagnostic bundle",

--- a/desktop-app/logexport_test.go
+++ b/desktop-app/logexport_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // The sanitizers are the last line of defense before a user attaches a
@@ -149,5 +150,50 @@ func TestScrubPII_MasksUserHomePaths(t *testing.T) {
 		if !strings.Contains(got, "<user>") {
 			t.Errorf("scrubPII did not insert the <user> mask:\n in: %s\nout: %s", c.in, got)
 		}
+	}
+}
+
+// The bundle filename must self-identify (model, STR version, date) so an
+// upload in a GitHub thread is readable without opening the zip - reporters
+// were renaming bundles by hand to carry exactly this (issue #435).
+
+func TestShortModel(t *testing.T) {
+	cases := map[string]string{
+		"SoundTouch 20":        "ST20",
+		"SoundTouch 10":        "ST10",
+		"SoundTouch 300":       "ST300",
+		"SoundTouch Portable":  "Portable",
+		"Bose SoundTouch 30":   "ST30",
+		"Bose Wave SoundTouch": "WaveSoundTouch",
+		"SoundTouch":           "SoundTouch",
+		"":                     "",
+		"weird/model name":     "weird-modelname",
+	}
+	for in, want := range cases {
+		if got := shortModel(in); got != want {
+			t.Errorf("shortModel(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFilenameToken(t *testing.T) {
+	if got := filenameToken("v0.9.18"); got != "v0.9.18" {
+		t.Errorf("version token mangled: %q", got)
+	}
+	if got := filenameToken("a b:c*d"); got != "a-b-c-d" {
+		t.Errorf("unsafe chars not hyphenated: %q", got)
+	}
+	long := strings.Repeat("x", 40)
+	if got := filenameToken(long); len(got) != 24 {
+		t.Errorf("token not capped at 24: %d", len(got))
+	}
+}
+
+func TestDiagnosticDefaultName_FallbackWithoutBoxes(t *testing.T) {
+	now := time.Date(2026, 7, 25, 6, 26, 3, 0, time.UTC)
+	got := diagnosticDefaultName(nil, now)
+	want := "str-diagnostic-20260725-062603.zip"
+	if got != want {
+		t.Errorf("diagnosticDefaultName(nil) = %q, want %q", got, want)
 	}
 }

--- a/desktop-app/ota_live_test.go
+++ b/desktop-app/ota_live_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"os"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// TestLiveAppUpdateFlow exercises the REAL app-integrated update + Spotify-engine
+// flow - the exact App methods the GUI "Update" button calls - against a live box
+// on the LAN. It exists so the flow is validated end to end WITHOUT the Wails GUI
+// (which Smart App Control blocks for unsigned local builds) and WITHOUT manual
+// SSH/curl. The key assertion is that the app flow leaves the Spotify engine
+// PRESENT: UpdateBoxAgent stages the sidecar before the agent push, so unlike a
+// bare agent OTA the engine must survive the single reboot.
+//
+// Opt-in: set STR_LIVE_BOX=<ip> (and STR_LIVE_PORT, default 8888; use 17008 for
+// BCO/taigan/scm). Skipped otherwise so CI never touches hardware.
+func TestLiveAppUpdateFlow(t *testing.T) {
+	host := os.Getenv("STR_LIVE_BOX")
+	if host == "" {
+		t.Skip("set STR_LIVE_BOX=<ip> (and optionally STR_LIVE_PORT) to run the live app-flow test")
+	}
+	port := 8888
+	if p := os.Getenv("STR_LIVE_PORT"); p != "" {
+		if n, err := strconv.Atoi(p); err == nil {
+			port = n
+		}
+	}
+	// No startup(): a.ctx stays nil, and every bound method is written to tolerate
+	// that (appCtx() -> Background, emitInstallProgress guards on a.ctx != nil).
+	a := NewApp()
+
+	v0, err := a.BoxAgentVersion(host, port)
+	if err != nil {
+		t.Fatalf("baseline version read (%s:%d): %v", host, port, err)
+	}
+	t.Logf("BEFORE  version=%s build=%s goLibrespot=%s foreignDirs=%q nandFree=%s",
+		v0["version"], v0["build"], v0["goLibrespot"], v0["foreignDirs"], v0["nandFreeBytes"])
+
+	// The app-integrated update: pushes THIS build's embedded agent AND stages the
+	// Spotify engine before the reboot (stageSidecarBeforeReboot inside).
+	t.Log("running App.UpdateBoxAgent (the GUI 'Update' path)...")
+	if err := a.UpdateBoxAgent(host, port); err != nil {
+		t.Fatalf("UpdateBoxAgent (app flow) returned an error: %v", err)
+	}
+
+	// Wait for the box to reboot and its agent to answer steadily again, exactly
+	// as the GUI's post-OTA version poll does.
+	deadline := time.Now().Add(4 * time.Minute)
+	var v1 map[string]string
+	for time.Now().Before(deadline) {
+		time.Sleep(8 * time.Second)
+		v, verr := a.BoxAgentVersion(host, port)
+		if verr == nil && v["version"] != "" {
+			v1 = v
+			// Give the post-reboot engine supervise a beat to report present.
+			if v["goLibrespot"] == "present" {
+				break
+			}
+		}
+	}
+	if v1 == nil {
+		t.Fatalf("box did not answer its agent version within the wait window after the app update")
+	}
+
+	// The GUI runs EnsureSpotifyEngine after the update as a safety net (it is a
+	// cheap "current" no-op when the sidecar staging already delivered the engine).
+	res, eerr := a.EnsureSpotifyEngine(host, port)
+	t.Logf("EnsureSpotifyEngine -> %q (err=%v)", res, eerr)
+
+	v2, err := a.BoxAgentVersion(host, port)
+	if err != nil {
+		t.Fatalf("post-flow version read: %v", err)
+	}
+	t.Logf("AFTER   version=%s build=%s goLibrespot=%s foreignDirs=%q nandFree=%s",
+		v2["version"], v2["build"], v2["goLibrespot"], v2["foreignDirs"], v2["nandFreeBytes"])
+
+	// The whole point: the app-integrated flow must leave Spotify usable.
+	if v2["goLibrespot"] != "present" {
+		t.Fatalf("app update flow did NOT leave the Spotify engine present (goLibrespot=%s); "+
+			"the sidecar staging or its re-delivery failed", v2["goLibrespot"])
+	}
+	// And the agent must actually be the build we pushed (not a revert).
+	if v2["build"] != appBuild && appBuild != "" {
+		t.Logf("NOTE: box build %q != app build %q (possible OTA revert, or a dev stamp mismatch)", v2["build"], appBuild)
+	}
+}

--- a/desktop-app/progress.go
+++ b/desktop-app/progress.go
@@ -64,6 +64,14 @@ func (p *transferProgress) report(done int64) {
 	if el := now.Sub(p.start).Seconds(); el > 0 {
 		bps = int64(float64(done) / el)
 	}
+	// Only emit once the Wails runtime is live: EventsEmit REQUIRES the real
+	// lifecycle context and Fatals on any other (appCtx() falls back to
+	// Background before startup). A bound App method can legitimately run before
+	// startup, and the OTA flow is exercised headless in tests, so a nil ctx must
+	// skip the UI event, not kill the process. Mirrors emitInstallProgress' guard.
+	if p.app == nil || p.app.ctx == nil {
+		return
+	}
 	wailsrt.EventsEmit(p.app.appCtx(), p.event, map[string]any{
 		"host": p.host, "pct": pct, "bytesPerSec": bps, "done": done, "total": p.total,
 	})

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -3903,6 +3903,15 @@ func (s *Server) handleAgentVersion(w http.ResponseWriter, _ *http.Request) {
 	if mod := detectConflictingMod(); mod != "" {
 		out["conflictingMod"] = mod
 	}
+	// The foreign (neither STR's nor Bose's) top-level /mnt/nv dirs, names only.
+	// Cheap: one readdir, no recursive sizing, so it is fine on every version
+	// poll. These are leftovers of OTHER SoundTouch mods that eat the NAND the
+	// Spotify engine needs; the desktop app names them when it has to tell the
+	// user to free space (#270 / Spotify-engine space-fail UX). Emitted only when
+	// something foreign exists, to keep the common response small.
+	if fd := foreignNANDDirNames(); len(fd) > 0 {
+		out["foreignDirs"] = strings.Join(fd, ",")
+	}
 	if wlanCredsWarningWarranted() {
 		out["wlanCreds"] = "missing"
 	}
@@ -4515,6 +4524,25 @@ func dirBytes(path string) int64 {
 // one of Bose's, i.e. a candidate leftover from a third-party post-cloud tool
 // or another custom firmware the owner ran before STR. Mirrors run.sh's
 // nand_inventory freshness check.
+// foreignNANDDirNames lists the top-level /mnt/nv directories that are neither
+// STR's nor Bose's own persistence (isForeignNANDDir), by name. Cheap: a single
+// readdir with no recursive sizing, so it is safe on every version poll. Wired
+// into /api/agent/version as foreignDirs so the desktop app can name the other
+// SoundTouch mods a user must remove to free space for the Spotify engine.
+func foreignNANDDirNames() []string {
+	entries, err := os.ReadDir(nandRoot)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() && isForeignNANDDir(e.Name()) {
+			out = append(out, e.Name())
+		}
+	}
+	return out
+}
+
 func isForeignNANDDir(name string) bool {
 	switch name {
 	case "streborn", "nv", "lost+found":

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -3871,6 +3871,19 @@ func (s *Server) handleAgentVersion(w http.ResponseWriter, _ *http.Request) {
 	if s.spotifyReload != nil {
 		out["engineHotSwap"] = "true"
 	}
+	// Box uptime, so the desktop app can sequence the post-OTA engine delivery
+	// deterministically (#466): the first ~2-3 minutes after a post-OTA boot are
+	// reboot-prone (Bose settling, shepherd recovery) and the first 16 MB push
+	// into that window reliably died with a connection reset. The app gates
+	// large pushes on "uptime past the settling window and still rising"; a
+	// DROP between two probes is a reboot the reachability probe alone misses.
+	if up, err := os.ReadFile("/proc/uptime"); err == nil {
+		if f := strings.Fields(string(up)); len(f) > 0 {
+			if secs, perr := strconv.ParseFloat(f[0], 64); perr == nil {
+				out["uptimeSec"] = strconv.FormatInt(int64(secs), 10)
+			}
+		}
+	}
 	// NAND headroom on the tiny (~31 MB) writable volume, so the desktop app can
 	// see before an OTA whether the ~10 MB agent + sidecar will fit and warn
 	// instead of pushing into a "no space left on device" failure (the stickless
@@ -4075,7 +4088,7 @@ func ensureSSHDRunning(logger *slog.Logger) bool {
 // On success the stick still returns 200 OK and then exits. The
 // rc.local bootstrap starts the new agent.
 func (s *Server) handleAgentUpdate(w http.ResponseWriter, r *http.Request) {
-	body, ok := readUploadedELF(w, r)
+	body, ok := readUploadedELF(w, r, s.logger, "agent-update")
 	if !ok {
 		return
 	}
@@ -4210,7 +4223,7 @@ func (s *Server) handleAgentUpdate(w http.ResponseWriter, r *http.Request) {
 // endpoint: LAN-only, size-bounded, ELF-magic checked. On any problem it writes
 // the HTTP error response and returns ok=false. Shared by handleAgentUpdate and
 // handleAgentSidecar so the two upload endpoints cannot drift on their guards.
-func readUploadedELF(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
+func readUploadedELF(w http.ResponseWriter, r *http.Request, logger *slog.Logger, what string) ([]byte, bool) {
 	if !requireMethod(w, r, http.MethodPost) {
 		return nil, false
 	}
@@ -4219,11 +4232,26 @@ func readUploadedELF(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
 		return nil, false
 	}
 	const maxSize = 30 * 1024 * 1024
-	body, err := io.ReadAll(io.LimitReader(r.Body, maxSize+1))
+	// Log the whole upload lifecycle. The #466 bundles showed the app-side
+	// view of a dying post-OTA push (RST after ~107 s) while the box-side log
+	// carried no trace of the upload at all, so the box-side failure mode
+	// (request never arrived vs stream stalled at byte N vs read completed
+	// but reply lost) was undiagnosable. These lines make the next bundle
+	// answer that directly.
+	logger.Info("upload started", "endpoint", what,
+		"contentLength", r.ContentLength, "remote", r.RemoteAddr)
+	upr := &uploadProgressReader{
+		r: io.LimitReader(r.Body, maxSize+1), start: time.Now(), logger: logger, what: what,
+	}
+	body, err := io.ReadAll(upr)
 	if err != nil {
+		logger.Warn("upload aborted mid-stream", "endpoint", what,
+			"bytesRead", upr.n, "elapsedMs", time.Since(upr.start).Milliseconds(), "err", err)
 		http.Error(w, "read: "+err.Error(), http.StatusBadRequest)
 		return nil, false
 	}
+	logger.Info("upload body received", "endpoint", what,
+		"bytes", len(body), "elapsedMs", time.Since(upr.start).Milliseconds())
 	if len(body) > maxSize {
 		http.Error(w, "binary too big", http.StatusRequestEntityTooLarge)
 		return nil, false
@@ -4238,6 +4266,29 @@ func readUploadedELF(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
 		return nil, false
 	}
 	return body, true
+}
+
+// uploadProgressReader logs a large upload's progress every few MB so the
+// box-side agent log shows exactly how far a doomed transfer got before its
+// connection died. Wraps the size-limited body reader in readUploadedELF.
+type uploadProgressReader struct {
+	r       io.Reader
+	n       int64
+	lastLog int64
+	start   time.Time
+	logger  *slog.Logger
+	what    string
+}
+
+func (u *uploadProgressReader) Read(p []byte) (int, error) {
+	n, err := u.r.Read(p)
+	u.n += int64(n)
+	if u.n-u.lastLog >= 4*1024*1024 {
+		u.lastLog = u.n
+		u.logger.Info("upload progress", "endpoint", u.what,
+			"bytes", u.n, "elapsedMs", time.Since(u.start).Milliseconds())
+	}
+	return n, err
 }
 
 // errInsufficientNAND is returned by writeBinaryAtomic when an actually
@@ -4936,7 +4987,7 @@ var nandHasRoom = func(dir string, need int64) bool {
 // running process until it exits, so killing+relaunching it on the write releases
 // that ~10 MB immediately instead of holding it until the next reboot.
 func (s *Server) handleAgentSidecar(w http.ResponseWriter, r *http.Request) {
-	body, ok := readUploadedELF(w, r)
+	body, ok := readUploadedELF(w, r, s.logger, "sidecar")
 	if !ok {
 		return
 	}
@@ -6442,8 +6493,24 @@ func (s *Server) handleDebugState(w http.ResponseWriter, r *http.Request) {
 		return out
 	}
 
+	// The NAND-mirrored agent log is the only log that survives a reboot on a
+	// box without SSH and without a previous.log (taigan writes none). Every
+	// mid-upload reboot investigation (#466) needs exactly the minutes BEFORE
+	// the current boot, so give this one a larger tail than the 8 KB default.
+	readTailN := func(path string, max int) string {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return "ERR: " + err.Error()
+		}
+		if len(b) > max {
+			return "...(truncated)\n" + string(b[len(b)-max:])
+		}
+		return string(b)
+	}
+
 	state := map[string]any{
 		"agent_log_tail": readTail("/tmp/streborn-agent.log"),
+		"agent_log_nand": readTailN("/mnt/nv/streborn/agent.log", 32*1024),
 		"previous_log":   readTail("/mnt/nv/streborn/previous.log"),
 		"setup_log":      readTail("/mnt/nv/streborn/setup.log"),
 		"boot_log":       readTail("/mnt/nv/streborn/boot.log"),


### PR DESCRIPTION
Bundles this branch's work for the v0.9.20 release:

- **feat(spotify)**: visible engine install with an honest out-of-space message naming the culprit software
- **fix(update)**: settle-gated, patient post-update Spotify engine delivery (10 min window, uptime-gated pushes) for both single-speaker and update-all; box-side upload tracing; `uptimeSec` in `/api/agent/version`; NAND agent-log tail in `/api/debug/state` (Refs #466)
- **fix(update)**: a speaker that confirms its update late is counted as updated in update-all instead of reported as stuck
- **feat(diagnostics)**: diagnostic bundles self-identify - model, STR version, and date in the default filename, per-box list in README and manifest (Refs #435 thread)
- **fix(presets)**: the volume restore after a standby recovery stands down when the user adjusted the box by hand, ending the "every preset starts at volume 10 after deep standby" clamp (Refs #435)
- **fix(app)**: postcss bumped past GHSA-r28c-9q8g-f849 (Dependabot alert 14)
- **test(app)**: headless live test of the app-integrated update + Spotify-engine flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)