### PR TITLE
fix(agent): the speaker's own log keeps hours more history for a diagnosis

### DIFF
--- a/cmd/agent/sysmon.go
+++ b/cmd/agent/sysmon.go
@@ -182,24 +182,110 @@ func pollBoxInfo(ctx context.Context, boxHost, region string, ann *discovery.Ann
 	}
 }
 
-// logResourceHealth records a one-line snapshot of available memory and
-// system load. On this hardware (~120 MB RAM, no swap) a slow leak ends
-// in an OOM freeze; this heartbeat makes the RAM/load trend leading up to
-// such a freeze visible in the on-box log for post-mortem analysis.
-// Best-effort: missing /proc entries just log -1.
+// resource-health logging state. Guarded by its own mutex; the health loop is
+// the only writer today, but the values are also read from the memory guard's
+// goroutine in tests.
+var (
+	resHealthMu       sync.Mutex
+	resHealthLastAt   time.Time
+	resHealthLastMem  int64
+	resHealthLastRSS  int64
+	resHealthLastThr  int64
+	resHealthHaveLast bool
+)
+
+// Thresholds for "something actually moved". Relative, because the interesting
+// signal is a trend, not an absolute number, and absolute numbers differ per
+// model.
+const (
+	resHealthMemDelta   = 0.08 // 8 % change in MemAvailable
+	resHealthRSSDelta   = 0.15 // 15 % change in the agent's own RSS
+	resHealthLowWater   = 0.20 // below 20 % free, every reading is interesting
+	resHealthAnchorEach = time.Hour
+)
+
+// logResourceHealth records a snapshot of available memory and system load WHEN
+// IT CHANGED. On this hardware (~120 MB RAM, no swap) a slow leak ends in an
+// OOM freeze, and the trend leading up to it is the thing worth having.
+//
+// It used to write one line every five minutes regardless. That reads as
+// harmless (12 lines an hour) until you look at what it costs where it matters:
+// the NAND log is a 32 KB ring and the only log that survives a reboot on a box
+// with no shell. Measured on a Portable 2026-08-06, routine heartbeats were
+// 29.6 % of that window, and on an idle box the whole window reaches back only
+// about seven hours. That is why the Lifestyle reboot-loop investigation ran
+// out of history: the cause had already rolled out.
+//
+// So: log the first reading, log whenever memory or the agent's own footprint
+// moves meaningfully, log every reading once free memory is low, and otherwise
+// drop one anchor an hour so a flat box still shows a trend line. Everything
+// else goes to Debug, where it costs nothing on NAND. No forensic signal is
+// lost; the flat repeats that were burying it are.
 func logResourceHealth(logger *slog.Logger) {
 	avail, total := readMemKB()
 	rss, threads := readSelfRSS()
-	logger.Info("resource health",
+	// The agent's own RSS and thread count travel with every line. If
+	// memAvailable trends down while these stay flat, the leak is BoseApp's
+	// (firmware); if these climb too, it is ours. That attributes the leak
+	// preceding the recurring BoseApp freeze without guesswork.
+	attrs := []any{
 		"memAvailableKB", avail,
 		"memTotalKB", total,
 		"loadavg", readLoadAvg(),
-		// The agent's own RSS and thread count. If memAvailable trends
-		// down while these stay flat, the leak is BoseApp's (firmware);
-		// if these climb too, it is ours. This attributes the leak that
-		// precedes the recurring BoseApp freeze without guesswork.
 		"agentRSSKB", rss,
-		"agentThreads", threads)
+		"agentThreads", threads,
+	}
+	why, worth := resourceHealthWorthLogging(avail, total, rss, threads, time.Now())
+	if !worth {
+		logger.Debug("resource health", attrs...)
+		return
+	}
+	logger.Info("resource health", append(attrs, "why", why)...)
+}
+
+// resourceHealthWorthLogging decides, and records the new baseline when it says
+// yes. Split out so the decision is testable without touching /proc.
+func resourceHealthWorthLogging(avail, total, rss, threads int64, now time.Time) (string, bool) {
+	resHealthMu.Lock()
+	defer resHealthMu.Unlock()
+	keep := func(why string) (string, bool) {
+		resHealthLastAt, resHealthLastMem, resHealthLastRSS, resHealthLastThr = now, avail, rss, threads
+		resHealthHaveLast = true
+		return why, true
+	}
+	if !resHealthHaveLast {
+		return keep("first")
+	}
+	// A box running low is the case this instrument exists for: never quiet it.
+	if total > 0 && float64(avail) < resHealthLowWater*float64(total) {
+		return keep("low-memory")
+	}
+	if moved(resHealthLastMem, avail, resHealthMemDelta) {
+		return keep("memory-moved")
+	}
+	if moved(resHealthLastRSS, rss, resHealthRSSDelta) {
+		return keep("agent-rss-moved")
+	}
+	if threads != resHealthLastThr {
+		return keep("threads-changed")
+	}
+	if now.Sub(resHealthLastAt) >= resHealthAnchorEach {
+		return keep("hourly-anchor")
+	}
+	return "", false
+}
+
+// moved reports a relative change of at least frac. A previous value of 0 (or a
+// failed read, which logs -1) counts as moved so the first real reading lands.
+func moved(prev, cur int64, frac float64) bool {
+	if prev <= 0 {
+		return cur > 0
+	}
+	d := float64(cur-prev) / float64(prev)
+	if d < 0 {
+		d = -d
+	}
+	return d >= frac
 }
 
 // memory-guard tunables. The Spotify Ogg path leaves a residual box-side

