### PR TITLE
fix(agent): the Wi-Fi password never leaves the speaker in a diagnostic

### DIFF
--- a/internal/webui/debug.go
+++ b/internal/webui/debug.go
@@ -214,7 +214,16 @@ func (s *Server) handleDebugState(w http.ResponseWriter, r *http.Request) {
 		// it exists to answer, how many networks a speaker is configured for,
 		// was therefore never answerable from a bundle (found 2026-08-05 while
 		// testing exactly that theory against nine speakers).
-		"wpa_supplicant": readTail(wpaConfPath),
+		//
+		// REDACTED AT THE SOURCE. That file holds the user's Wi-Fi password in
+		// psk="...", and this endpoint answers an unauthenticated GET on the
+		// LAN and is the body of every diagnostic bundle mailed in or attached
+		// to an issue. Fixing the path above turned a read that had always
+		// failed into a live disclosure, so the secret is removed here rather
+		// than downstream: the desktop app scrubs bundles too, but a value with
+		// a space in it (a perfectly ordinary passphrase) survived its pattern,
+		// and nothing scrubs a plain curl against this port at all.
+		"wpa_supplicant": redactWPASecrets(readTail(wpaConfPath)),
 		// What the speaker is REALLY configured for. The file above only shows
 		// what was persisted, and on at least one chassis that is the untouched
 		// vendor template while the speaker is on Wi-Fi via a network added at

--- a/internal/webui/wpasecrets.go
+++ b/internal/webui/wpasecrets.go
@@ -1,0 +1,67 @@
+package webui
+
+// Keep the user's Wi-Fi password out of everything that leaves the speaker.
+//
+// /etc/wpa_supplicant.conf holds the passphrase in plain text. The diagnostic
+// state is served by an unauthenticated GET on the LAN and is the body of every
+// bundle mailed in or attached to an issue, so the file cannot go out as it is.
+//
+// The whole file is still worth having: how many network={} blocks a speaker
+// carries is exactly the question that explains a box which keeps rejoining the
+// guest network, and key_mgmt / scan_ssid / priority all matter for that. Only
+// the secrets are replaced, in place, so the shape of the file survives.
+
+import (
+	"regexp"
+	"strings"
+)
+
+// wpaSecretKeys are the fields that carry a credential in a wpa_supplicant
+// config. Deliberately a list of names rather than a guess at what looks
+// secret: a new key nobody redacted is how these leaks happen.
+var wpaSecretKeys = []string{
+	"psk", "password", "passwd", "passphrase", "sae_password", "wep_key0",
+	"wep_key1", "wep_key2", "wep_key3", "private_key_passwd", "pin", "ext_password",
+}
+
+// wpaSecretLine matches `key=value` for one of the names above.
+//
+// The value pattern is the point of this whole file. A pattern that stops at
+// whitespace looks right and is wrong: `psk="two words"` would keep everything
+// after the space, which is a perfectly ordinary passphrase and the exact case
+// the desktop app's scrubber let through. So a QUOTED value is consumed to its
+// closing quote, and only an unquoted one stops at whitespace.
+var wpaSecretLine = regexp.MustCompile(
+	`(?im)^(\s*(?:` + strings.Join(wpaSecretKeys, "|") + `)\s*=\s*)("(?:[^"\\]|\\.)*"?|\S*)`)
+
+// redactWPASecrets replaces every credential value with a marker that says how
+// long it was, which is occasionally useful ("the password is empty" is a real
+// diagnosis) and reveals nothing else.
+func redactWPASecrets(conf string) string {
+	if conf == "" {
+		return conf
+	}
+	return wpaSecretLine.ReplaceAllStringFunc(conf, func(m string) string {
+		sub := wpaSecretLine.FindStringSubmatch(m)
+		if len(sub) != 3 {
+			return "<redacted>"
+		}
+		val := strings.Trim(sub[2], `"`)
+		return sub[1] + `"<redacted:` + itoa(len(val)) + ` chars>"`
+	})
+}
+
+// itoa avoids pulling strconv in for one call.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}

--- a/internal/webui/wpasecrets_test.go
+++ b/internal/webui/wpasecrets_test.go
@@ -1,0 +1,114 @@
+package webui
+
+import (
+	"strings"
+	"testing"
+)
+
+// The file this redacts is served by an unauthenticated GET and travels in
+// every diagnostic bundle, so a leaked passphrase reaches a mailbox or a public
+// issue. Each case below is a shape a real wpa_supplicant.conf takes.
+func TestRedactWPASecrets(t *testing.T) {
+	cases := []struct {
+		name, in, mustNotContain string
+	}{
+		{"plain psk", `network={
+	ssid="Home"
+	psk="hunter2"
+}`, "hunter2"},
+		{
+			// The case the desktop app's pattern let through: a value that stops
+			// at whitespace leaves the rest of the passphrase in the output.
+			name: "passphrase with spaces",
+			in: `network={
+	ssid="Home"
+	psk="correct horse battery staple"
+}`,
+			mustNotContain: "battery staple",
+		},
+		{"unquoted hashed psk", "\tpsk=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n", "0123456789abcdef"},
+		{"wep key", "\twep_key0=\"s3cr3t\"\n", "s3cr3t"},
+		{"sae password", "\tsae_password=\"my wpa3 secret\"\n", "wpa3 secret"},
+		{"eap password", "\tpassword=\"enterprise pw\"\n", "enterprise pw"},
+		{"private key passwd", "\tprivate_key_passwd=\"keypw\"\n", "keypw"},
+		{"leading spaces instead of tab", "   psk=\"spaced out\"\n", "spaced out"},
+		{"uppercase key", "\tPSK=\"ShoutedSecret\"\n", "ShoutedSecret"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redactWPASecrets(tc.in)
+			if strings.Contains(got, tc.mustNotContain) {
+				t.Errorf("the secret survived redaction:\n%s", got)
+			}
+			if !strings.Contains(got, "<redacted:") {
+				t.Errorf("nothing was redacted:\n%s", got)
+			}
+		})
+	}
+}
+
+// Everything the file is actually read FOR has to survive, or the redaction
+// destroys the diagnosis it was protecting.
+func TestRedactKeepsWhatTheFileIsReadFor(t *testing.T) {
+	in := `ctrl_interface=/var/run/wpa_supplicant
+update_config=1
+
+network={
+	ssid="Home"
+	psk="hunter2"
+	key_mgmt=WPA-PSK
+	priority=5
+}
+
+network={
+	ssid="Guest"
+	psk="another one"
+	scan_ssid=1
+}`
+	got := redactWPASecrets(in)
+	for _, want := range []string{
+		"ctrl_interface=/var/run/wpa_supplicant",
+		"update_config=1",
+		`ssid="Home"`,
+		`ssid="Guest"`,
+		"key_mgmt=WPA-PSK",
+		"priority=5",
+		"scan_ssid=1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("redaction destroyed %q, which is what the file is read for:\n%s", want, got)
+		}
+	}
+	// The count of network blocks is the single question this file answers.
+	if n := strings.Count(got, "network={"); n != 2 {
+		t.Errorf("network block count = %d, want 2", n)
+	}
+	if strings.Contains(got, "hunter2") || strings.Contains(got, "another one") {
+		t.Errorf("a secret survived:\n%s", got)
+	}
+}
+
+// An empty password is a real diagnosis ("the speaker has no key stored"), so
+// the marker carries the length and nothing else.
+func TestRedactReportsLengthOnly(t *testing.T) {
+	got := redactWPASecrets("\tpsk=\"\"\n")
+	if !strings.Contains(got, "<redacted:0 chars>") {
+		t.Errorf("an empty passphrase should still be visible AS empty: %q", got)
+	}
+	got = redactWPASecrets("\tpsk=\"abcdefg\"\n")
+	if !strings.Contains(got, "<redacted:7 chars>") {
+		t.Errorf("length not reported: %q", got)
+	}
+}
+
+func TestRedactHandlesAnAbsentFile(t *testing.T) {
+	// readTail returns an error string when the file is missing; it must pass
+	// through untouched rather than being mangled into something confusing.
+	in := "ERR: open /etc/wpa_supplicant.conf: no such file or directory"
+	if got := redactWPASecrets(in); got != in {
+		t.Errorf("error text was altered: %q", got)
+	}
+	if got := redactWPASecrets(""); got != "" {
+		t.Errorf("empty input became %q", got)
+	}
+}


