### PR TITLE
fix(app): NAND preflight asked a question the user could not answer

### DIFF
--- a/cmd/agent/wshandler.go
+++ b/cmd/agent/wshandler.go
@@ -475,9 +475,19 @@ func (h *presetWsHandler) recallPreset(ctx context.Context, seq uint64, pressAt 
 	if isNativeRadioLocation(location) {
 		h.logger.Info("hardware preset: native radio preset, the box activates it itself",
 			"slot", slot, "location", location)
-		if h.noteRecentPreset != nil {
-			if p, ok := h.store.Get(slot); ok {
+		if p, ok := h.store.Get(slot); ok {
+			if h.noteRecentPreset != nil {
 				h.noteRecentPreset(p)
+			}
+			// Record it as the last play even though STR does not drive this
+			// one. Standing back must not mean forgetting what is playing: the
+			// power-on resume and the box-side-drop recovery both read this
+			// record, and leaving it on the PREVIOUS station makes them bring
+			// that older station back. A user reported exactly that, a rare
+			// jump back to the station played before (Portable, v0.9.30).
+			if h.noteLastPlay != nil {
+				h.noteLastPlay(boxPresetURL(p), p.Name, p.Art,
+					upnp.MimeForCodecOrURL(p.Codec, p.StreamURL))
 			}
 		}
 		return

--- a/desktop-app/frontend/src/i18n/bundles/ar.json
+++ b/desktop-app/frontend/src/i18n/bundles/ar.json
@@ -1240,5 +1240,6 @@
   "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
   "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
   "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
-  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen.",
+  "update.tightNandNamedBody": "يبلغ مكبر الصوت عن {{freeMB}} ميغابايت فقط من المساحة الحرة، والتحديث يحتاج نحو {{needMB}} ميغابايت. يوجد برنامج SoundTouch آخر ({{software}}) يشغل مساحة على هذا المكبر. أزله وسيتوفر للتحديث مكان، وإلا فسيحرر التحديث المساحة بنفسه وقد يعيد تشغيل المكبر أكثر من مرة. هل تريد التحديث الآن؟"
 }

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -1240,5 +1240,6 @@
   "spotify.engineTooFull": "Nicht genug freier Speicher auf dem Lautsprecher für die Spotify-Engine. Entferne andere SoundTouch-Zusatzsoftware davon, um Platz zu schaffen, und versuche es erneut.",
   "spotify.engineTooFullNamed": "Nicht genug freier Speicher für die Spotify-Engine. Entferne zuerst diese andere SoundTouch-Software vom Lautsprecher: {{software}}. Danach erneut versuchen.",
   "spotify.engineInstallFailed": "Die Spotify-Engine konnte nicht installiert werden. Bitte erneut versuchen.",
-  "spotify.engineDeferredVisible": "Lautsprecher aktualisiert. Die Spotify-Engine ist noch nicht installiert - du kannst sie auf dem Lautsprecher-Bildschirm installieren."
+  "spotify.engineDeferredVisible": "Lautsprecher aktualisiert. Die Spotify-Engine ist noch nicht installiert - du kannst sie auf dem Lautsprecher-Bildschirm installieren.",
+  "update.tightNandNamedBody": "Der Lautsprecher meldet nur {{freeMB}} MB freien Speicher, das Update braucht etwa {{needMB}} MB. Auf dem Lautsprecher liegt andere SoundTouch Software ({{software}}) und belegt Platz. Wenn du sie entfernst, hat das Update genug Raum. Sonst räumt das Update selbst auf und startet den Lautsprecher unter Umständen mehrmals neu. Jetzt aktualisieren?"
 }

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -1240,5 +1240,6 @@
   "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
   "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
   "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
-  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen.",
+  "update.tightNandNamedBody": "The speaker reports only {{freeMB}} MB of free storage and the update needs about {{needMB}} MB. Other SoundTouch software ({{software}}) is using space on this speaker. Remove it and the update has room; otherwise the update will try to free space itself and may restart the speaker more than once. Update now?"
 }

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -1240,5 +1240,6 @@
   "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
   "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
   "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
-  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen.",
+  "update.tightNandNamedBody": "El altavoz informa de solo {{freeMB}} MB libres y la actualización necesita unos {{needMB}} MB. Otro software SoundTouch ({{software}}) ocupa espacio en este altavoz. Si lo eliminas, la actualización tendrá sitio; si no, la actualización liberará espacio por su cuenta y puede reiniciar el altavoz varias veces. ¿Actualizar ahora?"
 }

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -1240,5 +1240,6 @@
   "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
   "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
   "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
