### PR TITLE
docs: align the docs with the shipped state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,17 +12,19 @@ them back **without any Bose cloud dependency**.
 
 ### Components
 
-- **Stick Agent**: a small Go binary delivered via a USB stick used
-  for the initial install. The agent copies itself to the speaker's
-  NAND on first boot and from then on runs entirely from there, so
-  the stick can be removed for normal operation. It stands in for
-  `streaming.bose.com` and the Bose `bmx-cloud` services locally so
-  the speaker pairs and accepts presets.
+- **Stick Agent**: a small Go binary running on the speaker. The
+  normal first install happens over the network (the speaker's
+  setup port); the USB stick remains the fallback and recovery
+  path. The agent lives on the speaker's NAND and runs entirely
+  from there, so no stick is needed for normal operation. It stands
+  in for `streaming.bose.com` and the Bose `bmx-cloud` services
+  locally so the speaker pairs and accepts presets.
 - **Desktop App (ST Reborn)**: Wails application for Windows, macOS,
   Linux. Discovers running agents on the LAN via mDNS, ships a web
   UI for browsing internet radio, managing presets, and controlling
-  playback. Also performs the initial USB-stick provisioning and
-  later OTA agent updates.
+  playback. Also performs the initial install (network install by
+  default, USB-stick provisioning as the fallback) and later OTA
+  agent updates.
 - **Website**: Astro site (English and German) at `st-reborn.de`
   with downloads, FAQ, privacy, imprint. Maintained in a separate
   repository.
@@ -134,8 +136,9 @@ measurable, not aspirational:
 5. **Legal pages complete.** Website imprint, privacy policy, and
    their German equivalents have no placeholder text.
 