### PR DESCRIPTION
`/etc/wpa_supplicant.conf` holds the passphrase in plain text, and the debug state copied the file out verbatim. That state answers an **unauthenticated GET on the LAN** and is the body of every diagnostic bundle mailed in or attached to an issue, so a support request carried the reporter's Wi-Fi password with it.

**It did not leak before yesterday, and only because it was broken.** The read pointed at `/mnt/nv/wpa_supplicant.conf` while the file is written to `/etc/wpa_supplicant.conf`, so every bundle ever collected carried `no such file or directory` there. Fixing that path (2026-08-05, while testing the "how many networks is this speaker configured for" question) turned a silent failure into a live disclosure. No bundle collected before that carries a passphrase.

## Removed at the source, not downstream

The desktop app does scrub bundles, but its pattern is `psk=[^\s]*` — it stops at the first space. An ordinary passphrase with a space in it (`psk="correct horse battery staple"`) survives it partially, and the same applies to an SSID with a space. And nothing scrubs a plain `curl http://<speaker>:8888/api/debug/state` at all.

So the secret is removed on the speaker, before it is ever serialised.

## What survives, because it is the reason the file is read

```
ctrl_interface=...        kept
update_config=1           kept
network={ }               kept, and countable
ssid="Home"               kept
key_mgmt / priority       kept
scan_ssid                 kept
psk="hunter2"             -> psk="<redacted:7 chars>"
```

The block count is the single question this file exists to answer (a speaker that keeps rejoining the guest network has two of them). The length is kept because "the stored password is empty" is itself a diagnosis.

Covered keys: `psk`, `password`, `passwd`, `passphrase`, `sae_password`, `wep_key0..3`, `private_key_passwd`, `pin`, `ext_password` — a named list rather than a guess at what looks secret, because a new key nobody redacted is how these leaks happen.

Tests assert every shape a real config takes, including the space-containing passphrase the old pattern let through, and separately assert that nothing the file is read for was destroyed.

Refs #390