### PR TITLE
fix(presets): a speaker that drops native stations falls back instead of going silent

### DIFF
--- a/internal/boxws/client.go
+++ b/internal/boxws/client.go
@@ -102,6 +102,13 @@ type Client struct {
 	// Guarded by mu.
 	lastNativeActiveAt time.Time
 
+	// nativeStartedAt is when the box last ENTERED the native radio source.
+	// lastNativeActiveAt records when it left, which cannot tell how long the
+	// station actually lasted; this can. A speaker that drops the station it
+	// started a second ago has abandoned it, whoever it hands over to.
+	// Guarded by mu.
+	nativeStartedAt time.Time
+
 	// upnpEpisode is true while the box sits in the INVALID_SOURCE (or
 	// subsequent STANDBY) state it entered FROM STR's UPNP source. The
 	// rolling upnpFlapWindow only covers the fast give-up flap; a struggling

--- a/internal/boxws/dispatch.go
+++ b/internal/boxws/dispatch.go
@@ -127,6 +127,11 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 				// the ST20 was LOCAL_INTERNET_RADIO -> UPNP -> INVALID_SOURCE a
 				// few seconds after the station started, so the stamp below
 				// covers the direct and the indirect route alike.
+				if src == "LOCAL_INTERNET_RADIO" {
+					c.mu.Lock()
+					c.nativeStartedAt = time.Now()
+					c.mu.Unlock()
+				}
 				if prev == "LOCAL_INTERNET_RADIO" {
 					c.mu.Lock()
 					c.lastNativeActiveAt = time.Now()
@@ -138,6 +143,30 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 						time.Since(c.lastNativeActiveAt) < nativeDropWindow
 					c.mu.Unlock()
 					if recent {
+						c.fireNativeDropped()
+					}
+				}
+				// The other way a speaker abandons a native station: straight to
+				// STANDBY, never touching INVALID_SOURCE. The guard above missed
+				// that route entirely, so a speaker that cannot keep native
+				// stations never learned it and went silent on every single press
+				// (field 2026-08-06, a newly added ST10: "normal playback does not
+				// work either, the device switches to standby immediately").
+				//
+				// STANDBY is ambiguous where INVALID_SOURCE is not, because a user
+				// switching the speaker off looks the same. The discriminator is
+				// TIME, not the activity frame: that frame is known to fire from
+				// STR's own writes and to appear with nobody near the box. Nobody
+				// powers a speaker off within a breath of starting a station, so a
+				// station that lasted less than nativeStandbyDropWindow was
+				// dropped by the firmware. The reported case lasted 862 ms.
+				if src == "STANDBY" && prev == "LOCAL_INTERNET_RADIO" {
+					c.mu.Lock()
+					started := c.nativeStartedAt
+					c.mu.Unlock()
+					if !started.IsZero() && time.Since(started) < nativeStandbyDropWindow {
+						c.logger.Warn("box ws: the speaker dropped a native station to standby right after starting it, counting it as a native failure",
+							"lastedMs", time.Since(started).Milliseconds())
 						c.fireNativeDropped()
 					}
 				}

--- a/internal/boxws/nativestandbydrop_test.go
+++ b/internal/boxws/nativestandbydrop_test.go
@@ -1,0 +1,85 @@
+package boxws
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// dropCounter wires the native-dropped callback, which runs in its own
+// goroutine, and waits for it rather than sleeping a fixed amount.
+func dropCounter(c *Client) func() int64 {
+	var n atomic.Int64
+	c.SetOnNativeDropped(func() { n.Add(1) })
+	return func() int64 {
+		for i := 0; i < 100; i++ {
+			if n.Load() > 0 {
+				return n.Load()
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		return n.Load()
+	}
+}
+
+func srcFrame(src string) []byte {
+	return []byte(`<updates deviceID="AA"><nowSelectionUpdated><ContentItem source="` + src + `" /></nowSelectionUpdated></updates>`)
+}
+
+// A speaker that cannot keep native stations drops them straight to STANDBY on
+// some chassis, never touching INVALID_SOURCE. That route was not counted, so
+// the speaker never learned it and went silent on every press: reported for a
+// newly added ST10 on 2026-08-06, "normal playback does not work either, the
+// device switches to standby immediately". Its station lasted 862 ms.
+func TestNativeStationDroppedStraightToStandbyCounts(t *testing.T) {
+	c := &Client{logger: slog.New(slog.NewTextHandler(io.Discard, nil)), handler: &recHandler{}}
+	drops := dropCounter(c)
+	ctx := context.Background()
+
+	c.handleMessage(ctx, srcFrame("LOCAL_INTERNET_RADIO"))
+	time.Sleep(60 * time.Millisecond) // the station lasted a moment, like the report
+	c.handleMessage(ctx, srcFrame("STANDBY"))
+
+	if got := drops(); got == 0 {
+		t.Error("a station abandoned to standby was not counted as a native failure")
+	}
+}
+
+// The same transition is what a user switching the speaker off produces, so a
+// station that actually played must NOT be counted. Time is the discriminator:
+// the activity frame cannot be trusted for this (it fires from STR's own writes
+// and appears with nobody near the box).
+func TestAUserPoweringOffALongPlayingStationIsNotAFailure(t *testing.T) {
+	c := &Client{logger: slog.New(slog.NewTextHandler(io.Discard, nil)), handler: &recHandler{}}
+	drops := dropCounter(c)
+	ctx := context.Background()
+
+	c.handleMessage(ctx, srcFrame("LOCAL_INTERNET_RADIO"))
+	// Pretend the station ran well past the window before the user switched off.
+	c.mu.Lock()
+	c.nativeStartedAt = time.Now().Add(-2 * nativeStandbyDropWindow)
+	c.mu.Unlock()
+	c.handleMessage(ctx, srcFrame("STANDBY"))
+
+	if got := drops(); got != 0 {
+		t.Errorf("a user power-off after %v of playback counted as a native failure (%d)", 2*nativeStandbyDropWindow, got)
+	}
+}
+
+// A standby that did not come from the native source is none of this rule's
+// business.
+func TestStandbyFromAnotherSourceIsIgnored(t *testing.T) {
+	c := &Client{logger: slog.New(slog.NewTextHandler(io.Discard, nil)), handler: &recHandler{}}
+	drops := dropCounter(c)
+	ctx := context.Background()
+
+	c.handleMessage(ctx, srcFrame("BLUETOOTH"))
+	c.handleMessage(ctx, srcFrame("STANDBY"))
+
+	if got := drops(); got != 0 {
+		t.Errorf("a bluetooth power-off counted as a native failure (%d)", got)
+	}
+}

--- a/internal/boxws/teardown.go
+++ b/internal/boxws/teardown.go
@@ -33,6 +33,16 @@ const (
 	// generous because the alternative, missing the evidence, leaves a speaker
 	// stuck on a form it cannot keep.
 	nativeDropWindow = 10 * time.Second
+	// nativeStandbyDropWindow bounds the OTHER way a speaker abandons a native
+	// station: straight to STANDBY without ever touching INVALID_SOURCE.
+	//
+	// Deliberately much shorter than the window above, because STANDBY is
+	// ambiguous and INVALID_SOURCE is not: a user switching the speaker off
+	// produces the identical transition. Only the time tells them apart, and
+	// nobody powers a speaker off within a breath of starting a station. The
+	// reported failure lasted 862 ms; four seconds leaves room for a slow box
+	// while staying far below any human reaction to music starting.
+	nativeStandbyDropWindow = 4 * time.Second
 	// ownCmdKeyVeto: a physical key press this close to the STOP_STATE means
 	// the stop came from the user (remote/box stop key), NOT from STR's own
 	// command, even inside ownCmdTeardownWindow. The firmware sends a


### PR DESCRIPTION
STR already notices when a speaker accepts a native radio station and then abandons it, and moves that speaker back to the UPnP form it can keep. It only counted **one** of the two ways a speaker does this.

```
observed and handled:   LOCAL_INTERNET_RADIO -> (UPNP) -> INVALID_SOURCE
observed and IGNORED:   LOCAL_INTERNET_RADIO -> STANDBY
```

The second route was invisible, so the speaker never learned anything and went quiet on every single press.

Reported by mail today for a newly added SoundTouch 10 — *"normal playback does not work either, the device switches to standby immediately"*. Its log, from the bundle:

```
17:01:52.126  native presets: the box has LOCAL_INTERNET_RADIO registered, storing hardware presets natively
17:01:52.988  box ws: source changed from=LOCAL_INTERNET_RADIO to=STANDBY
```

862 milliseconds, repeatedly.

## Telling it apart from a user switching off

A drop to STANDBY is ambiguous where INVALID_SOURCE is not: a user powering the speaker off produces the identical transition, and counting that would disable native presets on a perfectly healthy speaker — the exact failure the existing guard's comment warns about.

The discriminator is **time**, deliberately not the box's activity frame. That frame was proven this week to fire as a consequence of STR's own writes, and phantom frames with nobody near the speaker were already on file, so it cannot carry a decision like this one. Nobody powers a speaker off within a breath of starting a station: under four seconds is the firmware dropping it, past that is the user.

A new `nativeStartedAt` stamp is needed because the existing one records when the box LEFT the native source, which cannot say how long the station actually lasted.

Tests: the reported case counts, a power-off after the window does not, and a standby from another source is ignored.

Refs #390