### PR TITLE
fix(playback): a station started from the app no longer needs a second try

### DIFF
--- a/internal/webui/boxsettings_http.go
+++ b/internal/webui/boxsettings_http.go
@@ -49,6 +49,81 @@ func isGroupedRejection(err error) bool {
 	return err != nil && strings.Contains(strings.ToLower(err.Error()), "member of group")
 }
 
+// isWrongStateRejection reports whether a play failure is the box refusing
+// SetAVTransportURI because its OWN transport is in the wrong state: the
+// firmware answers UPnP 501 "Action request came in wrong state" (also seen as
+// UpnpRcvdContentItemInWrongState) while it still holds a ContentItem it cannot
+// activate - a dead-cloud item, or the teardown of a recall that has not
+// finished yet.
+//
+// Matched on the description, never on the code: this firmware answers 501 for
+// several unrelated conditions, and the group refusal above is the other one.
+//
+// Both spellings count. The SOAP fault says "Action request came in wrong
+// state" while the box's own gabbo frames call the same condition
+// UpnpRcvdContentItemInWrongState, and an error can reach here carrying either.
+func isWrongStateRejection(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "wrong state") || strings.Contains(s, "wrongstate")
+}
+
+// clearTransportForReplay forces the box's UPnP transport out of a stuck
+// wrong-state: a Stop followed by an empty SetAVTransportURI so the firmware
+// releases the ContentItem it keeps trying to self-activate. Best-effort, both
+// calls are advisory and a wedged renderer may ACK them without acting, so
+// neither error is fatal. Mirrors the hardware-recall repair in cmd/agent
+// (clearTransportForRePush).
+func (s *Server) clearTransportForReplay(ctx context.Context) {
+	if s.renderer == nil {
+		return
+	}
+	if err := s.renderer.Stop(ctx); err != nil {
+		s.logger.Debug("wrong-state repair: transport stop returned (expected when nothing is playing)", "err", err)
+	}
+	if err := s.renderer.ClearURI(ctx); err != nil {
+		s.logger.Debug("wrong-state repair: clear transport URI returned", "err", err)
+	}
+}
+
+// playWithWrongStateRepair pushes a stream to the box and, when the box refuses
+// it because its transport sits in the wrong state, empties that transport and
+// pushes once more.
+//
+// Why this exists: the identical repair already ran for HARDWARE key presses
+// (cmd/agent verifyPlayURL), but a play started from the app went straight out
+// as SetAVTransportURI + Play and the raw SOAP fault was handed to the user.
+// Field report 2026-08-05 (DLF Nova, v0.9.34): the first Play answered 501
+// "Action request came in wrong state" and the speaker stayed silent, the
+// second attempt played. That is exactly the state a Stop + ClearURI clears, so
+// the user should not have to be the retry loop.
+//
+// One retry, not a loop: if an emptied transport still refuses, the cause is
+// not the stuck ContentItem and hammering it would only delay the error the
+// caller needs to show.
+func (s *Server) playWithWrongStateRepair(ctx context.Context, url, title, art, mime string) error {
+	push := func() error {
+		if mime != "" {
+			return s.renderer.PlayURLMime(ctx, url, title, art, mime)
+		}
+		return s.renderer.PlayURL(ctx, url, title, art)
+	}
+	err := push()
+	if !isWrongStateRejection(err) {
+		return err
+	}
+	s.logger.Warn("play: the speaker refused the stream in a wrong transport state, clearing the transport and pushing again",
+		"title", title, "err", err)
+	s.clearTransportForReplay(ctx)
+	if err := push(); err != nil {
+		return err
+	}
+	s.logger.Info("play: the clean-slate retry started the stream the box had just refused", "title", title)
+	return nil
+}
+
 // writeGroupedPlayError answers a play request the box rejected as a group
 // follower (#70) with a structured 409 instead of the raw SOAP fault, so the
 // app can tell the user to drive the group's lead speaker (and offer to jump