--- a/cmd/agent/sysmon_health_test.go
+++ b/cmd/agent/sysmon_health_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// reset clears the decision state so each test starts from "nothing said yet".
+func resetResHealth() {
+	resHealthMu.Lock()
+	defer resHealthMu.Unlock()
+	resHealthHaveLast = false
+	resHealthLastAt = time.Time{}
+	resHealthLastMem, resHealthLastRSS, resHealthLastThr = 0, 0, 0
+}
+
+// The instrument exists to show the memory trend before an OOM freeze. Quieting
+// it must never cost a movement, only the flat repeats that were burying them in
+// a 32 KB ring that has to survive a reboot.
+func TestResourceHealthLogsWhatMatters(t *testing.T) {
+	const total = 120000
+	t0 := time.Date(2026, 8, 6, 10, 0, 0, 0, time.UTC)
+
+	resetResHealth()
+	if why, ok := resourceHealthWorthLogging(60000, total, 11000, 9, t0); !ok || why != "first" {
+		t.Fatalf("first reading: why=%q ok=%v, want first/true", why, ok)
+	}
+	// A flat box a minute later says nothing new.
+	if _, ok := resourceHealthWorthLogging(60000, total, 11000, 9, t0.Add(time.Minute)); ok {
+		t.Error("an unchanged reading was logged; that is the noise this removes")
+	}
+	// Small drift is still noise.
+	if _, ok := resourceHealthWorthLogging(58000, total, 11050, 9, t0.Add(2*time.Minute)); ok {
+		t.Error("a 3 % drift was logged")
+	}
+	// A real drop is the signal.
+	if why, ok := resourceHealthWorthLogging(50000, total, 11050, 9, t0.Add(3*time.Minute)); !ok || why != "memory-moved" {
+		t.Errorf("a 14 %% memory drop: why=%q ok=%v, want memory-moved/true", why, ok)
+	}
+	// The agent's own footprint growing is how we tell OUR leak from BoseApp's.
+	if why, ok := resourceHealthWorthLogging(50000, total, 13500, 9, t0.Add(4*time.Minute)); !ok || why != "agent-rss-moved" {
+		t.Errorf("agent RSS +22 %%: why=%q ok=%v, want agent-rss-moved/true", why, ok)
+	}
+	// A thread count change is cheap to carry and pins a goroutine leak.
+	if why, ok := resourceHealthWorthLogging(50000, total, 13500, 14, t0.Add(5*time.Minute)); !ok || why != "threads-changed" {
+		t.Errorf("thread count change: why=%q ok=%v, want threads-changed/true", why, ok)
+	}
+}
+
+// Once memory is genuinely low, every reading counts: that is the run-up this
+// whole instrument was added for, and it must not be sampled away.
+func TestResourceHealthNeverQuietsALowBox(t *testing.T) {
+	const total = 120000
+	t0 := time.Date(2026, 8, 6, 10, 0, 0, 0, time.UTC)
+	resetResHealth()
+	resourceHealthWorthLogging(20000, total, 11000, 9, t0) // first
+	for i := 1; i <= 5; i++ {
+		why, ok := resourceHealthWorthLogging(20000, total, 11000, 9, t0.Add(time.Duration(i)*time.Minute))
+		if !ok || why != "low-memory" {
+			t.Fatalf("reading %d on a low box: why=%q ok=%v, want low-memory/true", i, why, ok)
+		}
+	}
+}
+
+// A box that never moves still needs a trend line, so one anchor an hour lands.
+func TestResourceHealthDropsAnHourlyAnchor(t *testing.T) {
+	const total = 120000
+	t0 := time.Date(2026, 8, 6, 10, 0, 0, 0, time.UTC)
+	resetResHealth()
+	resourceHealthWorthLogging(60000, total, 11000, 9, t0)
+	if _, ok := resourceHealthWorthLogging(60000, total, 11000, 9, t0.Add(59*time.Minute)); ok {
+		t.Error("logged before the hour was up")
+	}
+	if why, ok := resourceHealthWorthLogging(60000, total, 11000, 9, t0.Add(61*time.Minute)); !ok || why != "hourly-anchor" {
+		t.Errorf("after an hour: why=%q ok=%v, want hourly-anchor/true", why, ok)
+	}
+}
+
+// How much of the old traffic disappears on an idle box: the old code wrote one
+// line every five minutes forever, the new one writes one an hour.
+func TestResourceHealthIdleBoxCollapsesToHourlyAnchors(t *testing.T) {
+	const total = 120000
+	t0 := time.Date(2026, 8, 6, 10, 0, 0, 0, time.UTC)
+	resetResHealth()
+	logged := 0
+	for i := 0; i < 12*24; i++ { // 24 hours at the old 5-minute cadence
+		if _, ok := resourceHealthWorthLogging(60000, total, 11000, 9, t0.Add(time.Duration(i)*5*time.Minute)); ok {
+			logged++
+		}
+	}
+	if logged > 26 { // 24 anchors + the first reading, with a little slack
+		t.Errorf("an idle day still logged %d lines, want about 25 (was 288)", logged)
+	}
+	if logged < 20 {
+		t.Errorf("an idle day logged only %d lines; the trend anchor is missing", logged)
+	}
+}
+
+func TestMoved(t *testing.T) {
+	cases := []struct {
+		prev, cur int64
+		frac      float64
+		want      bool
+	}{
+		{100, 100, 0.08, false},
+		{100, 105, 0.08, false},
+		{100, 92, 0.08, true},
+		{100, 108, 0.08, true},
+		{0, 50, 0.08, true},  // first real reading after a failed read
+		{-1, 50, 0.08, true}, // /proc unreadable last time
+		{100, 0, 0.08, true}, // reading failed now: worth knowing
+	}
+	for _, tc := range cases {
+		if got := moved(tc.prev, tc.cur, tc.frac); got != tc.want {
+			t.Errorf("moved(%d, %d, %.2f) = %v, want %v", tc.prev, tc.cur, tc.frac, got, tc.want)
+		}
+	}
+}

