### PR TITLE
fix(app): let you add a speaker by IP even when other speakers are already listed

### DIFF
--- a/desktop-app/frontend/src/i18n/bundles/ar.json
+++ b/desktop-app/frontend/src/i18n/bundles/ar.json
@@ -182,6 +182,7 @@
   "speaker.manualIpHelp": "تعذّر العثور على السماعة؟ في بعض الشبكات (واي فاي الضيوف، VPN، أو التي تعزل الأجهزة) يكون البحث محظورًا. أدخل عنوان IP للسماعة (من جهاز التوجيه) للاتصال مباشرة.",
   "speaker.manualIpPlaceholder": "مثال: 192.168.1.50",
   "speaker.manualIpButton": "الاتصال عبر IP",
+  "speaker.addByIp": "إضافة عبر IP",
   "speaker.manualIpSearching": "جارٍ الاتصال بـ {{ip}}...",
   "speaker.manualIpNotFound": "لم تستجب أي سماعة على {{ip}}. تحقق من العنوان وأن الكمبيوتر والسماعة على الشبكة نفسها.",
   "speaker.retry": "البحث مجدّدًا",

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -199,6 +199,7 @@
   "speaker.manualIpHelp": "Lautsprecher wird nicht gefunden? In manchen Netzwerken (Gast-WLAN, VPN oder mit Geräte-Isolierung) ist die Suche blockiert. Gib die IP-Adresse des Lautsprechers (aus deinem Router) ein, um dich direkt zu verbinden.",
   "speaker.manualIpPlaceholder": "z. B. 192.168.1.50",
   "speaker.manualIpButton": "Per IP verbinden",
+  "speaker.addByIp": "Per IP hinzufügen",
   "speaker.manualIpSearching": "Verbinde mit {{ip}}...",
   "speaker.manualIpNotFound": "Kein Lautsprecher unter {{ip}} erreichbar. Prüfe die Adresse und ob PC und Lautsprecher im selben Netzwerk sind.",
   "speaker.retry": "Erneut suchen",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -199,6 +199,7 @@
   "speaker.manualIpHelp": "Can't find your speaker? On some networks (guest Wi-Fi, a VPN, or one that isolates devices) discovery is blocked. Type the speaker's IP address (from your router) to connect directly.",
   "speaker.manualIpPlaceholder": "e.g. 192.168.1.50",
   "speaker.manualIpButton": "Connect by IP",
+  "speaker.addByIp": "Add by IP",
   "speaker.manualIpSearching": "Connecting to {{ip}}...",
   "speaker.manualIpNotFound": "No speaker answered at {{ip}}. Check the address and that the PC and speaker share the same network.",
   "speaker.retry": "Search again",

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -182,6 +182,7 @@
   "speaker.manualIpHelp": "¿No encuentras el altavoz? En algunas redes (wifi de invitados, VPN o con aislamiento de dispositivos) la búsqueda está bloqueada. Escribe la dirección IP del altavoz (desde tu router) para conectarte directamente.",
   "speaker.manualIpPlaceholder": "p. ej. 192.168.1.50",
   "speaker.manualIpButton": "Conectar por IP",
+  "speaker.addByIp": "Añadir por IP",
   "speaker.manualIpSearching": "Conectando con {{ip}}...",
   "speaker.manualIpNotFound": "Ningún altavoz respondió en {{ip}}. Comprueba la dirección y que el PC y el altavoz estén en la misma red.",
   "speaker.retry": "Buscar de nuevo",

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -182,6 +182,7 @@
   "speaker.manualIpHelp": "Enceinte introuvable ? Sur certains réseaux (Wi-Fi invité, VPN ou avec isolation des appareils), la recherche est bloquée. Saisissez l'adresse IP de l'enceinte (depuis votre routeur) pour vous connecter directement.",
   "speaker.manualIpPlaceholder": "ex. 192.168.1.50",
   "speaker.manualIpButton": "Connexion par IP",
+  "speaker.addByIp": "Ajouter par IP",
   "speaker.manualIpSearching": "Connexion à {{ip}}...",
   "speaker.manualIpNotFound": "Aucune enceinte n'a répondu à {{ip}}. Vérifiez l'adresse et que le PC et l'enceinte sont sur le même réseau.",
   "speaker.retry": "Rechercher à nouveau",

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -182,6 +182,7 @@
   "speaker.manualIpHelp": "スピーカーが見つかりませんか？一部のネットワーク（ゲストWi-Fi、VPN、デバイス分離あり）では検索がブロックされます。ルーターで確認したスピーカーのIPアドレスを入力すると直接接続できます。",
   "speaker.manualIpPlaceholder": "例: 192.168.1.50",
   "speaker.manualIpButton": "IPで接続",