-  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen.",
+  "update.tightNandNamedBody": "L’enceinte ne signale que {{freeMB}} Mo libres et la mise à jour a besoin d’environ {{needMB}} Mo. Un autre logiciel SoundTouch ({{software}}) occupe de la place sur cette enceinte. Supprimez-le et la mise à jour aura la place ; sinon la mise à jour libérera elle-même de l’espace et pourra redémarrer l’enceinte plusieurs fois. Mettre à jour maintenant ?"
 }

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -1240,5 +1240,6 @@
   "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
   "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
   "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
-  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen.",
+  "update.tightNandNamedBody": "スピーカーの空き容量は {{freeMB}} MB ですが、更新には約 {{needMB}} MB が必要です。このスピーカーでは別の SoundTouch ソフトウェア ({{software}}) が容量を使っています。削除すれば更新に十分な空きができます。削除しない場合、更新が自分で容量を空け、スピーカーが複数回再起動することがあります。今すぐ更新しますか?"
 }

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -1240,5 +1240,6 @@
   "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
   "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
   "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
-  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen.",
+  "update.tightNandNamedBody": "Garsiakalbis praneša tik apie {{freeMB}} MB laisvos vietos, o naujinimui reikia apie {{needMB}} MB. Šiame garsiakalbyje vietą užima kita SoundTouch programinė įranga ({{software}}). Pašalink ją ir naujinimui užteks vietos; kitaip naujinimas pats atlaisvins vietos ir gali kelis kartus paleisti garsiakalbį iš naujo. Naujinti dabar?"
 }

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -1240,5 +1240,6 @@
   "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
   "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
   "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
-  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen.",
+  "update.tightNandNamedBody": "Skaļrunis ziņo tikai par {{freeMB}} MB brīvas vietas, bet atjauninājumam vajag ap {{needMB}} MB. Šajā skaļrunī vietu aizņem cita SoundTouch programmatūra ({{software}}). Noņem to, un atjauninājumam pietiks vietas; citādi atjauninājums pats atbrīvos vietu un var vairākas reizes restartēt skaļruni. Atjaunināt tagad?"
 }

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -1240,5 +1240,6 @@
   "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
   "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
   "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
-  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen.",
+  "update.tightNandNamedBody": "De speaker meldt slechts {{freeMB}} MB vrije opslag en de update heeft ongeveer {{needMB}} MB nodig. Andere SoundTouch software ({{software}}) neemt ruimte in op deze speaker. Verwijder die en de update heeft ruimte genoeg; anders maakt de update zelf ruimte vrij en start de speaker mogelijk meerdere keren opnieuw op. Nu bijwerken?"
 }

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -1240,5 +1240,6 @@
   "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
   "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
   "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
-  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen.",
+  "update.tightNandNamedBody": "Głośnik zgłasza tylko {{freeMB}} MB wolnego miejsca, a aktualizacja potrzebuje około {{needMB}} MB. Inne oprogramowanie SoundTouch ({{software}}) zajmuje miejsce na tym głośniku. Usuń je, a aktualizacja będzie miała miejsce; w przeciwnym razie aktualizacja sama zwolni miejsce i może kilka razy zrestartować głośnik. Zaktualizować teraz?"
 }

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -1240,5 +1240,6 @@
   "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
   "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
   "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
