### PR TITLE
fix(presets): surface the silent recall-refusal state with the storm banner + restart button

### DIFF
--- a/desktop-app/app_discovery.go
+++ b/desktop-app/app_discovery.go
@@ -116,6 +116,11 @@ type BoxInfo struct {
 	// reboot. Storm1036SinceSec is how long it has been going.
 	Storm1036         bool `json:"storm1036,omitempty"`
 	Storm1036SinceSec int  `json:"storm1036SinceSec,omitempty"`
+	// RecallRefusal is the storm's quiet sibling: the agent latched
+	// consecutive recalls whose source self-dropped to STANDBY without a
+	// single 1036. Joined into the same banner (a soft restart clears both).
+	RecallRefusal         bool `json:"recallRefusal,omitempty"`
+	RecallRefusalSinceSec int  `json:"recallRefusalSinceSec,omitempty"`
 	// WLANCredsMissing is true when STR has no saved Wi-Fi on the box: it only
 	// stays online while the stick or an ethernet cable is inserted and strands
 	// the user on the next cold boot. The UI warns the user to run STR's own
@@ -812,6 +817,8 @@ func classifyKnownBox(cached, probed BoxInfo, probeOK, bosePortOpen bool) (recor
 	cached.WLANCredsMissing = false
 	cached.Storm1036 = false
 	cached.Storm1036SinceSec = 0
+	cached.RecallRefusal = false
+	cached.RecallRefusalSinceSec = 0
 	if bosePortOpen {
 		return cached, true, false
 	}
@@ -965,6 +972,8 @@ func mergeSameKind(a, b BoxInfo) BoxInfo {
 		out.BoxHealth = b.BoxHealth
 		out.Storm1036 = b.Storm1036
 		out.Storm1036SinceSec = b.Storm1036SinceSec
+		out.RecallRefusal = b.RecallRefusal
+		out.RecallRefusalSinceSec = b.RecallRefusalSinceSec
 	default:
 		if out.ConflictingMod == "" {
 			out.ConflictingMod = b.ConflictingMod
@@ -972,6 +981,10 @@ func mergeSameKind(a, b BoxInfo) BoxInfo {
 		if !out.Storm1036 {
 			out.Storm1036 = b.Storm1036
 			out.Storm1036SinceSec = b.Storm1036SinceSec
+		}
+		if !out.RecallRefusal {
+			out.RecallRefusal = b.RecallRefusal
+			out.RecallRefusalSinceSec = b.RecallRefusalSinceSec
 		}
 		if !out.WLANCredsMissing {
 			out.WLANCredsMissing = b.WLANCredsMissing
@@ -1341,6 +1354,11 @@ func probeSTR(ctx context.Context, ip string) (BoxInfo, bool) {
 		Storm1036:      jsonStringField(s, "preset1036Storm") == "active",
 		Storm1036SinceSec: func() int {
 			n, _ := strconv.Atoi(jsonStringField(s, "preset1036SinceSec"))
+			return n
+		}(),
+		RecallRefusal: jsonStringField(s, "presetRefusal") == "active",
+		RecallRefusalSinceSec: func() int {
+			n, _ := strconv.Atoi(jsonStringField(s, "presetRefusalSinceSec"))
 			return n
 		}(),
 		WLANCredsMissing: jsonStringField(s, "wlanCreds") == "missing",

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -1850,7 +1850,9 @@ function checkBoxIssueBanner() {
   // and the remedy people find on their own, pulling the plug, resets the box
   // clock and poisons the next boot, while a soft restart clears it (#419
   // Finding 4). Saying so at the moment it happens is the whole point.
-  const storm = boxes.filter(b => b && b.storm1036);
+  // recallRefusal is the storm's quiet sibling (no 1036 ever fires, the box
+  // just drops its source for every recall); same remedy, same banner.
+  const storm = boxes.filter(b => b && (b.storm1036 || b.recallRefusal));
   const msgs = [];
   if (conflict.length) {
     const names = conflict.map(b => getBoxLabel(b)).join(', ');

--- a/internal/webui/agent_admin.go
+++ b/internal/webui/agent_admin.go
@@ -140,6 +140,15 @@ func (s *Server) handleAgentVersion(w http.ResponseWriter, _ *http.Request) {
 			}
 		}
 	}
+	// Silent-refusal latch: the 1036 storm's quiet sibling (the box drops its
+	// source on its own for every recall without ever sending a 1036). Same
+	// remedy, so the desktop app joins it into the storm banner.
+	if active, since := s.RecallRefusal(); active {
+		out["presetRefusal"] = "active"
+		if !since.IsZero() {
+			out["presetRefusalSinceSec"] = strconv.FormatInt(int64(time.Since(since).Seconds()), 10)
+		}
+	}
 	// The foreign (neither STR's nor Bose's) top-level /mnt/nv dirs, names only.
 	// Cheap: one readdir, no recursive sizing, so it is fine on every version
 	// poll. These are leftovers of OTHER SoundTouch mods that eat the NAND the

--- a/internal/webui/resume_standby.go
+++ b/internal/webui/resume_standby.go
@@ -895,6 +895,10 @@ func (s *Server) HandleEnterStandby() {
 		return
 	}
 	if recallActive && (!newKeySinceRecall || !keyAdjacentToFlip) && !deliberateStop {
+		// Feed the refusal accounting: this drop is NOT a user power-off, so
+		// an exhausted verify seeing STANDBY must not excuse itself with "the
+		// user switched it off" (silent-refusal family, see wedge.go).
+		s.NoteNonUserStandbyDrop()
 		s.logger.Info("standby bounce: source dropped during the user's own recall with no adjacent new key press, leaving transport and latches alone (#419)")
 		return
 	}

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -258,6 +258,11 @@ type Server struct {
 	wedge            wedgeState
 	streamActivityFn func() (lastFetch, lastFailure time.Time)
 
+	// refusal tracks the silent variant of the not-logged-in refusal family:
+	// recalls that exhaust while the box drops its source to STANDBY on its
+	// own, without ever sending a 1036. See wedge.go / RecallRefusal.
+	refusal refusalState
+
 	// loginErr tracks the last time the box rejected a source as not-logged-in
 	// (errorUpdate 1036), so verifyRecall stands its retry down while a forced
 	// re-login runs instead of thrashing the box. See wedge.go / NoteBoxLoginError.

--- a/internal/webui/verify_standdown_test.go
+++ b/internal/webui/verify_standdown_test.go
@@ -102,3 +102,61 @@ func TestLoginErrorWindows(t *testing.T) {
 		t.Fatal("an old login error must not suppress wedge accounting")
 	}
 }
+
+// TestSilentRefusalLatch covers the quiet sibling of the 1036 storm: recalls
+// that exhaust while the box dropped its source to STANDBY on its own (no
+// adjacent key press, no 1036). Field case 2026-08-01: two independent ST10s
+// failed every recall this way and the app showed nothing, because the
+// standby read as a user power-off and no 1036 ever fired.
+func TestSilentRefusalLatch(t *testing.T) {
+	disc := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// User power-off: STANDBY with no non-user drop classified -> ignored.
+	s := &Server{logger: disc}
+	s.noteRecallExhaustedWithSource("STANDBY")
+	if active, _ := s.RecallRefusal(); active {
+		t.Fatal("user power-off must not latch the refusal state")
+	}
+
+	// Box self-drop (classifier stamped non-user): two strikes latch.
+	s.NoteNonUserStandbyDrop()
+	s.noteRecallExhaustedWithSource("STANDBY")
+	if active, _ := s.RecallRefusal(); active {
+		t.Fatal("one silent failure must stay quiet")
+	}
+	s.NoteNonUserStandbyDrop()
+	s.noteRecallExhaustedWithSource("STANDBY")
+	if active, _ := s.RecallRefusal(); !active {
+		t.Fatal("two consecutive silent failures must latch the refusal state")
+	}
+
+	// Observed playback clears it.
+	s.NoteBoxHealthy()
+	if active, _ := s.RecallRefusal(); active {
+		t.Fatal("playback must clear the refusal state")
+	}
+
+	// A recent 1036 attributes the failure to the login: the storm banner owns
+	// that messaging, no refusal strike.
+	s2 := &Server{logger: disc}
+	s2.NoteNonUserStandbyDrop()
+	s2.NoteBoxLoginError()
+	s2.noteRecallExhaustedWithSource("STANDBY")
+	s2.NoteNonUserStandbyDrop()
+	s2.noteRecallExhaustedWithSource("STANDBY")
+	if active, _ := s2.RecallRefusal(); active {
+		t.Fatal("1036-attributed failures must not latch the silent-refusal state")
+	}
+
+	// Recent stream activity absolves: the content failed, not the box.
+	s3 := &Server{logger: disc}
+	now := time.Now()
+	s3.SetStreamActivityFn(func() (time.Time, time.Time) { return now, time.Time{} })
+	s3.NoteNonUserStandbyDrop()
+	s3.noteRecallExhaustedWithSource("STANDBY")
+	s3.NoteNonUserStandbyDrop()
+	s3.noteRecallExhaustedWithSource("STANDBY")
+	if active, _ := s3.RecallRefusal(); active {
+		t.Fatal("recent stream activity must absolve the silent failures")
+	}
+}

--- a/internal/webui/wedge.go
+++ b/internal/webui/wedge.go
@@ -117,12 +117,29 @@ func (s *Server) SetStreamActivityFn(fn func() (lastFetch, lastFailure time.Time
 // whether this failure looks like the box (not the station) and counts a
 // strike; the second consecutive strike latches wedged.
 func (s *Server) NoteRecallExhausted() {
-	// A user power-off mid-recall exhausts the verify too; standby is not a
-	// wedge. Read the live state once, best-effort.
+	// Read the live state once, best-effort; the decision lives in
+	// noteRecallExhaustedWithSource so it is testable without a box.
 	npCtx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
 	np := s.snapshotNowPlaying(npCtx)
 	cancel()
-	if np.Source == "STANDBY" || np.Source == "" {
+	s.noteRecallExhaustedWithSource(np.Source)
+}
+
+func (s *Server) noteRecallExhaustedWithSource(source string) {
+	if source == "" {
+		return
+	}
+	if source == "STANDBY" {
+		// A user power-off mid-recall exhausts the verify too; that standby
+		// is not a wedge. But when HandleEnterStandby just classified the
+		// drop as NOT a user power-off (the #419 mid-recall branch: no
+		// adjacent key press), the standby is the box giving up on its own -
+		// the silent variant of the not-logged-in refusal family, which never
+		// sends a 1036 and therefore never trips the storm banner. Count it
+		// toward its own latch so the app can finally say "restart the
+		// speaker" instead of failing without a word (field: two independent
+		// ST10 reports, 2026-08-01).
+		s.noteSilentRefusalCandidate()
 		return
 	}
 	// A recall that exhausted while the box was rejecting sources as
@@ -175,6 +192,99 @@ func (s *Server) NoteBoxHealthy() {
 	if wasWedged {
 		s.logger.Info("box wedge cleared: playback observed")
 	}
+	s.refusal.mu.Lock()
+	wasRefusing := s.refusal.latched
+	s.refusal.strikes = 0
+	s.refusal.latched = false
+	s.refusal.since = time.Time{}
+	s.refusal.lastNonUserDrop = time.Time{}
+	s.refusal.mu.Unlock()
+	if wasRefusing {
+		s.logger.Info("silent recall refusal cleared: playback observed")
+	}
+}
+
+// refusalState tracks recalls that exhausted while the box dropped its source
+// to STANDBY on its own (no adjacent key press, no 1036): the silent variant
+// of the not-logged-in refusal family. It sneaks past both existing detectors
+// - no 1036 means no storm, and the self-drop to STANDBY made the exhausted
+// verify look like a user power-off - so users saw no message at all while
+// nothing played. The latched state is surfaced on the version envelope next
+// to the 1036 storm and joins the app's storm banner, whose soft-restart
+// button is the right remedy (a plug pull also clears it but poisons the box
+// clock, #419 F4).
+type refusalState struct {
+	mu              sync.Mutex
+	strikes         int
+	latched         bool
+	since           time.Time
+	lastNonUserDrop time.Time
+}
+
+// refusalStrikesToLatch mirrors wedgeStrikesToLatch: two consecutive silent
+// failures latch, a single odd failure stays quiet.
+const refusalStrikesToLatch = 2
+
+// NoteNonUserStandbyDrop records that HandleEnterStandby classified a
+// UPNP->STANDBY drop as NOT a user power-off (#419 mid-recall branch), so an
+// exhausted verify seeing STANDBY can tell "the box gave up on its own" from
+// "the user switched it off".
+func (s *Server) NoteNonUserStandbyDrop() {
+	s.refusal.mu.Lock()
+	s.refusal.lastNonUserDrop = time.Now()
+	s.refusal.mu.Unlock()
+}
+
+func (s *Server) nonUserStandbyDropRecent(window time.Duration) bool {
+	s.refusal.mu.Lock()
+	defer s.refusal.mu.Unlock()
+	return !s.refusal.lastNonUserDrop.IsZero() && time.Since(s.refusal.lastNonUserDrop) < window
+}
+
+// noteSilentRefusalCandidate decides whether an exhausted recall that ended in
+// STANDBY counts toward the silent-refusal latch. Same absolution ladder as
+// the wedge: a user power-off (no non-user drop classified), a recent 1036
+// (the storm banner owns that messaging), or recent stream activity (a content
+// problem, not the box) all keep it quiet.
+func (s *Server) noteSilentRefusalCandidate() {
+	if !s.nonUserStandbyDropRecent(wedgeStrikeWindow) {
+		return
+	}
+	if s.loginErrorRecentWithin(loginErrWedgeSkipWindow) {
+		return
+	}
+	if s.streamActivityFn != nil {
+		fetch, fail := s.streamActivityFn()
+		if (!fetch.IsZero() && time.Since(fetch) < wedgeStrikeWindow) ||
+			(!fail.IsZero() && time.Since(fail) < wedgeStrikeWindow) {
+			return
+		}
+	}
+	s.refusal.mu.Lock()
+	s.refusal.strikes++
+	latch := s.refusal.strikes >= refusalStrikesToLatch && !s.refusal.latched
+	if latch {
+		s.refusal.latched = true
+		s.refusal.since = time.Now()
+	}
+	strikes := s.refusal.strikes
+	s.refusal.mu.Unlock()
+	if latch {
+		// Bundle-forensics marker: this line separates the silent-refusal
+		// family from a wedge and from the 1036 storm in a diagnostic.
+		s.logger.Warn("box refuses recalls silently: source self-drops to STANDBY with no 1036 and no stream fetch; surfacing the restart hint", "strikes", strikes)
+	} else {
+		s.logger.Warn("silent recall refusal suspected (strike recorded)", "strikes", strikes)
+	}
+}
+
+// RecallRefusal reports whether the silent-refusal state is latched, and since
+// when. Surfaced on the version envelope so the desktop app can join it into
+// the storm banner (same remedy: a soft restart).
+func (s *Server) RecallRefusal() (active bool, since time.Time) {
+	s.refusal.mu.Lock()
+	defer s.refusal.mu.Unlock()
+	return s.refusal.latched, s.refusal.since
 }
 
 // BoxStateHint reports the speaker-side condition that would make streams fail


### PR DESCRIPTION
Re-filed #516 (auto-closed when its base branch `refactor/wave1-splits` was deleted on the #515 merge; a closed PR cannot be retargeted). Same single commit, full description, user impact and risk assessment in #516 and #517. Diff vs main is now exactly the refusal-banner commit; fleet-validated this morning on all four boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)