### PR TITLE
fix(presets): saving a station's website as a preset is refused instead of making a dead key

### DIFF
--- a/internal/webui/artproxy.go
+++ b/internal/webui/artproxy.go
@@ -133,7 +133,8 @@ func (s *Server) handleArt(w http.ResponseWriter, r *http.Request) {
 // day it was written.
 //
 // Station artwork lives on the public internet, so the fix is simply to refuse
-// everything else. The check sits in the DIALER rather than on the URL string,
+// everything else. The preset-URL probe reuses this guard for the same reason,
+// which is why the messages name the check and not one caller. The check sits in the DIALER rather than on the URL string,
 // which is what makes it hold: it sees the address actually being connected
 // to, so a hostname that resolves to 127.0.0.1, a redirect into the network,
 // and an IPv6 or IPv4-mapped form of the same address are all caught, and none
@@ -141,11 +142,11 @@ func (s *Server) handleArt(w http.ResponseWriter, r *http.Request) {
 func publicOnlyControl(_ string, address string, _ syscall.RawConn) error {
 	host, _, err := net.SplitHostPort(address)
 	if err != nil {
-		return fmt.Errorf("art proxy: unparseable address %q", address)
+		return fmt.Errorf("public-only dial: unparseable address %q", address)
 	}
 	ip := net.ParseIP(host)
 	if ip == nil {
-		return fmt.Errorf("art proxy: unresolved address %q", host)
+		return fmt.Errorf("public-only dial: unresolved address %q", host)
 	}
 	if v4 := ip.To4(); v4 != nil {
 		ip = v4
@@ -153,12 +154,12 @@ func publicOnlyControl(_ string, address string, _ syscall.RawConn) error {
 	switch {
 	case ip.IsLoopback(), ip.IsPrivate(), ip.IsLinkLocalUnicast(), ip.IsLinkLocalMulticast(),
 		ip.IsInterfaceLocalMulticast(), ip.IsMulticast(), ip.IsUnspecified():
-		return fmt.Errorf("art proxy: refusing to fetch from %s (not a public address)", ip)
+		return fmt.Errorf("public-only dial: refusing %s (not a public address)", ip)
 	}
 	// Carrier-grade NAT (100.64.0.0/10). Not covered by IsPrivate, and it is
 	// where a router's own management interface often lives.
 	if v4 := ip.To4(); v4 != nil && v4[0] == 100 && v4[1] >= 64 && v4[1] <= 127 {
-		return fmt.Errorf("art proxy: refusing to fetch from %s (carrier-grade NAT range)", ip)
+		return fmt.Errorf("public-only dial: refusing %s (carrier-grade NAT range)", ip)
 	}
 	return nil
 }

--- a/internal/webui/presets_http.go
+++ b/internal/webui/presets_http.go
@@ -207,6 +207,23 @@ func (s *Server) handlePresetSlot(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
+		// The URL survived every structural gate above, so it is a well-formed
+		// http(s) link to something. Last question: is that something actually a
+		// stream? A field bundle carried three presets pointing at the station's
+		// HOME PAGE, which save cleanly and can never play. The probe refuses only
+		// on positive evidence of a web page and allows every uncertain answer, so
+		// a station that is merely down or speaks legacy ICY still saves.
+		if p.Type != "spotify" && p.StreamURL != "" {
+			if looksLikeWebPage(r.Context(), p.StreamURL) {
+				s.logger.Warn("preset save refused: the URL answers as a web page, not a stream",
+					"slot", slot, "name", p.Name, "url", p.StreamURL)
+				writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+					"error": "That address is the station's website, not its stream, so the key would never play. Search for the station in ST Reborn and save it from the search result.",
+					"code":  "stream-url-is-webpage",
+				})
+				return
+			}
+		}
 		// Stamp the account a Spotify preset belongs to (go-librespot's current
 		// login) so a later recall can switch back to it on a multi-account box
 		// (#27). Two cases: (a) no account yet, fill it from the current login;

--- a/internal/webui/presetvalidate.go
+++ b/internal/webui/presetvalidate.go
@@ -25,7 +25,9 @@ package webui
 
 import (
 	"context"
+	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -44,12 +46,41 @@ const presetProbeTimeout = 4 * time.Second
 // server labels them like one.
 var playlistExts = map[string]bool{".pls": true, ".m3u": true, ".m3u8": true, ".asx": true, ".xspf": true}
 
-// presetProbeClient is a seam for the tests and nothing else. The guarded
-// client refuses loopback by design, and a test server IS loopback, so without
-// this every test would exercise the "unreachable, allow it" branch and prove
-// nothing about the classification. Production always uses the guarded client.
+// probeClient dials PUBLIC addresses only, a stricter rule than the stream
+// proxy's, which deliberately allows private LAN ranges so a user's own local
+// Icecast or DLNA server keeps playing.
+//
+// The probe can afford the stricter rule precisely because it fails open: a
+// preset pointing at a LAN stream comes back "could not tell" and saves exactly
+// as before. Nothing legitimate is lost, and in exchange the save endpoint stops
+// being a way for anyone who can reach the agent's port to make the SPEAKER
+// probe arbitrary hosts inside the network. CodeQL flagged that
+// (go/request-forgery) the first time this shipped, and it was right to.
+//
+// The check lives in the DIALER, not on the URL string: it sees the address
+// actually being connected to, so a hostname resolving to 127.0.0.1, an
+// IPv4-mapped IPv6 form, and a redirect back into the network are all caught.
+var probeClient = &http.Client{
+	Transport: &http.Transport{
+		DialContext:         (&net.Dialer{Timeout: presetProbeTimeout, Control: publicOnlyControl}).DialContext,
+		TLSHandshakeTimeout: presetProbeTimeout,
+	},
+	CheckRedirect: func(_ *http.Request, via []*http.Request) error {
+		if len(via) >= 4 {
+			return errors.New("preset probe: too many redirects")
+		}
+		return nil
+	},
+}
+
+// presetProbeClient is a seam for the tests and nothing else. The real client
+// refuses loopback, and a test server IS loopback, so without this every test
+// would exercise the "unreachable, allow it" branch and prove nothing about the
+// classification. Production always uses probeClient.
 var presetProbeClient = func(timeout time.Duration) *http.Client {
-	return netutil.GuardedClient(timeout)
+	c := *probeClient
+	c.Timeout = timeout
+	return &c
 }
 
 // looksLikeWebPage reports whether url positively answers as a web page rather

--- a/internal/webui/presetvalidate.go
+++ b/internal/webui/presetvalidate.go
@@ -1,0 +1,108 @@
+package webui
+
+// Is that URL a radio station, or the station's home page?
+//
+// A field bundle (2026-08-02) carried three presets whose stored URL was the
+// station's WEBSITE, e.g. www.radiohamburg.de/. Those save without complaint,
+// map onto a hardware key, and can never play: the box fetches the proxy, the
+// proxy fetches a web page, and the user is left pressing a dead button with no
+// idea why. The save is the only moment where that is cheap to catch.
+//
+// The check is deliberately ONE-SIDED. It refuses a save only on positive
+// evidence that the URL serves a web page; every other outcome, including every
+// error, allows the save. That asymmetry is the whole design:
+//
+//   - A station that is temporarily down, rate-limiting, or behind a slow CDN
+//     must still be savable. Refusing there would be a far worse bug than the
+//     one this fixes, and it would be intermittent, which is worse again.
+//   - Legacy SHOUTcast v1 servers answer "ICY 200 OK" instead of an HTTP status
+//     line. Go's net/http rejects that as malformed (the whole class of old
+//     stations that PR #458 fixed in the stream proxy, which has its own
+//     ICY-rewriting dialer this probe deliberately does not reuse). Here that
+//     error simply reads as "inconclusive", so those stations keep saving.
+//   - A playlist (.pls/.m3u/.m3u8) is a legitimate target that some servers
+//     mislabel as text/html, so playlists skip the probe entirely.
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/JRpersonal/streborn/internal/netutil"
+)
+
+// presetProbeTimeout bounds the added latency of a preset save. A station's
+// response headers arrive in well under a second; anything slower is treated as
+// inconclusive rather than making the user wait.
+const presetProbeTimeout = 4 * time.Second
+
+// playlistExts are resolved elsewhere and are never a web page even when the
+// server labels them like one.
+var playlistExts = map[string]bool{".pls": true, ".m3u": true, ".m3u8": true, ".asx": true, ".xspf": true}
+
+// presetProbeClient is a seam for the tests and nothing else. The guarded
+// client refuses loopback by design, and a test server IS loopback, so without
+// this every test would exercise the "unreachable, allow it" branch and prove
+// nothing about the classification. Production always uses the guarded client.
+var presetProbeClient = func(timeout time.Duration) *http.Client {
+	return netutil.GuardedClient(timeout)
+}
+
+// looksLikeWebPage reports whether url positively answers as a web page rather
+// than as audio. False means "no, or we could not tell" - the caller must treat
+// both the same way and allow the save.
+func looksLikeWebPage(ctx context.Context, rawURL string) bool {
+	if rawURL == "" || netutil.SafeHTTPURL(rawURL) != nil {
+		return false // a bad scheme is caught by the existing gates, not here
+	}
+	if u, err := url.Parse(rawURL); err == nil {
+		if playlistExts[strings.ToLower(path.Ext(u.Path))] {
+			return false
+		}
+	}
+	ctx, cancel := context.WithTimeout(ctx, presetProbeTimeout)
+	defer cancel()
+	// GET, not HEAD: plenty of Icecast and SHOUTcast servers answer HEAD with
+	// 405 or with headers that do not match what a real listener gets. The body
+	// is closed the moment the headers are in, so a live stream is not drained.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return false
+	}
+	// Some servers only send icy-metaint (and their true content type) when the
+	// client identifies as a stream player.
+	req.Header.Set("Icy-MetaData", "1")
+	req.Header.Set("User-Agent", "STR/preset-check")
+	resp, err := presetProbeClient(presetProbeTimeout).Do(req)
+	if err != nil {
+		return false // unreachable, malformed (ICY), TLS trouble: inconclusive
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1))
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return false // a 403/404/503 says nothing about what the URL normally is
+	}
+	// An audio content type, or ICY metadata, settles it: this is a stream.
+	ct := strings.ToLower(strings.TrimSpace(resp.Header.Get("Content-Type")))
+	if resp.Header.Get("icy-metaint") != "" || resp.Header.Get("icy-name") != "" {
+		return false
+	}
+	if ct != "" && !strings.HasPrefix(ct, "text/html") && !strings.HasPrefix(ct, "application/xhtml") {
+		return false
+	}
+	if strings.HasPrefix(ct, "text/html") || strings.HasPrefix(ct, "application/xhtml") {
+		return true
+	}
+	// No content type at all: sniff the first bytes. A web page starts with a
+	// doctype or an html tag; audio does not.
+	head := make([]byte, 512)
+	n, _ := io.ReadFull(io.LimitReader(resp.Body, int64(len(head))), head)
+	s := strings.ToLower(strings.TrimSpace(string(head[:n])))
+	return strings.HasPrefix(s, "<!doctype html") || strings.HasPrefix(s, "<html")
+}

