### PR TITLE
fix(playback): Pause and Stop work again on a station the speaker plays itself

### DIFF
--- a/desktop-app/app_transport.go
+++ b/desktop-app/app_transport.go
@@ -194,5 +194,36 @@ func reachabilityHint(err error) error {
 	if err == nil || errors.Is(err, context.Canceled) {
 		return err
 	}
+	// A speaker that ANSWERED cannot be behind a firewall that blocks this app,
+	// and the hint below then sends the user hunting through antivirus settings
+	// for nothing. Field report 2026-08-06: an update failed with
+	// `status 400 ... body=""` on every attempt over two days, and the advice
+	// under it talked about firewalls and separate Wi-Fi networks while the
+	// speaker was replying to each request. That is the same wrong-blame the
+	// install path already had to fix.
+	//
+	// An HTTP status means the connection was made and something answered. What
+	// answered was not STR: on a speaker whose agent is not up, the firmware's
+	// own listener replies with a bare status. So say that instead.
+	if answeredNotSTR(err) {
+		return fmt.Errorf("%w\n\nThe speaker answered, so this is not your firewall and not a Wi-Fi problem: something on the speaker replied to every request. What answered was not ST Reborn, which is what a speaker looks like while it is still starting up, or when its ST Reborn software did not come up at all. Unplug the speaker for ten seconds, plug it back in, wait about three minutes until it is fully up, and try the update again", err)
+	}
 	return fmt.Errorf("%w\n\nThe app could not reach the speaker. This is usually a firewall or antivirus blocking ST Reborn, or this PC and the speaker being on different Wi-Fi networks. Allow ST Reborn through your firewall/antivirus (or turn it off briefly to test), and make sure both are on the same Wi-Fi network", err)
+}
+
+// answeredNotSTR reports whether the failure carries evidence that the speaker
+// replied: an HTTP status line rather than a connection that never completed.
+// Matched on the shapes this project's own errors carry ("status 400 on <ip>",
+// "status 404", "unexpected status"), because those are the ones that reach a
+// user, and deliberately NOT on timeouts or refusals, which really can be a
+// firewall.
+// A status anywhere in the chain wins even when the run also contains a
+// timeout. The field report ends in an SSH timeout, but the preflight before it
+// got a 400: the speaker demonstrably answered, so the firewall advice is wrong
+// regardless of how the attempt finished.
+func answeredNotSTR(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "status 4") ||
+		strings.Contains(msg, "status 5") ||
+		strings.Contains(msg, "unexpected status")
 }

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -199,6 +199,7 @@ import {
   savePresetCase,
   dismissNotice,
   noticeDismissed,
+  activeSlotFromLocation,
 } from './utils.js';
 
 // Group membership (who follows master X) and the shared zoneLive poll live