--- a/internal/autopair/autopair.go
+++ b/internal/autopair/autopair.go
@@ -397,6 +397,9 @@ func (m *Manager) RunBackground(ctx context.Context, startDelay, interval time.D
 	}
 	tick := time.NewTicker(cur)
 	defer tick.Stop()
+	// The pairing state the last heartbeat reported. Empty means "nothing said
+	// yet", so the first heartbeat always lands and a bundle has its baseline.
+	lastHeartbeatState := ""
 	for {
 		m.tickCount++
 		// The first cycle after start forces a re-assert even when the box
@@ -414,8 +417,23 @@ func (m *Manager) RunBackground(ctx context.Context, startDelay, interval time.D
 					state = "not paired"
 				}
 			}
-			m.logger.Warn("autopair phase: heartbeat",
-				"tick", m.tickCount, "state", state, "interval", cur.String())
+			// A heartbeat that says the same thing as the last one is not worth
+			// a line, and certainly not a WARN. It fired every five minutes
+			// regardless: measured on a Portable 2026-08-06 these were part of
+			// the 29.6 % of the 32 KB NAND ring taken by pure routine, in the
+			// one log that survives a reboot on a box with no shell.
+			//
+			// A CHANGE is the notable event and keeps its WARN, so a box that
+			// silently loses its pairing still stands out in a bundle. Steady
+			// state goes to Debug, where it costs no NAND.
+			if state != lastHeartbeatState {
+				m.logger.Warn("autopair phase: heartbeat",
+					"tick", m.tickCount, "state", state, "was", lastHeartbeatState, "interval", cur.String())
+				lastHeartbeatState = state
+			} else {
+				m.logger.Debug("autopair phase: heartbeat",
+					"tick", m.tickCount, "state", state, "interval", cur.String())
+			}
 		}
 		// Settle to the steady interval once the fast post-boot window elapses;
 		// a box not yet observed paired holds the fast cadence longer (capped).