--- a/internal/webui/presetvalidate_test.go
+++ b/internal/webui/presetvalidate_test.go
@@ -1,0 +1,156 @@
+package webui
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// withLocalProbe points the probe at a plain client for the duration of a test.
+// The production client refuses loopback (SSRF guard) and a test server is
+// loopback, so without this every assertion below would silently pass through
+// the "could not reach it, allow the save" branch and test nothing at all.
+func withLocalProbe(t *testing.T) {
+	t.Helper()
+	prev := presetProbeClient
+	presetProbeClient = func(timeout time.Duration) *http.Client {
+		return &http.Client{Timeout: timeout}
+	}
+	t.Cleanup(func() { presetProbeClient = prev })
+}
+
+// The probe must refuse ONLY on positive evidence of a web page. Every other
+// answer, including every failure, has to allow the save: a station that is
+// down, rate-limiting or speaking legacy ICY is still a station, and refusing
+// it would be an intermittent bug that looks like STR losing presets.
+func TestLooksLikeWebPage(t *testing.T) {
+	withLocalProbe(t)
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		want    bool
+	}{
+		{
+			name: "station home page is refused",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				_, _ = w.Write([]byte("<!doctype html><html><body>Radio Hamburg</body></html>"))
+			},
+			want: true,
+		},
+		{
+			name: "html with no content type is sniffed and refused",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header()["Content-Type"] = nil
+				_, _ = w.Write([]byte("<!DOCTYPE html>\n<html lang=\"de\">"))
+			},
+			want: true,
+		},
+		{
+			name: "mp3 stream is allowed",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "audio/mpeg")
+				_, _ = w.Write([]byte("\xff\xfb\x90\x00"))
+			},
+			want: false,
+		},
+		{
+			name: "icecast without a content type but with ICY headers is allowed",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("icy-name", "Studio D")
+				w.Header().Set("icy-metaint", "16384")
+				w.Header().Set("Content-Type", "text/html") // some servers really do this
+				_, _ = w.Write([]byte("\xff\xfb"))
+			},
+			want: false,
+		},
+		{
+			name: "a station that is down is allowed",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = w.Write([]byte("<html>maintenance</html>"))
+			},
+			want: false,
+		},
+		{
+			name: "a 404 is allowed",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			},
+			want: false,
+		},
+		{
+			name: "aac stream is allowed",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "audio/aac")
+			},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(tc.handler)
+			defer srv.Close()
+			if got := looksLikeWebPage(context.Background(), srv.URL+"/stream"); got != tc.want {
+				t.Errorf("looksLikeWebPage = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A playlist is resolved elsewhere and is legitimately served as text by some
+// servers, so it must never be probed into a refusal.
+func TestPlaylistURLsSkipTheProbe(t *testing.T) {
+	withLocalProbe(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<!doctype html><html>"))
+	}))
+	defer srv.Close()
+	for _, ext := range []string{".pls", ".m3u", ".m3u8", ".asx", ".xspf"} {
+		if looksLikeWebPage(context.Background(), srv.URL+"/listen"+ext) {
+			t.Errorf("%s was refused; playlists must skip the probe", ext)
+		}
+	}
+}
+
+// An unreachable host is inconclusive, never a refusal.
+func TestUnreachableHostIsAllowed(t *testing.T) {
+	withLocalProbe(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL + "/gone"
+	srv.Close() // nothing is listening any more
+	if looksLikeWebPage(context.Background(), url) {
+		t.Error("an unreachable station was refused; it must be allowed")
+	}
+}
+
+// The scheme gate belongs to the existing save path, and a non-http URL must
+// not even be dialled here.
+func TestNonHTTPSchemeIsNotProbed(t *testing.T) {
+	if looksLikeWebPage(context.Background(), "spotify:playlist:37i9dQZF1DXcBWIGoYBM5M") {
+		t.Error("a spotify URI was treated as a web page")
+	}
+	if looksLikeWebPage(context.Background(), "") {
+		t.Error("an empty URL was treated as a web page")
+	}
+}
+
+// The production probe must keep its SSRF guard: a preset URL pointing at the
+// speaker's own loopback services is never dialled, and the save is allowed
+// rather than refused (the structural gates own that case, not this probe).
+// This test deliberately does NOT install the local-probe seam.
+func TestProbeKeepsTheSSRFGuard(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<!doctype html><html>"))
+	}))
+	defer srv.Close()
+	// The server serves HTML on loopback. With the guard in place the dial never
+	// happens, so the answer is "could not tell", not "web page".
+	if looksLikeWebPage(context.Background(), srv.URL+"/stream") {
+		t.Error("the guarded probe reached a loopback address; the SSRF guard is not in the path")
+	}
+}


