### PR TITLE
fix(agent): fall back to UPnP presets when the box abandons the native station

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -833,6 +833,9 @@ func run() error {
 	// natively, so re-probe the moment it says the list changed instead of waiting
 	// for the cached verdict to expire.
 	wsClient.SetOnSourcesChanged(invalidateNativeRadioReady)
+	// A speaker that accepts a native station and then abandons it gets its
+	// presets put back on the UPnP form (see noteNativeStreamDropped).
+	wsClient.SetOnNativeDropped(noteNativeStreamDropped)
 
 	// Seed the box-native preset snapshot once at start and, if the NAND preset
 	// store came up empty while the box still lists STR presets, restore what

--- a/cmd/agent/nativepresets.go
+++ b/cmd/agent/nativepresets.go
@@ -102,6 +102,57 @@ func disableNativePresets(reason string) {
 		"reason", reason, "attempt", n, "of", nativeFailureBudget)
 }
 
+// nativeDropBudget is how many times the box may abandon a native station it
+// just accepted before the agent stops storing presets that way on this
+// speaker.
+const nativeDropBudget = 4
+
+var nativeDrops struct {
+	sync.Mutex
+	n int
+}
+
+// noteNativeStreamDropped records the box leaving a native station on its own.
+//
+// This is the playback-side counterpart to the write-side latch. A speaker can
+// accept the native preset perfectly and then refuse to KEEP it: measured on a
+// SoundTouch 20 (2nd generation, v0.9.30), all twelve native presses ended in
+// the box abandoning the station within seconds, rescued only by STR's re-push,
+// while the same build on the owner's ST30 dropped once in eight presses. The
+// write-side latch saw nothing, because the writes were fine.
+//
+// After a few drops the speaker is put back on the UPnP form, which works there.
+// A slower path is a far better outcome than a station that keeps falling over.
+func noteNativeStreamDropped() {
+	nativeDrops.Lock()
+	nativeDrops.n++
+	n := nativeDrops.n
+	nativeDrops.Unlock()
+	if n < nativeDropBudget {
+		return
+	}
+	if disabled, _ := nativePresetsDisabled(); disabled {
+		return
+	}
+	if l := nativeReadyLogger; l != nil {
+		l.Warn("native presets: this speaker keeps dropping the station it just started, switching its presets back to the slower form that works here",
+			"drops", n)
+	}
+	// Latch immediately: unlike a lost write, this is not a boot-window
+	// artefact that a retry fixes. The next reconcile sweep then sees native
+	// unavailable and rewrites every slot in the UPnP form.
+	forceDisableNativePresets("box repeatedly abandoned a native station it had accepted")
+}
+
+// forceDisableNativePresets latches native presets off at once, for evidence
+// that does not improve on a retry.
+func forceDisableNativePresets(reason string) {
+	nativeReady.Lock()
+	nativeReady.disabled = true
+	nativeReady.why = reason
+	nativeReady.Unlock()
+}
+
 // noteNativeWriteLanded records a sweep whose native writes stuck, clearing the
 // consecutive-failure count so an early-boot miss cannot accumulate across an
 // otherwise healthy run.

