### PR TITLE
fix(multiroom): dissolving a group no longer leaves one speaker playing on its own

### DIFF
--- a/internal/webui/dissolvestragglers.go
+++ b/internal/webui/dissolvestragglers.go
@@ -1,0 +1,97 @@
+package webui
+
+// Dissolving a group has to reach every speaker that is playing because of it.
+//
+// The teardown drives the MASTER's firmware: RemoveZoneSlave, repeated until the
+// master reports an empty zone. That covers every member the master actually
+// registered, and misses the ones it never did.
+//
+// Those exist. A field bundle from 2026-08-06 shows a group formed with
+//
+//	requested:2  verified:1  missing:[DEV#...]  ok:true
+//
+// The speaker in `missing` got audio all the same, because the mirror path
+// pushes the stream to it directly. When the group was dissolved it was not in
+// the master's member list, nothing told it to stop, and it kept playing in an
+// empty room. The owner reported exactly that: "when the group was dissolved the
+// Wave carried on playing."
+//
+// The rule here is deliberately narrow. Silencing a speaker that is meanwhile
+// playing something ELSE would be a worse bug than the one being fixed, so a
+// straggler is only stopped when it is demonstrably still carrying the group's
+// content: same now-playing location as the master had at the moment the
+// dissolve started. Anything else is left alone.
+
+import (
+	"context"
+	"time"
+
+	"github.com/JRpersonal/streborn/internal/boxapi"
+)
+
+// stragglerStopBudget bounds the whole sweep. It runs after the user pressed
+// "dissolve" and is best-effort: a speaker that cannot be reached in time keeps
+// playing, which is exactly the state we started from, so a long wait buys
+// nothing.
+const stragglerStopBudget = 8 * time.Second
+
+// playingLocation returns a speaker's now-playing location if it is actually
+// producing sound, and "" otherwise. A speaker that is idle, in standby or
+// unreadable is not a straggler and must not be touched.
+func playingLocation(ctx context.Context, host string) string {
+	return playingLocationFn(ctx, host)
+}
+
+// Seams for the tests. Both calls below reach the firmware on a fixed port, so
+// a test server on a random port can never be reached through them: without
+// these, every case would silently take the "unreadable, leave it alone" path
+// and assert nothing at all. Production always uses the real implementations.
+var (
+	playingLocationFn = func(ctx context.Context, host string) string {
+		np := fetchNowPlaying(ctx, host)
+		switch np.PlayStatus {
+		case "PLAY_STATE", "BUFFERING_STATE":
+			return np.Location
+		}
+		return ""
+	}
+	stopKeyFn = func(ctx context.Context, host string) error {
+		return boxapi.New(host).Key(ctx, "STOP")
+	}
+)
+
+// stopStragglers silences group members that are still carrying the master's
+// content after the firmware teardown. masterLocation is what the master was
+// playing when the dissolve began; an empty value disables the sweep entirely,
+// because without it there is nothing to compare against and stopping speakers
+// on a guess is not worth the risk.
+func (s *Server) stopStragglers(ctx context.Context, masterLocation string, members []boxapi.ZoneMember) {
+	if masterLocation == "" || len(members) == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), stragglerStopBudget)
+	defer cancel()
+	for _, m := range members {
+		if m.IP == "" || m.IP == s.boxHost {
+			continue // no address, or ourselves: the master keeps playing
+		}
+		loc := playingLocation(ctx, m.IP)
+		if loc == "" {
+			continue // idle or unreadable: nothing to stop
+		}
+		if loc != masterLocation {
+			// It moved on to something of its own while the group ran. Leaving
+			// it alone is the whole point of comparing at all.
+			s.logger.Info("dissolve: a former member plays something else now, leaving it alone",
+				"member", m.IP)
+			continue
+		}
+		if err := stopKeyFn(ctx, m.IP); err != nil {
+			s.logger.Warn("dissolve: a member kept playing and did not take the stop key",
+				"member", m.IP, "err", err)
+			continue
+		}
+		s.logger.Info("dissolve: stopped a member the master never registered, which was still playing the group's stream",
+			"member", m.IP)
+	}
+}

