### PR TITLE
fix(agent): native station descriptor carried no artwork

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -999,11 +999,11 @@ func run() error {
 	// registered, otherwise "" and the UPnP form is kept.
 	setNativeReadyLogger(logger)
 	boxcli.SetDiagLogger(logger)
-	webuiSrv.SetNativePresetLocatorFn(func(name, streamURL string) string {
+	webuiSrv.SetNativePresetLocatorFn(func(name, streamURL, art string) string {
 		if !nativeRadioReady(context.Background(), *boxHost) {
 			return ""
 		}
-		return webui.OrionStationLocation(streamURL, name)
+		return webui.OrionStationLocation(streamURL, name, art)
 	})
 	wg.Add(1)
 	go func() {

--- a/cmd/agent/nativepresets.go
+++ b/cmd/agent/nativepresets.go
@@ -410,7 +410,7 @@ func nativePresetLocation(ctx context.Context, boxHost string, p presets.Preset)
 	if stream == "" {
 		return ""
 	}
-	return webui.OrionStationLocation(stream, p.Name)
+	return webui.OrionStationLocation(stream, p.Name, p.Art)
 }
 
 // nativeStorable reports whether a preset may be stored on the native radio

--- a/internal/webui/boxpresets_snapshot.go
+++ b/internal/webui/boxpresets_snapshot.go
@@ -53,7 +53,7 @@ func (s *Server) handleBoxSyncPresets(w http.ResponseWriter, r *http.Request) {
 			Slot:           p.Slot,
 			Name:           p.Name,
 			StreamURL:      stream,
-			NativeLocation: s.nativePresetLocation(p.Name, stream),
+			NativeLocation: s.nativePresetLocation(p.Name, stream, p.Art),
 		})
 	}
 	syncCtx, cancel := context.WithTimeout(r.Context(), 30*time.Second)

--- a/internal/webui/lir.go
+++ b/internal/webui/lir.go
@@ -154,12 +154,28 @@ func (s *Server) handleOrionStation(w http.ResponseWriter, r *http.Request) {
 // alphanumeric plus "-" and "_", so it survives tokenisation intact.
 // handleOrionStation accepts every alphabet, so this stays compatible with
 // locations written by older builds.
-func OrionStationLocation(streamURL, name string) string {
+// art is the station logo the speaker shows next to the name. Passing it
+// matters: the UPnP path always carried the artwork, and leaving it empty here
+// silently cost users the station logo on the speaker's display when their
+// presets converted to the native form (reported on a SoundTouch 20, 2026-08-04:
+// "the logo that was there before does not appear anymore"). Empty is still
+// accepted, for stations that simply have no image.
+func OrionStationLocation(streamURL, name, art string) string {
 	payload, _ := json.Marshal(map[string]any{
-		"streamUrl": streamURL, "name": name, "imageUrl": "",
+		"streamUrl": streamURL, "name": name, "imageUrl": firstArtURL(art),
 		"streamType": "liveRadio", "isRealtime": true,
 	})
 	return "/station?data=" + base64.RawURLEncoding.EncodeToString(payload)
+}
+
+// firstArtURL takes the first entry of STR's pipe-separated art fallback chain.
+// Presets store several candidate logo URLs separated by "|" so the app can try
+// the next when one 404s; the speaker understands exactly one.
+func firstArtURL(art string) string {
+	if i := strings.IndexByte(art, '|'); i >= 0 {
+		return art[:i]
+	}
+	return art
 }
 
 // handleOrionToken answers the token endpoint the BMX service registry points

--- a/internal/webui/nativeprobe.go
+++ b/internal/webui/nativeprobe.go
@@ -75,7 +75,7 @@ func (s *Server) handleNativeProbe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	loc := OrionStationLocation(stream, name)
+	loc := OrionStationLocation(stream, name, "")
 	full := "http://127.0.0.1:8888/core02/svc-bmx-adapter-orion/prod/orion" + loc
 	q := func(v string) string { return `"` + v + `"` }
 	slot := strconv.Itoa(in.Slot)

--- a/internal/webui/options.go
+++ b/internal/webui/options.go
@@ -33,17 +33,17 @@ func (s *Server) SetBoxNameFn(fn func() (name, model string)) { s.boxNameFn = fn
 // The function returns the orion station location, or "" when the box has not
 // registered the radio source and the slot must keep the UPnP form. cmd/agent
 // owns that probe because it also owns the box host and the association state.
-func (s *Server) SetNativePresetLocatorFn(fn func(name, streamURL string) string) {
+func (s *Server) SetNativePresetLocatorFn(fn func(name, streamURL, art string) string) {
 	s.nativePresetLocator = fn
 }
 
 // nativePresetLocation asks the wired locator for a slot's native location,
 // returning "" when no locator is wired (the desktop-side and test servers).
-func (s *Server) nativePresetLocation(name, streamURL string) string {
+func (s *Server) nativePresetLocation(name, streamURL, art string) string {
 	if s.nativePresetLocator == nil {
 		return ""
 	}
-	return s.nativePresetLocator(name, streamURL)
+	return s.nativePresetLocator(name, streamURL, art)
 }
 
 // writeBoxPreset stores one slot on the box in the best form this speaker
@@ -59,9 +59,9 @@ func (s *Server) nativePresetLocation(name, streamURL string) string {
 // isSpotify slots are never native: the box activates a native item entirely by
 // itself, and a Spotify preset needs STR to tell the local engine which
 // playlist to load.
-func (s *Server) writeBoxPreset(ctx context.Context, slot int, name, streamURL string, isSpotify bool) error {
+func (s *Server) writeBoxPreset(ctx context.Context, slot int, name, streamURL, art string, isSpotify bool) error {
 	if !isSpotify {
-		if loc := s.nativePresetLocation(name, streamURL); loc != "" {
+		if loc := s.nativePresetLocation(name, streamURL, art); loc != "" {
 			if err := boxcli.AddPresetNative(ctx, s.boxHost, slot, name, loc); err == nil {
 				return nil
 			}

--- a/internal/webui/playback.go
+++ b/internal/webui/playback.go
@@ -179,7 +179,7 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request) {
 	// a network library file is a finite ranged file and must keep the direct
 	// route (#139). Any refusal falls through to the UPnP push below.
 	if !playDirect && req.Mime == "" {
-		if loc := s.nativePresetLocation(req.Title, playURL); loc != "" {
+		if loc := s.nativePresetLocation(req.Title, playURL, req.Icon); loc != "" {
 			if err := s.selectNativeStation(playCtx, loc, req.Title); err == nil {
 				s.logger.Info("play request: started natively, the speaker fetches the stream itself",
 					"title", req.Title, "url", req.URL)
@@ -492,7 +492,7 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 	// source back to the form the native work exists to avoid. Falls through to
 	// the UPnP push on any refusal, so a speaker that cannot do this keeps
 	// exactly today's behaviour. See nativeselect.go.
-	if loc := s.nativePresetLocation(p.Name, playURL); loc != "" {
+	if loc := s.nativePresetLocation(p.Name, playURL, p.Art); loc != "" {
 		if err := s.selectNativeStation(playCtx, loc, p.Name); err == nil {
 			s.logger.Info("preset slot recall (app): started natively, the speaker fetches the stream itself",
 				"slot", slot, "name", p.Name)

--- a/internal/webui/presets_http.go
+++ b/internal/webui/presets_http.go
@@ -107,7 +107,7 @@ func (s *Server) handlePresetSlot(w http.ResponseWriter, r *http.Request) {
 			// it at this slot's stream proxy URL like every other preset.
 			if s.boxHost != "" {
 				boxCtx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
-				if err := s.writeBoxPreset(boxCtx, slot, p.Name, boxPresetURL(slot, false), false); err != nil {
+				if err := s.writeBoxPreset(boxCtx, slot, p.Name, boxPresetURL(slot, false), p.Art, false); err != nil {
 					s.logger.Warn("box preset sync failed", "slot", slot, "err", err)
 				}
 				cancel()
@@ -284,7 +284,7 @@ func (s *Server) handlePresetSlot(w http.ResponseWriter, r *http.Request) {
 			// instead of failing on /stream/<slot> (no Spotify source) and
 			// flashing "service unavailable" (#22).
 			proxyURL := boxPresetURL(slot, p.Type == "spotify")
-			if err := s.writeBoxPreset(boxCtx, slot, p.Name, proxyURL, p.Type == "spotify"); err != nil {
+			if err := s.writeBoxPreset(boxCtx, slot, p.Name, proxyURL, p.Art, p.Type == "spotify"); err != nil {
 				s.logger.Warn("box preset sync failed", "slot", slot, "err", err)
 			}
 			cancel()

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -180,7 +180,7 @@ type Server struct {
 	// LOCAL_INTERNET_RADIO station (returning its orion location) instead of a
 	// UPnP stream that the box refuses to activate on its own. nil until wired
 	// by cmd/agent, and nil on the desktop side, where "" keeps the UPnP form.
-	nativePresetLocator func(name, streamURL string) string
+	nativePresetLocator func(name, streamURL, art string) string
 
 	// now_playing micro-cache. The Bose firmware app (:8090) on BCO
 	// speakers cannot sustain a high request rate, so /api/status caches


### PR DESCRIPTION
Reported on #510 (SoundTouch 20, v0.9.31): "the logo that was there before does not appear anymore" after a preset press.

Correct. `OrionStationLocation` hardcoded `"imageUrl": ""`, so every preset converted to the native form lost its logo on the speaker display. The UPnP path always passed `p.Art`.

The artwork is now threaded through the locator hook to the descriptor. STR stores several candidate logo URLs separated by `|` so the app can fall through when one 404s; the speaker understands exactly one, so the first is used.