### PR TITLE
fix(presets): restart hint also on the error-refusal path (+ honest clock-jump log)

### DIFF
--- a/desktop-app/frontend/wailsjs/go/models.ts
+++ b/desktop-app/frontend/wailsjs/go/models.ts
@@ -43,6 +43,8 @@ export namespace main {
 	    conflictingMod?: string;
 	    storm1036?: boolean;
 	    storm1036SinceSec?: number;
+	    recallRefusal?: boolean;
+	    recallRefusalSinceSec?: number;
 	    wlanCredsMissing?: boolean;
 	    serialNumber: string;
 	    kind: string;
@@ -68,6 +70,8 @@ export namespace main {
 	        this.conflictingMod = source["conflictingMod"];
 	        this.storm1036 = source["storm1036"];
 	        this.storm1036SinceSec = source["storm1036SinceSec"];
+	        this.recallRefusal = source["recallRefusal"];
+	        this.recallRefusalSinceSec = source["recallRefusalSinceSec"];
 	        this.wlanCredsMissing = source["wlanCredsMissing"];
 	        this.serialNumber = source["serialNumber"];
 	        this.kind = source["kind"];

--- a/internal/webui/resume_standby.go
+++ b/internal/webui/resume_standby.go
@@ -740,6 +740,11 @@ const (
 	// actively pulling a stream this recently, so STR only ever resumes music
 	// the drop actually interrupted, never long-idle boxes.
 	spontResumeStreamWindow = 60 * time.Second
+	// clockJumpAgeFloor: an "age" beyond this cannot be a real gap between a
+	// stream fetch and a source drop within one agent run; it means the wall
+	// clock moved under us (no battery RTC: these boxes boot in 2015 until
+	// NTP lands). Used only to log the honest reason.
+	clockJumpAgeFloor = 24 * time.Hour
 )
 
 // recallOwnsRetryWindow is how long after a user-started play the recall's own
@@ -1011,9 +1016,22 @@ func (s *Server) handleSpontaneousSourceOff(sinceKey time.Duration) {
 		return
 	}
 	fetch, _ := s.streamActivityFn()
-	if fetch.IsZero() || time.Since(fetch) > spontResumeStreamWindow {
+	if age := time.Since(fetch); fetch.IsZero() || age > spontResumeStreamWindow {
+		// An age far beyond any plausible uptime means the stamp was taken
+		// before the box corrected its clock, not that the stream is old:
+		// these speakers have no battery RTC and boot in 2015 until NTP
+		// lands, which produced a "did not serve recently" stand-down with
+		// lastFetchAgoS of about twenty years (field: ST10, 2026-08-02).
+		// The verdict stays the same - a stand-down never wakes a box, and
+		// deep standby is sacred - but the log must not blame the stream for
+		// what is a clock jump, or the next bundle gets read wrong.
+		if age > clockJumpAgeFloor {
+			s.logger.Info("spontaneous-off recovery: stream-activity stamp predates a clock correction, standing down (not a stale stream)",
+				"lastFetchAgoS", int(age.Seconds()))
+			return
+		}
 		s.logger.Info("spontaneous-off recovery: the stream proxy did not serve this box recently, standing down",
-			"lastFetchAgoS", int(time.Since(fetch).Seconds()), "windowS", int(spontResumeStreamWindow.Seconds()))
+			"lastFetchAgoS", int(age.Seconds()), "windowS", int(spontResumeStreamWindow.Seconds()))
 		return
 	}
 	// Single-flight + crash-loop guard. The #381 attempt counter caps a

--- a/internal/webui/verify_standdown_test.go
+++ b/internal/webui/verify_standdown_test.go
@@ -136,16 +136,19 @@ func TestSilentRefusalLatch(t *testing.T) {
 		t.Fatal("playback must clear the refusal state")
 	}
 
-	// A recent 1036 attributes the failure to the login: the storm banner owns
-	// that messaging, no refusal strike.
+	// A recent 1036 used to hand the messaging to the storm marker and latch
+	// nothing here. The field disproved that contract on 2026-08-02: the storm
+	// marker needs six rejections in ten minutes, a box that refused three
+	// times left its owner with no message at all, and the cure (soft restart)
+	// is identical either way. So a 1036-attributed refusal now latches too.
 	s2 := &Server{logger: disc}
 	s2.NoteNonUserStandbyDrop()
 	s2.NoteBoxLoginError()
 	s2.noteRecallExhaustedWithSource("STANDBY")
 	s2.NoteNonUserStandbyDrop()
 	s2.noteRecallExhaustedWithSource("STANDBY")
-	if active, _ := s2.RecallRefusal(); active {
-		t.Fatal("1036-attributed failures must not latch the silent-refusal state")
+	if active, _ := s2.RecallRefusal(); !active {
+		t.Fatal("1036-attributed refusals must latch the restart hint too")
 	}
 
 	// Recent stream activity absolves: the content failed, not the box.
@@ -158,5 +161,35 @@ func TestSilentRefusalLatch(t *testing.T) {
 	s3.noteRecallExhaustedWithSource("STANDBY")
 	if active, _ := s3.RecallRefusal(); active {
 		t.Fatal("recent stream activity must absolve the silent failures")
+	}
+}
+
+// TestLoginRefusalLatchesToo closes the gap the 2026-08-02 field bundle
+// exposed: a box that answers 1036 for every press latched NOTHING (the wedge
+// path skips it as a login failure, and the 1036 storm marker needs six
+// rejections in ten minutes), so a user with three rejections saw no banner
+// and no restart button - in the one case where the soft restart is the cure.
+func TestLoginRefusalLatchesToo(t *testing.T) {
+	s := &Server{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	// Box awake (not STANDBY) and a fresh 1036: the wedge attribution skips,
+	// but the refusal latch must count it.
+	s.NoteBoxLoginError()
+	s.noteRecallExhaustedWithSource("INVALID_SOURCE")
+	if active, _ := s.RecallRefusal(); active {
+		t.Fatal("one refused recall must stay quiet")
+	}
+	s.NoteBoxLoginError()
+	s.noteRecallExhaustedWithSource("INVALID_SOURCE")
+	if active, _ := s.RecallRefusal(); !active {
+		t.Fatal("two consecutive 1036-refused recalls must latch the restart hint")
+	}
+	// The wedge state must NOT latch from these: the advice differs (a wedge
+	// needs a power-cycle, a login refusal a soft restart).
+	if status, _ := s.BoxHealth(); status != "ok" {
+		t.Fatalf("login refusals must not latch a wedge, got %q", status)
+	}
+	s.NoteBoxHealthy()
+	if active, _ := s.RecallRefusal(); active {
+		t.Fatal("observed playback must clear the refusal latch")
 	}
 }

--- a/internal/webui/wedge.go
+++ b/internal/webui/wedge.go
@@ -150,6 +150,14 @@ func (s *Server) noteRecallExhaustedWithSource(source string) {
 	// verify exhausts ~26s after the press.
 	if s.loginErrorRecentWithin(loginErrWedgeSkipWindow) {
 		s.logger.Info("recall exhausted during a not-logged-in window; not counting a wedge strike (login failure, not a wedge)")
+		// It is not a wedge, but it is not nothing either: the box refused
+		// the recall because it thinks it is signed out, and the cure is the
+		// same soft restart the refusal banner offers. Until now this branch
+		// latched NOTHING, and the 1036 storm marker needs six rejections in
+		// ten minutes, so a user whose box refused "only" three times saw no
+		// message at all while no preset played (field: ST10, 2026-08-02,
+		// three rejections across two minutes, then a plug pull).
+		s.noteRefusalStrike("login")
 		return
 	}
 	if s.streamActivityFn != nil {
@@ -250,9 +258,9 @@ func (s *Server) noteSilentRefusalCandidate() {
 	if !s.nonUserStandbyDropRecent(wedgeStrikeWindow) {
 		return
 	}
-	if s.loginErrorRecentWithin(loginErrWedgeSkipWindow) {
-		return
-	}
+	// A recent 1036 does NOT excuse this any more: it used to hand the
+	// messaging to the storm marker, which only fires at six rejections in
+	// ten minutes and therefore left the three-rejection case silent.
 	if s.streamActivityFn != nil {
 		fetch, fail := s.streamActivityFn()
 		if (!fetch.IsZero() && time.Since(fetch) < wedgeStrikeWindow) ||
@@ -260,6 +268,14 @@ func (s *Server) noteSilentRefusalCandidate() {
 			return
 		}
 	}
+	s.noteRefusalStrike("silent")
+}
+
+// noteRefusalStrike counts one refused recall toward the restart hint and
+// latches it on the second consecutive one. kind names the observed flavour
+// for the bundle: "silent" (source self-dropped, no 1036) or "login" (the box
+// answered 1036). Both end in the same advice, so they share one latch.
+func (s *Server) noteRefusalStrike(kind string) {
 	s.refusal.mu.Lock()
 	s.refusal.strikes++
 	latch := s.refusal.strikes >= refusalStrikesToLatch && !s.refusal.latched
@@ -270,11 +286,11 @@ func (s *Server) noteSilentRefusalCandidate() {
 	strikes := s.refusal.strikes
 	s.refusal.mu.Unlock()
 	if latch {
-		// Bundle-forensics marker: this line separates the silent-refusal
-		// family from a wedge and from the 1036 storm in a diagnostic.
-		s.logger.Warn("box refuses recalls silently: source self-drops to STANDBY with no 1036 and no stream fetch; surfacing the restart hint", "strikes", strikes)
+		// Bundle-forensics marker: this line separates the refusal family
+		// from a wedge and names which flavour was observed.
+		s.logger.Warn("box refuses recalls: surfacing the restart hint", "kind", kind, "strikes", strikes)
 	} else {
-		s.logger.Warn("silent recall refusal suspected (strike recorded)", "strikes", strikes)
+		s.logger.Warn("recall refusal suspected (strike recorded)", "kind", kind, "strikes", strikes)
 	}
 }
 


### PR DESCRIPTION
Two defects the 2026-08-02 support bundles proved, both in code that shipped today.

**1. The loud refusal still latched nothing.** v0.9.28 covered the SILENT variant (box drops its source without a word). A box that answers 1036 for every press still produced no user message: `NoteRecallExhausted` skips the wedge strike during a login window (correct - a power-cycle is the wrong advice), and the 1036 storm marker needs 6 rejections in 10 minutes. Field bundle: an ST10 refused 3 presses across 2 minutes (12:42:06, 12:42:28, 12:43:47), the log even says `recall exhausted during a not-logged-in window; not counting a wedge strike`, the app showed nothing, and the owner pulled the plug - which costs the box its clock and makes the next boot worse. Both flavours now feed one latch and one hint (`kind=silent`/`kind=login` in the log for bundle forensics), because the cure is the same soft restart. The wedge state is unaffected, so the power-cycle advice stays reserved for real wedges.

**2. A poisoned boot clock blamed the stream.** The spontaneous-off recovery logged `the stream proxy did not serve this box recently, standing down` with `lastFetchAgoS=633437444` (~20 years) on a box that had booted in 2015 and corrected its clock afterwards. The stand-down verdict is deliberately unchanged (standing down never wakes a box; deep standby stays sacred), but the reason is now named correctly so the next bundle is not misread.

Tests: `TestLoginRefusalLatchesToo` added. `TestSilentRefusalLatch` asserted the old "1036-attributed failures must not latch" contract - updated with the field evidence for why that contract was wrong. ARM cross-build and the webui suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)