### PR TITLE
fix(multiroom): a stereo partner address must be a speaker on the local network

### DIFF
--- a/internal/webui/lanpeer.go
+++ b/internal/webui/lanpeer.go
@@ -1,0 +1,37 @@
+// Deciding whether an address the caller handed us is a speaker on this LAN.
+
+package webui
+
+import "net"
+
+// isLANPeer reports whether host is a plain IP address on the local network,
+// i.e. something that can legitimately be another SoundTouch speaker.
+//
+// It exists because several agent endpoints take a peer address from the
+// request body and then dial it. That is a caller-controlled destination, and
+// without a check the speaker can be aimed at any host reachable from where it
+// sits, which on a home network is everything. The endpoints in question all
+// have the same true answer: a peer is another speaker, and another speaker is
+// on the LAN.
+//
+// Deliberately strict about what it accepts:
+//
+//   - A hostname is refused. Names resolve, and what they resolve to can change
+//     between this check and the dial, so allowing them would make the check
+//     decorative rather than real.
+//   - Loopback is refused. The agent's own services live there, and a peer that
+//     is "us" is never a stereo partner; allowing it would turn a peer field
+//     into a way to reach services bound to localhost.
+//   - Link-local and unique-local addresses are accepted alongside RFC1918:
+//     IPv6-only home networks are ordinary, and a speaker there is still a
+//     speaker.
+func isLANPeer(host string) bool {
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false // not a bare IP: a name, an empty string, or junk
+	}
+	if ip.IsLoopback() || ip.IsUnspecified() || ip.IsMulticast() {
+		return false
+	}
+	return ip.IsPrivate() || ip.IsLinkLocalUnicast()
+}

--- a/internal/webui/lanpeer_test.go
+++ b/internal/webui/lanpeer_test.go
@@ -1,0 +1,43 @@
+package webui
+
+import "testing"
+
+func TestIsLANPeer(t *testing.T) {
+	cases := []struct {
+		host string
+		want bool
+		why  string
+	}{
+		// The real thing: another speaker on a home network.
+		{"192.168.1.44", true, "RFC1918 /16"},
+		{"10.0.0.5", true, "RFC1918 /8"},
+		{"172.16.9.9", true, "RFC1918 /12"},
+		{"169.254.4.4", true, "link-local, a speaker before DHCP"},
+		{"fe80::1", true, "IPv6 link-local"},
+		{"fd00::1", true, "IPv6 unique-local"},
+
+		// Off the LAN entirely: the case the check exists for.
+		{"93.184.216.34", false, "public IPv4"},
+		{"2606:4700::1111", false, "public IPv6"},
+		{"8.8.8.8", false, "public resolver"},
+
+		// Our own services are not a peer, and a peer field must not become a
+		// way to reach things bound to localhost.
+		{"127.0.0.1", false, "loopback"},
+		{"::1", false, "IPv6 loopback"},
+		{"0.0.0.0", false, "unspecified"},
+
+		// A name would resolve after the check and could resolve elsewhere at
+		// dial time, which would make the check decorative.
+		{"speaker.local", false, "hostname"},
+		{"localhost", false, "hostname that looks harmless"},
+		{"", false, "empty"},
+		{"192.168.1.44:8888", false, "host:port, not a bare IP"},
+		{"not an ip", false, "junk"},
+	}
+	for _, c := range cases {
+		if got := isLANPeer(c.host); got != c.want {
+			t.Errorf("isLANPeer(%q) = %v, want %v (%s)", c.host, got, c.want, c.why)
+		}
+	}
+}

--- a/internal/webui/zones_stereo.go
+++ b/internal/webui/zones_stereo.go
@@ -535,6 +535,17 @@ func (s *Server) formStereoPair(w http.ResponseWriter, ctx context.Context, c *b
 	master.Role = "LEFT"
 	partner := slaves[0]
 	partner.Role = "RIGHT"
+	// The partner's address arrives in the request body and is then dialled
+	// several times over: its /info is read, the pair document is pushed to it,
+	// and a stale pair is removed from it. A stereo partner is by definition
+	// another speaker on this LAN, so anything else is either a mistake or an
+	// attempt to aim the speaker at a host it has no business reaching. Rejecting
+	// it here covers every one of those dials with a single check.
+	if partner.IP != "" && !isLANPeer(partner.IP) {
+		s.logger.Warn("stereo: refusing a partner address that is not on the local network", "partnerIP", partner.IP)
+		http.Error(w, "the partner speaker must be on the local network", http.StatusBadRequest)
+		return
+	}
 	if name == "" {
 		name = "Stereo pair"
 	}


### PR DESCRIPTION
Closes the `go/request-forgery` CodeQL alert on `zones_stereo.go` (critical, open since 2026-08-02).

The partner's address arrives in the request body and is then dialled several times over: its `/info` is read, the canonical pair document is pushed to it, and a stale pair is removed from it. Nothing checked what that address was.

A stereo partner is by definition another speaker on the same LAN, so the check is exactly that: a bare private or link-local IP. Hostnames are refused because what a name resolves to can change between the check and the dial, which would make the check decorative; loopback is refused because the agent's own services live there and a peer that is "us" is never a stereo partner. One check at the entry point covers every downstream dial.

The other two open `go/request-forgery` alerts are **not** the same thing and are left alone:

- `artproxy.go:77` dials through `publicOnlyControl`, and redirects go through the same dialer, so it is already guarded at dial time. CodeQL cannot see a dial-time `Control` hook. False positive.
- `debug.go:345` is deliberately unguarded, because the diagnostic exists to probe the box's own loopback services. It is LAN-gated and scheme-gated via `netutil.SafeHTTPURL`. That tradeoff is a judgement call rather than a bug, so I have not touched it.

18 table cases covering RFC1918, link-local, IPv6 ULA, public v4/v6, loopback, unspecified, hostnames and host:port.