### PR TITLE
fix(agent): native preset press did not update last-play

### DIFF
--- a/cmd/agent/wshandler.go
+++ b/cmd/agent/wshandler.go
@@ -475,9 +475,19 @@ func (h *presetWsHandler) recallPreset(ctx context.Context, seq uint64, pressAt 
 	if isNativeRadioLocation(location) {
 		h.logger.Info("hardware preset: native radio preset, the box activates it itself",
 			"slot", slot, "location", location)
-		if h.noteRecentPreset != nil {
-			if p, ok := h.store.Get(slot); ok {
+		if p, ok := h.store.Get(slot); ok {
+			if h.noteRecentPreset != nil {
 				h.noteRecentPreset(p)
+			}
+			// Record it as the last play even though STR does not drive this
+			// one. Standing back must not mean forgetting what is playing: the
+			// power-on resume and the box-side-drop recovery both read this
+			// record, and leaving it on the PREVIOUS station makes them bring
+			// that older station back. A user reported exactly that, a rare
+			// jump back to the station played before (Portable, v0.9.30).
+			if h.noteLastPlay != nil {
+				h.noteLastPlay(boxPresetURL(p), p.Name, p.Art,
+					upnp.MimeForCodecOrURL(p.Codec, p.StreamURL))
 			}
 		}
 		return


### PR DESCRIPTION
Found in a v0.9.30 field bundle (Portable, all six slots native). A user reported the speaker rarely jumping back to the previously played station on a station change.

Cause: the native stand-back branch in the hardware-preset handler returns before `noteLastPlay`, which the UPnP path calls. So a key press on a native preset never updated the last-play record, and both the power-on resume and the box-side-drop recovery read a stale station and pushed it.

Standing back from driving playback must not mean forgetting what is playing. The branch now records the slot as last-play (it already recorded the recently-played card).

Refs #482