--- a/internal/webui/playback.go
+++ b/internal/webui/playback.go
@@ -193,12 +193,7 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	var playErr error
-	if mime != "" {
-		playErr = s.renderer.PlayURLMime(playCtx, playURL, req.Title, req.Icon, mime)
-	} else {
-		playErr = s.renderer.PlayURL(playCtx, playURL, req.Title, req.Icon)
-	}
+	playErr := s.playWithWrongStateRepair(playCtx, playURL, req.Title, req.Icon, mime)
 	if playErr != nil {
 		if isGroupedRejection(playErr) {
 			s.writeGroupedPlayError(w, playErr)
@@ -513,12 +508,7 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 	// fixed audio/mpeg label made those stations play silence (#252). A preset
 	// stored without a codec falls back to reading it off the station URL.
 	mime := upnp.MimeForCodecOrURL(p.Codec, p.StreamURL)
-	var playErr error
-	if mime != "" {
-		playErr = s.renderer.PlayURLMime(playCtx, playURL, p.Name, p.Art, mime)
-	} else {
-		playErr = s.renderer.PlayURL(playCtx, playURL, p.Name, p.Art)
-	}
+	playErr := s.playWithWrongStateRepair(playCtx, playURL, p.Name, p.Art, mime)
 	if playErr != nil {
 		// Log the failed radio recall: this 502 used to be returned with no
 		// agent-side trace at all, so a remote diagnostic bundle showed a recall

--- a/internal/webui/wrongstate_replay_test.go
+++ b/internal/webui/wrongstate_replay_test.go
@@ -1,0 +1,191 @@
+package webui
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/JRpersonal/streborn/internal/upnp"
+)
+
+// wrongStateFault is what the firmware answered a user's play on 2026-08-05
+// (DLF Nova, v0.9.34): HTTP 500 carrying UPnP 501, but a DIFFERENT description
+// than the grouped-follower refusal that shares the same code.
+const wrongStateFault = `<?xml version="1.0"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Body><s:Fault><faultcode>s:Client</faultcode><faultstring>UPnPError</faultstring><detail><UPnPError xmlns="urn:schemas-upnp-org:control-1-0"><errorCode>501</errorCode><errorDescription>Action request came in wrong state</errorDescription></UPnPError></detail></s:Fault></s:Body></s:Envelope>`
+
+func TestIsWrongStateRejection(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"field fault", errors.New("SetURI: soap SetAVTransportURI status 500: " + wrongStateFault), true},
+		{"gabbo spelling", errors.New("UpnpRcvdContentItemInWrongState"), true},
+		{"case-insensitive", errors.New("ACTION REQUEST CAME IN WRONG STATE"), true},
+		// The two 501s must stay apart: a grouped follower needs the 409 that
+		// tells the user to drive the lead speaker, NOT a transport wipe.
+		{"grouped follower is not this", errors.New("SetURI: soap status 500: " + groupedFault), false},
+		{"unrelated 402", errors.New("soap status 500: <errorCode>402</errorCode> No URI supplied"), false},
+		{"plain network error", errors.New("connection refused"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isWrongStateRejection(tc.err); got != tc.want {
+				t.Errorf("isWrongStateRejection(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// wrongStateBox is a fake box that fails the first SetAVTransportURI with the
+// wrong-state fault and accepts everything afterwards, which is exactly what
+// the reporter saw: first attempt silent, second attempt played.
+type wrongStateBox struct {
+	mu      sync.Mutex
+	actions []string
+	bodies  []string
+	setURIs int
+}
+
+func (b *wrongStateBox) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		action := r.Header.Get("SOAPACTION")
+		switch {
+		case strings.Contains(action, "#SetAVTransportURI"):
+			action = "SetAVTransportURI"
+		case strings.Contains(action, "#Play"):
+			action = "Play"
+		case strings.Contains(action, "#Stop"):
+			action = "Stop"
+		}
+		b.mu.Lock()
+		b.actions = append(b.actions, action)
+		b.bodies = append(b.bodies, string(raw))
+		first := false
+		if action == "SetAVTransportURI" {
+			b.setURIs++
+			first = b.setURIs == 1
+		}
+		b.mu.Unlock()
+		if first {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(wrongStateFault))
+			return
+		}
+		_, _ = w.Write([]byte(`<?xml version="1.0"?><s:Envelope><s:Body/></s:Envelope>`))
+	}
+}
+
+func (b *wrongStateBox) seen() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]string(nil), b.actions...)
+}
+
+// A box that refuses the first push because its transport is in the wrong state
+// must be emptied and pushed again, so the USER's single click plays. Before
+// this, the raw SOAP fault went back to the app and only a second manual
+// attempt worked.
+func TestWrongStatePlayRetriesFromCleanSlate(t *testing.T) {
+	rec := &wrongStateBox{}
+	box := httptest.NewServer(rec.handler())
+	t.Cleanup(box.Close)
+	s := &Server{
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		queue:    newPlayQueue(),
+		renderer: &upnp.Renderer{ControlURL: box.URL, Client: box.Client()},
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/play",
+		strings.NewReader(`{"url":"http://stream.example/dlfnova","title":"DLF Nova"}`))
+	s.handlePlay(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response is not JSON: %v (%s)", err, w.Body.String())
+	}
+	if resp["status"] != "playing" {
+		t.Errorf(`status = %q, want "playing"`, resp["status"])
+	}
+
+	// The repair itself: a Stop and an EMPTY SetAVTransportURI have to sit
+	// between the refused push and the retry. Asserting only "it returned 200"
+	// would still pass if the retry blindly replayed the same URI, which is the
+	// loop this exists to prevent.
+	got := rec.seen()
+	if len(got) < 4 {
+		t.Fatalf("box saw %v, want at least SetAVTransportURI, Stop, SetAVTransportURI, Play", got)
+	}
+	if got[0] != "SetAVTransportURI" {
+		t.Errorf("first action = %q, want SetAVTransportURI", got[0])
+	}
+	var sawStop, sawClear bool
+	rec.mu.Lock()
+	for i, a := range rec.actions {
+		if i == 0 {
+			continue // the refused push
+		}
+		if a == "Stop" {
+			sawStop = true
+		}
+		if a == "SetAVTransportURI" && strings.Contains(rec.bodies[i], "<CurrentURI></CurrentURI>") {
+			sawClear = true
+		}
+	}
+	rec.mu.Unlock()
+	if !sawStop {
+		t.Errorf("no Stop after the refusal; actions were %v", got)
+	}
+	if !sawClear {
+		t.Errorf("no empty SetAVTransportURI (ClearURI) after the refusal; actions were %v", got)
+	}
+	if got[len(got)-1] != "Play" {
+		t.Errorf("last action = %q, want Play", got[len(got)-1])
+	}
+}
+
+// A grouped follower must NOT be dragged through the transport wipe: it still
+// answers the structured 409 so the app can point at the lead speaker.
+func TestGroupedRejectionSkipsTheWrongStateRepair(t *testing.T) {
+	var calls int
+	var mu sync.Mutex
+	box := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(groupedFault))
+	}))
+	t.Cleanup(box.Close)
+	s := &Server{
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		queue:    newPlayQueue(),
+		renderer: &upnp.Renderer{ControlURL: box.URL, Client: box.Client()},
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/play",
+		strings.NewReader(`{"url":"http://stream.example/relax","title":"Test Station"}`))
+	s.handlePlay(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 (body %s)", w.Code, w.Body.String())
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 1 {
+		t.Errorf("box saw %d calls, want exactly 1 (no Stop/ClearURI/retry on a grouped follower)", calls)
+	}
+}