--- a/internal/webui/dissolvestragglers_test.go
+++ b/internal/webui/dissolvestragglers_test.go
@@ -1,0 +1,169 @@
+package webui
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/JRpersonal/streborn/internal/boxapi"
+)
+
+// fakeSpeaker answers /now_playing with a chosen state and records stop keys.
+type fakeSpeaker struct {
+	mu       sync.Mutex
+	source   string
+	status   string
+	location string
+	keys     []string
+	srv      *httptest.Server
+}
+
+func newFakeSpeaker(source, status, location string) *fakeSpeaker {
+	f := &fakeSpeaker{source: source, status: status, location: location}
+	f.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/key") {
+			b, _ := io.ReadAll(r.Body)
+			f.mu.Lock()
+			f.keys = append(f.keys, string(b))
+			f.mu.Unlock()
+			return
+		}
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		_, _ = w.Write([]byte(`<nowPlaying source="` + f.source + `">` +
+			`<ContentItem location="` + f.location + `"/>` +
+			`<playStatus>` + f.status + `</playStatus></nowPlaying>`))
+	}))
+	return f
+}
+
+func (f *fakeSpeaker) stops() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for _, k := range f.keys {
+		if strings.Contains(k, "STOP") && strings.Contains(k, "press") {
+			n++
+		}
+	}
+	return n
+}
+
+// The box calls in this file reach the firmware on a fixed port, so the tests
+// swap the two helpers the sweep uses. Without that every case would fall
+// through the "unreadable, leave it alone" branch and assert nothing.
+func withFakeFleet(t *testing.T, byHost map[string]*fakeSpeaker) {
+	t.Helper()
+	prevLoc := playingLocationFn
+	prevStop := stopKeyFn
+	playingLocationFn = func(_ context.Context, host string) string {
+		f := byHost[host]
+		if f == nil {
+			return ""
+		}
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		if f.status != "PLAY_STATE" && f.status != "BUFFERING_STATE" {
+			return ""
+		}
+		return f.location
+	}
+	stopKeyFn = func(_ context.Context, host string) error {
+		f := byHost[host]
+		if f == nil {
+			return http.ErrServerClosed
+		}
+		f.mu.Lock()
+		f.keys = append(f.keys, `<key state="press" sender="Gabbo">STOP</key>`)
+		f.mu.Unlock()
+		return nil
+	}
+	t.Cleanup(func() { playingLocationFn, stopKeyFn = prevLoc, prevStop })
+}
+
+func newDissolveServer() *Server {
+	return &Server{logger: slog.New(slog.NewTextHandler(io.Discard, nil)), boxHost: "192.0.2.10"}
+}
+
+// The reported case: a member the master never registered is still carrying the
+// group's stream and must be stopped.
+func TestStragglerOnTheGroupStreamIsStopped(t *testing.T) {
+	const groupURL = "http://192.0.2.10:8888/stream/2"
+	straggler := newFakeSpeaker("UPNP", "PLAY_STATE", groupURL)
+	defer straggler.srv.Close()
+	withFakeFleet(t, map[string]*fakeSpeaker{"192.0.2.54": straggler})
+
+	s := newDissolveServer()
+	s.stopStragglers(context.Background(), groupURL,
+		[]boxapi.ZoneMember{{DeviceID: "DEV-A", IP: "192.0.2.54"}})
+
+	if got := straggler.stops(); got != 1 {
+		t.Errorf("stop keys sent = %d, want 1", got)
+	}
+}
+
+// A speaker that moved on to something of its own must be left alone. Silencing
+// it would be worse than the bug being fixed.
+func TestAMemberPlayingSomethingElseIsLeftAlone(t *testing.T) {
+	other := newFakeSpeaker("BLUETOOTH", "PLAY_STATE", "bt://phone")
+	defer other.srv.Close()
+	withFakeFleet(t, map[string]*fakeSpeaker{"192.0.2.54": other})
+
+	s := newDissolveServer()
+	s.stopStragglers(context.Background(), "http://192.0.2.10:8888/stream/2",
+		[]boxapi.ZoneMember{{DeviceID: "DEV-A", IP: "192.0.2.54"}})
+
+	if got := other.stops(); got != 0 {
+		t.Errorf("a speaker playing its own source was stopped %d time(s)", got)
+	}
+}
+
+// A member the firmware already tore down is silent and needs nothing.
+func TestAnAlreadySilentMemberIsNotTouched(t *testing.T) {
+	quiet := newFakeSpeaker("STANDBY", "STOP_STATE", "")
+	defer quiet.srv.Close()
+	withFakeFleet(t, map[string]*fakeSpeaker{"192.0.2.54": quiet})
+
+	s := newDissolveServer()
+	s.stopStragglers(context.Background(), "http://192.0.2.10:8888/stream/2",
+		[]boxapi.ZoneMember{{DeviceID: "DEV-A", IP: "192.0.2.54"}})
+
+	if got := quiet.stops(); got != 0 {
+		t.Errorf("a silent member was sent %d stop key(s)", got)
+	}
+}
+
+// Without knowing what the master was playing there is nothing to compare
+// against, and stopping speakers on a guess is not worth the risk.
+func TestNoMasterLocationDisablesTheSweep(t *testing.T) {
+	playing := newFakeSpeaker("UPNP", "PLAY_STATE", "http://192.0.2.10:8888/stream/2")
+	defer playing.srv.Close()
+	withFakeFleet(t, map[string]*fakeSpeaker{"192.0.2.54": playing})
+
+	s := newDissolveServer()
+	s.stopStragglers(context.Background(), "", []boxapi.ZoneMember{{DeviceID: "DEV-A", IP: "192.0.2.54"}})
+
+	if got := playing.stops(); got != 0 {
+		t.Errorf("the sweep ran without a master location and stopped %d speaker(s)", got)
+	}
+}
+
+// The speaker running the dissolve is the master. It keeps playing.
+func TestTheMasterItselfIsNeverStopped(t *testing.T) {
+	self := newFakeSpeaker("UPNP", "PLAY_STATE", "http://192.0.2.10:8888/stream/2")
+	defer self.srv.Close()
+	withFakeFleet(t, map[string]*fakeSpeaker{"192.0.2.10": self})
+
+	s := newDissolveServer()
+	s.stopStragglers(context.Background(), "http://192.0.2.10:8888/stream/2",
+		[]boxapi.ZoneMember{{DeviceID: "SELF", IP: "192.0.2.10"}})
+
+	if got := self.stops(); got != 0 {
+		t.Errorf("the master was stopped %d time(s)", got)
+	}
+}