--- a/internal/boxws/client.go
+++ b/internal/boxws/client.go
@@ -54,6 +54,13 @@ type Client struct {
 	// rather than repeatedly while AUX stays the active source.
 	lastSource string
 
+	// unknownFrames counts the frame shapes STR does not handle, keyed by the
+	// element name, so the first of each shape can be logged in full and the
+	// repeats only counted. unknownSummaryAt times the periodic roll-up.
+	// Guarded by mu.
+	unknownFrames    map[string]int
+	unknownSummaryAt time.Time
+
 	// lastInvalidSourceAt / lastPresetPressAt time the box's own UPnP-source
 	// teardown. On scm/mojo firmware (ST30) a preset switch AND an involuntary
 	// stream drop both tear STR's UPNP source down through INVALID_SOURCE and

--- a/internal/boxws/dispatch.go
+++ b/internal/boxws/dispatch.go
@@ -431,10 +431,20 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 					return
 				}
 			}
-			// Surface anything still unrecognized so we can map the events STR does
-			// not yet handle (the preset long-press store gesture). INFO and rare,
-			// so it stays in a diagnostic bundle without spamming the NAND log.
-			c.logger.Info("box ws unrecognized frame", "bytes", len(data), "body", preview(data, 1800))
+			// Surface anything still unrecognized so we can map the events STR
+			// does not yet handle (the preset long-press store gesture).
+			//
+			// "rare" was the assumption, and it was wrong. Some of these repeat
+			// forever: a Portable emits userInactivityUpdate every few minutes,
+			// and sourcesUpdated / swUpdateStatusUpdated / balanceUpdated arrive
+			// on every source change. Measured 2026-08-06, unrecognized frames
+			// were 15.6 % of the 32 KB NAND log, the only log that survives a
+			// reboot on a box with no shell, at up to 1800 bytes per line.
+			//
+			// The forensic value is in learning that a frame SHAPE exists, not
+			// in the hundredth copy of it. So the first of each shape is logged
+			// in full, and repeats are counted and reported once an hour.
+			c.logUnrecognizedFrame(data)
 		}
 		return
 	}
