### PR TITLE
fix(agent): resolve a stored str-<ip> placeholder to the real speaker name

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -2111,11 +2111,26 @@ func probeStalePeers(logger *slog.Logger) {
 			if port == 0 {
 				continue
 			}
+			// While we have the speaker on the line anyway, turn a placeholder
+			// name into the real one. A roster entry restored from NAND, or one
+			// seeded by the app before the speaker was identified, keeps the
+			// "str-<ip>" stand-in forever otherwise: the mDNS path never revisits
+			// a name it did not just receive, so the owner kept seeing an address
+			// where a name belongs (#494, seen live 2026-07-28).
+			var friendly string
 			peersMu.Lock()
+			if e := peersByIP[c.ip]; e != nil && placeholderPeerName(e.name) {
+				peersMu.Unlock()
+				friendly = peerFriendlyName(c.ip)
+				peersMu.Lock()
+			}
 			if e := peersByIP[c.ip]; e != nil {
 				e.lastSeen = time.Now()
 				e.reachable = true
 				e.port = port
+				if friendly != "" {
+					e.name = friendly
+				}
 			}
 			peersMu.Unlock()
 		}
@@ -2215,7 +2230,10 @@ func browsePeers(ctx context.Context, logger *slog.Logger) []webui.PeerLink {
 				e = &peerEntry{}
 				peersByIP[f.ip] = e
 			}
-			if f.name != "" {
+			// Never let a placeholder overwrite a name we already know: mDNS can
+			// answer with the instance name only, and replacing "Kitchen" with
+			// "str-192.0.2.5" is the #494 defect arriving by the back door.
+			if f.name != "" && !(placeholderPeerName(f.name) && e.name != "" && !placeholderPeerName(e.name)) {
 				e.name = f.name
 			}
 			e.lastSeen = now

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -2233,7 +2233,7 @@ func browsePeers(ctx context.Context, logger *slog.Logger) []webui.PeerLink {
 			// Never let a placeholder overwrite a name we already know: mDNS can
 			// answer with the instance name only, and replacing "Kitchen" with
 			// "str-192.0.2.5" is the #494 defect arriving by the back door.
-			if f.name != "" && !(placeholderPeerName(f.name) && e.name != "" && !placeholderPeerName(e.name)) {
+			if f.name != "" && (!placeholderPeerName(f.name) || e.name == "" || placeholderPeerName(e.name)) {
 				e.name = f.name
 			}
 			e.lastSeen = now


### PR DESCRIPTION
Follow-up to #502, which only covered names arriving fresh over mDNS. Live retest on the fleet showed the picker still listing `str-192.168.178.49` for a speaker whose `friendlyName` is `SoundTouch 10b`, because that entry came from the NAND-persisted roster and the mDNS path never revisits a name it did not just receive.

- The stand-in is now replaced during the reachability re-confirmation that every listed speaker passes through regularly (`probeStalePeers`), where the speaker is on the line anyway. The lock is released around the HTTP call so a slow peer cannot block the roster.
- A stand-in arriving over mDNS can no longer overwrite a real name that is already stored, which was the same defect entering by the back door.

Test suite green.