+  "speaker.addByIp": "IP で追加",
   "speaker.manualIpSearching": "{{ip}} に接続しています...",
   "speaker.manualIpNotFound": "{{ip}} で応答するスピーカーがありません。アドレスと、PCとスピーカーが同じネットワークにあるか確認してください。",
   "speaker.retry": "再検索",

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -182,6 +182,7 @@
   "speaker.manualIpHelp": "Nerandate garsiakalbio? Kai kuriuose tinkluose (svečių Wi-Fi, VPN ar su įrenginių izoliacija) paieška blokuojama. Įveskite garsiakalbio IP adresą (iš maršruto parinktuvo), kad prisijungtumėte tiesiogiai.",
   "speaker.manualIpPlaceholder": "pvz. 192.168.1.50",
   "speaker.manualIpButton": "Jungtis per IP",
+  "speaker.addByIp": "Pridėti pagal IP",
   "speaker.manualIpSearching": "Jungiamasi prie {{ip}}...",
   "speaker.manualIpNotFound": "Joks garsiakalbis neatsiliepė adresu {{ip}}. Patikrinkite adresą ir ar kompiuteris bei garsiakalbis yra tame pačiame tinkle.",
   "speaker.retry": "Ieškoti iš naujo",

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -182,6 +182,7 @@
   "speaker.manualIpHelp": "Neizdodas atrast skaļruni? Dažos tīklos (viesu Wi-Fi, VPN vai ar ierīču izolāciju) meklēšana ir bloķēta. Ievadiet skaļruņa IP adresi (no maršrutētāja), lai izveidotu tiešu savienojumu.",
   "speaker.manualIpPlaceholder": "piem. 192.168.1.50",
   "speaker.manualIpButton": "Savienot pēc IP",
+  "speaker.addByIp": "Pievienot pēc IP",
   "speaker.manualIpSearching": "Savienojas ar {{ip}}...",
   "speaker.manualIpNotFound": "Neviens skaļrunis neatbildēja uz {{ip}}. Pārbaudiet adresi un vai dators un skaļrunis ir vienā tīklā.",
   "speaker.retry": "Meklēt vēlreiz",

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -182,6 +182,7 @@
   "speaker.manualIpHelp": "Speaker niet gevonden? In sommige netwerken (gast-wifi, VPN of met apparaatisolatie) is het zoeken geblokkeerd. Voer het IP-adres van de speaker (uit je router) in om direct te verbinden.",
   "speaker.manualIpPlaceholder": "bijv. 192.168.1.50",
   "speaker.manualIpButton": "Verbinden via IP",
+  "speaker.addByIp": "Toevoegen via IP",
   "speaker.manualIpSearching": "Verbinden met {{ip}}...",
   "speaker.manualIpNotFound": "Geen speaker bereikbaar op {{ip}}. Controleer het adres en of pc en speaker in hetzelfde netwerk zitten.",
   "speaker.retry": "Opnieuw zoeken",

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -182,6 +182,7 @@
   "speaker.manualIpHelp": "Nie znaleziono głośnika? W niektórych sieciach (Wi-Fi dla gości, VPN lub z izolacją urządzeń) wyszukiwanie jest zablokowane. Wpisz adres IP głośnika (z routera), aby połączyć się bezpośrednio.",
   "speaker.manualIpPlaceholder": "np. 192.168.1.50",
   "speaker.manualIpButton": "Połącz przez IP",
+  "speaker.addByIp": "Dodaj przez IP",
   "speaker.manualIpSearching": "Łączenie z {{ip}}...",
   "speaker.manualIpNotFound": "Żaden głośnik nie odpowiedział pod {{ip}}. Sprawdź adres oraz czy komputer i głośnik są w tej samej sieci.",
   "speaker.retry": "Szukaj ponownie",

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -182,6 +182,7 @@
   "speaker.manualIpHelp": "Hoparlör bulunamıyor mu? Bazı ağlarda (misafir Wi-Fi, VPN veya cihaz yalıtımı olan ağlar) arama engellenir. Doğrudan bağlanmak için hoparlörün IP adresini (yönlendiricinizden) girin.",
   "speaker.manualIpPlaceholder": "ör. 192.168.1.50",
   "speaker.manualIpButton": "IP ile bağlan",
+  "speaker.addByIp": "IP ile ekle",
   "speaker.manualIpSearching": "{{ip}} adresine bağlanılıyor...",
   "speaker.manualIpNotFound": "{{ip}} adresinde hoparlör yanıt vermedi. Adresi ve bilgisayar ile hoparlörün aynı ağda olduğunu kontrol edin.",
   "speaker.retry": "Yeniden ara",

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -182,6 +182,7 @@
   "speaker.manualIpHelp": "Не вдається знайти колонку? У деяких мережах (гостьовий Wi-Fi, VPN або з ізоляцією пристроїв) пошук заблоковано. Введіть IP-адресу колонки (з роутера), щоб підключитися напряму.",
   "speaker.manualIpPlaceholder": "напр. 192.168.1.50",
   "speaker.manualIpButton": "Підключити за IP",
