### PR TITLE
fix(agent): never switch a speaker on by itself, and rescue speakers with no DNS

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/JRpersonal/streborn/internal/boxurl"
 	"github.com/JRpersonal/streborn/internal/boxws"
 	"github.com/JRpersonal/streborn/internal/clocksync"
+	"github.com/JRpersonal/streborn/internal/dnsboot"
 	"github.com/JRpersonal/streborn/internal/hosts"
 	"github.com/JRpersonal/streborn/internal/marge"
 	"github.com/JRpersonal/streborn/internal/netutil"
@@ -373,6 +374,16 @@ func run() error {
 		return margeSrv.RecentRequestLines(60)
 	})
 	webui.RegisterDebugSection("clock_status", clockStatusSnapshot)
+	// dns_status makes the #487 fault class visible in one glance: a bundle
+	// with an empty nameserver list explains dead radio, a stuck clock, an
+	// unpaired box and a crash-looping Spotify engine all at once.
+	webui.RegisterDebugSection("dns_status", func() any {
+		return map[string]any{
+			"nameservers":     dnsboot.Nameservers(),
+			"resolv_conf":     dnsboot.RawResolvConf(),
+			"default_gateway": dnsboot.DefaultGateway(),
+		}
+	})
 	bmxSrv := bmx.New(logger.With("comp", "bmx"))
 	// The AutoPair manager is created up here so it can also be used in the
 	// WS and webui handlers.