@@ -4422,24 +4423,6 @@ async function healPresetLogos() {
 // these in internal/boxurl. Keep the two in sync.
 const BOX_LOOPBACK = 'http://127.0.0.1:8888';
 const boxSpotifyDefaultUrl = () => `${BOX_LOOPBACK}/spotify/stream.ogg`;
-
-// activeSlotFromLocation extracts the slot number from a stream proxy
-// URL like http://127.0.0.1:8888/stream/3. Since build 2335 the
-// speaker's content items always run through the proxy, so the older
-// direct-URL comparison no longer matches. The slot match keeps the
-// green "playing" highlight stable even when the real CDN URL
-// rotates its tokens.
-function activeSlotFromLocation(loc) {
-  if (!loc) return null;
-  // Spotify presets point the box at the per-slot /spotify/stream-<slot>.ogg
-  // (both the hardware and the soft recall), so the slot is in the URL: prefer
-  // it so the right Spotify tile lights up even when several presets share the
-  // generic "Spotify" now-playing name.
-  const sp = loc.match(/\/spotify\/stream-(\d+)\.ogg/);
-  if (sp) return parseInt(sp[1], 10);
-  const m = loc.match(/\/stream\/(\d+)(?:[/?#]|$)/);
-  return m ? parseInt(m[1], 10) : null;
-}
 
 // decodeProxyUrl unwraps a stream-proxy URL
 // (http://<host>:8888/stream/raw?u=<base64url real URL>) back to the real

--- a/desktop-app/frontend/src/nativeslot.test.js
+++ b/desktop-app/frontend/src/nativeslot.test.js
@@ -1,0 +1,71 @@
+// Which preset tile lights up green while something is playing.
+//
+// The speaker names its content item differently depending on how the station
+// is played, and the app has to recognise all of them. Native radio presets
+// broke this: the box plays them itself and the location is an ORION
+// descriptor, so the plain /stream/<n> match found nothing and no tile lit up
+// (discussion #555, with the speaker reporting LOCAL_INTERNET_RADIO +
+// PLAY_STATE + the station name, i.e. playing perfectly well).
+import { describe, it, expect } from 'vitest';
+import { activeSlotFromLocation, slotFromOrionStation } from './utils.js';
+
+// Builds the descriptor exactly as the agent writes it: unpadded base64url.
+function orion(payload) {
+  const json = JSON.stringify(payload);
+  const b64 = Buffer.from(json, 'utf8').toString('base64')
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return '/station?data=' + b64;
+}
+
+describe('activeSlotFromLocation', () => {
+  it('finds the slot in a stream proxy URL', () => {
+    expect(activeSlotFromLocation('http://127.0.0.1:8888/stream/3')).toBe(3);
+    expect(activeSlotFromLocation('http://127.0.0.1:8888/stream/6?x=1')).toBe(6);
+  });
+
+  it('prefers the Spotify per-slot URL', () => {
+    expect(activeSlotFromLocation('http://192.0.2.1:8888/spotify/stream-4.ogg')).toBe(4);
+  });
+
+  it('finds the slot inside a native ORION station descriptor', () => {
+    const loc = orion({
+      imageUrl: '', isRealtime: true, name: 'absolute relax',
+      streamType: 'liveRadio', streamUrl: 'http://127.0.0.1:8888/stream/2',
+    });
+    expect(activeSlotFromLocation(loc)).toBe(2);
+  });
+
+  it('handles the full path form the speaker reports', () => {
+    const loc = '/core02/svc-bmx-adapter-orion/prod/orion' + orion({
+      name: 'WDR 5', streamUrl: 'http://127.0.0.1:8888/stream/6',
+    });
+    expect(activeSlotFromLocation(loc)).toBe(6);
+  });
+
+  it('accepts the standard base64 alphabet older builds wrote', () => {
+    const json = JSON.stringify({ streamUrl: 'http://127.0.0.1:8888/stream/5' });
+    const loc = '/station?data=' + Buffer.from(json, 'utf8').toString('base64');
+    expect(activeSlotFromLocation(loc)).toBe(5);
+  });
+
+  it('returns null rather than throwing on rubbish', () => {
+    expect(activeSlotFromLocation('')).toBe(null);
+    expect(activeSlotFromLocation(null)).toBe(null);
+    expect(activeSlotFromLocation('/station?data=not-base64!!')).toBe(null);
+    expect(activeSlotFromLocation('/station?data=' + Buffer.from('{oops', 'utf8').toString('base64'))).toBe(null);
+    expect(activeSlotFromLocation('http://example.com/some/other/thing')).toBe(null);
+  });
+
+  it('returns null for a station whose payload carries no proxy slot', () => {
+    // A native station pointing straight at a CDN has no slot to find, and
+    // guessing one would light up the wrong tile.
+    const loc = orion({ name: 'Direct', streamUrl: 'https://cdn.example/live.mp3' });
+    expect(activeSlotFromLocation(loc)).toBe(null);
+  });
+});
+
+describe('slotFromOrionStation', () => {
+  it('ignores a location that is not a station descriptor', () => {
+    expect(slotFromOrionStation('http://127.0.0.1:8888/stream/3')).toBe(null);
+  });
+});

--- a/desktop-app/frontend/src/utils.js
+++ b/desktop-app/frontend/src/utils.js
@@ -370,3 +370,52 @@ export function noticeDismissed(kind, version) {
 export function clearNoticeDismissal(kind) {
   storeDel(dismissKey(kind));
 }
+
+// activeSlotFromLocation extracts the slot number from a stream proxy
+// URL like http://127.0.0.1:8888/stream/3. Since build 2335 the
+// speaker's content items always run through the proxy, so the older
+// direct-URL comparison no longer matches. The slot match keeps the
+// green "playing" highlight stable even when the real CDN URL
+// rotates its tokens.
+export function activeSlotFromLocation(loc) {
+  if (!loc) return null;
+  // Spotify presets point the box at the per-slot /spotify/stream-<slot>.ogg
+  // (both the hardware and the soft recall), so the slot is in the URL: prefer
+  // it so the right Spotify tile lights up even when several presets share the
+  // generic "Spotify" now-playing name.
+  const sp = loc.match(/\/spotify\/stream-(\d+)\.ogg/);
+  if (sp) return parseInt(sp[1], 10);
+  const m = loc.match(/\/stream\/(\d+)(?:[/?#]|$)/);
+  if (m) return parseInt(m[1], 10);
+  // A NATIVE radio preset does not carry the proxy URL in its location at all:
+  // the speaker plays it itself and the content item is the ORION descriptor
+  // /station?data=<base64url JSON>, with the proxy URL inside the payload. The
+  // plain match above therefore stopped finding anything the moment presets
+  // migrated to the native form, so no tile lit up and the app looked like it
+  // had lost track of what was playing (reported in discussion #555:
+  // "die Sender werden nicht mehr als abgespielt angezeigt", with the speaker
+  // reporting source=LOCAL_INTERNET_RADIO, PLAY_STATE and the station name).
+  return slotFromOrionStation(loc);
+}
+
+// slotFromOrionStation digs the slot out of an ORION station descriptor, or
+// returns null when the location is not one. Failure is silent on purpose: this
+// runs on every status poll and a malformed payload must cost a highlight, not
+// throw inside the render.
+export function slotFromOrionStation(loc) {
+  const d = loc.match(/[?&]data=([A-Za-z0-9\-_=+/]+)/);
+  if (!d) return null;
+  try {
+    // The agent writes unpadded base64url; older builds wrote the standard
+    // alphabet. Accept both, like the agent's own decoder does.
+    let b64 = d[1].replace(/-/g, '+').replace(/_/g, '/');
+    while (b64.length % 4) b64 += '=';
+    const payload = JSON.parse(atob(b64));
+    const url = payload && payload.streamUrl;
+    if (!url) return null;
+    const m = String(url).match(/\/stream\/(\d+)(?:[/?#]|$)/);
+    return m ? parseInt(m[1], 10) : null;
+  } catch {
+    return null;
+  }
+}

--- a/desktop-app/reachability_hint_test.go
+++ b/desktop-app/reachability_hint_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// The hint is what a stuck user reads, so blaming the wrong thing costs them an
+// afternoon. A speaker that ANSWERED is not behind a firewall, and saying so
+// sent a reporter hunting through antivirus settings for two days while his
+// speaker replied to every request (field 2026-08-06).
+func TestReachabilityHintDoesNotBlameTheFirewallWhenTheSpeakerAnswered(t *testing.T) {
+	answered := []string{
+		`HTTP preflight rejected the listener at :8888 and SSH fallback also failed: ssh handshake failed: exit status 255 (ssh: connect to host 192.168.1.14 port 22: Connection timed out) (preflight: status 400 on 192.168.1.14 — body="")`,
+		"version read failed: status 400",
+		"unexpected status 503 from the speaker",
+		"status 500 on 192.0.2.7",
+	}
+	for _, msg := range answered {
+		got := reachabilityHint(errors.New(msg)).Error()
+		// The word may appear in the negation ("this is not your firewall").
+		// What must be gone is the ADVICE that sends the user into their
+		// antivirus settings for a speaker that was answering all along.
+		if strings.Contains(got, "Allow ST Reborn through your firewall") {
+			t.Errorf("still sends the user into antivirus settings although the speaker answered:\n%s", got)
+		}
+		if strings.Contains(got, "different Wi-Fi networks") {
+			t.Errorf("still blames the network although the speaker answered:\n%s", got)
+		}
+		if !strings.Contains(got, "answered") {
+			t.Errorf("does not say the speaker answered:\n%s", got)
+		}
+		if !strings.Contains(strings.ToLower(got), "unplug") {
+			t.Errorf("gives no usable next step:\n%s", got)
+		}
+	}
+}
+
+// A connection that never completed really can be a firewall, and that advice
+// has to survive: it was added for a user whose security suite filtered the app
+// while their browser worked fine.
+func TestReachabilityHintStillBlamesTheFirewallWhenNothingAnswered(t *testing.T) {
+	silent := []string{
+		"dial tcp 192.0.2.7:8888: connect: connection refused",
+		"context deadline exceeded (Client.Timeout exceeded while awaiting headers)",
+		"dial tcp 192.0.2.7:8888: connect: no route to host",
+	}
+	for _, msg := range silent {
+		got := reachabilityHint(errors.New(msg)).Error()
+		if !strings.Contains(got, "Allow ST Reborn through your firewall") {
+			t.Errorf("lost the firewall advice for a silent speaker:\n%s", got)
+		}
+	}
+}
+
+// A cancelled context is the app shutting down, never a diagnosis for the user.
+func TestReachabilityHintLeavesCancellationAlone(t *testing.T) {
+	if got := reachabilityHint(context.Canceled); got != context.Canceled {
+		t.Errorf("cancellation was decorated: %v", got)
+	}
+	if got := reachabilityHint(nil); got != nil {
+		t.Errorf("nil became %v", got)
+	}
+}
+
+func TestAnsweredNotSTR(t *testing.T) {
+	cases := []struct {
+		msg  string
+		want bool
+	}{
+		{"status 400 on 192.0.2.1", true},
+		{"unexpected status", true},
+		{"status 503", true},
+		{"connection refused", false},
+		{"i/o timeout", false},
+		{"no route to host", false},
+		// Both in one chain: the preflight answered, SSH then timed out. The
+		// answer wins, because it proves the speaker was reachable.
+		{`ssh handshake failed: Connection timed out (preflight: status 400 body="")`, true},
+	}
+	for _, tc := range cases {
+		if got := answeredNotSTR(errors.New(tc.msg)); got != tc.want {
+			t.Errorf("answeredNotSTR(%q) = %v, want %v", tc.msg, got, tc.want)
+		}
+	}
+}

--- a/internal/boxapi/boxapi.go
+++ b/internal/boxapi/boxapi.go
@@ -564,6 +564,23 @@ func (c *Client) LeaveSetup(ctx context.Context) error {
 	return c.postXML(ctx, "/setup", `<setupState state="SETUP_LEAVE" />`)
 }
 
+// Key sends one Bose remote key to the speaker: a press followed by a release,
+// which is what the firmware expects and what the physical remote does.
+//
+// This is the only way to control playback the speaker runs ITSELF. STR's
+// transport controls drive the UPnP renderer, which is correct while STR pushes
+// the audio and does nothing at all once the box plays a native radio station
+// on its own: that is the box's own player, not the UPnP one.
+func (c *Client) Key(ctx context.Context, key string) error {
+	for _, state := range []string{"press", "release"} {
+		body := fmt.Sprintf(`<key state="%s" sender="Gabbo">%s</key>`, state, xmlEscape(key))
+		if err := c.postXML(ctx, "/key", body); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Standby puts the speaker into Bose standby, the real power-off rather than a
 // transport stop.
 //

--- a/internal/boxws/dispatch.go
+++ b/internal/boxws/dispatch.go
@@ -23,11 +23,18 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 	// they short-circuit before the typed parse.
 	switch {
 	case strings.Contains(s, "QPLAY_SKIP_NEXT_FAILED"):
+		// A skip key is a CONCRETE event, so the userActivityUpdate the firmware
+		// sends alongside it is explained and must not also be read as a thumb
+		// press. Without this the remote's skip keys fired the thumb webhook as
+		// well: reported on 2026-08-06, "my ST20s do skip through songs using
+		// the remote, but doing so also triggers the webhook" (#536).
+		c.noteExplainedActivity()
 		if c.handler != nil {
 			c.handler.OnRemoteSkip(ctx, true)
 		}
 		return
 	case strings.Contains(s, "QPLAY_SKIP_PREV_FAILED"):
+		c.noteExplainedActivity()
 		if c.handler != nil {
 			c.handler.OnRemoteSkip(ctx, false)
 		}

--- a/internal/boxws/thumb_skip_test.go
+++ b/internal/boxws/thumb_skip_test.go
@@ -1,0 +1,54 @@
+package boxws
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// A remote skip key is a concrete event. The firmware sends a generic
+// userActivityUpdate alongside it, and reading THAT as a thumb press fired the
+// webhook on every skip: "my ST20s do skip through songs using the remote, but
+// doing so also triggers the webhook" (#536, 2026-08-06).
+func TestRemoteSkipDoesNotAlsoFireTheThumbWebhook(t *testing.T) {
+	for _, frame := range []string{
+		`<updates deviceID="AA"><errorUpdate><error name="QPLAY_SKIP_NEXT_FAILED"/></errorUpdate></updates>`,
+		`<updates deviceID="AA"><errorUpdate><error name="QPLAY_SKIP_PREV_FAILED"/></errorUpdate></updates>`,
+	} {
+		h := &recHandler{}
+		c := &Client{logger: slog.New(slog.NewTextHandler(io.Discard, nil)), handler: h}
+		ctx := context.Background()
+
+		c.handleMessage(ctx, []byte(frame))
+		// The activity ping the firmware sends with the key press.
+		c.handleMessage(ctx, []byte(`<userActivityUpdate deviceID="AA" />`))
+		// Long enough for the thumb settle timer to have fired if it was armed.
+		time.Sleep(thumbSettle + 250*time.Millisecond)
+
+		h.mu.Lock()
+		thumbs, skips := h.thumbs, len(h.skips)
+		h.mu.Unlock()
+		if thumbs != 0 {
+			t.Errorf("%s: thumb webhook fired %d time(s) for a skip key", frame[:60], thumbs)
+		}
+		if skips == 0 {
+			t.Errorf("%s: the skip itself was lost", frame[:60])
+		}
+	}
+}
+
+// A lone activity frame is still a thumb press: the fix must not silence the
+// feature it protects.
+func TestALoneActivityFrameStillFiresTheThumbWebhook(t *testing.T) {
+	h := &recHandler{}
+	c := &Client{logger: slog.New(slog.NewTextHandler(io.Discard, nil)), handler: h}
+	c.handleMessage(context.Background(), []byte(`<userActivityUpdate deviceID="AA" />`))
+	time.Sleep(thumbSettle + 250*time.Millisecond)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.thumbs != 1 {
+		t.Errorf("thumb webhook fired %d times for a lone activity frame, want 1", h.thumbs)
+	}
+}

--- a/internal/webui/transport.go
+++ b/internal/webui/transport.go
@@ -20,6 +20,13 @@ func (s *Server) handlePause(w http.ResponseWriter, r *http.Request) {
 	// A pause is also a deliberate "stop pulling" intent: the box stops reading
 	// from the proxy, which fires the same disconnect path. Suppress the resume.
 	s.NoteUserStop()
+	// A source the speaker plays ITSELF (a native radio station) does not run on
+	// the UPnP transport, so a UPnP Pause would succeed against an idle
+	// transport and the music would carry on. See transportsource.go.
+	if s.transportKeyFallback(r.Context(), "PAUSE") {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "paused"})
+		return
+	}
 	if err := s.renderer.Pause(r.Context()); err != nil {
 		// Pausing while the speaker is idle makes the box answer with a
 		// UPnP "Action request came in wrong state" fault. Pause is an
@@ -58,6 +65,13 @@ func (s *Server) handleResume(w http.ResponseWriter, r *http.Request) {
 	// auto-re-push is allowed again for the rest of the session; it also anchors
 	// the standby-flip discriminator like any other explicit play (#419).
 	s.NoteUserPlay()
+	// A native station paused by a remote key resumes with one too: the UPnP
+	// Play would start STR's own idle transport instead, which on some chassis
+	// yanks the box off the station it was paused on.
+	if s.transportKeyFallback(r.Context(), "PLAY") {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "playing"})
+		return
+	}
 	if err := s.renderer.Play(r.Context()); err != nil {
 		if isWrongTransportState(err) {
 			// The box is no longer in PAUSED. Re-push the last stream so the user
@@ -108,6 +122,12 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 	s.NoteUserStop()
 	// A stop ends any active library queue (no auto-advance after the user stops).
 	s.stopQueue()
+	// Same as Pause: a station the speaker fetches itself is not on the UPnP
+	// transport, so the stop has to go to the box's own player.
+	if s.transportKeyFallback(r.Context(), "STOP") {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "stopped"})
+		return
+	}
 	if err := s.renderer.Stop(r.Context()); err != nil {
 		// Same idempotent treatment as Pause: stopping an already-idle
 		// box yields a "wrong state" UPnP fault that the user need not

--- a/internal/webui/transportsource.go
+++ b/internal/webui/transportsource.go
@@ -1,0 +1,69 @@
+package webui
+
+// Pause and Stop have to reach whatever is actually playing.
+//
+// STR's transport controls drive the UPnP renderer, and for most of this
+// project's life that was right: STR pushed the audio, so the UPnP transport
+// WAS the playback. Native radio presets changed that. A native station is
+// fetched by the speaker itself and runs on the box's own player, with the
+// active source reading LOCAL_INTERNET_RADIO. A UPnP Pause then acts on an idle
+// transport: it succeeds, reports success, and the music keeps playing.
+//
+// That is what a reporter described on 2026-08-06 without knowing the cause:
+// "starting stations works, volume works, AUX and Bluetooth work, but Pause and
+// Stop have no effect." His bundle shows source=LOCAL_INTERNET_RADIO,
+// playStatus=PLAY_STATE and every port reachable, which rules out the speaker
+// being unwell and leaves only the wrong addressee.
+//
+// So the control follows the source: UPNP keeps the renderer path exactly as it
+// was, and anything the box plays itself gets a remote key instead, which is
+// what the physical remote sends.
+
+import (
+	"context"
+	"time"
+
+	"github.com/JRpersonal/streborn/internal/boxapi"
+)
+
+// boxOwnedSource reports whether the speaker is playing this source ITSELF, so
+// the UPnP renderer is not the thing to talk to.
+//
+// An allowlist of STR's own sources rather than a list of everything else: the
+// source names differ per model and a name we forgot must fall on the safe
+// side. Getting it wrong in this direction sends a harmless extra remote key;
+// getting it wrong the other way is the dead Pause button this fixes.
+func boxOwnedSource(src string) bool {
+	switch src {
+	case "", "UPNP", "STANDBY", "INVALID_SOURCE":
+		return false
+	default:
+		return true
+	}
+}
+
+// transportKeyFallback sends the Bose remote key for a transport action when
+// the speaker owns the playback. Returns true when it handled the request.
+//
+// Deliberately best-effort and quiet: the UPnP attempt already ran (or was
+// skipped), the user pressed a button, and the worst outcome of an extra key on
+// a box that was not playing anything is nothing at all.
+func (s *Server) transportKeyFallback(ctx context.Context, key string) bool {
+	if s.boxHost == "" {
+		return false
+	}
+	src := fetchNowPlaying(ctx, s.boxHost).Source
+	if !boxOwnedSource(src) {
+		return false
+	}
+	kctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 6*time.Second)
+	defer cancel()
+	if err := boxapi.New(s.boxHost).Key(kctx, key); err != nil {
+		s.logger.Warn("transport: the speaker plays this source itself and did not take the remote key",
+			"source", src, "key", key, "err", err)
+		return false
+	}
+	s.logger.Info("transport: the speaker plays this source itself, sent the remote key instead of a UPnP action",
+		"source", src, "key", key)
+	return true
+}

--- a/internal/webui/transportsource_test.go
+++ b/internal/webui/transportsource_test.go
@@ -1,0 +1,44 @@
+package webui
+
+import (
+	"testing"
+)
+
+// The allowlist decides who receives a Pause. Getting it wrong towards "the box
+// owns it" costs one harmless remote key; getting it wrong the other way is the
+// dead Pause button this whole file exists to fix, so the defaults matter.
+func TestBoxOwnedSource(t *testing.T) {
+	cases := []struct {
+		src  string
+		want bool
+	}{
+		// STR pushes the audio on these, so the UPnP renderer is the right
+		// addressee and must keep the proven path.
+		{"UPNP", false},
+		{"", false},
+		{"STANDBY", false},
+		{"INVALID_SOURCE", false},
+		// The speaker runs these itself.
+		{"LOCAL_INTERNET_RADIO", true},
+		{"SPOTIFY", true},
+		{"BLUETOOTH", true},
+		{"AUX", true},
+		{"TUNEIN", true},
+		// A source name no one has seen yet falls on the safe side.
+		{"SOME_FUTURE_SOURCE", true},
+	}
+	for _, tc := range cases {
+		if got := boxOwnedSource(tc.src); got != tc.want {
+			t.Errorf("boxOwnedSource(%q) = %v, want %v", tc.src, got, tc.want)
+		}
+	}
+}
+
+// Without a box host there is nothing to send a key to, and the caller must
+// fall through to its existing path rather than reporting success.
+func TestTransportKeyFallbackWithoutABox(t *testing.T) {
+	s := &Server{}
+	if s.transportKeyFallback(t.Context(), "PAUSE") {
+		t.Error("claimed to have handled the key with no box configured")
+	}
+}


### PR DESCRIPTION
Reported by mail today: *"starting stations works, volume works, AUX and Bluetooth work, but Pause and Stop have no effect."* The reporter suspected a dead web server on port 17008 — that was a red herring (his ST 10 is a rhino chassis and never had a :17008 listener at all).

His bundle rules out an unwell speaker:

```
reachable: 8090=true  8888=true  8091=true    health=ok
now:       source=LOCAL_INTERNET_RADIO  playStatus=PLAY_STATE
log:       "preset slot recall (app): started natively, the speaker fetches the stream itself"
           "box ws: source changed from=UPNP to=LOCAL_INTERNET_RADIO"
```

## The commands were going to the wrong place

STR's transport controls drive the UPnP renderer, and for most of this project's life that was correct: STR pushed the audio, so the UPnP transport **was** the playback. Native radio presets changed that. The speaker fetches the station itself and runs it on its own player, with the active source reading `LOCAL_INTERNET_RADIO`. A UPnP Pause then acts on an idle transport: it succeeds, reports success, and the music keeps playing.

**Every user whose presets migrated to the native form has had dead Pause and Stop buttons since**, in the desktop app and on the phone page alike. Volume and input switching kept working because those go to the Bose API, which is why the symptom looks so confusing from outside.

## The control follows the source

- `UPNP` (and empty / `STANDBY` / `INVALID_SOURCE`) keep the renderer path exactly as it was, untouched.
- Anything the speaker owns gets the Bose remote key (`PAUSE` / `STOP` / `PLAY`), press plus release, which is what the physical remote sends.

Resume is included deliberately: a station paused by a key has to be resumed by one. A UPnP Play would start STR's own idle transport and, on some chassis, pull the box off the station it was paused on.

The source test is an **allowlist of STR's own sources** rather than a list of everything else, because source names differ per model (a CineMate reports its TV input as LOCAL where an ST10 says AUX). An unknown name is treated as box-owned, so the cost of being wrong is one harmless extra remote key rather than another dead button.

Refs #390