+  "speaker.addByIp": "Додати за IP",
   "speaker.manualIpSearching": "Підключення до {{ip}}...",
   "speaker.manualIpNotFound": "Жодна колонка не відповіла за адресою {{ip}}. Перевірте адресу та чи ПК і колонка в одній мережі.",
   "speaker.retry": "Шукати знову",

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -1869,14 +1869,45 @@ function checkBoxIssueBanner() {
   el.classList.remove('hidden');
 }
 
-// manualIpInputBusy reports whether the empty state's manual connect-by-IP
-// input is in use (focused or holding text). While it is, the empty state
-// must not be re-rendered: the recovery burst repaints every ~6s and a
-// rebuild wiped the user's half-typed address and their focus.
+// manualIpInputBusy reports whether a manual connect-by-IP input is in use
+// (focused or holding text). While one is, the speaker area must not be
+// re-rendered: the recovery burst repaints every ~6s and a rebuild wiped the
+// user's half-typed address and their focus. Both the empty state's field and
+// the one behind the "add by IP" tile count.
 function manualIpInputBusy() {
-  const el = document.getElementById('emptyIpInput');
-  if (!el) return false;
-  return document.activeElement === el || !!(el.value || '').trim();
+  return ['emptyIpInput', 'listIpInput'].some(id => {
+    const el = document.getElementById(id);
+    if (!el) return false;
+    return document.activeElement === el || !!(el.value || '').trim();
+  });
+}
+
+// wireManualIp connects one connect-by-IP input/button pair. Shared by the
+// empty state and by the "add by IP" tile that sits at the end of a populated
+// speaker list: on a routed network, discovery finds ONE speaker and the empty
+// state disappears, which used to leave no way at all to add the second and
+// third by address (#420).
+function wireManualIp(inputId, btnId) {
+  const ipInput = document.getElementById(inputId);
+  const addIp = document.getElementById(btnId);
+  if (!ipInput || !addIp) return;
+  const tryAddIp = async () => {
+    const ip = (ipInput.value || '').trim();
+    if (!ip) { ipInput.focus(); return; }
+    addIp.disabled = true;
+    showToast(t('speaker.manualIpSearching', { ip }));
+    try {
+      await AddBoxByIP(ip);
+      ipInput.value = ''; // so the next address can be typed straight away
+      await discoverBoxes(); // RefreshKnownBoxes now includes the cached box
+    } catch (e) {
+      showError(t('speaker.manualIpNotFound', { ip }));
+    } finally {
+      addIp.disabled = false;
+    }
+  };
+  addIp.onclick = tryAddIp;
+  ipInput.onkeydown = (e) => { if (e.key === 'Enter') tryAddIp(); };
 }
 
 // offlineAgo renders "how long unseen" for an offline speaker tile via