-Code signing, notarization, additional models, and Wails sandboxing
-are post-1.0. Forward-looking ideas beyond v1.0, currently an iOS
+macOS notarization, additional models, and Wails sandboxing are
+post-1.0 (Windows installers are already Certum-signed since
+v0.9.20). Forward-looking ideas beyond v1.0, currently an iOS
 PWA proposal and a factory-reset wizard for the desktop app, live
 in [`docs/ROADMAP.md`](docs/ROADMAP.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,11 +46,10 @@ extra Wails toolchain dependencies.
 git clone https://github.com/JRpersonal/streborn.git
 cd streborn
 
-# Sanity check (Linux). On Windows/macOS hosts the agent's Linux-only
-# syscalls make `go build ./...` fail in internal/webui; cross-compile
-# instead (GOOS=linux GOARCH=arm GOARM=5 go build ./... or make build-arm)
-# and run go test on the packages that build on your host. GOARM=5
-# (softfloat) is intentional: some early SoundTouch CPUs lack working
+# Sanity check. Both modules build natively on Linux, macOS, and Windows
+# (Linux-only syscalls sit behind build tags). The speaker binary is still
+# a cross-compile: GOOS=linux GOARCH=arm GOARM=5, or just `make build-arm`.
+# GOARM=5 (softfloat) is intentional: some early SoundTouch CPUs lack working
 # VFP and a hardware-float agent SIGILLs at startup (issue #302).
 go build ./...
 go test ./...
@@ -107,6 +106,10 @@ the desktop app falls back to a configured external path.
   - Use a non-user-facing type (`chore`, `ci`, `build`, `test`,
     `refactor`, `docs`, `style`) for work that should NOT appear in the
     notes; those are dropped from the changelog automatically.
+  - If one squashed commit ships several user-visible changes, name the
+    extras as `Release-Note: type(scope): summary` trailers in the
+    commit body; each trailer is parsed like a subject and lands in the
+    notes.
 
   See [`docs/RELEASE-NOTES.md`](docs/RELEASE-NOTES.md) for the full
   pipeline.
@@ -117,9 +120,8 @@ the desktop app falls back to a configured external path.
 
 Tick these in your PR description:
 
-- [ ] `go vet ./...` and `go test ./...` pass locally (on
-      Windows/macOS: for the packages that build on your host, plus
-      the ARM cross-compile).
+- [ ] `go vet ./...` and `go test ./...` pass locally, and
+      `make build-arm` cross-compiles cleanly.
 - [ ] If the change touches the stick agent, I have either tested
       on real hardware or noted in the PR that I have not.
 - [ ] No personal data, real LAN IPs, MAC addresses, or device

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ The desktop app: browse and assign presets, search internet radio, control Spoti
 | [![DLNA library](docs/screenshots/OS%20Hero/app-library.jpg)](docs/screenshots/OS%20Hero/app-library.jpg) | [![USB stick setup](docs/screenshots/OS%20Hero/app-stick-step1.jpg)](docs/screenshots/OS%20Hero/app-stick-step1.jpg) | [![Stick: Wi-Fi, name, region](docs/screenshots/OS%20Hero/app-stick-step2.jpg)](docs/screenshots/OS%20Hero/app-stick-step2.jpg) |
 | DLNA music library | Install and setup | Wi-Fi, name, region |
 
-The interface is available in eleven languages (English, German, French, Spanish, Japanese, Ukrainian, Dutch, Polish, Lithuanian, Latvian, Turkish). The full per-language screenshot set lives in [`docs/screenshots/`](docs/screenshots/) and is regenerated automatically with `npm run shoot` in `desktop-app/frontend/screenshots/`, a headless Playwright harness that mocks the backend with demo data, so no speaker is needed.
+The interface is available in twelve languages (English, German, French, Spanish, Japanese, Ukrainian, Dutch, Polish, Lithuanian, Latvian, Turkish, Arabic). The full per-language screenshot set lives in [`docs/screenshots/`](docs/screenshots/) and is regenerated automatically with `npm run shoot` in `desktop-app/frontend/screenshots/`, a headless Playwright harness that mocks the backend with demo data, so no speaker is needed.
 
-## Status (June 2026)
+## Status (August 2026)
 
 STR is pre-1.0. This section is the honest snapshot. No marketing.
 
@@ -64,8 +64,8 @@ STR is pre-1.0. This section is the honest snapshot. No marketing.
 | Model                       | Status                   |
 | --------------------------- | ------------------------ |
 | SoundTouch 10               | ✅ Verified on hardware  |
-| SoundTouch 20               | ✅ Works (same platform) |
-| SoundTouch 30               | ✅ Works (same platform) |
+| SoundTouch 20               | ✅ Works (contributor-confirmed) |
+| SoundTouch 30               | ✅ Works (confirmed on hardware) |
 | SoundTouch Portable         | ✅ Verified on hardware  |
 | Wave SoundTouch series III and IV | ✅ Works (network install) |
 | SoundTouch 300              | ✅ Works (network install) |
@@ -82,8 +82,8 @@ Per-model detail and the variant fingerprints are in [`docs/MODELS.md`](./docs/M
 
 ### What I do not do for security yet
 
-- No client authentication on the stick web UI (`:8888`). Any device on the LAN that can reach the speaker can edit presets and trigger playback.
-- No encryption between the desktop app and the stick. Both sit on the LAN, the LAN is the trust boundary.
+- No client authentication on the agent's web UI (`:8888`). Any device on the LAN that can reach the speaker can edit presets and trigger playback.
+- No encryption between the desktop app and the agent. Both sit on the LAN, the LAN is the trust boundary.
 - No verification of the stock speaker firmware integrity.
 - No sandboxing of the desktop application.
 
@@ -102,13 +102,13 @@ Implication: a speaker being passed on or sold needs a separate "Uninstall STR" 
 
 Per my own criteria in [`CLAUDE.md`](./CLAUDE.md):
 
-1. Two models verified end to end: met (ST10 and Portable verified, ST20 contributor-confirmed, ST30 live with the final pass pending; see [`docs/MODELS.md`](./docs/MODELS.md)).
+1. Two models verified end to end: met (ST10 and Portable verified, ST20 contributor-confirmed with the final stability pass pending, ST30 working on both module variants; see [`docs/MODELS.md`](./docs/MODELS.md)).
 2. Hardware preset buttons need to survive cold boot, standby cycle, and Wi-Fi outage. I observe this working, but I do not yet have a regression test that pins it.
 3. First-install experience: SmartScreen and Gatekeeper documentation on the website Verify page with the exact click path and a linked SHA256 plus Sigstore attestation. Partially in place, not finalised.
 4. Threat model document published. Present in [`docs/THREAT-MODEL.md`](./docs/THREAT-MODEL.md). It does not yet cover the persistence-across-factory-reset point above, which I owe.
 5. Legal pages on the website (imprint, privacy, both German). Some sections still contain placeholders.
 
-Code signing, notarization, additional models beyond the 1.0 threshold, sandboxing the Wails app, and the hardening steps (token auth on `:8888`, iptables egress lockdown, automatic `passwd root` on install) I see as post-1.0.
+Notarization (macOS), additional models beyond the 1.0 threshold, sandboxing the Wails app, and the hardening steps (token auth on `:8888`, iptables egress lockdown, automatic `passwd root` on install) I see as post-1.0. Windows code signing already ships: release binaries are Authenticode-signed with a Certum open-source certificate.
 
 ## Quick start for developers
 
@@ -159,6 +159,8 @@ Every release on GitHub Releases is built by the official workflow and ships wit
 ```bash
 gh attestation verify STR-Windows-vX.Y.Z.exe --owner JRpersonal
 ```
+
+Windows builds are additionally Authenticode-signed with a Certum open-source code-signing certificate; check the signature in the file's Properties > Digital Signatures tab or with `signtool verify /pa`.
 
 For the threat model and the vulnerability reporting process see [SECURITY.md](./SECURITY.md) and [docs/THREAT-MODEL.md](./docs/THREAT-MODEL.md).
 

--- a/README.md
+++ b/README.md
@@ -15,22 +15,22 @@
   <img src="docs/screenshots/OS%20Hero/app-listen.jpg" alt="ST Reborn desktop app" width="820">
 </p>
 
-Bose discontinued their SoundTouch cloud service in February 2026. STR keeps the speakers usable: a USB stick installs a small Go agent onto the speaker that stands in for the discontinued cloud locally, talks to the speaker over the home network, and brings back internet radio, Spotify, your own media library, multiroom, and the hardware preset buttons. **Once the agent is installed, the stick can be removed**: the agent persists on the speaker and survives reboots.
+Bose discontinued their SoundTouch cloud service in February 2026 and switched the servers off for good on 6 May 2026. STR keeps the speakers usable: a small Go agent is installed onto the speaker itself, stands in for the discontinued cloud locally, and brings back internet radio, Spotify, your own media library, multiroom, and the hardware preset buttons. **The install runs over your home network from the desktop app**, so no USB stick and no second device are needed. The agent persists on the speaker and starts with it on every boot.
 
 ## How it works in one paragraph
 
-After the first boot with the stick attached, the agent copies itself into the speaker's persistent storage and from then on starts automatically every time the speaker powers on, no stick required for normal use. It hosts a stand-in for the Bose cloud on the loopback interface and redirects the relevant DNS names so the speaker treats it as the real cloud. Playback then happens over UPnP AVTransport on the speaker, which is supported natively, whether the source is an internet radio station, a Spotify playlist, or a track from a media server on your own network. The hardware preset buttons are wired through the speaker's local WebSocket, so a button press recalls the saved source; the same bus lets a remote key fire a webhook to control your smart home. Several speakers can be grouped into a multiroom zone or a stereo pair.
+The desktop app finds the speaker on the network, reaches it on its setup port and copies the agent into the speaker's persistent storage. From then on it starts automatically every time the speaker powers on. A USB stick is still supported as a fallback and recovery path, but it is no longer the normal way to install. It hosts a stand-in for the Bose cloud on the loopback interface and redirects the relevant DNS names so the speaker treats it as the real cloud. Playback then happens over UPnP AVTransport on the speaker, which is supported natively, whether the source is an internet radio station, a Spotify playlist, or a track from a media server on your own network. The hardware preset buttons are wired through the speaker's local WebSocket, so a button press recalls the saved source; the same bus lets a remote key fire a webhook to control your smart home. Several speakers can be grouped into a multiroom zone or a stereo pair.
 
 ## Screenshots
 
-The desktop app: browse and assign presets, search internet radio, control Spotify, browse your local media library, manage speaker settings, and prepare the USB stick.
+The desktop app: browse and assign presets, search internet radio, control Spotify, browse your local media library, manage speaker settings, and install STR onto a speaker over the network.
 
 | | | |
 |:--:|:--:|:--:|
 | [![Presets and playback](docs/screenshots/OS%20Hero/app-listen.jpg)](docs/screenshots/OS%20Hero/app-listen.jpg) | [![Internet radio search](docs/screenshots/OS%20Hero/app-search.jpg)](docs/screenshots/OS%20Hero/app-search.jpg) | [![Speaker settings](docs/screenshots/OS%20Hero/app-settings1.jpg)](docs/screenshots/OS%20Hero/app-settings1.jpg) |
 | Presets and playback | Internet radio search | Speaker settings |
 | [![DLNA library](docs/screenshots/OS%20Hero/app-library.jpg)](docs/screenshots/OS%20Hero/app-library.jpg) | [![USB stick setup](docs/screenshots/OS%20Hero/app-stick-step1.jpg)](docs/screenshots/OS%20Hero/app-stick-step1.jpg) | [![Stick: Wi-Fi, name, region](docs/screenshots/OS%20Hero/app-stick-step2.jpg)](docs/screenshots/OS%20Hero/app-stick-step2.jpg) |
-| DLNA music library | USB stick setup | Wi-Fi, name, region |
+| DLNA music library | Install and setup | Wi-Fi, name, region |
 
 The interface is available in eleven languages (English, German, French, Spanish, Japanese, Ukrainian, Dutch, Polish, Lithuanian, Latvian, Turkish). The full per-language screenshot set lives in [`docs/screenshots/`](docs/screenshots/) and is regenerated automatically with `npm run shoot` in `desktop-app/frontend/screenshots/`, a headless Playwright harness that mocks the backend with demo data, so no speaker is needed.
 
@@ -40,17 +40,17 @@ STR is pre-1.0. This section is the honest snapshot. No marketing.
 
 ### What works
 
-- Discovery of installed sticks over mDNS, list view in the desktop app. Speakers without STR show up too, marked "ready for STR", and can be installed in-app.
+- Discovery of speakers running STR over mDNS, list view in the desktop app. Speakers without STR show up too, marked "ready for STR", and can be installed in-app.
 - Playback control: play / pause / stop / volume / bass / source switch (AUX, Bluetooth, Standby) via the speaker's existing UPnP AVTransport endpoint on port 8091. I never route audio through the dead Bose cloud.
 - Radio search via radio-browser.info, queried directly by the desktop app (no API key); only the final stream URL goes to the speaker. HLS-only stations (BBC and co.) are converted on the fly by the agent's stream proxy. On a blocked or dead stream the app automatically tries another listing of the same station.
-- Six preset slots, persisted on the stick agent. Hardware preset buttons 1 to 6 work after install via a hook into Bose's WebSocket bus (gabbo). Existing non-STR presets (e.g. Deezer) are left untouched.
+- Six preset slots, persisted by the agent on the speaker. Hardware preset buttons 1 to 6 work after install via a hook into Bose's WebSocket bus (gabbo). Existing non-STR presets (e.g. Deezer) are left untouched.
 - Spotify Connect (beta): a supervised go-librespot sidecar on the speaker. Spotify playlists, albums, and tracks save to preset slots and the hardware buttons, with multi-account switching and live now-playing. The raw Ogg stream is decoded by the speaker, never by the dead cloud.
 - Local media library: browse media servers on your home network over DLNA / UPnP AV (SSDP discovery, ContentDirectory browse), including FRITZ!Box, Synology, Plex and miniDLNA, and save any track as a preset. Lossless files (FLAC) play directly; the agent's stream proxy feeds the box.
 - Multiroom zones and stereo pairs (beta): group several speakers to play in sync, or pair two as a left/right stereo pair. Groups persist on the speaker and reform automatically after a reboot, standby cycle, or Wi-Fi outage.
 - Smart-home triggers (webhooks): turn a remote-control key, the power button, or an AUX change into a user-configured HTTP call, so a press can drive Home Assistant, ioBroker, Node-RED, or anything with an HTTP endpoint.
 - OTA agent updates from the desktop app, with an SSH fallback and a pre-reboot stick refresh so the update cannot be reverted by the boot sync. Build stamp comparison catches version drift.
 - WLAN reconfigure from the desktop app. I rewrite `/etc/wpa_supplicant.conf` in full because appending breaks Wi-Fi.
-- Setup wizard for the USB stick, including preset region, friendly name, box language, and Wi-Fi credentials. FAT32 formatting helper bundled.
+- Setup wizard for the install, including preset region, friendly name, box language, and Wi-Fi credentials. The network install is the normal path; the USB stick route (with a bundled FAT32 formatting helper) remains available as a fallback.
 - Diagnostics export (anonymised), true factory reset, and a full "Uninstall STR" that returns the speaker to stock.
 
 ### In the works
@@ -67,11 +67,13 @@ STR is pre-1.0. This section is the honest snapshot. No marketing.
 | SoundTouch 20               | ✅ Works (same platform) |
 | SoundTouch 30               | ✅ Works (same platform) |
 | SoundTouch Portable         | ✅ Verified on hardware  |
-| Wave SoundTouch series IV   | ✅ Works (network install) |
+| Wave SoundTouch series III and IV | ✅ Works (network install) |
 | SoundTouch 300              | ✅ Works (network install) |
-| SoundTouch SA-5 amplifier   | ❌ Not supported yet     |
+| Bose SA-4 amplifier         | ✅ Works (network install) |
+| Bose SA-5 amplifier         | ✅ Works (network install) |
+| CineMate 520 and 130        | ✅ Works (network install) |
 
-Per-model detail and the variant fingerprints are in [`docs/MODELS.md`](./docs/MODELS.md). If you own a model marked "Not supported yet", I would like to hear from you so we can work out how close it is. The SoundTouch SA-5 amplifier has a tracking issue to talk it through: #274.
+Per-model detail and the variant fingerprints are in [`docs/MODELS.md`](./docs/MODELS.md). The SoundTouch 300, the SA-4 and SA-5 amplifiers, the Wave systems and the CineMate soundbars never read a USB stick at boot, so the network install is what made these models possible in the first place. If you own a model that is not listed here, I would like to hear from you so we can work out how close it is.
 
 ### What I do for security
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,13 +35,13 @@ credited unless they prefer to stay anonymous.
 
 ## Threat Model
 
-STR (SoundTouch Reborn) installs a small agent onto a Bose SoundTouch speaker via a USB stick that is used for the initial install. After the install, the agent runs from the speaker's own persistent storage and the stick can be removed. It also ships a desktop application and a website.
+STR (SoundTouch Reborn) installs a small agent onto a Bose SoundTouch speaker, normally over the network from the desktop app; a USB stick serves as the fallback and recovery install path. After the install, the agent runs from the speaker's own persistent storage. It also ships a desktop application and a website.
 
 Critical trust boundaries:
 
 1. **Binary release** users download to their machine
 2. **Code that runs on the speaker** with root privileges
-3. **TLS certificate authority** that the stick installs in the speaker's trust store
+3. **TLS certificate authority** that the agent installs in the speaker's trust store
 4. **GitHub repository** and its build artifacts
 5. **Website** that hosts download links and donation channels
 
@@ -129,8 +129,8 @@ The full breakdown is in [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md#telemetry
 
 ## Known Limitations
 
-- **Pre-1.0 SSH posture (hardening pending):** the agent keeps the speaker's SSH service running on every boot so diagnostics and repair work even when the agent is down; the firmware root account uses a well-known default with no password. Any LAN device can reach a root shell on the speaker while it is powered. Planned v1.0 hardening makes SSH opt-in via a stick marker. Until then, run the speaker on a trusted network or its own VLAN.
-- Windows installers are currently **not code signed** with an EV certificate. Windows SmartScreen may warn on first download. Plans exist to acquire an EV code signing certificate once donations cover the annual cost.
+- **SSH follows the USB stick:** the firmware root account uses a well-known default with no password, so STR keeps SSH opt-in. SSH is only started while the STR stick is inserted (Bose's `remote_services` marker) and closes again on the next stickless reboot; the agent no longer keeps it open on every boot. A persistent opt-in marker (`/mnt/nv/streborn/enable-ssh`) exists for maintainers and is flagged in the desktop app. While SSH is open, run the speaker on a trusted network or its own VLAN.
+- Windows releases are **code signed** with a Certum Open Source code signing certificate (since v0.9.20), so SmartScreen shows a verified publisher. SHA256 sums and Sigstore attestations additionally cover every release artifact.
 - macOS builds are **not notarized** yet. Same reason.
 - The desktop app does not implement application sandboxing. Future versions may use OS provided sandboxing.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -66,7 +66,7 @@ recall, and the smart-home webhooks all run on the LAN.
 |---|---|---|---|
 | **Stick agent** | `cmd/agent/`, `internal/` | Go binary on the speaker NAND, started by `/mnt/nv/streborn/run-override.sh` from Bose `rc.local` | Emulates the Bose cloud (marge, BMX), proxies radio streams (incl. HLS conversion), owns the preset store, announces over mDNS, hooks the speaker's WebSocket bus to re-enable hardware preset buttons, manages multiroom zones (NAND `zones.json`, auto-reform), and fires user-configured webhooks on box events (NAND `webhooks.json`). On whitelisted chassis it also installs the iptables PREROUTING REDIRECTs that make it LAN-reachable, and serves the `:17002` BatteryMonitor fallback on the Portable. |
 | **Spotify plane (beta)** | `internal/spotify/`, `go-librespot` binary on NAND | go-librespot runs as a Spotify Connect receiver, supervised by the agent's `spotify.Manager` | Spotify Connect on the speaker without the Bose cloud. go-librespot decodes nothing: with the fork's `audio_output_pipe_passthrough` it writes the raw Ogg/Vorbis bitstream to a pipe; the agent serves it at `/spotify/stream.ogg` on :8888 and points the box's UPnP renderer there. Preset recall drives go-librespot's local play API (no token plane). Multi-account is done by swapping credentials + restarting go-librespot (fragile, see fork issue #1). |
-| **Desktop app** | `desktop-app/` | Wails app (Go backend + Vite frontend), built for Windows, macOS, Linux | Discovers agents over mDNS, talks to them by REST, ships a UI for radio search (app-side, direct to radio-browser.info), presets, playback (with the live now-playing track + bitrate), a DLNA media library, Spotify Connect (beta), multiroom (beta), settings, webhooks (smart-home triggers), diagnostics export, OTA agent updates, USB stick provisioning, and box maintenance (true factory reset, uninstall STR, setup-AP Wi-Fi push). |
+| **Desktop app** | `desktop-app/` | Wails app (Go backend + Vite frontend), built for Windows, macOS, Linux | Discovers agents over mDNS, talks to them by REST, ships a UI for radio search (app-side, direct to radio-browser.info), presets, playback (with the live now-playing track + bitrate), a DLNA media library, Spotify Connect (beta), multiroom (beta), settings, webhooks (smart-home triggers), diagnostics export, OTA agent updates, network first-install (stick-free `:17000` unlock, USB stick as fallback), and box maintenance (true factory reset, uninstall STR, setup-AP Wi-Fi push). |
 | **Local library (DLNA)** | `dlna/` (top level so Wails can import it) | Imported by the desktop app | SSDP discovery + ContentDirectory browse of LAN media servers (FRITZ!Box, Synology, Plex, miniDLNA). The app saves a track's stream URL as a normal preset; the box pulls it via the streamproxy. |
 | **Multiroom (beta)** | `internal/zones/`, `internal/boxapi` zone primitives | Agent endpoints `/api/box/zone` + `/api/box/group` | Groups speakers via the box's native `/setZone` (firmware-synced) or a per-agent mirror fallback, plus stereo pairs. Membership persists in `/mnt/nv/streborn/zones.json` and auto-reforms after reboot/standby/Wi-Fi outage. |
 | **Setup wizard** | `sticksetup/`, `cmd/winformat/` (in-app); `setup/` (legacy PowerShell) | Embedded in the desktop app; `winformat.exe` handles FAT32 formatting | Prepares a FAT32 USB stick with Wi-Fi credentials, region, friendly name, language, and the bootstrap shell scripts, then drives the install over SSH. The standalone PowerShell wizard in `setup/` is legacy. |
@@ -99,16 +99,16 @@ ioBroker, Node-RED, or any HTTP endpoint on the LAN.
 |---|---|---|
 | Stick agent language | Go 1.25+ (module `github.com/JRpersonal/streborn`) | Static single binary cross-compiles to `linux/arm/v7` from any host. No runtime on the speaker beyond BusyBox. |
 | Desktop backend | Go via Wails v2 (`github.com/wailsapp/wails/v2`); own module, imports the shared top-level packages `discovery/`, `dlna/`, `radiobrowser/`, `sticksetup/`, `wifiprofiles/` | Same language as the agent. Go forbids importing the agent module's `internal/`, which is why the shared packages are top-level. |
-| Desktop frontend | Vite 6 + vanilla JS (no framework), i18n layer with 11 locales (EN, DE, ES, FR, JA, LT, LV, NL, PL, TR, UK) | Keeps the binary small and the build chain dependency-light. No React/Vue tax for the UI. |
+| Desktop frontend | Vite 8 + vanilla JS (no framework), i18n layer with 12 locales (EN, DE, ES, FR, JA, LT, LV, NL, PL, TR, UK, AR), including right-to-left layout for Arabic | Keeps the binary small and the build chain dependency-light. No React/Vue tax for the UI. |
 | mDNS | `github.com/grandcat/zeroconf` | Pure Go, dual stack, works on all three desktop OSes and on the speaker. |
 | WebSocket | `github.com/gorilla/websocket` | Reuses the gabbo subprotocol the Bose firmware expects on `:8080`. |
 | Radio source | `radio-browser.info` HTTP API | Free, no key, community-maintained. Replaces the dead Bose TuneIn integration. The stream proxy also reads the live ICY `StreamTitle` so the app can show the current track. |
 | Spotify | `go-librespot` (fork `JRpersonal/go-librespot`, Ogg passthrough patch) | Open-source Spotify Connect client in Go. Passthrough avoids decoding on the weak ARM CPU: the raw Ogg/Vorbis is handed straight to the box, which decodes it. The passthrough patch is offered upstream as `devgianlu/go-librespot` PR #316. |
 | Setup wizard host script | PowerShell 5.1 on Windows | Ships with every Windows; no Python install required for the user. |
 | FAT32 helper | Custom Go tool (`cmd/winformat`) | Avoids elevation prompts and shell quoting around `diskutil` / `format`. |
-| Distribution | Portable `.exe` + `.zip` (Windows), `.dmg` via `hdiutil` (macOS), `.tar.gz` with a per-user `install.sh` (Linux) | No installer framework; code signing is deferred on cost (#72), so the Verify page documents the SmartScreen/Gatekeeper click-paths instead. |
+| Distribution | Portable `.exe` + `.zip` (Windows), `.dmg` via `hdiutil` (macOS), `.tar.gz` with a per-user `install.sh` (Linux) | No installer framework. The Windows build is code-signed with a Certum "Open Source" certificate in a dedicated `sign-windows` release job; macOS notarization is still deferred, so the Verify page documents the Gatekeeper click-path. |
 | CI | GitHub Actions, all actions SHA-pinned | Build provenance via Sigstore (`actions/attest-build-provenance`). |
-| Verification | SHA256 + Sigstore today; code signing deferred on cost (see #72) | Verify page documents the click-paths through SmartScreen and Gatekeeper. |
+| Verification | SHA256 + Sigstore attestations, plus a Certum code signature on the Windows build | Signed Windows builds show a verified publisher; the Verify page still documents the Gatekeeper click-path for the unnotarized macOS build. |
 
 ## Network ports
 
@@ -132,7 +132,7 @@ firmware ports are stock. External reachability splits by chassis:
 
 | Port | Listener | Role | LAN reachable |
 |---|---|---|---|
-| 22 | sshd (Bose, started by STR) | **Pre-1.0: open on every boot.** `run.sh` (`ensure_sshd_running`) starts sshd unconditionally and deliberately never stops it, so diagnostics and SSH repair work even when the agent is down. Becomes opt-in via a stick marker as part of the v1.0 hardening (see `THREAT-MODEL.md`). | LAN |
+| 22 | sshd (Bose, started by STR) | **Opt-in.** `run.sh` (`ensure_sshd_running`) force-starts sshd only when the NAND marker `/mnt/nv/streborn/enable-ssh` is present. Otherwise SSH follows Bose's own gate: open while an STR stick with `remote_services` is inserted, closed on a stickless steady-state boot. The trade-off is that SSH diagnostics and the SSH-OTA fallback need the stick plugged back in (see `THREAT-MODEL.md`). | LAN (only while enabled) |
 | 80 | _(nobody , firmware OUTBOUND)_ | **Not a listener.** This is the firmware's **outbound** HTTP cloud call (to `streaming.bose.com`). iptables NAT-redirects it to STR's :9080; **STR never binds :80** and the firmware does not listen on it. Listed only because STR claims this outbound traffic. | outbound (firmware) -> redirected to :9080 |
 | 443 | STR marge HTTPS | TLS cloud-stub for `streaming.bose.com` after the Hosts redirect. | loopback (firmware) |
 | 3678 | go-librespot local API (started by STR) | The agent's `spotify.Manager` drives playback here (`/player/play`, shuffle, next, volume) and reads track events. | loopback |
@@ -144,6 +144,7 @@ firmware ports are stock. External reachability splits by chassis:
 | 8443 | STR marge HTTPS (alt) | Same handler as :443; used when :443 cannot be claimed. | sm2: direct (INPUT ACCEPT) / whitelisted chassis: loopback |
 | 8888 | STR webui + streamproxy | `/api/*` for the desktop app, the `/stream/<slot>` radio reverse proxy that survives CDN token expiry, and `/spotify/stream.ogg` (the raw Ogg the box pulls for Spotify). HLS playlists are converted to one continuous ADTS/MP3 stream; `/api/stream-status` reports upstream failures. | sm2: direct (INPUT ACCEPT) / whitelisted chassis: via :17008 REDIRECT |
 | 9080 | STR marge HTTP | Plain-text marge target after the firmware's outbound :80 is NAT-redirected. | sm2: direct (INPUT ACCEPT) / whitelisted chassis: loopback |
+| 17000 | TAP command shell (Bose) | Stock telnet-style diagnostic shell (`envswitch`, `sys configuration`, `sys reboot`). The desktop app drives it for the stick-free SSH unlock during a network install and for uninstall/repair (`desktop-app/telnet_enable_ssh.go`, `internal/boxcli`). STR does not bind it. | LAN |
 | 17002 | STR BatteryMonitor fallback | **Portable only.** Bound when the Bose `BatteryMonitor` service is wedged, so BoseApp's battery client connects instead of connect-storming a dead port. This is the ~27 min reboot fix (v0.6.18); see [`FIRMWARE-NOTES.md`](./FIRMWARE-NOTES.md). | loopback (firmware) |
 | 17008 | SoftwareUpdate (Bose) | On whitelisted chassis (taigan, spotty, scm) this is STR's external entry point: the PREROUTING REDIRECT sends external :17008 to loopback :8888, which is how the desktop app reaches the agent. | external entry (whitelisted chassis) |
 | 40020 | scmmond (Bose) | System-control / battery-MCU manager that feeds `BatteryMonitor`. STR does not bind it. | internal |
@@ -176,7 +177,7 @@ sequenceDiagram
   Agent->>Net: Announce _streborn._tcp.local<br/>TXT: deviceID, model, version, name
   App->>Net: Browse _streborn._tcp.local
   Net-->>App: Service records
-  App->>App: Deduplicate + classify str/stock<br/>(desktop-app/app.go)
+  App->>App: Deduplicate + classify str/stock<br/>(desktop-app/app_discovery.go)
   App->>Agent: GET /api/status (over LAN)
   Agent-->>App: XML now_playing (proxied from the box :8090, cached)
   Note over App,Agent: presets and agent version are separate calls<br/>(/api/presets, /api/agent/version)
@@ -351,9 +352,12 @@ sequenceDiagram
   Note over Box: From now on /mnt/nv/rc.local -> run-override.sh<br/>starts the agent on every boot. No stick needed.
 ```
 
-The first install needs the SSH channel that Bose opens only while the
-box boots with a `remote_services` stick inserted: that is the only way
-to run the first command (`install.sh`) on a factory box and seed
+The first install needs a shell on the box. The app opens one
+stick-free over the Bose `:17000` TAP shell (`envswitch boseurls` /
+`accountid` injection, see `desktop-app/telnet_enable_ssh.go`) and then
+runs the install over SSH. Where that unlock does not take, the
+fallback is the SSH channel Bose opens while the box boots with a
+`remote_services` stick inserted, which runs `install.sh` and seeds
 `/mnt/nv/rc.local`. From the second boot on, Bose's own init runs the
 NAND `rc.local` and no SSH is involved. Moving the first install off SSH
 is evaluated in
@@ -523,15 +527,15 @@ configuration plus the agent binary that gets copied into NAND.
 | You want to... | Read this |
 |---|---|
 | ...trace a hardware button press end to end | `internal/boxws/boxws.go`, then `internal/upnp/upnp.go` |
-| ...understand the marge cloud emulation | `internal/marge/marge.go` + `templates.go`; check the spy log on `:9080/__spy/log` (same handler on the marge TLS port; the BMX stub on `:8081` serves `/healthz` only) |
+| ...understand the marge cloud emulation | `internal/marge/` (`routes.go` for the route table, `responses.go` + `templates.go` for the stub bodies, `group.go` for multiroom, `spy.go` for the spy log); check the spy log on `:9080/__spy/log` (same handler on the marge TLS port; the BMX stub on `:8081` serves `/healthz` only) |
 | ...see how presets are stored | `internal/presets/presets.go` |
-| ...follow a Spotify recall (play, shuffle, multi-account, Ogg serve) | `internal/spotify/manager.go`; the recall hook is in `cmd/agent/main.go` (`playSpotifyPreset`, `verifySpotifyPlaying`) |
+| ...follow a Spotify recall (play, shuffle, multi-account, Ogg serve) | `internal/spotify/` (`manager.go` supervision, `recall.go` play/shuffle, `accounts.go` multi-account, `serve.go` + `ogg.go` the stream); the recall hook is in `cmd/agent/wshandler.go` (`playSpotifyPreset`, `verifySpotifyPlaying`) |
 | ...trace the radio stream proxy + ICY title | `internal/streamproxy/streamproxy.go` (HLS conversion: `hls.go` + `mpegts.go`) |
 | ...follow the desktop-app boot | `desktop-app/main.go`, then `desktop-app/frontend/src/main.js` |
 | ...inspect the stick boot sequence | `usb-stick/rc.local`, `usb-stick/run.sh`, `usb-stick/install.sh` |
 | ...understand discovery semantics | `discovery/` (top level so Wails can import it) |
 | ...follow the app-side radio search | `desktop-app/radio.go` -> `radiobrowser/` |
-| ...browse the DLNA library | `dlna/dlna.go`, App methods in `desktop-app/app.go` |
+| ...browse the DLNA library | `dlna/dlna.go`, App methods in `desktop-app/app_library.go` |
 | ...trace multiroom zones | `internal/zones/zones.go`, `/api/box/zone` in `internal/webui` |
 | ...check the release pipeline | `.github/workflows/release.yml`, `Makefile` (`wails-build`, `agent-embed`) |
 

--- a/docs/FIRMWARE-NOTES.md
+++ b/docs/FIRMWARE-NOTES.md
@@ -88,7 +88,9 @@ log-churn source that rotated the 32 KB NAND log in ~3.5 h.
 
 ## Reaching the agent on BCO speakers (chipset whitelist)
 
-On the newer "BCO" chassis (Portable, and the scm/spotty ST20 revision)
+On the newer "BCO" chassis (the Portable, and every `scm`-module
+chassis observed so far — the scm revisions of the ST20, ST30 and Wave,
+plus the SA-4 — as well as `sm2` boxes carrying the SMSC bridge)
 the network chipset only routes inbound external TCP to listeners owned
 by a Bose binary. A normal listener like the STR agent on `:8888` is not
 reachable from the LAN as-is. STR works around this two ways:
@@ -152,7 +154,7 @@ streams) plays but HTTPS radio (e.g. Virgin Radio) and the Spotify sidecar's
 The stream proxy mitigates this for radio: when the local clock is
 implausibly old it still verifies the certificate chain to the system roots
 and the hostname, but relaxes the time-validity window (see
-`clockTolerantTLS` in `internal/streamproxy/streamproxy.go`). Verification
+`clockTolerantTLSConfig` in `internal/streamproxy/tlsclock.go`). Verification
 tightens again automatically once the clock is corrected. The agent
 additionally corrects an implausibly old clock at start and keeps retrying
 from an HTTP Date header until a sane time is set

--- a/docs/MODEL-VARIANTS.md
+++ b/docs/MODEL-VARIANTS.md
@@ -193,10 +193,10 @@ and installed end to end since:
 | `scm` | `lisa` | `SoundTouch SA-4` | SCM, PackagedProduct, **Lightswitch**, **SMSC** | **validated** — a user network-installed STR end to end 2026-07-09. The stick was never an option (it does not read USB at boot); the stick-free `:17000` network install is the path. |
 | `scm` | `lisa` | `Wave SoundTouch` | SCM, PackagedProduct, Lightswitch, SMSC | **validated** — the agent runs via the `:17008` REDIRECT like the `scm` ST20; stick-free network install confirmed end to end (#182, 2026-07-09 and 2026-07-11). |
 | `sm2` | `lisa` | `Wave SoundTouch` | SCM, PackagedProduct, SMSC | **validated** — seen 2026-07-04 (#182, `variantMode=NoAP`): the Wave ships on BOTH module types. Stick-free network install confirmed end to end (#182, 2026-07-09 and 2026-07-11: presets, NAS/DLNA playback, ST20 grouping). |
-| `sm2` | `burns` | `SoundTouch SA-5` | SCM, PackagedProduct, SMSC | seen 2026-07-04 (#274 fleet bundle): fw 27.0.6, no STR, stick never read. Agent should run, first-install path still unvalidated. |
-| `sm2` | `lisa` | `CineMate 520` | SCM, PackagedProduct | **validated** — a user network-installed STR end to end 2026-07-09. Other CineMate models remain untested. |
+| `sm2` | `burns` | `SoundTouch SA-5` | SCM, PackagedProduct, SMSC | **validated** — an owner runs STR v0.9.25 end to end (#274, 2026-08-01): network install, app + phone-remote control and Now Playing. Known gap: the SA-5 reports three AUX inputs where STR models one (#390). |
+| `sm2` | `lisa` | `CineMate 520` | SCM, PackagedProduct | **validated** — a user network-installed STR end to end 2026-07-09. The CineMate 130 is separately user-confirmed (#491, v0.9.27, 2026-08-01; full fingerprint pending from the #491 diagnostics — reports its TV/AUX input as source `LOCAL`). Other CineMate models remain untested. |
 
-The Wave, SA-4, and CineMate 520 are now **Working** (docs/MODELS.md); the untested-model UI warning was removed in v0.9.2 (#283 follow-up). The SA-5 (`burns`) remains unvalidated. Note: in a diagnostic a stock `scm/lisa` box shows `reachable8888=true` because that field probes **:17008**, where Bose's own SoftwareUpdate answers; the authoritative "STR present" signal is the `strDetected` field, not `reachable8888`.
+The Wave, SA-4, and CineMate 520 are now **Working** (docs/MODELS.md); the untested-model UI warning was removed in v0.9.2 (#283 follow-up). The SA-5 (`burns`) is now also user-confirmed (#274, 2026-08-01). Note: in a diagnostic a stock `scm/lisa` box shows `reachable8888=true` because that field probes **:17008**, where Bose's own SoftwareUpdate answers; the authoritative "STR present" signal is the `strDetected` field, not `reachable8888`.
 
 ## Why this matters for STR
 

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -99,7 +99,8 @@ The box display/voice language is the Bose `sysLanguage` integer (full
 enum 0..25 resolved; English = 3, German = 2, Danish = 1, ...). STR no
 longer hard-codes one language: the setup wizard picks it from the
 chosen country, refined by the app's UI language, and the box-language
-picker lists all 25 languages by their native name. Speakers with no
+picker lists all 24 defined languages by their native name (0 is the
+factory sentinel and 14 is undefined, so neither is offered). Speakers with no
 matching language fall back to English (for a Ukrainian UI the box
 display falls back to Russian, which is more readable than English,
 while the app UI itself never offers Russian).

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -24,6 +24,15 @@ user-facing commit types: `feat` -> New features, `fix` -> Fixes,
 Noise (`chore`, `ci`, `build`, `test`, `style`, `refactor`, `docs`) is
 dropped so the reader sees only what tells them whether to upgrade.
 
+Commit bodies can extend or retract the list. A
+`Release-Note: type(scope): summary` trailer anywhere in a body adds an
+extra entry, parsed exactly like a subject (useful when a squash merge
+collapses several user-visible changes into one subject; the carrier
+commit's own type may be non-user-facing). A
+`Release-Note-Drop: <summary>` trailer withdraws a previously announced
+entry by its rendered summary, case-insensitively, for work that changed
+course before the release went out.
+
 The release workflow (`.github/workflows/release.yml`) runs it in the
 `release` job:
 
@@ -119,7 +128,7 @@ The website is already notified on each release via
 
 ## What the desktop app already does (this repo)
 
-- `CheckAppUpdate` (desktop-app/app.go) forwards the endpoint's full JSON
+- `CheckAppUpdate` (desktop-app/app_appinfo.go) forwards the endpoint's full JSON
   to the frontend (including `notesUrl` when present).
 - The update banner (desktop-app/frontend/src/main.js, `checkAppUpdate`)
   is kept discreet: version plus a single "What's new" link to the

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,8 @@ For the security-specific roadmap see
 
 ## Post-1.0 (already named in CLAUDE.md)
 
-- Code signing and notarization for Windows and macOS installers.
+- macOS code signing and notarization. (Windows installers are
+  Certum-signed since v0.9.20.)
 - Promote the remaining model statuses to Verified (Portable is
   Verified, ST20 spotty contributor-confirmed, ST30 live-confirmed;
   see [`MODELS.md`](MODELS.md)).
@@ -31,8 +32,8 @@ i18n, switch the default UI to English.
 | Phase | Scope | Status |
 |-------|-------|--------|
 | A | Extract leaf modules (`state`, `utils`, `localization`, `logos`, `api`) out of `main.js`. All comments and identifiers English. | **done** — merged via [#40](https://github.com/JRpersonal/streborn/pull/40) |
-| B | Extract view modules + shared services along the existing section-comment seams (see the refactoring backlog below for the concrete module cut). After this `main.js` shrinks to the DOM skeleton + router + bootstrap (~600 lines; the old ~150-line estimate predates the feature growth). | not started — `src/views/` exists but is empty; `main.js` has grown to 6892 lines, which makes this the highest-leverage refactor in the repo |
-| C | i18n system: minimal `t()` helper plus `en` and `de` bundles in `desktop-app/frontend/src/i18n/`. Locale detected from `navigator.language`, with explicit override stored in `localStorage`. **Default is English** per the global-audience rule; German remains a first-class supported locale but is no longer the implicit fallback. | **done** — shipped in #46 and grown to 11 locale bundles. Caveat: 9 of the 10 non-English bundles are ~285-301 keys behind `en.json` (silent English fallback); a CI completeness check is in the refactoring backlog |
+| B | Extract view modules + shared services along the existing section-comment seams (see the refactoring backlog below for the concrete module cut). After this `main.js` shrinks to the DOM skeleton + router + bootstrap (~600 lines; the old ~150-line estimate predates the feature growth). | in progress — 7 view modules extracted to `src/views/` (library, multiroom, podcasts, recent, settings, setup, spotify) plus service modules (`api`, `groups`, `searchflow`, `share`); `main.js` still holds 6967 lines, so finishing the cut remains the highest-leverage refactor in the repo |
+| C | i18n system: minimal `t()` helper plus `en` and `de` bundles in `desktop-app/frontend/src/i18n/`. Locale detected from `navigator.language`, with explicit override stored in `localStorage`. **Default is English** per the global-audience rule; German remains a first-class supported locale but is no longer the implicit fallback. | **done** — shipped in #46 and grown to 12 locale bundles (incl. Arabic). All bundles are complete (key-for-key with `en.json`); the completeness gap was closed in #514. |
 | D | Translate the remaining inline German comments and the few mixed-language handler strings still sitting in `main.js` (and any view module that ends up holding them after Phase B). Closes the CLAUDE.md "all code/comments/identifiers in English" rule. | mostly done via the #46 i18n sweep; ~a dozen German comments remain in `main.js` (and the older on-stick scripts are still German, tracked in the backlog below) — finish when Phase B touches those regions |
 
 Why this is on the roadmap rather than just done: Phase A alone
@@ -80,11 +81,11 @@ Each item is a single reviewable PR; line numbers as of v0.7.21.
    `playSpotifyPreset` vs app `handlePlaySlot`) into one orchestrator:
    they have already drifted (the soft verify still carries the
    restart-on-re-Play bug the hardware path fixed in v0.7.4).
-8. File splits, pure moves, no behavior change: `desktop-app/app.go`
-   (3158 lines -> ~10 files incl. `boxssh.go` for the SSH transport
-   shared by 6 features), `cmd/agent/main.go` (2026 lines),
-   `internal/webui/webui.go` (2485 lines), `internal/spotify/manager.go`
-   (1510 lines), `internal/streamproxy/streamproxy.go` (1052 lines).
+8. **done** — all five splits landed: `desktop-app/app.go` (now ~190
+   lines + 15 focused files incl. `boxssh.go`), `cmd/agent/main.go`
+   (10 files), `internal/webui` (14-file split, `webui.go` removed),
+   `internal/spotify/manager.go`, and
+   `internal/streamproxy/streamproxy.go`.
 9. Frontend Phase B (see table above): cut `main.js` along its
    existing section comments into ~9 view modules + 6 services;
    pre-step: decompose the 910-line `renderBoxSettings`. Delete the

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -14,14 +14,16 @@ companion.
 
 STR runs in a residential LAN and consists of:
 
-1. A small Go agent installed onto a Bose SoundTouch speaker via a
-   USB stick. After the install the agent runs from the speaker's
-   own persistent storage; the stick is only needed for the initial
-   setup. Agent updates are delivered over the LAN by the desktop
-   app (a stick that is still inserted gets refreshed so it cannot
-   revert the update on the next boot).
-2. A cross-platform desktop application that discovers sticks via
-   mDNS and offers a web UI.
+1. A small Go agent installed onto a Bose SoundTouch speaker,
+   normally over the network by the desktop app (via the speaker's
+   setup service on `:17000`); a USB stick remains available as the
+   fallback and recovery install path. After the install the agent
+   runs from the speaker's own persistent storage. Agent updates are
+   delivered over the LAN by the desktop app (a stick that is still
+   inserted gets refreshed so it cannot revert the update on the
+   next boot).
+2. A cross-platform desktop application that discovers running
+   agents via mDNS and offers a web UI.
 3. A static website that hosts downloads and documentation.
 
 The agent emulates a handful of cloud endpoints which the speaker
@@ -46,12 +48,12 @@ as a DNS server for any other device, and does not phone home.
   app's webview and into the speaker (playback + presets), so they are
   treated as an attacker-controlled input boundary.
 - **Bundled go-librespot sidecar and its credentials.** The Spotify
-  Connect beta runs a third-party GPL binary on the speaker, built by
-  this repo's CI from a pinned fork and Sigstore-attested, and
-  persists Spotify credentials on the speaker's NAND for preset
-  recall. Anyone with the (pre-1.0 open) root SSH access can read
-  those credentials, which strengthens the case for the SSH hardening
-  below.
+  Connect integration runs a third-party GPL binary on the speaker,
+  built by this repo's CI from a pinned fork and Sigstore-attested,
+  and persists Spotify credentials on the speaker's NAND for preset
+  recall. Anyone with root SSH access (open while the install stick
+  is inserted, or when the persistent opt-in marker is set) can read
+  those credentials, which is part of why SSH is kept opt-in.
 
 Each boundary is covered in detail in
 [`SECURITY.md`](../SECURITY.md).
@@ -102,18 +104,17 @@ STR:
   control playback. This is unchanged by STR.
 - The speakers ship with a passwordless `root` account, and Bose's
   init starts an SSH service when a `remote_services` marker is
-  present on a mounted USB stick. **Pre-1.0, STR itself keeps that
-  SSH service running on every boot** (`ensure_sshd_running` in
-  `usb-stick/run.sh`), stick or no stick: when an install or update
-  leaves the agent down, SSH is the only channel that still lets the
-  desktop app pull diagnostics and repair the box, and the project
-  currently weights that recovery path over closing the port. This is
-  an STR-maintained LAN exposure, mitigated only by network
-  isolation; it flips to opt-in (stick marker) as part of the v1.0
-  hardening roadmap below. The desktop app's yellow banner is a
-  stick-removal reminder keyed on the stick's mount state; it is NOT
-  an SSH-state indicator, and SSH remains open after the stick is
-  removed.
+  present on a mounted USB stick. STR follows that gate: SSH is open
+  while the STR stick is inserted (install / recovery / diagnostics)
+  and closes again on the next stickless reboot; STR no longer
+  forces SSH open on every boot. A maintainer who needs persistent
+  debug SSH on a stickless box can opt back in by creating
+  `/mnt/nv/streborn/enable-ssh` (or a `/mnt/nv/remote_services`
+  marker); a reboot does not close SSH in that case. The desktop
+  app's yellow banner reflects the actual SSH state the agent
+  reports: it recommends a restart while SSH is still open after the
+  stick was pulled, and shows a distinct notice when the persistent
+  marker is set.
 
 If your speaker is on a network with untrusted devices (guest Wi-Fi,
 shared student housing, public-facing IoT segment), put it on a
@@ -148,9 +149,9 @@ coordinated review per `.github/CODEOWNERS`.
 - STR does not encrypt traffic between the desktop app and the
   stick. Both sit on the same LAN, and the LAN is the trust
   boundary.
-- STR does not authenticate clients of the stick web UI. Any device
-  on the LAN that can reach the stick on `:8888` can edit presets
-  and trigger playback.
+- STR does not authenticate clients of the agent web UI. Any device
+  on the LAN that can reach the agent (`:8888`, or `:17008` on
+  SMSC-chassis boxes) can edit presets and trigger playback.
 - STR does not sandbox the desktop application. It runs with the
   privileges of the user who launched it.
 - STR does not attempt to verify the integrity of the stock speaker

--- a/docs/streaming/spotify.md
+++ b/docs/streaming/spotify.md
@@ -1,6 +1,10 @@
 # Spotify Connect: integration spike
 
-Status: spike / design. Tracks #78. No code shipped yet.
+Status: shipped. Spotify Connect went live as a beta in v0.7.0 and has been
+hardened through the v0.9.x line (go-librespot sidecar, see the decision
+update below); #78 carries the history. The rest of this document is the
+spike trail plus the shipping notes, kept for the reasoning behind the
+architecture.
 
 ## TL;DR (updated after live testing)
 


### PR DESCRIPTION
README modernization from the parallel session (network-install-first narrative, current model table) plus a 6-agent currency audit of every doc against the code: 44 verified corrections across ARCHITECTURE, THREAT-MODEL, SECURITY, MODELS/MODEL-VARIANTS/FIRMWARE-NOTES, CONTRIBUTING, RELEASE-NOTES, ROADMAP, spotify.md, CLAUDE.md and README. Highlights: SSH documented as shipped opt-in, Certum signing reality, :17000 TAP-shell port row, post-split file references, 12 locales incl. RTL Arabic, spotify.md no longer claims 'no code shipped yet'. Ten decision-needing items are tracked in a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)