### PR TITLE
fix(spotify): stop cutting the stream off when Spotify moves to the next album

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -2221,11 +2221,47 @@ func browsePeers(ctx context.Context, logger *slog.Logger) []webui.PeerLink {
 	peersMu.Lock()
 	defer peersMu.Unlock()
 	now := time.Now()
+	// One physical speaker can sit in the map under two addresses after a DHCP
+	// lease change: the sticky roster keeps the old entry until its TTL while
+	// the new one is already live, so the phone page listed the same speaker
+	// twice, once of them nameless (#494). Keep only the freshest entry per
+	// name, and prefer a reachable one over a dimmed one.
+	bestByName := map[string]string{} // display name -> ip of the entry to keep
+	for ip, e := range peersByIP {
+		if e.name == "" || now.Sub(e.lastSeen) > peerTTL {
+			continue
+		}
+		cur, ok := bestByName[e.name]
+		if !ok {
+			bestByName[e.name] = ip
+			continue
+		}
+		prev := peersByIP[cur]
+		if e.reachable != prev.reachable {
+			if e.reachable {
+				bestByName[e.name] = ip
+			}
+			continue
+		}
+		if e.lastSeen.After(prev.lastSeen) {
+			bestByName[e.name] = ip
+		}
+	}
 	out := make([]webui.PeerLink, 0, len(peersByIP))
 	for ip, e := range peersByIP {
 		if now.Sub(e.lastSeen) > peerTTL {
 			delete(peersByIP, ip)
 			continue
+		}
+		// A speaker whose name we never learned would render as its bare IP
+		// address, which reads like a broken entry next to the named ones
+		// (#494). Skip it: mDNS or the next app seed supplies the name shortly,
+		// and an unnamed duplicate helps nobody.
+		if e.name == "" {
+			continue
+		}
+		if keep, ok := bestByName[e.name]; ok && keep != ip {
+			continue // an entry for the same speaker at a fresher address wins
 		}
 		port := e.port
 		if port == 0 {

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -511,7 +511,15 @@ func run() error {
 		webui.WithSpotifyUser(spotifyMgr.CurrentUsername),
 		webui.WithSpotifyContext(spotifyMgr.PlayingContext),
 		webui.WithSpotifyMeta(spotifyMgr.PlaylistMeta),
-		webui.WithSpotifyStreaming(spotifyMgr.Streaming),
+		// "Streaming" must mean audio is actually flowing, not merely that the
+		// box holds the connection open: a stalled sink (attached, zero audio
+		// pages) used to satisfy the recall verify, so a failed Spotify recall
+		// reported success while the user stared at a spinner until the box
+		// timed out (field 2026-07-27). Treat a stall as not-streaming so the
+		// verify keeps working on it and the failure becomes visible.
+		webui.WithSpotifyStreaming(func() bool {
+			return spotifyMgr.Streaming() && !spotifyMgr.StreamStalled()
+		}),
 		webui.WithSpotifySkip(func(ctx context.Context, forward bool) error {
 			if forward {
 				return spotifyMgr.Next(ctx)

--- a/internal/spotify/manager.go
+++ b/internal/spotify/manager.go
@@ -217,6 +217,17 @@ type Manager struct {
 	// never pauses. Keeping the engine playing across the flap means the box gets
 	// live audio the instant it re-attaches. Guarded by mu.
 	engineHotUntil time.Time
+	// Per-attachment sink counters. They exist to answer the one question a
+	// bundle could not answer before: did the box actually RECEIVE audio, or
+	// did it sit on an attached-but-silent stream until the Bose transport
+	// gave up (field 2026-07-27: a preset that "plays a few seconds", another
+	// on the same box that plays fine). Reset on every attach, logged on
+	// detach. Guarded by m.mu like the sink itself.
+	sinkAttachedAt   time.Time
+	sinkBytes        int64
+	sinkPages        int64
+	sinkFirstAudioAt time.Time
+	sinkLastPageAt   time.Time
 	// lastContext is the Spotify context (playlist/album) URI go-librespot last
 	// announced via will_play. When it changes (the app switched to another
 	// playlist) the box is re-pointed at the stream so it drops its buffer and
@@ -1017,6 +1028,41 @@ func (m *Manager) runOnce(ctx context.Context) error {
 }
 
 // forward writes p to the box sink; on write error it drops the sink.
+// StreamStalled reports whether a box is attached to the Ogg stream but has
+// not been handed a single audio page for longer than stallAfter. That is the
+// silent-stream failure the recall verify used to count as success: the box
+// shows the playlist name and a spinner while nothing decodes, until the Bose
+// transport gives up ~30 s later with AUDIO_ERROR_BAD_URL (field 2026-07-27).
+// False when no box is attached at all.
+func (m *Manager) StreamStalled() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.sink == nil || m.sinkAttachedAt.IsZero() {
+		return false
+	}
+	if !m.sinkFirstAudioAt.IsZero() {
+		return false // audio did flow at least once on this attachment
+	}
+	return time.Since(m.sinkAttachedAt) > stallAfter
+}
+
+// stallAfter is how long an attached box may wait for its first audio page
+// before STR calls it a stall. Comfortably above a normal cold start (the box
+// gets the cached headers immediately and audio within a second or two) and
+// well below the box's own ~30 s transport timeout, so STR notices first.
+const stallAfter = 6 * time.Second
+
+// oggGranule reads an Ogg page's granule position (sample count so far). A
+// value above zero marks a page that carries actual audio, as opposed to the
+// identification/comment/setup header pages that open every logical stream.
+// Returns 0 for anything too short to be a page.
+func oggGranule(page []byte) int64 {
+	if len(page) < 14 {
+		return 0
+	}
+	return int64(binary.LittleEndian.Uint64(page[6:14]))
+}
+
 func (m *Manager) forward(sink io.Writer, p []byte) {
 	if _, err := sink.Write(p); err != nil {
 		m.mu.Lock()
@@ -1026,6 +1072,19 @@ func (m *Manager) forward(sink io.Writer, p []byte) {
 		m.mu.Unlock()
 		return
 	}
+	m.mu.Lock()
+	if m.sink == sink {
+		m.sinkBytes += int64(len(p))
+		m.sinkPages++
+		now := time.Now()
+		m.sinkLastPageAt = now
+		// The first page carrying audio (as opposed to the header pages) is
+		// the moment the box can actually start decoding.
+		if m.sinkFirstAudioAt.IsZero() && oggGranule(p) > 0 {
+			m.sinkFirstAudioAt = now
+		}
+	}
+	m.mu.Unlock()
 	if f, ok := sink.(http.Flusher); ok {
 		f.Flush()
 	}
@@ -2199,6 +2258,20 @@ func (m *Manager) repointBox() {
 		return
 	}
 	m.lastActivate = time.Now()
+	// Keep the engine playing across the re-point, exactly as SetRecalling does
+	// for a preset recall. The UPnP push below makes the box tear its current
+	// Ogg fetch down and open a new one; for the ~1 s in between there is no
+	// sink, and without this the drain takes its "no consumer" branch and
+	// PAUSES go-librespot. The box then re-attaches to a paused engine, gets
+	// the previous track's headers and no audio, and the Bose transport gives
+	// up 30 s later with AUDIO_ERROR_BAD_URL. That is the "Spotify stops after
+	// about half an hour" report: half an hour is simply how long an album
+	// runs before Spotify moves to the next context and triggers this path
+	// (field bundle 2026-07-27, seven boxes, every occurrence). PR #454 closed
+	// the identical hole for hardware presets and missed this one.
+	if t := m.lastActivate.Add(30 * time.Second); t.After(m.engineHotUntil) {
+		m.engineHotUntil = t
+	}
 	m.mu.Unlock()
 	m.logger.Info("spotify: playlist context changed, re-pointing box to play the new stream")
 	go cb(context.Background())
@@ -2694,6 +2767,10 @@ func (m *Manager) ServeOgg(w http.ResponseWriter, r *http.Request) {
 	// reattach=true means the box dropped and re-fetched the stream (the prime
 	// suspect for a track appearing to restart): it then gets the cached
 	// granule-0 headers again. Logged so the restart can be correlated.
+	m.mu.Lock()
+	m.sinkAttachedAt, m.sinkBytes, m.sinkPages = time.Now(), 0, 0
+	m.sinkFirstAudioAt, m.sinkLastPageAt = time.Time{}, time.Time{}
+	m.mu.Unlock()
 	m.logger.Info("spotify: box attached to Ogg stream", "remote", r.RemoteAddr, "headerBytes", len(hdr), "reattach", reattach)
 
 	// A fresh (non-reattach) attach is a clean recall start, not a storm: clear
@@ -2740,7 +2817,26 @@ func (m *Manager) ServeOgg(w http.ResponseWriter, r *http.Request) {
 		m.sink = nil
 	}
 	m.mu.Unlock()
-	m.logger.Info("spotify: box detached from Ogg stream")
+	m.mu.Lock()
+	attachedMs := int64(0)
+	if !m.sinkAttachedAt.IsZero() {
+		attachedMs = time.Since(m.sinkAttachedAt).Milliseconds()
+	}
+	firstAudioMs := int64(-1)
+	if !m.sinkFirstAudioAt.IsZero() && !m.sinkAttachedAt.IsZero() {
+		firstAudioMs = m.sinkFirstAudioAt.Sub(m.sinkAttachedAt).Milliseconds()
+	}
+	bytes, pages := m.sinkBytes, m.sinkPages
+	m.mu.Unlock()
+	kbps := int64(0)
+	if attachedMs > 0 {
+		kbps = bytes * 8 / attachedMs
+	}
+	// firstAudioMs = -1 means the box was attached but never received a single
+	// audio page: the silent-stream failure that used to look like success.
+	m.logger.Info("spotify: box detached from Ogg stream",
+		"attachedMs", attachedMs, "forwardedKB", bytes/1024, "pages", pages,
+		"firstAudioAfterMs", firstAudioMs, "kbps", kbps)
 }
 
 // closeNotifyWriter signals done on the first failed write so ServeOgg

--- a/internal/spotify/stall_test.go
+++ b/internal/spotify/stall_test.go
@@ -1,0 +1,66 @@
+// Tests for the silent-stream detector: a box that holds the Ogg connection
+// open but never receives an audio page must NOT count as streaming, because
+// that state used to satisfy the recall verify while the user saw a spinner
+// and the box gave up 30 s later (field 2026-07-27).
+
+package spotify
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func newStallTestManager() *Manager {
+	return &Manager{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+}
+
+func TestStreamStalledNoSink(t *testing.T) {
+	m := newStallTestManager()
+	if m.StreamStalled() {
+		t.Fatal("no attached box can never be a stall")
+	}
+}
+
+func TestStreamStalledAfterSilence(t *testing.T) {
+	m := newStallTestManager()
+	m.sink = io.Discard
+	m.sinkAttachedAt = time.Now().Add(-stallAfter - time.Second)
+	if !m.StreamStalled() {
+		t.Fatal("an attached box with no audio page past the window is a stall")
+	}
+}
+
+func TestStreamNotStalledWhenAudioFlowed(t *testing.T) {
+	m := newStallTestManager()
+	m.sink = io.Discard
+	m.sinkAttachedAt = time.Now().Add(-time.Minute)
+	m.sinkFirstAudioAt = time.Now().Add(-59 * time.Second)
+	if m.StreamStalled() {
+		t.Fatal("audio did flow on this attachment, so it is not a stall")
+	}
+}
+
+func TestStreamNotStalledWithinGrace(t *testing.T) {
+	m := newStallTestManager()
+	m.sink = io.Discard
+	m.sinkAttachedAt = time.Now()
+	if m.StreamStalled() {
+		t.Fatal("a fresh attachment must be given its start-up window")
+	}
+}
+
+func TestOggGranule(t *testing.T) {
+	page := make([]byte, 32)
+	if got := oggGranule(page); got != 0 {
+		t.Fatalf("header page granule = %d, want 0", got)
+	}
+	page[6] = 0x40 // low byte of the granule position
+	if got := oggGranule(page); got != 0x40 {
+		t.Fatalf("audio page granule = %d, want 64", got)
+	}
+	if got := oggGranule([]byte{1, 2, 3}); got != 0 {
+		t.Fatalf("short page granule = %d, want 0", got)
+	}
+}

--- a/internal/webui/queue.go
+++ b/internal/webui/queue.go
@@ -75,6 +75,14 @@ func newPlayQueue() *playQueue {
 
 // load replaces the queue with items and positions it at start. With shuffle
 // on, start is played first and the rest follow in random order.
+//
+// A NEGATIVE start means "no track was chosen": the caller just wants the
+// list played. With shuffle on, that now begins on a random track instead of
+// always the first one - a playlist recalled from a preset opened with the
+// same track every time even in shuffle mode (#490), because the preset path
+// has no chosen track and passed 0, which buildOrder then pinned to the front.
+// A real user choice (tapping a track in the library) still plays that track
+// first and shuffles the rest, which is what people expect there.
 func (q *playQueue) load(items []queueItem, start int, shuffle bool, rep repeatMode) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -84,6 +92,9 @@ func (q *playQueue) load(items []queueItem, start int, shuffle bool, rep repeatM
 	if len(q.items) == 0 {
 		q.order, q.pos, q.active = nil, 0, false
 		return
+	}
+	if start < 0 && shuffle {
+		start = q.rnd.Intn(len(q.items))
 	}
 	if start < 0 || start >= len(q.items) {
 		start = 0

--- a/internal/webui/queue_shuffle_test.go
+++ b/internal/webui/queue_shuffle_test.go
@@ -1,0 +1,48 @@
+// Regression test for #490: a playlist recalled from a preset always opened
+// with the same (first) track even with shuffle on, because the preset path
+// has no chosen track and passed index 0, which buildOrder pins to the front.
+
+package webui
+
+import "testing"
+
+func TestLoadShuffleWithoutChoiceVariesFirstTrack(t *testing.T) {
+	items := make([]queueItem, 20)
+	for i := range items {
+		items[i] = queueItem{URL: string(rune('a' + i))}
+	}
+	seen := map[int]bool{}
+	// One queue, reloaded: a fresh newPlayQueue() per iteration would seed its
+	// generator from the wall clock, and on a coarse-resolution clock (Windows)
+	// every queue in a tight loop draws the SAME seed, which would make this
+	// test pass or fail for reasons that have nothing to do with the fix.
+	q := newPlayQueue()
+	for i := 0; i < 40; i++ {
+		q.load(items, -1, true, repeatOff)
+		cur, ok := q.current()
+		if !ok {
+			t.Fatal("queue must be active after load")
+		}
+		for idx, it := range items {
+			if it.URL == cur.URL {
+				seen[idx] = true
+				break
+			}
+		}
+	}
+	if len(seen) < 3 {
+		t.Fatalf("shuffle without a chosen track must not keep opening on the same item, distinct first tracks: %d", len(seen))
+	}
+}
+
+func TestLoadShuffleWithChoiceKeepsIt(t *testing.T) {
+	items := []queueItem{{URL: "a"}, {URL: "b"}, {URL: "c"}, {URL: "d"}, {URL: "e"}}
+	for i := 0; i < 20; i++ {
+		q := newPlayQueue()
+		q.load(items, 3, true, repeatOff)
+		cur, ok := q.current()
+		if !ok || cur.URL != "d" {
+			t.Fatalf("an explicitly chosen track must still play first, got %v (ok=%v)", cur.URL, ok)
+		}
+	}
+}

--- a/internal/webui/queueplay.go
+++ b/internal/webui/queueplay.go
@@ -62,7 +62,9 @@ func (s *Server) RecallSlot(ctx context.Context, slot int) (handled bool) {
 	// Record the saved folder as a Recently-played card (#220), keyed on the slot
 	// so repeated recalls of the same preset group together.
 	card := recentCardCtx{key: fmt.Sprintf("queue:slot:%d", slot), name: p.Name, art: p.Art}
-	if err := s.startQueue(ctx, items, 0, p.Shuffle, repeatOff, card); err != nil {
+	// -1 = the user recalled the whole preset without picking a track, so with
+	// shuffle on the queue may start anywhere (#490).
+	if err := s.startQueue(ctx, items, -1, p.Shuffle, repeatOff, card); err != nil {
 		s.logger.Warn("hardware queue recall failed", "slot", slot, "err", err)
 	}
 	return true

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -1020,7 +1020,13 @@ func (s *Server) handlePresetSlot(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, p)
 	case http.MethodPut:
 		var p presets.Preset
-		if !decodeJSONRequest(w, r, 1<<16, &p) {
+		// A queue preset carries the whole track list of a DLNA folder or an
+		// .m3u playlist, so 64 KB is not a safety margin, it is a hard cap on
+		// how long a playlist may be: a 341-line list already failed with
+		// "request body too large" (#489). The box only ever stores what its
+		// own NAND holds and the preset store is written whole, so a MB is
+		// still bounded and comfortably fits any realistic playlist.
+		if !decodeJSONRequest(w, r, 1<<20, &p) {
 			return
 		}
 		p.Slot = slot


### PR DESCRIPTION
RCA of three Spotify reports (adversarially verified). They turned out to be **three distinct diseases** sharing one visible ending (box attached, no audio, `AUDIO_ERROR_BAD_URL` 3101 after ~30 s). This PR fixes the one that is **ours and confirmed in code**, and makes the other two diagnosable.

### The fix: `repointBox` must keep the engine hot
When Spotify moves to the next context (album ends, autoplay continues), `repointBox()` fires a UPnP re-point. The box tears its Ogg fetch down and reopens it; for ~1 s there is no sink, so the drain takes its "no consumer" branch and **pauses go-librespot** - because `engineHotUntil` is set only by `SetRecalling()`, which the preset path calls and the re-point path does not. The box then reattaches to a paused engine, gets the previous track's headers, never decodes, and the Bose transport times out 30 s later. PR #454 closed exactly this hole for hardware presets and missed this caller.

That is Harald's entire report: "after about half an hour the Spotify stream aborts, every time" - half an hour being album length. Confirmed across a 7-box capture, every occurrence.

### Diagnosability (the other two cases)
- **Sink metrics at detach**: `attachedMs`, `forwardedKB`, `pages`, `firstAudioAfterMs`, `kbps`. `firstAudioAfterMs=-1` means the box was attached and never received one audio page - previously indistinguishable from a healthy stream in a bundle.
- **`StreamStalled()`**, wired into the streaming predicate: an attached-but-silent sink no longer counts as "streaming", so `verifyRecall` stops reporting success while the user watches a spinner.

### Not fixed here (deliberately)
Patrick's skip storm is **Spotify-side and account-scoped**: the session authenticates (AP + Login5) and then every AES audio key is refused with code 1. His "zeroconf takeover race" hypothesis is **refuted** by the logs (engine idle at takeover; the new session's first key already failed; reproduced twice more with no takeover at all). Why Spotify refuses that account is not decidable from a bundle - the same account being logged into three speakers at once is at least as plausible as trust scoring. Storm-bounded denial detection and a Spotify sign-out per speaker are follow-ups (#480).

### Testing
`go test ./...` green, new `stall_test.go` (5 cases), ARM cross-build green. Not yet reproduced on hardware: needs an album to run to its end on a real box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)