@@ -608,6 +619,7 @@ func run() error {
 		// (scm) firmware that bounces UPNP<->STANDBY does not turn itself back on
 		// (#197). Zone-guarded and debounced in the webui.
 		onEnterStandby: webuiSrv.HandleEnterStandby,
+		onStandbyExit:  webuiSrv.RunDeferredResume,
 		// Let the hardware-recall verify stand down when the user powered the box
 		// off mid-recall, so it does not re-push the stream into a power-off (#197).
 		// The absolute variant is preferred: the rolling 6s window could expire
@@ -912,6 +924,12 @@ func run() error {
 	// install time to do the boot Date sync, so without this the very first
 	// requests could hit a 2015 clock until the goroutine catches up. Best-effort
 	// - if the network is not up yet the goroutine below keeps retrying (#375).
+	// DNS bootstrap BEFORE the clock sync: a box whose DHCP lease carries no
+	// nameserver cannot resolve the clock hosts, cannot pair (autopair is
+	// gated on a plausible clock) and cannot play radio, and every repair path
+	// STR owns needs the very thing that is missing (#487). Repairing the
+	// resolver first unlocks all three. No-op on a healthy box.
+	dnsboot.EnsureResolver(logger.With("comp", "dnsboot"))
 	noteBootClock(logger)
 	func() {
 		sctx, cancel := context.WithTimeout(ctx, 6*time.Second)
@@ -1372,6 +1390,10 @@ type presetWsHandler struct {
 	// press (#183). This recovers that stuck wake. Wired to
 	// webui.RecoverAfterReconnect, which reuses the power-on resume guards. nil-safe.
 	onBoxReconnect func()
+	// onStandbyExit fires when the box leaves STANDBY (the user switched it on).
+	// Wired to webui.Server.RunDeferredResume so a stream the firmware dropped
+	// while the box was off comes back on the user's own wake. nil-safe.
+	onStandbyExit func()
 	// onEnterStandby fires when STR's UPnP source drops to STANDBY (a power-off
 	// seen over gabbo). It clears the box transport so ST20 (scm) firmware that
 	// oscillates UPNP<->STANDBY does not switch the speaker back on (#197). Wired to
@@ -2501,6 +2523,12 @@ func (h *presetWsHandler) OnConnected(_ context.Context) {
 // presses emit no frame and no other trigger ever fires).
 func (h *presetWsHandler) OnStandbyExit(_ context.Context) {
 	requestPresetKeyResync(h.logger)
+	// The user just switched the box on. If the firmware had dropped a stream
+	// while the box was off, STR replays it NOW - on the user's own action -
+	// instead of powering the speaker on by itself (#487).
+	if h.onStandbyExit != nil {
+		go h.onStandbyExit()
+	}
 }
 
 // resyncUnlessIdleStandby is OnConnected's re-sync decision, off the WS hot

--- a/internal/clocksync/clocksync.go
+++ b/internal/clocksync/clocksync.go
@@ -33,10 +33,18 @@ var maxPlausible = time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC)
 // dateHosts are queried over plain HTTP — no TLS, so there is no chicken-and-egg
 // with the very clock we are trying to fix — for their Date response header.
 // Same set as run.sh try_http_date_sync.
+// The IP literals at the end are the escape hatch for a box with no working
+// name resolution at all: a speaker whose DHCP lease carries no DNS server
+// could never fix its clock, which in turn hard-gated autopair and left the
+// box displaying "SoundTouch not configured" forever, with radio dead on top
+// (#487 field bundle, 2026-07-27). These answer plain HTTP on the bare
+// address, so the clock heals even before the DNS bootstrap lands.
 var dateHosts = []string{
 	"http://www.google.com/",
 	"http://www.cloudflare.com/",
 	"http://www.bose.com/",
+	"http://1.1.1.1/",
+	"http://8.8.8.8/",
 }
 
 // Implausible reports whether now is too far in the past to be a real wall

--- a/internal/dnsboot/dnsboot.go
+++ b/internal/dnsboot/dnsboot.go
@@ -1,0 +1,156 @@
+// Package dnsboot repairs a speaker that has no usable DNS resolver.
+//
+// Field case #487 (2026-07-27, Wave): the box came up with no nameserver the
+// agent could see, so Go fell back to its built-in 127.0.0.1:53 / [::1]:53
+// pair and EVERY name lookup failed. That single fault produced three
+// unrelated-looking symptoms and locked itself in place:
+//
+//   - Radio: the stream proxy could not resolve any station host, so the box
+//     aborted the stream within ~400 ms and displayed "Service Unavailable".
+//   - Clock and pairing: every clock-sync host was a NAME, so the clock stayed
+//     at the 2015 firmware epoch; autopair is gated on a plausible clock, so
+//     the box never paired and displayed "SoundTouch not configured".
+//   - Spotify: go-librespot crash-looped on apresolve.spotify.com.
+//
+// Every repair path STR owns needed the very thing that was broken, so the box
+// could not heal across reboots or re-installs. This package breaks that loop:
+// it detects the missing resolver and bind-mounts a working resolv.conf over
+// the read-only rootfs one, the same trick run.sh already uses for /etc/hosts.
+// Fixing it at the file level (rather than only inside our own Go process)
+// also repairs the Bose firmware's own name lookups, so its NTP starts working
+// and the clock, autopair and the display heal on their own afterwards.
+package dnsboot
+
+import (
+	"bufio"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+const (
+	resolvPath = "/etc/resolv.conf"
+	// ourResolv lives in tmpfs: the rootfs is mounted read-only on these
+	// chassis, so the file we bind-mount from must be somewhere writable.
+	ourResolv = "/tmp/streborn-resolv.conf"
+	routePath = "/proc/net/route"
+)
+
+// publicFallbacks are appended after the router so name resolution still works
+// when the gateway does not answer DNS itself.
+var publicFallbacks = []string{"1.1.1.1", "8.8.8.8"}
+
+// Nameservers returns the nameserver addresses configured in resolv.conf.
+// An empty slice means the box has no usable resolver, which is the fault this
+// package exists for. Read-only, safe to call from diagnostics.
+func Nameservers() []string {
+	return parseNameservers(readFile(resolvPath))
+}
+
+// RawResolvConf returns the current resolv.conf contents for the diagnostic
+// bundle ("" when the file is missing).
+func RawResolvConf() string { return readFile(resolvPath) }
+
+// DefaultGateway returns the box's IPv4 default gateway from /proc/net/route,
+// or "" when there is none. This is the best first nameserver candidate: on a
+// home LAN the router almost always resolves.
+func DefaultGateway() string {
+	f, err := os.Open(routePath)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	first := true
+	for sc.Scan() {
+		if first { // header line
+			first = false
+			continue
+		}
+		fields := strings.Fields(sc.Text())
+		if len(fields) < 3 || fields[1] != "00000000" {
+			continue // not the default route
+		}
+		if ip := hexLEToIP(fields[2]); ip != "" {
+			return ip
+		}
+	}
+	return ""
+}
+
+// EnsureResolver repairs a missing resolver and reports whether it had to act.
+// It is a no-op (returning false) when the box already has a nameserver, so it
+// is safe to call unconditionally at agent start. Best-effort by design: a box
+// where the bind mount is not permitted keeps working exactly as before, and
+// the agent's own lookups are additionally covered by the resolver fallback in
+// the HTTP clients.
+func EnsureResolver(logger *slog.Logger) bool {
+	if ns := Nameservers(); len(ns) > 0 {
+		return false
+	}
+	gw := DefaultGateway()
+	servers := make([]string, 0, len(publicFallbacks)+1)
+	if gw != "" {
+		servers = append(servers, gw)
+	}
+	servers = append(servers, publicFallbacks...)
+
+	var b strings.Builder
+	b.WriteString("# written by STR (dnsboot): the box had no usable nameserver.\n")
+	for _, s := range servers {
+		fmt.Fprintf(&b, "nameserver %s\n", s)
+	}
+	if err := os.WriteFile(ourResolv, []byte(b.String()), 0o644); err != nil {
+		logger.Warn("dns bootstrap: could not stage a resolv.conf", "err", err)
+		return false
+	}
+	// bind-mount over the read-only rootfs file, mirroring the /etc/hosts
+	// handling in run.sh. A plain copy would fail on ubifs mounted ro.
+	out, err := exec.Command("mount", "--bind", ourResolv, resolvPath).CombinedOutput()
+	if err != nil {
+		logger.Warn("dns bootstrap: bind mount failed, the agent's own lookups still use the built-in fallback",
+			"err", err, "out", strings.TrimSpace(string(out)))
+		return false
+	}
+	logger.Warn("dns bootstrap: the speaker had NO nameserver configured; installed one so radio, clock sync and pairing can work",
+		"servers", strings.Join(servers, ","), "gateway", gw)
+	return true
+}
+
+func parseNameservers(body string) []string {
+	var out []string
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if rest, ok := strings.CutPrefix(line, "nameserver"); ok {
+			if v := strings.TrimSpace(rest); v != "" {
+				out = append(out, v)
+			}
+		}
+	}
+	return out
+}
+
+func readFile(p string) string {
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// hexLEToIP converts a /proc/net/route little-endian hex address to dotted
+// quad notation ("0101A8C0" -> "192.168.1.1"). Returns "" for a zero or
+// malformed value.
+func hexLEToIP(h string) string {
+	v, err := strconv.ParseUint(h, 16, 32)
+	if err != nil || v == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d.%d.%d.%d", v&0xff, (v>>8)&0xff, (v>>16)&0xff, (v>>24)&0xff)
+}

--- a/internal/spotify/manager.go
+++ b/internal/spotify/manager.go
@@ -677,13 +677,36 @@ func (m *Manager) Run(ctx context.Context) {
 		} else {
 			rapidCrashes = 0
 		}
+		// Back off when the engine keeps dying instantly. A box with a broken
+		// network (no DNS: go-librespot cannot resolve apresolve.spotify.com,
+		// #487) otherwise relaunches every 3 s forever, and each crash writes
+		// several log lines: the 32 KB NAND forensic buffer was burned down to
+		// ~84 s of history, destroying exactly the evidence such a box needs.
+		// Healthy playback resets rapidCrashes, so a normal restart still
+		// takes the fast 3 s path.
+		wait := 3 * time.Second
+		if rapidCrashes >= 3 {
+			wait = time.Duration(rapidCrashes) * 5 * time.Second
+			if wait > spotifyMaxRestartBackoff {
+				wait = spotifyMaxRestartBackoff
+			}
+			if rapidCrashes == 3 || rapidCrashes%10 == 0 {
+				m.logger.Warn("spotify: engine keeps failing right after launch, slowing the restarts down (check the speaker's network/DNS)",
+					"rapidCrashes", rapidCrashes, "retryInS", int(wait.Seconds()))
+			}
+		}
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(3 * time.Second):
+		case <-time.After(wait):
 		}
 	}
 }
+
+// spotifyMaxRestartBackoff caps the crash-loop backoff. One minute keeps a
+// recovered network unnoticeably fast to pick up while cutting the log churn
+// of a permanently offline box by a factor of twenty.
+const spotifyMaxRestartBackoff = 60 * time.Second
 
 // waitForBinary blocks until the go-librespot binary is present (m.Ready) or ctx
 // is cancelled, returning true the moment it appears. It returns immediately when

--- a/internal/webui/deferred_resume_test.go
+++ b/internal/webui/deferred_resume_test.go
@@ -1,0 +1,50 @@
+// Tests for the #487 rule: STR never powers a speaker on by itself. A stream
+// the firmware dropped while the box was off is armed as a deferred resume and
+// replayed only when the user switches the box on (the gabbo standby exit).
+
+package webui
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func TestArmAndRunDeferredResume(t *testing.T) {
+	s := &Server{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	s.armDeferredResume("http://127.0.0.1:8888/stream/3", "Radio X", "", "", time.Now())
+	s.deferredMu.Lock()
+	armed := s.deferred != nil
+	s.deferredMu.Unlock()
+	if !armed {
+		t.Fatal("armDeferredResume must store the resume")
+	}
+	// Without a renderer the replay cannot run, but it must still CONSUME the
+	// arm so a later wake does not replay it twice.
+	defer func() { _ = recover() }()
+	s.RunDeferredResume()
+	s.deferredMu.Lock()
+	left := s.deferred
+	s.deferredMu.Unlock()
+	if left != nil {
+		t.Fatal("RunDeferredResume must consume the arm exactly once")
+	}
+}
+
+func TestDeferredResumeExpires(t *testing.T) {
+	s := &Server{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	s.armDeferredResume("http://127.0.0.1:8888/stream/3", "Radio X", "", "", time.Now())
+	s.deferredMu.Lock()
+	s.deferred.armedAt = time.Now().Add(-deferredResumeTTL - time.Minute)
+	s.deferredMu.Unlock()
+	// An expired arm must be dropped without touching the renderer (which is
+	// nil here: a replay attempt would panic and fail the test).
+	s.RunDeferredResume()
+	s.deferredMu.Lock()
+	left := s.deferred
+	s.deferredMu.Unlock()
+	if left != nil {
+		t.Fatal("an expired deferred resume must be dropped")
+	}
+}

--- a/internal/webui/standby_bounce_test.go
+++ b/internal/webui/standby_bounce_test.go
@@ -249,6 +249,10 @@ func TestHandleEnterStandby_SpontaneousDropResumesActiveStream(t *testing.T) {
 	s.SetUserActivityFn(func() time.Time { return time.Now().Add(-5 * time.Minute) })
 	s.SetStreamActivityFn(func() (time.Time, time.Time) { return time.Now(), time.Time{} })
 	s.setLastPlay("http://127.0.0.1:8888/stream/3", "Station", "", "")
+	// The #419 shape: the firmware killed the SOURCE while the box stayed
+	// awake. Only then may the recovery push immediately (a box that is
+	// actually off is handled by the deferred path, see the test below).
+	s.boxSourceFn = func() string { return "UPNP" }
 
 	s.HandleEnterStandby()
 
@@ -306,4 +310,35 @@ func TestHandleEnterStandby_KeyAfterOwnPushStillLatches(t *testing.T) {
 	if !waitForAction(t, rec, "Stop") {
 		t.Fatalf("a real power-off must still clear the transport (#197), got %v", rec.list())
 	}
+}
+
+// TestHandleEnterStandby_StandbyDefersInsteadOfWaking encodes the #487 rule:
+// when the box is genuinely in standby, STR must NOT power it on. The Wave
+// emits no userActivityUpdate for its power key, so a real user power-off
+// reaches this path looking exactly like a firmware drop, and the wake that
+// used to live here switched the speaker back on 6 s after its owner had
+// switched it off. The resume must be deferred to the user's next wake.
+func TestHandleEnterStandby_StandbyDefersInsteadOfWaking(t *testing.T) {
+	s, rec := newPlayTestServer(t)
+	s.SetUserActivityFn(func() time.Time { return time.Now().Add(-5 * time.Minute) })
+	s.SetStreamActivityFn(func() (time.Time, time.Time) { return time.Now(), time.Time{} })
+	s.setLastPlay("http://127.0.0.1:8888/stream/3", "Station", "", "")
+	s.boxSourceFn = func() string { return "STANDBY" }
+
+	s.HandleEnterStandby()
+
+	deadline := time.Now().Add(6 * time.Second)
+	for time.Now().Before(deadline) {
+		s.deferredMu.Lock()
+		armed := s.deferred != nil
+		s.deferredMu.Unlock()
+		if armed {
+			if rec.has("SetAVTransportURI") {
+				t.Fatalf("a box in standby must not be pushed to, got %v", rec.list())
+			}
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("the resume was not deferred for the next user wake, actions %v", rec.list())
 }

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -213,6 +213,14 @@ type Server struct {
 	// lastPlay remembers the stream STR last told the box to play, so the
 	// auto-re-push (#4) can resume it when the Bose renderer drops a long
 	// stream on its own (reported: radio stops after ~11 min, no STR error).
+	// boxSourceFn seams the now_playing source read (boxSourceNow) so the
+	// standby-vs-awake decision is assertable without a live box.
+	boxSourceFn func() string
+	// deferred holds a resume waiting for the user to switch the box on; STR
+	// never powers a speaker on by itself (#487). Guarded by deferredMu.
+	deferredMu sync.Mutex
+	deferred   *deferredResume
+
 	lastPlayMu sync.Mutex
 	lastPlay   *lastPlayInfo
 	// rePushInFlight coalesces stream-drop resumes (see HandleStreamDisconnect).
@@ -3299,16 +3307,20 @@ func (s *Server) handleSpontaneousSourceOff(sinceKey time.Duration) {
 	s.logger.Info("standby bounce: firmware powered off STR's source with no user input, not treating as a user stop (#419)",
 		"lastKeyAgoS", int(sinceKey.Seconds()))
 	if !spontaneousResumeEnabled() {
+		s.logger.Info("spontaneous-off recovery: disabled by setting, standing down")
 		return
 	}
 	// Only recover music the drop actually interrupted: the stream proxy must
 	// have served the box this recently. A long-idle box that drifts to standby
 	// on its own is left alone.
 	if s.streamActivityFn == nil {
+		s.logger.Info("spontaneous-off recovery: no stream-activity signal wired, standing down")
 		return
 	}
 	fetch, _ := s.streamActivityFn()
 	if fetch.IsZero() || time.Since(fetch) > spontResumeStreamWindow {
+		s.logger.Info("spontaneous-off recovery: the stream proxy did not serve this box recently, standing down",
+			"lastFetchAgoS", int(time.Since(fetch).Seconds()), "windowS", int(spontResumeStreamWindow.Seconds()))
 		return
 	}
 	// Single-flight + crash-loop guard. The #381 attempt counter caps a
@@ -3321,6 +3333,8 @@ func (s *Server) handleSpontaneousSourceOff(sinceKey time.Duration) {
 	}
 	s.standbyStopMu.Unlock()
 	if tooSoon || s.autoResumeBlocked() {
+		s.logger.Info("spontaneous-off recovery: standing down",
+			"reason", map[bool]string{true: "another recovery ran just now", false: "auto-resume blocked (crash-loop guard or opt-out)"}[tooSoon])
 		return
 	}
 	s.lastPlayMu.Lock()
@@ -3332,6 +3346,7 @@ func (s *Server) handleSpontaneousSourceOff(sinceKey time.Duration) {
 	}
 	s.lastPlayMu.Unlock()
 	if boxURL == "" {
+		s.logger.Info("spontaneous-off recovery: no last-play to restore, standing down")
 		return
 	}
 	go func() {
@@ -3349,10 +3364,25 @@ func (s *Server) handleSpontaneousSourceOff(sinceKey time.Duration) {
 			return
 		}
 		s.noteAutoResumeAttempt()
-		if s.boxHost != "" {
-			wctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
-			_ = boxcli.WakeAndWait(wctx, s.boxHost, 6*time.Second, s.logger)
-			cancel()
+		// NEVER power a box on from an automatic path (#487 field capture,
+		// 2026-07-27): the Wave emits no userActivityUpdate for its power key,
+		// so a real user power-off is indistinguishable here from a firmware
+		// drop, and the wake that used to sit at this line switched the
+		// speaker back on 6 s after its owner had switched it off. A box that
+		// is genuinely still in STANDBY is therefore left alone, and the
+		// resume is DEFERRED: armDeferredResume hands it to the standby-exit
+		// path, so the stream comes back the moment the user turns the box on
+		// themselves. The #419 case this function exists for is unaffected -
+		// there the firmware drops the SOURCE while the box stays awake, and
+		// the re-push below still runs immediately.
+		// An unknown source (probe failed) counts as "possibly off" and defers
+		// too: pushing a transport into a box that is actually off can switch
+		// scm firmware back on, which is the same harm by another route.
+		if src := s.boxSourceNow(); src == "STANDBY" || src == "" {
+			s.armDeferredResume(boxURL, title, art, mime, capturedTS)
+			s.logger.Info("spontaneous-off recovery: box is in standby, NOT powering it on; resume deferred to the next user wake",
+				"source", src, "url", boxURL)
+			return
 		}
 		s.boxCmdMu.Lock()
 		defer s.boxCmdMu.Unlock()
@@ -3378,6 +3408,103 @@ func (s *Server) handleSpontaneousSourceOff(sinceKey time.Duration) {
 		}
 		s.logger.Info("spontaneous-off recovery: resumed the stream the firmware dropped (#419)", "url", boxURL, "title", title)
 	}()
+}
+
+// boxSourceNow reads the box's current source attribute ("" on any error).
+// Used by the spontaneous-off recovery to tell "the firmware dropped the
+// source while the box stayed awake" (recoverable right now) from "the box is
+// off" (must never be powered on automatically, #487).
+func (s *Server) boxSourceNow() string {
+	if s.boxSourceFn != nil {
+		return s.boxSourceFn()
+	}
+	if s.boxHost == "" {
+		return ""
+	}
+	cl := &http.Client{Timeout: 4 * time.Second}
+	resp, err := cl.Get("http://" + s.boxHost + ":8090/now_playing")
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+	if m := regexp.MustCompile(`source="([^"]*)"`).FindSubmatch(b); len(m) == 2 {
+		return string(m[1])
+	}
+	return ""
+}
+
+// deferredResume is a stream the firmware dropped while the box was (or went)
+// off. STR refuses to power a speaker on by itself, so the recovery waits here
+// until the user switches the box on and the gabbo standby-exit arrives.
+type deferredResume struct {
+	boxURL, title, art, mime string
+	capturedTS               time.Time
+	armedAt                  time.Time
+}
+
+// deferredResumeTTL bounds how long a deferred resume stays armed. Long enough
+// to cover "switched off in the evening, on again next morning" without
+// resurrecting a stream from days ago.
+const deferredResumeTTL = 18 * time.Hour
+
+// armDeferredResume stores the resume for the next user wake. A newer arm
+// replaces an older one: the most recent interrupted stream is what the user
+// expects back.
+func (s *Server) armDeferredResume(boxURL, title, art, mime string, capturedTS time.Time) {
+	s.deferredMu.Lock()
+	s.deferred = &deferredResume{boxURL: boxURL, title: title, art: art, mime: mime, capturedTS: capturedTS, armedAt: time.Now()}
+	s.deferredMu.Unlock()
+}
+
+// RunDeferredResume replays a stream armed by armDeferredResume, if any. Wired
+// to the gabbo standby-exit (the box just left STANDBY, i.e. the user turned it
+// on), so the music the firmware dropped comes back on the user's own action
+// instead of STR waking the speaker. All the usual guards still apply: a
+// deliberate stop, a zone, a newer play, an opt-out or an expired arm cancel it.
+func (s *Server) RunDeferredResume() {
+	s.deferredMu.Lock()
+	d := s.deferred
+	s.deferred = nil
+	s.deferredMu.Unlock()
+	if d == nil {
+		return
+	}
+	if time.Since(d.armedAt) > deferredResumeTTL {
+		s.logger.Info("deferred resume: too old, dropping", "ageMin", int(time.Since(d.armedAt).Minutes()))
+		return
+	}
+	if !spontaneousResumeEnabled() || s.autoResumeBlocked() {
+		s.logger.Info("deferred resume: auto-resume disabled or blocked, standing down")
+		return
+	}
+	if s.userStoppedRecently() || s.standbyStoppedRecently() || s.boxInZone() {
+		s.logger.Info("deferred resume: a deliberate stop or a zone is in play, standing down")
+		return
+	}
+	s.lastPlayMu.Lock()
+	cur := s.lastPlay
+	s.lastPlayMu.Unlock()
+	if resumeIsStale(d.boxURL, d.capturedTS, cur) {
+		s.logger.Info("deferred resume: a newer play took over, standing down")
+		return
+	}
+	s.boxCmdMu.Lock()
+	defer s.boxCmdMu.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	var err error
+	if d.mime != "" {
+		err = s.renderer.PlayURLMime(ctx, d.boxURL, d.title, d.art, d.mime)
+	} else {
+		err = s.renderer.PlayURL(ctx, d.boxURL, d.title, d.art)
+	}
+	if err != nil {
+		s.logger.Warn("deferred resume: re-push failed", "err", err, "url", d.boxURL)
+		return
+	}
+	s.logger.Info("deferred resume: restored the stream the firmware had dropped, on the user's own wake (#487)",
+		"url", d.boxURL, "title", d.title)
 }
 
 // HandleStreamDisconnect is called by the stream proxy when the Bose renderer


### PR DESCRIPTION
Four fixes from the 2026-07-27 field bundles (two Wave reporters, seven diagnostic exports), analysed with an adversarially verified RCA.

### 1. STR must never power a speaker on (#487 capture)
The Wave emits no `userActivityUpdate` for its power key, so a genuine user power-off reaches `handleSpontaneousSourceOff` looking exactly like a firmware drop (lastKey was 49 s old). The captured log shows the recovery sending sys power **6 s after the owner switched the speaker off**, then resuming slot 6.

The wake is gone from the automatic path. The recovery still runs immediately for the real #419 shape (source dead, box awake); when the box is in standby - or its state cannot be read - the stream is armed as a **deferred resume** and replayed on the next genuine user wake via the v0.9.22 standby-exit hook. All five previously silent stand-down paths now log a reason.

Regression guard: the reviewer flagged the naive fix ("stand down on STANDBY") as disabling #419 outright; this design keeps it armed. New tests encode both halves (`TestHandleEnterStandby_SpontaneousDropResumesActiveStream` with an awake box, `TestHandleEnterStandby_StandbyDefersInsteadOfWaking`) plus the deferred-resume lifecycle.

### 2. DNS bootstrap (new failure class, confirmed in code + logs)
A reporter's box had **no usable nameserver**: Go fell back to its built-in 127.0.0.1:53 / [::1]:53 pair and every lookup failed. One fault, three symptoms, self-locking:
- stream proxy cannot resolve any station -> box aborts in ~400 ms -> "Service Unavailable"
- `clocksync.dateHosts` were all hostnames -> clock stuck at the 2015 epoch
- autopair is gated on a plausible clock -> box never pairs -> "SoundTouch not configured"
- go-librespot crash-loops on apresolve.spotify.com

New `internal/dnsboot`: detects a missing/empty resolver, stages `/tmp/streborn-resolv.conf` (default gateway from /proc/net/route, then 1.1.1.1 / 8.8.8.8) and bind-mounts it over the read-only rootfs file, mirroring the existing /etc/hosts handling. Fixing it at file level also repairs the **firmware's own** lookups, so NTP, the clock, pairing and the display heal without further code. `clocksync` additionally gains IP-literal fallbacks so the clock can recover even before the mount.

### 3. `dns_status` in the diagnostic bundle
resolv.conf contents, parsed nameservers and the default gateway, next to `clock_status`. This case cost a full bundle round trip to find.

### 4. Spotify engine crash-loop backoff
3 s -> 60 s after repeated instant failures. An offline box relaunched the engine every 3 s and burned the 32 KB NAND forensic log down to **84 seconds** of history, destroying exactly the evidence such a box needs.

## Testing
- `go test ./...` green (new: deferred_resume_test.go, extended standby_bounce_test.go)
- `GOOS=linux GOARCH=arm GOARM=5` cross-build green
- Not yet on hardware: the DNS path needs a box that actually lacks a resolver (reporter has one), the deferred resume needs a power-off cycle.

Refs #487, refs #419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)