### PR DESCRIPTION
A field bundle (2026-08-02) carried three presets whose stored URL was the station **website**, e.g. `www.radiohamburg.de/`. Those save without complaint, map onto a hardware key, and can never play: the box fetches the proxy, the proxy fetches a web page, and the user is left pressing a dead button with no idea why.

The save is the only moment where this is cheap to catch, so the URL is probed once before it is stored.

## The check is deliberately one-sided

It refuses **only** on positive evidence that the URL serves a web page. Every other outcome, including every error, allows the save. That asymmetry is the whole design:

- A station that is temporarily down, rate-limiting, or behind a slow CDN must still be savable. Refusing there would be a worse bug than the one this fixes, and it would be intermittent, which is worse again.
- **Legacy SHOUTcast v1** answers `ICY 200 OK` instead of an HTTP status line, and Go rejects that as malformed. That is the whole class of stations PR #458 fixed in the stream proxy. Here the error simply reads as inconclusive, so those stations keep saving. The probe deliberately does not reuse the proxy's ICY-rewriting dialer: failing open covers the case at a fraction of the risk.
- Playlists (`.pls/.m3u/.m3u8/.asx/.xspf`) are resolved elsewhere and are mislabelled as `text/html` by some servers, so they skip the probe entirely.
- ICY headers (`icy-metaint`, `icy-name`) settle it as a stream even when the server also claims `text/html`, which real Icecast servers do.

Bounded at 4s so a save stays responsive, and it goes through the SSRF-guarded client like every other caller-supplied URL fetch.

## A note on the tests

The first version of the test suite was **vacuous and passed anyway**. `httptest` listens on loopback, the guarded client refuses loopback by design, so every case fell through the "could not reach it, allow the save" branch and proved nothing. The tests now install a seam (`presetProbeClient`) for the classification cases, and one test deliberately does **not** install it, asserting that the production path still refuses to dial loopback.

Covered: home page refused, HTML sniffed without a content type, mp3/aac allowed, Icecast-claiming-HTML allowed, 503 and 404 allowed, unreachable allowed, playlists skipped, non-HTTP scheme not dialled, SSRF guard still in the path.

Refs #390