@@ -1926,24 +1957,7 @@ function renderBoxSelect() {
     if (rt) rt.onclick = () => discoverBoxes();
     // Manual connect-by-IP: the fallback when discovery is blocked by the
     // network (AP isolation, a different subnet, a VPN, or a security suite).
-    const ipInput = document.getElementById('emptyIpInput');
-    const addIp = document.getElementById('emptyAddIpBtn');
-    const tryAddIp = async () => {
-      const ip = (ipInput.value || '').trim();
-      if (!ip) { ipInput.focus(); return; }
-      addIp.disabled = true;
-      showToast(t('speaker.manualIpSearching', { ip }));
-      try {
-        await AddBoxByIP(ip);
-        await discoverBoxes(); // RefreshKnownBoxes now includes the cached box
-      } catch (e) {
-        showError(t('speaker.manualIpNotFound', { ip }));
-      } finally {
-        addIp.disabled = false;
-      }
-    };
-    if (addIp) addIp.onclick = tryAddIp;
-    if (ipInput) ipInput.onkeydown = (e) => { if (e.key === 'Enter') tryAddIp(); };
+    wireManualIp('emptyIpInput', 'emptyAddIpBtn');
     updateBoxUiVisibility();
   checkWedgeBanner();
   checkBoxIssueBanner();
@@ -2024,9 +2038,21 @@ function renderBoxSelect() {
       : '';
     return `<span class="box-btn${active}${updCls}${playingNow ? ' playing-now' : ''}${offCls}" data-host="${b.host}" data-port="${b.port}"${offAttr} role="button" tabindex="0">${groupMark}${offMark}${playMark}${escapeHtml(label)}${model} <small>${b.host}</small>${ver}${updDot}<span class="box-edit" data-host="${b.host}" data-port="${b.port}" title="${escapeAttr(t('speaker.editTitle'))}">&#9881;</span></span>`;
   };
+  // "Add by IP" tile, always available once at least one speaker is listed.
+  // On a routed network mDNS and the local /24 scan find only the speakers on
+  // this subnet, and the empty state's address field is gone the moment the
+  // first one shows up, so there was no path left to add the others (#420).
+  // Collapsed to a small tile until clicked, so it stays out of the way for
+  // everyone whose speakers are simply found.
+  const addIpTile = () => `
+    <span class="box-btn box-add-ip" id="addIpTile" role="button" tabindex="0" title="${escapeAttr(t('speaker.manualIpHelp'))}">+ ${escapeHtml(t('speaker.addByIp'))}</span>
+    <span class="manual-ip-row box-add-ip-row hidden" id="addIpRow">
+      <input type="text" id="listIpInput" class="manual-ip-input" placeholder="${escapeAttr(t('speaker.manualIpPlaceholder'))}" inputmode="decimal" autocomplete="off" spellcheck="false">
+      <button class="btn btn-mini" id="listAddIpBtn">${escapeHtml(t('speaker.manualIpButton'))}</button>
+    </span>`;
   const groups = Object.keys(memberCount).filter(m => memberCount[m] >= 2).sort();
   if (groups.length === 0) {
-    sel.innerHTML = state.boxes.map(pill).join('');
+    sel.innerHTML = state.boxes.map(pill).join('') + addIpTile();
   } else {
     const colorOf = {};
     groups.forEach((m, i) => { colorOf[m] = (i % 4) + 1; });
@@ -2045,8 +2071,21 @@ function renderBoxSelect() {
       html += `<div class="box-group box-group-c${colorOf[m]}">${groupLabel}${members.map(pill).join('')}</div>`;
     }
     html += state.boxes.filter(b => { const mm = masterOf(b); return !(mm && memberCount[mm] >= 2); }).map(pill).join('');
-    sel.innerHTML = html;
+    sel.innerHTML = html + addIpTile();
   }
+  const ipTile = document.getElementById('addIpTile');
+  const ipRow = document.getElementById('addIpRow');
+  if (ipTile && ipRow) {
+    const openIpRow = () => {
+      ipTile.classList.add('hidden');
+      ipRow.classList.remove('hidden');
+      const inp = document.getElementById('listIpInput');
+      if (inp) inp.focus();
+    };
+    ipTile.onclick = openIpRow;
+    ipTile.onkeydown = (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openIpRow(); } };
+  }
+  wireManualIp('listIpInput', 'listAddIpBtn');
   sel.querySelectorAll('.box-btn').forEach(btn => {
     btn.onclick = async (e) => {
       // A click on the gear icon opens the settings view rather than

--- a/desktop-app/frontend/src/style.css
+++ b/desktop-app/frontend/src/style.css
@@ -535,6 +535,19 @@ body {
   border: 1px solid var(--c-border); border-radius: 6px;
 }
 .manual-ip-input:focus { border-color: var(--brand); outline: none; }
+
+/* "Add by IP" tile at the end of a populated speaker list (#420): on a routed
+   network only the local subnet is discovered, and the empty state's address
+   field vanishes with the first speaker found. Dashed and muted so it reads as
+   an action, not as another speaker. */
+.box-btn.box-add-ip {
+  border-style: dashed;
+  opacity: 0.72;
+  font-weight: 500;
+}
+.box-btn.box-add-ip:hover { opacity: 1; }
+.box-add-ip-row { display: inline-flex; margin-top: 0; vertical-align: middle; }
+.box-add-ip-row .manual-ip-input { max-width: 190px; }
 .reconnect-banner {
   background: var(--brand-bg);
   border: 1px solid var(--brand-border);


### PR DESCRIPTION
## What

On a routed network, discovery only reaches the local subnet. The app finds one speaker, the empty state disappears with it, and the connect-by-IP field lived only in that empty state. So the field a user needs most was hidden exactly when it became necessary, and there was no way to add the second and third speaker by address.

Reported in #420 after the reporter verified that the original routed-subnet fix (v0.9.13) works: they had to edit `known-speakers.json` by hand to get their other two speakers in.

## Fix

- A collapsed "add by IP" tile at the end of the speaker list, which opens the same address field.
- The connect-by-IP wiring is now one shared helper instead of being inlined in the empty state, so both entry points behave identically (Enter key, toast, error, refresh).
- `manualIpInputBusy()` covers both inputs, so a discovery repaint cannot wipe a half-typed address.
- New string `speaker.addByIp` in all 12 locales.

## Risk

Frontend only, additive. With no speakers listed nothing changes; the tile only exists in the populated branch. Frontend build is green.

Closes #420.