@@ -502,5 +512,77 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 	if c.handler != nil {
 		c.handler.OnPresetSelected(ctx, slot,
 			pe.ContentItem.Location, pe.ContentItem.ItemName)
+	}
+}
+
+// unknownSummaryEvery bounds how often the repeat counts are rolled up. Long
+// enough that a chatty box costs one line an hour, short enough that a bundle
+// pulled during a fault still shows what has been arriving.
+const unknownSummaryEvery = time.Hour
+
+// frameShape names a frame by its first element, which is what makes two frames
+// "the same kind": the bodies differ per device and per value, the shape does
+// not. Falls back to a short prefix when no element name can be read, so an
+// unparseable frame still groups with its own kind instead of being unique
+// every time (which would defeat the whole point).
+func frameShape(data []byte) string {
+	s := string(data)
+	i := strings.IndexByte(s, '<')
+	if i < 0 {
+		return strings.TrimSpace(preview(data, 24))
+	}
+	rest := s[i+1:]
+	end := strings.IndexAny(rest, " \t\r\n/>")
+	if end <= 0 {
+		return strings.TrimSpace(preview(data, 24))
+	}
+	name := rest[:end]
+	// An <updates> wrapper says nothing; the interesting name is the child.
+	if name == "updates" {
+		if j := strings.IndexByte(rest, '<'); j >= 0 {
+			inner := rest[j+1:]
+			if e := strings.IndexAny(inner, " \t\r\n/>"); e > 0 {
+				return "updates/" + inner[:e]
+			}
+		}
+	}
+	return name
+}
+
+// logUnrecognizedFrame logs the FIRST frame of each shape in full and counts
+// the rest, rolling the counts up once an hour.
+//
+// The old behaviour logged every one at up to 1800 bytes. On a Portable that
+// was 15.6 % of the 32 KB NAND ring (measured 2026-08-06), i.e. it was
+// consuming the very history a post-mortem needs, to repeat facts already in
+// the log. Learning that a shape exists is the whole forensic value here.
+func (c *Client) logUnrecognizedFrame(data []byte) {
+	shape := frameShape(data)
+	c.mu.Lock()
+	if c.unknownFrames == nil {
+		c.unknownFrames = map[string]int{}
+	}
+	c.unknownFrames[shape]++
+	n := c.unknownFrames[shape]
+	var summary []any
+	now := time.Now()
+	if n > 1 && !c.unknownSummaryAt.IsZero() && now.Sub(c.unknownSummaryAt) >= unknownSummaryEvery {
+		c.unknownSummaryAt = now
+		for k, v := range c.unknownFrames {
+			summary = append(summary, k, v)
+		}
+	} else if c.unknownSummaryAt.IsZero() {
+		c.unknownSummaryAt = now
+	}
+	c.mu.Unlock()
+
+	if n == 1 {
+		c.logger.Info("box ws unrecognized frame (first of this shape)",
+			"shape", shape, "bytes", len(data), "body", preview(data, 1800))
+	} else {
+		c.logger.Debug("box ws unrecognized frame", "shape", shape, "count", n)
+	}
+	if len(summary) > 0 {
+		c.logger.Info("box ws unrecognized frames so far", summary...)
 	}
 }

--- a/internal/boxws/unknownframe_test.go
+++ b/internal/boxws/unknownframe_test.go
@@ -1,0 +1,76 @@
+package boxws
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestFrameShape(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{`<userInactivityUpdate deviceID="AA" />`, "userInactivityUpdate"},
+		{`<updates deviceID="AA"><sourcesUpdated /></updates>`, "updates/sourcesUpdated"},
+		{`<updates deviceID='AA'><balanceUpdated></balanceUpdated></updates>`, "updates/balanceUpdated"},
+		{`<SoundTouchSdkInfo serverVersion="4" />`, "SoundTouchSdkInfo"},
+		{`<swUpdateStatusUpdated/>`, "swUpdateStatusUpdated"},
+	}
+	for _, tc := range cases {
+		if got := frameShape([]byte(tc.in)); got != tc.want {
+			t.Errorf("frameShape(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// Two frames of the same shape carrying different device ids or values must
+// group together, or the dedupe achieves nothing on exactly the frames that
+// repeat forever.
+func TestFrameShapeIgnoresPayload(t *testing.T) {
+	a := frameShape([]byte(`<userInactivityUpdate deviceID="08DF1F0C9870" />`))
+	b := frameShape([]byte(`<userInactivityUpdate deviceID="FFEEDDCCBBAA" />`))
+	if a != b {
+		t.Errorf("same shape with different ids grouped apart: %q vs %q", a, b)
+	}
+}
+
+// The forensic value is learning a shape EXISTS. The hundredth copy of it costs
+// NAND in the only log that survives a reboot, and buys nothing.
+func TestUnrecognizedFrameLogsTheFirstOfEachShapeOnly(t *testing.T) {
+	var buf bytes.Buffer
+	c := &Client{logger: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))}
+
+	inactivity := []byte(`<userInactivityUpdate deviceID="08DF1F0C9870" />`)
+	for i := 0; i < 40; i++ {
+		c.logUnrecognizedFrame(inactivity)
+	}
+	c.logUnrecognizedFrame([]byte(`<updates deviceID="AA"><sourcesUpdated /></updates>`))
+	for i := 0; i < 10; i++ {
+		c.logUnrecognizedFrame([]byte(`<updates deviceID="BB"><sourcesUpdated /></updates>`))
+	}
+
+	out := buf.String()
+	if n := strings.Count(out, "first of this shape"); n != 2 {
+		t.Errorf("logged %d first-of-shape lines for 2 shapes, want 2", n)
+	}
+	// 51 frames arrived; at INFO only the two introductions may appear.
+	if n := strings.Count(out, "box ws unrecognized frame"); n != 2 {
+		t.Errorf("%d INFO lines for 51 frames, want 2\n%s", n, out)
+	}
+	for _, want := range []string{"userInactivityUpdate", "updates/sourcesUpdated"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("shape %q never reached the log", want)
+		}
+	}
+}
+
+// The first frame keeps its full body: that is what makes it possible to map an
+// event STR does not handle yet.
+func TestUnrecognizedFrameKeepsTheFirstBody(t *testing.T) {
+	var buf bytes.Buffer
+	c := &Client{logger: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))}
+	c.logUnrecognizedFrame([]byte(`<presetStoreGesture slot="3" hold="long" />`))
+	out := buf.String()
+	if !strings.Contains(out, `slot=`) || !strings.Contains(out, "presetStoreGesture") {
+		t.Errorf("the first frame lost its body:\n%s", out)
+	}
+}