--- a/internal/webui/zones_stereo.go
+++ b/internal/webui/zones_stereo.go
@@ -1185,6 +1185,11 @@ func (s *Server) handleZoneDissolve(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.logger.Info("zone: dissolving (beta)", "master", master.DeviceID, "slaves", len(slaves))
+	// What the master is playing RIGHT NOW, before anything is torn down. It is
+	// the only way to tell, afterwards, whether a member that is still making
+	// noise is carrying the group's content or something of its own. See
+	// dissolvestragglers.go.
+	masterLocation := playingLocation(ctx, s.boxHost)
 	if master.DeviceID != "" && len(slaves) > 0 {
 		// Loop until the firmware reports an empty zone (or the ctx deadline): a
 		// single RemoveZoneSlave can leave a straggler, which forced a SECOND
@@ -1205,6 +1210,10 @@ func (s *Server) handleZoneDissolve(w http.ResponseWriter, r *http.Request) {
 			s.logger.Info("zone: members still present after removeZoneSlave, retrying", "remaining", len(cur), "attempt", attempt)
 		}
 	}
+	// The teardown above only reaches members the MASTER registered. One it
+	// never registered still got audio and would play on in an empty room, so
+	// silence any that are demonstrably still on the group's stream.
+	s.stopStragglers(ctx, masterLocation, slaves)
 	if s.zones != nil {
 		if err := s.zones.Clear(); err != nil {
 			s.logger.Warn("zone: clear store failed", "err", err)


### PR DESCRIPTION
A field bundle from 2026-08-06 shows a group formed with `requested:2 verified:1 missing:[...]` and `ok:true`. The speaker in `missing` got audio anyway, because the mirror path pushes the stream to it directly. Dissolving drives the master's firmware, which only knows the members it registered, so nothing ever told that speaker to stop and it carried on playing in an empty room. The owner reported exactly that.

The teardown now sweeps the members afterwards and stops the ones still carrying the group's content. The rule is deliberately narrow: a speaker is only stopped when its now-playing location still matches what the master was playing when the dissolve began. A speaker that moved on to something of its own is left alone, because silencing that would be a worse bug than the one being fixed.

Refs #442