### PR DESCRIPTION
A speaker can refuse the very first play with UPnP 501 `Action request came in wrong state` while its transport still holds a content item it cannot activate. Until now that SOAP fault went straight back to the app: the speaker stayed silent, and only a second attempt played.

The identical repair already existed for **hardware** key presses (`cmd/agent` `verifyPlayURL` clears the transport and pushes again). This gives the **app-initiated** play the same clean slate.

## What changes

- `isWrongStateRejection` classifies the fault. Matched on the description, never on the code: this firmware answers 501 for several unrelated conditions. Both spellings are covered (`Action request came in wrong state` and the gabbo `UpnpRcvdContentItemInWrongState`).
- `clearTransportForReplay` = Stop + empty SetAVTransportURI, mirroring `clearTransportForRePush` in `cmd/agent`.
- `playWithWrongStateRepair` wraps the push: on a wrong-state refusal it empties the transport and pushes once more. One retry, not a loop, since an emptied transport that still refuses has a different cause and hammering it only delays the error the user needs to see.
- Used by the two user-initiated paths: `POST /api/play` and the app-side preset slot recall.

The grouped-follower refusal shares UPnP code 501 and deliberately keeps its structured 409, so a zone member is never dragged through a transport wipe. A test asserts that.

## Evidence

Field report 2026-08-05 on v0.9.34 (DLF Nova): first attempt produced the fault below and the speaker stayed silent, the second attempt played.

```
PlayURL: Error: SetURI: soap SetAVTransportURI status 500:
<errorCode>501</errorCode>
<errorDescription>Action request came in wrong state</errorDescription>
```

## Tests

`internal/webui/wrongstate_replay_test.go`: the classifier table (including that a grouped refusal does NOT match), a fake box that refuses the first SetAVTransportURI and then accepts, asserting the Stop and the EMPTY SetAVTransportURI actually sit between the refusal and the retry (a blind replay would fail), and that a grouped follower still sees exactly one call.

Not yet verified on hardware.

Refs #435