### PR DESCRIPTION
The log on the speaker's flash is a 32 KB ring and the only one that survives a reboot on a box with no shell, so it is what a post-mortem actually has. Measured on a Portable, live, on 2026-08-06:

```
Meldung                                    Zeilen    Bytes   Anteil
box ws unrecognized frame                      21     5125   15.6%
resource health                                24     3934   12.0%
autopair phase: heartbeat                       5      634    1.9%
-----------------------------------------------------------------
Routine-Rauschen                             9693 von 32781   29.6%
```

Nearly a third of the window, on a box that had been up for two hours. On an **idle** speaker the three writers produce roughly 4.3 KB/hour between them, so the whole window reaches back about **seven hours**. That is why the Lifestyle reboot-loop investigation ran out of history before it reached the cause: it had already rolled out.

All three wrote because a timer fired, not because anything happened.

## What changed

**Resource snapshot** (`cmd/agent/sysmon.go`) went out every five minutes forever. It now logs the first reading, **every** reading once free memory is below 20 %, any meaningful move in memory (8 %), in the agent's own RSS (15 %) or in its thread count, and otherwise one anchor an hour so a flat speaker still shows a trend line. An idle day drops from 288 lines to about 25 (asserted by a test). Each kept line now carries `why=` so a bundle says what made it interesting.

**Unrecognized gabbo frames** (`internal/boxws`) were logged in full at up to 1800 bytes, every time. "Rare" was the assumption and it was wrong: a Portable emits `userInactivityUpdate` every few minutes, and `sourcesUpdated` / `swUpdateStatusUpdated` / `balanceUpdated` on every source change. The first frame of each **shape** keeps its full body, which is what makes an unmapped event identifiable in the first place; repeats are counted and rolled up hourly. Shape is the element name (`updates/sourcesUpdated`), so the same event with a different deviceID groups with itself.

**Autopair heartbeat** (`internal/autopair`) wrote a WARN every five minutes regardless. A change still warns and now names what it changed from, so a speaker that silently loses its pairing still stands out; steady state goes to Debug.

## What did not change

Nothing that ever indicated a fault got quieter. A low-memory box is logged on every single reading, a pairing change still warns, and a frame shape never seen before is still logged in full. What got quieter is the repetition that was pushing those out of the window.

Tests cover the decision function directly (movement, low-memory, hourly anchor, the idle-day volume), frame-shape grouping, and that 51 frames of two shapes produce exactly two INFO lines.

Refs #390