-  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen.",
+  "update.tightNandNamedBody": "Hoparlör yalnızca {{freeMB}} MB boş alan bildiriyor, güncelleme yaklaşık {{needMB}} MB gerektiriyor. Bu hoparlörde başka SoundTouch yazılımı ({{software}}) yer kaplıyor. Onu kaldırırsan güncellemeye yer açılır; aksi halde güncelleme kendisi yer açar ve hoparlörü birkaç kez yeniden başlatabilir. Şimdi güncellensin mi?"
 }

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -1240,5 +1240,6 @@
   "spotify.engineTooFull": "Not enough free space on the speaker for the Spotify engine. Remove other SoundTouch add-ons from it to free space, then try again.",
   "spotify.engineTooFullNamed": "Not enough free space for the Spotify engine. Remove this other SoundTouch software from the speaker first: {{software}}. Then try again.",
   "spotify.engineInstallFailed": "Could not install the Spotify engine. Please try again.",
-  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen."
+  "spotify.engineDeferredVisible": "Speaker updated. The Spotify engine is not installed yet - you can install it from this speaker's screen.",
+  "update.tightNandNamedBody": "Колонка повідомляє лише {{freeMB}} МБ вільної памʼяті, а оновленню потрібно близько {{needMB}} МБ. Інше програмне забезпечення SoundTouch ({{software}}) займає місце на цій колонці. Видали його, і оновленню вистачить місця; інакше оновлення звільнить місце саме і може кілька разів перезапустити колонку. Оновити зараз?"
 }

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -3414,11 +3414,28 @@ async function doBoxUpdate(targetBox) {
     const v = await BoxAgentVersion(targetBox.host, targetBox.port);
     const free = parseInt(v.nandFreeBytes || '', 10);
     const agentBytes = (state.appInfo && state.appInfo.agentBinBytes) || 0;
-    if (Number.isFinite(free) && free > 0 && agentBytes > 0 && free < agentBytes) {
+    // Count the space the update frees BEFORE it needs it. The agent drops the
+    // Spotify engine to make room and reinstalls it afterwards, so a speaker
+    // with the engine installed effectively has that much more headroom.
+    // Comparing raw free space against the whole agent asked users to approve
+    // an update that was never at risk: a field case warned at 12.0 MB free for
+    // a 12.3 MB update on a speaker carrying a 16 MB engine, and the user went
+    // looking on the web to find out whether it was safe to continue.
+    const engineBytes = (v.goLibrespot === 'present')
+      ? (parseInt(v.goLibrespotSizeBytes || '', 10) || 0) : 0;
+    const effectiveFree = (Number.isFinite(free) ? free : 0) + engineBytes;
+    if (Number.isFinite(free) && free > 0 && agentBytes > 0 && effectiveFree < agentBytes) {
       const fmtMB = (n) => (n / 1048576).toFixed(1);
+      // Only one thing here is ever the user's to act on: other SoundTouch
+      // software occupying the storage. Name it when it is there, because then
+      // the warning carries an instruction instead of a decision they have no
+      // basis to make.
+      const foreign = foreignSoftwareLabel(v);
       const ok = await confirmWarn(
         t('update.tightNandTitle'),
-        t('update.tightNandBody', { freeMB: fmtMB(free), needMB: fmtMB(agentBytes) })
+        foreign
+          ? t('update.tightNandNamedBody', { freeMB: fmtMB(free), needMB: fmtMB(agentBytes), software: foreign })
+          : t('update.tightNandBody', { freeMB: fmtMB(free), needMB: fmtMB(agentBytes) })
       );
       if (!ok) return; // user cancelled: no OTA, no reboot
     }


### PR DESCRIPTION
Field case (v0.9.30, Portable): the dialog fired at 12.0 MB free for a 12.3 MB update on a speaker carrying a 16.5 MB Spotify engine. The update drops that engine to make room and reinstalls it afterwards, so the headroom was never in doubt. The user could not know that and searched the web before daring to continue; the update then worked, and his bundle shows all six presets native and the engine back.

Two changes:
- Count the engine as reclaimable headroom before comparing against the agent size, so the question is not asked when the update frees the space itself.
- When the warning IS shown and foreignDirs/conflictingMod are set, name the other SoundTouch software. That is the only case where the user has an action, and `foreignSoftwareLabel` already existed for it.

New string `update.tightNandNamedBody` in all 12 locales. The hard-warning case is unchanged, and an unknown free figure still never blocks.