--- a/internal/boxws/client.go
+++ b/internal/boxws/client.go
@@ -88,6 +88,13 @@ type Client struct {
 	// standby handling entirely. Guarded by mu.
 	lastUpnpActiveAt time.Time
 
+	// lastNativeActiveAt is when the box last stopped being on a native radio
+	// station. Used to tell a station the box ABANDONED (it reaches
+	// INVALID_SOURCE shortly after) from the normal teardown of a preset
+	// change (which returns to the native source within a few hundred ms).
+	// Guarded by mu.
+	lastNativeActiveAt time.Time
+
 	// upnpEpisode is true while the box sits in the INVALID_SOURCE (or
 	// subsequent STANDBY) state it entered FROM STR's UPNP source. The
 	// rolling upnpFlapWindow only covers the fast give-up flap; a struggling
@@ -145,6 +152,9 @@ type Client struct {
 	// onSourcesChanged fires when the box announces a changed source list.
 	// Guarded by loginErrMu, like onLoginError.
 	onSourcesChanged func()
+	// onNativeDropped fires when the box abandons a native radio station it had
+	// just accepted. Guarded by loginErrMu.
+	onNativeDropped  func()
 	lastLoginErrFire time.Time
 }
 
@@ -175,6 +185,25 @@ func (c *Client) SetOnSourcesChanged(fn func()) {
 	c.loginErrMu.Lock()
 	c.onSourcesChanged = fn
 	c.loginErrMu.Unlock()
+}
+
+// SetOnNativeDropped registers a callback fired when the box leaves a native
+// radio station on its own, i.e. it accepted the station and then abandoned it.
+// The agent counts these to decide whether this speaker can keep native presets
+// at all. Runs in its own goroutine so the read loop is never blocked.
+func (c *Client) SetOnNativeDropped(fn func()) {
+	c.loginErrMu.Lock()
+	c.onNativeDropped = fn
+	c.loginErrMu.Unlock()
+}
+
+func (c *Client) fireNativeDropped() {
+	c.loginErrMu.Lock()
+	fn := c.onNativeDropped
+	c.loginErrMu.Unlock()
+	if fn != nil {
+		go fn()
+	}
 }
 
 // fireSourcesChanged invokes the sources-changed callback, if one is registered.

--- a/internal/boxws/dispatch.go
+++ b/internal/boxws/dispatch.go
@@ -103,6 +103,37 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 				if src == "AUX" {
 					c.handler.OnSourceAux(ctx)
 				}
+				// A native radio station the box abandons on its own. Measured on
+				// a SoundTouch 20 (2nd gen, v0.9.30): every one of twelve native
+				// presses ended LOCAL_INTERNET_RADIO -> INVALID_SOURCE within a
+				// few seconds, and only the re-push recovery got audio back,
+				// while the same build on the owner's ST30 dropped once in eight.
+				// The write succeeded on both, so the write-side latch never saw
+				// anything wrong. This is the playback-side counterpart: a box
+				// that will not KEEP a native station has to fall back to the
+				// UPnP form, which works there.
+				// The discriminator is reaching INVALID_SOURCE, not leaving the
+				// native source: a normal preset change also goes
+				// LOCAL_INTERNET_RADIO -> UPNP and back within a few hundred
+				// milliseconds, and counting that would disable native presets
+				// on a perfectly healthy speaker. The failure route observed on
+				// the ST20 was LOCAL_INTERNET_RADIO -> UPNP -> INVALID_SOURCE a
+				// few seconds after the station started, so the stamp below
+				// covers the direct and the indirect route alike.
+				if prev == "LOCAL_INTERNET_RADIO" {
+					c.mu.Lock()
+					c.lastNativeActiveAt = time.Now()
+					c.mu.Unlock()
+				}
+				if src == "INVALID_SOURCE" {
+					c.mu.Lock()
+					recent := !c.lastNativeActiveAt.IsZero() &&
+						time.Since(c.lastNativeActiveAt) < nativeDropWindow
+					c.mu.Unlock()
+					if recent {
+						c.fireNativeDropped()
+					}
+				}
 				// #197: some ST20 (scm) firmware oscillates UPNP->STANDBY->UPNP on a
 				// power-off, re-selecting STR's UPnP source so the speaker switches
 				// itself back on. When STR's own source (UPNP) drops to STANDBY, give

--- a/internal/boxws/nativedrop_test.go
+++ b/internal/boxws/nativedrop_test.go
@@ -1,0 +1,92 @@
+package boxws
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// A normal preset change also leaves the native source for a moment
+// (LOCAL_INTERNET_RADIO -> UPNP -> LOCAL_INTERNET_RADIO within a few hundred
+// milliseconds). Counting that as the box abandoning the station would switch
+// a perfectly healthy speaker back to the slower preset form, so the signal
+// must be reaching INVALID_SOURCE, not merely leaving the native source.
+func TestNativeDropOnlyFiresOnInvalidSource(t *testing.T) {
+	frame := func(src string) []byte {
+		return []byte(`<updates><nowPlayingUpdated><nowPlaying source="` + src +
+			`"><ContentItem source="` + src + `"/></nowPlaying></nowPlayingUpdated></updates>`)
+	}
+
+	t.Run("normal preset change does not count as a drop", func(t *testing.T) {
+		var drops atomic.Int32
+		c := newTestClientForDrop(&drops)
+		ctx := context.Background()
+		c.handleMessage(ctx, frame("LOCAL_INTERNET_RADIO"))
+		c.handleMessage(ctx, frame("UPNP"))
+		c.handleMessage(ctx, frame("LOCAL_INTERNET_RADIO"))
+		if n := settle(&drops); n != 0 {
+			t.Fatalf("a preset change counted %d drops, want 0", n)
+		}
+	})
+
+	t.Run("box abandoning the station counts, via UPNP", func(t *testing.T) {
+		var drops atomic.Int32
+		c := newTestClientForDrop(&drops)
+		ctx := context.Background()
+		c.handleMessage(ctx, frame("LOCAL_INTERNET_RADIO"))
+		c.handleMessage(ctx, frame("UPNP"))
+		c.handleMessage(ctx, frame("INVALID_SOURCE"))
+		if n := settle(&drops); n != 1 {
+			t.Fatalf("the observed ST20 failure counted %d drops, want 1", n)
+		}
+	})
+
+	t.Run("an unrelated invalid source does not count", func(t *testing.T) {
+		var drops atomic.Int32
+		c := newTestClientForDrop(&drops)
+		ctx := context.Background()
+		c.handleMessage(ctx, frame("SPOTIFY"))
+		c.handleMessage(ctx, frame("INVALID_SOURCE"))
+		if n := settle(&drops); n != 0 {
+			t.Fatalf("an INVALID_SOURCE with no native station before it counted %d drops, want 0", n)
+		}
+	})
+}
+
+// newTestClientForDrop wires the counter. The callback runs in its own
+// goroutine (the read loop must never block on it), so the helper below waits
+// for it instead of reading the counter straight after the frame.
+func newTestClientForDrop(drops *atomic.Int32) *Client {
+	c := New(slog.New(slog.NewTextHandler(io.Discard, nil)), "ws://test", nopHandlerForDrop{})
+	c.SetOnNativeDropped(func() { drops.Add(1) })
+	return c
+}
+
+// settle waits briefly for any fired callback goroutine to land, then returns
+// the count. A "want 0" case still waits, so it cannot pass merely by being
+// read too early.
+func settle(drops *atomic.Int32) int32 {
+	for i := 0; i < 100; i++ {
+		if drops.Load() > 0 {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	time.Sleep(10 * time.Millisecond)
+	return drops.Load()
+}
+
+type nopHandlerForDrop struct{}
+
+func (nopHandlerForDrop) OnPresetSelected(context.Context, int, string, string) {}
+func (nopHandlerForDrop) OnRemoteSkip(context.Context, bool)                    {}
+func (nopHandlerForDrop) OnUserStop(context.Context)                            {}
+func (nopHandlerForDrop) OnThumbActivity(context.Context)                       {}
+func (nopHandlerForDrop) OnPowerKey(context.Context)                            {}
+func (nopHandlerForDrop) OnSourceAux(context.Context)                           {}
+func (nopHandlerForDrop) OnZoneChanged(context.Context, ZoneState)              {}
+func (nopHandlerForDrop) OnPowerWake(context.Context)                           {}
+func (nopHandlerForDrop) OnPresetsChanged(context.Context, []BoxPreset)         {}

--- a/internal/boxws/teardown.go
+++ b/internal/boxws/teardown.go
@@ -26,6 +26,13 @@ const (
 	// source a STANDBY entry still counts as an STR-driven power-off (the
 	// UPNP -> INVALID_SOURCE -> STANDBY give-up completes within ~1-2s).
 	upnpFlapWindow = 5 * time.Second
+	// nativeDropWindow bounds how long after the box left a native radio
+	// station a jump to INVALID_SOURCE still counts as the box abandoning that
+	// station rather than an unrelated later event. The observed failure took
+	// about a second from leaving the source to INVALID_SOURCE; the window is
+	// generous because the alternative, missing the evidence, leaves a speaker
+	// stuck on a form it cannot keep.
+	nativeDropWindow = 10 * time.Second
 	// ownCmdKeyVeto: a physical key press this close to the STOP_STATE means
 	// the stop came from the user (remote/box stop key), NOT from STR's own
 	// command, even inside ownCmdTeardownWindow. The firmware sends a


### PR DESCRIPTION
Field bundle (v0.9.30, SoundTouch 20 2nd generation + ST30 from the same owner):

| speaker | native presses | drops to INVALID_SOURCE | rescue re-pushes |
|---|---|---|---|
| ST20 | 12 | 12 | 8 |
| ST30 | 8 | 1 | 0 |

The ST20 accepts the native station, plays it, and abandons it a few seconds later (`LOCAL_INTERNET_RADIO -> UPNP -> INVALID_SOURCE`); only the re-push recovery gets audio back. That is the owner's "gelingt nur mit mehreren Anläufen". The existing latch never saw it, because it only covers failed WRITES and the writes were fine.

The client now reports a native station the box abandoned, and after four of those the agent latches native off, so the next reconcile sweep rewrites the slots in the UPnP form that works on that speaker.

The discriminator is reaching INVALID_SOURCE, not leaving the native source: a normal preset change also goes LOCAL_INTERNET_RADIO -> UPNP and back within a few hundred ms, and counting that would disable native presets on healthy speakers. `TestNativeDropOnlyFiresOnInvalidSource` pins all three cases.

The same owner's second symptom, preset 2 playing preset 1's station, is the stale last-play bug already fixed in v0.9.31 (#533).