### PR TITLE
fix(presets): the key-registration refresh no longer hijacks a user-chosen source

### DIFF
--- a/cmd/agent/reconcile.go
+++ b/cmd/agent/reconcile.go
@@ -341,8 +341,15 @@ func periodicPresetReconcile(store *presets.Store, boxHost string, logger *slog.
 // resyncSafeSource reports whether a preset re-sync may run while the box is
 // on this source. AddPreset names UPNP and the firmware activates that source
 // on the write, so a re-sync is only safe when the box is idle or already on
-// STR's own source. Anything the user picked (Bluetooth, AUX, the box's own
-// Spotify, a Wave's tuner) would be yanked away mid-listen.
+// STR's own source. Anything the user picked would be yanked away mid-listen.
+//
+// Deliberately an ALLOWLIST, never a list of sources to avoid: the input
+// sources are named differently per model and we do not know them all. A
+// CineMate reports its TV input as LOCAL where an ST10 says AUX, an SA-5
+// answers AUX with sourceAccount AUX1..AUX3, and the Wave's tuner sources are
+// invisible to STR entirely. With an allowlist an unknown name is treated as
+// "the user chose this", which costs at most one deferred key refresh; a
+// denylist would silently interrupt every model whose source name we forgot.
 func resyncSafeSource(src string) bool {
 	switch src {
 	case "UPNP", "INVALID_SOURCE":

--- a/cmd/agent/reconcile.go
+++ b/cmd/agent/reconcile.go
@@ -284,7 +284,20 @@ func periodicPresetReconcile(store *presets.Store, boxHost string, logger *slog.
 		// in standby gets its re-sync from the standby-exit hook the moment
 		// it wakes.
 		if !force && time.Since(lastAwakeForce) > 20*time.Minute {
-			if src := boxNowPlayingSource(boxHost); src != "" && src != "STANDBY" {
+			src := boxNowPlayingSource(boxHost)
+			switch {
+			case src == "" || src == "STANDBY":
+				// asleep or unreadable: the standby-exit hook owns the wake
+			case !resyncSafeSource(src):
+				// The box is on a source the USER chose. AddPreset names
+				// UPNP, and the firmware activates that source on the write:
+				// a field bundle caught the insurance pass yanking a running
+				// BLUETOOTH session to UPNP 43 ms after the re-sync line
+				// (2026-08-02). Dead-key insurance is not worth interrupting
+				// what someone is listening to; the next wake, press or
+				// maintenance tick on our own source re-registers the keys.
+				logger.Info("preset reconcile: periodic awake re-sync skipped, the box is on a user-chosen source", "source", src)
+			default:
 				force = true
 				logger.Info("preset reconcile: periodic awake re-sync (dead-key insurance, #487)")
 			}
@@ -325,6 +338,20 @@ func periodicPresetReconcile(store *presets.Store, boxHost string, logger *slog.
 // reconcileOnce returns true once the box is out of OOB and reachable.
 // When forceFull is set it re-pushes EVERY stick preset rather than only
 // the slots missing from the box's /presets list (see fullDone above).
+// resyncSafeSource reports whether a preset re-sync may run while the box is
+// on this source. AddPreset names UPNP and the firmware activates that source
+// on the write, so a re-sync is only safe when the box is idle or already on
+// STR's own source. Anything the user picked (Bluetooth, AUX, the box's own
+// Spotify, a Wave's tuner) would be yanked away mid-listen.
+func resyncSafeSource(src string) bool {
+	switch src {
+	case "UPNP", "INVALID_SOURCE":
+		return true
+	default:
+		return false
+	}
+}
+
 func reconcileOnce(store *presets.Store, boxHost string, logger *slog.Logger, forceFull bool) bool {
 	stick := store.All()
 	if len(stick) == 0 {
@@ -377,8 +404,22 @@ func reconcileOnce(store *presets.Store, boxHost string, logger *slog.Logger, fo
 		// could never fire, so healed slots never logged and - worse -
 		// persistent AddPreset failures were swallowed silently, invisible
 		// in every diagnostic bundle (#342).
-		boxwrites.NoteN("addpreset", boxNowPlayingSource(boxHost), len(missing))
+		// Forensics for the "the speaker turns itself on" reports (#486 and
+		// the 2026-08-02 bundle): AddPreset names UPNP as its source, and the
+		// firmware appears to ACTIVATE that source on the write, so a re-sync
+		// into a sleeping box can wake it. The ledger already records the
+		// source before the write; capture it again right after so a bundle
+		// shows the flip as cause and effect instead of correlation, and name
+		// which slot the batch started with (the flip lands ~23-43 ms in, i.e.
+		// during the FIRST AddPreset, not the batch as a whole).
+		srcBefore := boxNowPlayingSource(boxHost)
+		boxwrites.NoteN("addpreset", srcBefore, len(missing))
 		errs := boxcli.SyncAllPresets(context.Background(), boxHost, missing)
+		if srcAfter := boxNowPlayingSource(boxHost); srcAfter != srcBefore {
+			logger.Warn("preset forensics: the box changed source across a preset write",
+				"before", srcBefore, "after", srcAfter, "slots", len(missing),
+				"firstSlot", missing[0].Slot, "forced", forceFull)
+		}
 		for _, spec := range missing {
 			if serr, failed := errs[spec.Slot]; failed {
 				syncFailed = true

--- a/cmd/agent/reconcile_test.go
+++ b/cmd/agent/reconcile_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+// TestResyncSafeSource pins the allowlist: input source names differ per model
+// (CineMate says LOCAL where an ST10 says AUX, an SA-5 answers AUX1..AUX3), so
+// anything we do not explicitly know must count as the user's choice and block
+// the key-registration write, which would otherwise switch the box to UPNP.
+func TestResyncSafeSource(t *testing.T) {
+	for _, src := range []string{"UPNP", "INVALID_SOURCE"} {
+		if !resyncSafeSource(src) {
+			t.Errorf("%s must allow the re-sync (idle or our own source)", src)
+		}
+	}
+	for _, src := range []string{
+		"BLUETOOTH", "AUX", "AUX1", "LOCAL", "SPOTIFY", "DEEZER",
+		"AIRPLAY", "TUNEIN", "STORED_MUSIC", "QPLAY", "PRODUCT", "HDMI_1",
+		"STANDBY", "",
+	} {
+		if resyncSafeSource(src) {
+			t.Errorf("%s is a user-chosen, idle-unknown or unknown source: the re-sync must not run", src)
+		}
+	}
+}

--- a/desktop-app/frontend/wailsjs/go/models.ts
+++ b/desktop-app/frontend/wailsjs/go/models.ts
@@ -43,6 +43,8 @@ export namespace main {
 	    conflictingMod?: string;
 	    storm1036?: boolean;
 	    storm1036SinceSec?: number;
+	    recallRefusal?: boolean;
+	    recallRefusalSinceSec?: number;
 	    wlanCredsMissing?: boolean;
 	    serialNumber: string;
 	    kind: string;
@@ -68,6 +70,8 @@ export namespace main {
 	        this.conflictingMod = source["conflictingMod"];
 	        this.storm1036 = source["storm1036"];
 	        this.storm1036SinceSec = source["storm1036SinceSec"];
+	        this.recallRefusal = source["recallRefusal"];
+	        this.recallRefusalSinceSec = source["recallRefusalSinceSec"];
 	        this.wlanCredsMissing = source["wlanCredsMissing"];
 	        this.serialNumber = source["serialNumber"];
 	        this.kind = source["kind"];


### PR DESCRIPTION
Field bundle 2026-08-02 (three boxes, mail report): the 20-minute dead-key insurance pass (#487) pulled a **running Bluetooth session** to UPNP 43 ms after its re-sync line, and the same write pattern flips a sleeping box to UPNP 23 ms after the boot force. Mechanism, visible in the code: `AddPreset` is sent as `ws AddPreset UPNP audio <url> ... <slot>` and the firmware **activates** the named source on the write. The gate only excluded `STANDBY`, so every other source passed.

**Fix:** the periodic pass now runs only while the box is idle or already on STR's own source. Deliberately an **allowlist** (`UPNP`, `INVALID_SOURCE`), never a list of sources to avoid: input names differ per model - a CineMate reports its TV input as `LOCAL` where an ST10 says `AUX`, an SA-5 answers `AUX` with `sourceAccount` AUX1..AUX3, and Wave tuner sources are invisible to STR. An unknown name therefore counts as "the user chose this" and costs at most a deferred key refresh, where a denylist would silently interrupt every model whose name we forgot. `TestResyncSafeSource` pins that.

**Plus the forensics for the "speaker turns itself on" family (#486):** the source is now sampled before AND after every preset write and a change is logged with both values, the batch size and the first slot. Today's evidence is a 23 ms correlation; the next bundle will show cause and effect.

**Deliberately NOT changed here:** the boot-time force, which is documented as ungated on purpose (a just-booted box legitimately reads STANDBY, and gating it regressed first-press-after-reboot registration, #4). That one needs the new forensics before it is touched - see the assessment in the issue.

ARM cross-build and `go test ./cmd/agent/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)