### PR TITLE
fix(agent): quiet the speaker before an update instead of letting the transfer fight the audio

### DIFF
--- a/internal/webui/agent_admin.go
+++ b/internal/webui/agent_admin.go
@@ -348,7 +348,7 @@ func ensureSSHDRunning(logger *slog.Logger) bool {
 // On success the stick still returns 200 OK and then exits. The
 // rc.local bootstrap starts the new agent.
 func (s *Server) handleAgentUpdate(w http.ResponseWriter, r *http.Request) {
-	body, ok := readUploadedELF(w, r, s.logger, "agent-update")
+	body, ok := s.readUploadedELF(w, r, s.logger, "agent-update")
 	if !ok {
 		return
 	}
@@ -508,7 +508,7 @@ func uploadMemKB() (avail, total int64) {
 	return
 }
 
-func readUploadedELF(w http.ResponseWriter, r *http.Request, logger *slog.Logger, what string) ([]byte, bool) {
+func (s *Server) readUploadedELF(w http.ResponseWriter, r *http.Request, logger *slog.Logger, what string) ([]byte, bool) {
 	if !requireMethod(w, r, http.MethodPost) {
 		return nil, false
 	}
@@ -516,6 +516,12 @@ func readUploadedELF(w http.ResponseWriter, r *http.Request, logger *slog.Logger
 		http.Error(w, "update only allowed from LAN", http.StatusForbidden)
 		return nil, false
 	}
+	// Quieten the speaker before the transfer starts, not after: the audio and
+	// the upload otherwise compete for the same radio and the same CPU, and the
+	// audio is what loses. Deliberately after the method and LAN checks, so a
+	// stray request cannot silence a speaker without even being a real upload.
+	// See hushforupload.go.
+	s.hushForUpload(what)
 	const maxSize = 30 * 1024 * 1024
 	// Log the whole upload lifecycle. The #466 bundles showed the app-side
 	// view of a dying post-OTA push (RST after ~107 s) while the box-side log
@@ -1312,7 +1318,7 @@ var nandHasRoom = func(dir string, need int64) bool {
 // running process until it exits, so killing+relaunching it on the write releases
 // that ~10 MB immediately instead of holding it until the next reboot.
 func (s *Server) handleAgentSidecar(w http.ResponseWriter, r *http.Request) {
-	body, ok := readUploadedELF(w, r, s.logger, "sidecar")
+	body, ok := s.readUploadedELF(w, r, s.logger, "sidecar")
 	if !ok {
 		return
 	}

--- a/internal/webui/hushforupload.go
+++ b/internal/webui/hushforupload.go
@@ -1,0 +1,95 @@
+// Silencing the speaker before a large OTA transfer.
+//
+// An update pushes two ARM binaries over the speaker's Wi-Fi: the agent (~12 MB)
+// and the Spotify engine (~16 MB). On a SoundTouch that transfer runs at roughly
+// 150 KB/s and occupies the box for a minute or two, and the speaker has to
+// serve the audio stream through the same radio and the same modest CPU at the
+// same time.
+//
+// It loses. A field bundle from 2026-08-06 catches it exactly: the engine upload
+// starts, and 44 seconds in the box gives up on the stream it was playing with
+// AUDIO_ERROR_BAD_URL, flaps UPNP -> INVALID_SOURCE, gets resumed by the re-push
+// machinery two seconds later, and drops again. The owner described it as the
+// stream "stopping/starting when playing after update", and noted it was gone
+// after a cold reboot, which is simply the state where no transfer is running.
+//
+// Fighting for the bandwidth is the wrong answer, because the update needs it
+// and the listener cannot have both. So the speaker is quietened first: the
+// transfer gets the box to itself, and instead of a minute of broken audio and
+// firmware errors the speaker simply goes quiet for the update, which is what a
+// speaker doing an update is expected to do.
+//
+// Scope is deliberately narrow. Only what STR itself is driving gets stopped.
+// A speaker playing Bluetooth, AUX or its own native Spotify is left alone: the
+// transfer will disturb that too, but reaching in and silencing a source STR
+// does not own is a bigger intrusion than the stutter it prevents.
+
+package webui
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// hushBudget bounds the whole thing. It runs in front of an upload the user is
+// waiting on, so a speaker that will not answer must not delay the update: the
+// worst case of giving up is the stuttering playback we had before.
+const hushBudget = 6 * time.Second
+
+// Seams for the tests. Both reach the firmware on a fixed port, so a test server
+// on a random port cannot be reached through them; without these every case
+// would take the "cannot read the source, leave it alone" path and assert
+// nothing. Production always uses the real implementations.
+var (
+	hushReadNowPlaying = func(ctx context.Context, host string) nowPlayingSnapshot {
+		return fetchNowPlaying(ctx, host)
+	}
+	hushStop = func(ctx context.Context, s *Server) error {
+		if s.renderer == nil {
+			return errNoRenderer
+		}
+		return s.renderer.Stop(ctx)
+	}
+)
+
+// errNoRenderer: nothing of STR's is driving this speaker, so there is nothing
+// of ours to stop.
+var errNoRenderer = errors.New("no renderer")
+
+// hushForUpload stops STR's own playback so a large OTA transfer does not have
+// to compete with it. Best-effort and never fatal: an update must go ahead
+// whatever the speaker says about what it is playing.
+func (s *Server) hushForUpload(what string) {
+	ctx, cancel := context.WithTimeout(context.Background(), hushBudget)
+	defer cancel()
+
+	np := hushReadNowPlaying(ctx, s.boxHost)
+	switch {
+	case np.Source == "":
+		// Unreadable. Stopping blind could silence a source STR does not own,
+		// which is the one outcome worse than the stutter.
+		s.logger.Debug("upload: could not read what the speaker is playing, leaving it alone", "endpoint", what)
+		return
+	case np.Source == "STANDBY" || np.Source == "INVALID_SOURCE":
+		return // nothing playing, nothing to quieten
+	case np.PlayStatus != "PLAY_STATE" && np.PlayStatus != "BUFFERING_STATE":
+		return // a source is selected but silent; stopping it would change nothing
+	case boxOwnedSource(np.Source):
+		s.logger.Info("upload: the speaker is playing its own source, leaving it alone for the transfer",
+			"endpoint", what, "source", np.Source)
+		return
+	}
+
+	// Latch the stop as deliberate BEFORE it happens. Without this the
+	// UPNP -> STANDBY flip it causes reads as a spontaneous firmware drop and
+	// the re-push machinery puts the stream straight back on, which is the
+	// exact fight this is meant to end.
+	s.NoteUserStop()
+	if err := hushStop(ctx, s); err != nil {
+		s.logger.Warn("upload: could not stop playback before the transfer", "endpoint", what, "err", err)
+		return
+	}
+	s.logger.Info("upload: stopped playback so the transfer has the speaker to itself",
+		"endpoint", what, "source", np.Source)
+}

--- a/internal/webui/hushforupload_test.go
+++ b/internal/webui/hushforupload_test.go
@@ -1,0 +1,167 @@
+package webui
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+)
+
+// stopCounter records stop calls so a test can tell "we silenced the speaker"
+// from "we left it alone". Installed over the hushStop seam, because the
+// renderer field is a concrete type with no interface to fake.
+type stopCounter struct {
+	mu    sync.Mutex
+	stops int
+	err   error
+}
+
+func (r *stopCounter) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.stops
+}
+
+func withStopSeam(t *testing.T, r *stopCounter) {
+	t.Helper()
+	prev := hushStop
+	hushStop = func(context.Context, *Server) error {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		r.stops++
+		return r.err
+	}
+	t.Cleanup(func() { hushStop = prev })
+}
+
+// withNowPlaying installs the read seam. The real one reaches :8090 on a fixed
+// port, so without this every case would take the "unreadable, leave it alone"
+// branch and prove nothing.
+func withNowPlaying(t *testing.T, np nowPlayingSnapshot) {
+	t.Helper()
+	prev := hushReadNowPlaying
+	hushReadNowPlaying = func(context.Context, string) nowPlayingSnapshot { return np }
+	t.Cleanup(func() { hushReadNowPlaying = prev })
+}
+
+func newHushServer() *Server {
+	return &Server{
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		boxHost: "192.0.2.10",
+	}
+}
+
+// The reported case: the speaker is playing STR's own stream and a 16 MB engine
+// upload is about to start. It must go quiet first.
+func TestPlaybackIsStoppedBeforeAnUpload(t *testing.T) {
+	withNowPlaying(t, nowPlayingSnapshot{Source: "UPNP", PlayStatus: "PLAY_STATE"})
+	r := &stopCounter{}
+	withStopSeam(t, r)
+	s := newHushServer()
+
+	s.hushForUpload("sidecar")
+
+	if got := r.count(); got != 1 {
+		t.Errorf("Stop calls = %d, want 1", got)
+	}
+	// Without the latch the re-push machinery reads the stop as a firmware drop
+	// and puts the stream straight back on, which is the fight being ended here.
+	if !s.userStoppedRecently() {
+		t.Error("the stop was not latched as deliberate, so the re-push will undo it")
+	}
+}
+
+// A speaker playing Bluetooth is not ours to silence. The transfer disturbs it
+// too, but reaching in is the bigger intrusion.
+func TestASourceTheSpeakerOwnsIsLeftAlone(t *testing.T) {
+	for _, src := range []string{"BLUETOOTH", "AUX", "SPOTIFY"} {
+		t.Run(src, func(t *testing.T) {
+			withNowPlaying(t, nowPlayingSnapshot{Source: src, PlayStatus: "PLAY_STATE"})
+			r := &stopCounter{}
+			withStopSeam(t, r)
+			s := newHushServer()
+
+			s.hushForUpload("agent-update")
+
+			if got := r.count(); got != 0 {
+				t.Errorf("a %s source was stopped %d time(s)", src, got)
+			}
+			if s.userStoppedRecently() {
+				t.Errorf("a %s source was latched as a user stop", src)
+			}
+		})
+	}
+}
+
+// Nothing playing, nothing to do. Sending a stop anyway would be a needless
+// write to a speaker that may be counting down to deep standby.
+func TestASilentSpeakerIsNotTouched(t *testing.T) {
+	cases := []nowPlayingSnapshot{
+		{Source: "STANDBY", PlayStatus: "STOP_STATE"},
+		{Source: "INVALID_SOURCE"},
+		{Source: "UPNP", PlayStatus: "STOP_STATE"},
+		{Source: "UPNP", PlayStatus: "PAUSE_STATE"},
+	}
+	for _, np := range cases {
+		withNowPlaying(t, np)
+		r := &stopCounter{}
+		withStopSeam(t, r)
+		s := newHushServer()
+
+		s.hushForUpload("sidecar")
+
+		if got := r.count(); got != 0 {
+			t.Errorf("source=%q status=%q was stopped %d time(s)", np.Source, np.PlayStatus, got)
+		}
+	}
+}
+
+// A speaker that will not say what it is playing gets left alone: stopping
+// blind could silence a source STR does not own.
+func TestAnUnreadableSpeakerIsLeftAlone(t *testing.T) {
+	withNowPlaying(t, nowPlayingSnapshot{})
+	r := &stopCounter{}
+	withStopSeam(t, r)
+	s := newHushServer()
+
+	s.hushForUpload("sidecar")
+
+	if got := r.count(); got != 0 {
+		t.Errorf("an unreadable speaker was stopped %d time(s)", got)
+	}
+}
+
+// The update is what the user is waiting for. A speaker that refuses the stop
+// must not hold it up, and must not leave the code path in a broken state.
+func TestAFailedStopDoesNotBlockTheUpload(t *testing.T) {
+	withNowPlaying(t, nowPlayingSnapshot{Source: "UPNP", PlayStatus: "BUFFERING_STATE"})
+	r := &stopCounter{err: errors.New("box refused")}
+	withStopSeam(t, r)
+	s := newHushServer()
+
+	s.hushForUpload("agent-update") // must simply return
+
+	if got := r.count(); got != 1 {
+		t.Errorf("Stop attempts = %d, want 1", got)
+	}
+}
+
+// The seam must not be the only thing being tested. Without it installed the
+// real read runs, cannot reach a firmware port from a unit test, and the
+// function must fall through to "leave it alone" rather than stopping blind.
+func TestWithoutTheSeamsNothingIsStopped(t *testing.T) {
+	r := &stopCounter{}
+	withStopSeam(t, r) // installed on purpose: it is the WITNESS, not the subject
+	s := newHushServer()
+
+	// hushReadNowPlaying is deliberately NOT installed, so the real read runs.
+	// It cannot reach a firmware port from a unit test, and the function must
+	// then fall through to "leave it alone" rather than stopping blind.
+	s.hushForUpload("sidecar")
+
+	if got := r.count(); got != 0 {
+		t.Errorf("with no reachable speaker the code stopped playback %d time(s)", got)
+	}
+}


### PR DESCRIPTION
Diagnosed from the bundle in #510.

An update pushes ~12 MB of agent and ~16 MB of Spotify engine over the speaker's Wi-Fi, at roughly 150 KB/s, while the same radio and the same CPU are serving the audio stream. The log shows what happens:

```
10:22:56  upload starts
10:23:37  upload progress bytes=4194672 elapsedMs=41050
10:23:40  stream proxy end: bose disconnected  slot=5 elapsed=1m21s
10:23:41  box reported error 3101 AUDIO_ERROR_BAD_URL
10:23:41  source changed UPNP -> INVALID_SOURCE
10:23:42  re-push: box dropped the stream while idle, resuming
```

The reporter called it the stream "stopping/starting when playing after update", gone after a cold reboot, which is just the state where no transfer is running.

The speaker is now quietened before the transfer starts, so it gets the box to itself. The stop is latched as deliberate first, or the re-push machinery puts the stream straight back on. Only what STR itself drives is stopped: Bluetooth, AUX and native Spotify are left alone, and so is a speaker that is silent or unreadable.

7 tests, including one that deliberately does NOT install the read seam, so the "cannot reach the speaker" path is proven to leave playback alone rather than stopping blind.

Refs #510