### PR TITLE
fix(app): an update no longer fails forever against a speaker that is answering

### DIFF
--- a/desktop-app/app_transport.go
+++ b/desktop-app/app_transport.go
@@ -4,6 +4,7 @@ package main
 // agent HTTP transport: base URLs, the per-host port cache, and boxDo with port fallback.
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -58,6 +59,66 @@ func altAgentPort(p int) int {
 	return 8888
 }
 
+// altAgentPortFor is a seam. The two agent ports are fixed numbers, so a test
+// that wants to exercise the fallback across two servers cannot use httptest,
+// which hands out a random loopback port. Tests replace this to name a port
+// they control; nothing in the app ever assigns to it.
+var altAgentPortFor = altAgentPort
+
+// notTheAgent reports whether a response plainly did not come from the STR
+// agent, so the port that produced it must not be cached or trusted.
+//
+// This only ever fires on /api/ paths, which are ours alone: any other path may
+// legitimately be served by whatever else is on the box.
+//
+// Two shapes are recognised, both observed in the field:
+//
+//   - 404. The Bose firmware on :8090 answers unknown /api/ paths with it, and
+//     caching that port made a post-OTA name/Wi-Fi write silently fail.
+//   - A 4xx with no body at all. Every refusal the agent itself produces goes
+//     through http.Error and therefore carries a reason; a bare status line
+//     with an empty body is a minimal firmware listener, not us. Field report
+//     2026-08-07: a speaker answered `status 400 ... body=""` to every request
+//     for two days across three app versions, because the first such 400 was
+//     cached as the agent's port and boxDo then returned it immediately
+//     without ever trying the other candidate. The agent was on the other one.
+//
+// A 5xx is deliberately NOT included: the agent does return bodiless 5xx in
+// places, and a struggling agent is still the agent. Treating it as a stranger
+// would send the app to the wrong port at exactly the wrong moment.
+func notTheAgent(resp *http.Response, path string) bool {
+	if resp == nil || !strings.HasPrefix(path, "/api/") {
+		return false
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return true
+	}
+	return resp.StatusCode >= 400 && resp.StatusCode < 500 && bodyIsEmpty(resp)
+}
+
+// bodyIsEmpty reports whether resp has no body, without consuming it: the
+// response may still be handed back to the caller as the best answer we got.
+// A body of unknown length is peeked one byte deep and the byte is put back.
+func bodyIsEmpty(resp *http.Response) bool {
+	if resp.ContentLength == 0 {
+		return true
+	}
+	if resp.ContentLength > 0 || resp.Body == nil {
+		return false
+	}
+	br := bufio.NewReader(resp.Body)
+	_, err := br.Peek(1)
+	resp.Body = readCloser{Reader: br, Closer: resp.Body}
+	return err == io.EOF
+}
+
+// readCloser rejoins a buffered reader to the original body's Closer, so the
+// peeked byte is still delivered and the connection is still released.
+type readCloser struct {
+	io.Reader
+	io.Closer
+}
+
 // candidatePorts is the ordered, deduped list of agent ports to try for a
 // host: the cached working port first (if any), then the caller's port,
 // then the alternate. So the common case is one direct hit; a wrong/stale
@@ -70,7 +131,7 @@ func (a *App) candidatePorts(host string, port int) []int {
 	if cp, ok := a.cachedPort(host); ok {
 		order = append(order, cp)
 	}
-	order = append(order, port, altAgentPort(port))
+	order = append(order, port, altAgentPortFor(port))
 	seen := map[int]bool{}
 	out := order[:0]
 	for _, p := range order {
@@ -122,13 +183,13 @@ func (a *App) boxDoTimeout(host string, port int, method, path, contentType, bod
 		client = &c
 	}
 	var lastErr error
-	// stale404 holds a 404 that came from a port which is NOT the STR agent (the
-	// Bose stock firmware answers unknown /api/ paths on :8090 with 404). It is
-	// kept only as a fallback so a genuine agent 404 (a real missing resource) is
-	// still surfaced when no better port answers.
-	var stale404 *http.Response
+	// stranger holds the best answer from a port that is NOT the STR agent (see
+	// notTheAgent). It is kept only as a fallback, so a genuine agent 404 or 400
+	// is still surfaced when no other port answers at all, and it is never
+	// cached: caching it is what let one bare 400 capture a host for two days.
+	var stranger *http.Response
 	cands := a.candidatePorts(host, port)
-	for i, p := range cands {
+	for _, p := range cands {
 		url := fmt.Sprintf("http://%s:%d%s", host, p, path)
 		var rdr io.Reader
 		if body != "" {
@@ -136,8 +197,8 @@ func (a *App) boxDoTimeout(host string, port int, method, path, contentType, bod
 		}
 		req, err := http.NewRequestWithContext(a.appCtx(), method, url, rdr)
 		if err != nil {
-			if stale404 != nil {
-				stale404.Body.Close()
+			if stranger != nil {
+				stranger.Body.Close()
 			}
 			return nil, err
 		}
@@ -146,37 +207,35 @@ func (a *App) boxDoTimeout(host string, port int, method, path, contentType, bod
 		}
 		resp, err := client.Do(req)
 		if err == nil {
-			// A 404 on an /api/ path means this port is not the STR agent: the
-			// Bose firmware on :8090 answers unknown /api/ paths with 404, and
-			// caching :8090 here made a post-OTA name/Wi-Fi write silently fail
-			// (the box still carried its pre-install stock port). Skip the port
-			// and try the next candidate; only fall back to the 404 if nothing
-			// better answers, so a real agent 404 is not masked.
-			if resp.StatusCode == http.StatusNotFound && strings.HasPrefix(path, "/api/") && i < len(cands)-1 {
-				if stale404 != nil {
-					stale404.Body.Close()
+			// Something answered, but not necessarily us. A port that is
+			// demonstrably not the agent must neither be cached nor end the
+			// search, or the real agent on the other port is never reached.
+			// Keep the reply as a fallback and carry on.
+			if notTheAgent(resp, path) {
+				if stranger != nil {
+					stranger.Body.Close()
 				}
-				stale404 = resp
+				stranger = resp
 				a.forgetPort(host)
 				continue
 			}
 			a.rememberPort(host, p)
-			if stale404 != nil {
-				stale404.Body.Close()
+			if stranger != nil {
+				stranger.Body.Close()
 			}
 			return resp, nil
 		}
 		lastErr = err
 		if !isTransportNotReady(err) {
-			if stale404 != nil {
-				return stale404, nil
+			if stranger != nil {
+				return stranger, nil
 			}
 			return nil, err
 		}
 		a.forgetPort(host)
 	}
-	if stale404 != nil {
-		return stale404, nil
+	if stranger != nil {
+		return stranger, nil
 	}
 	return nil, reachabilityHint(lastErr)
 }
@@ -206,10 +265,20 @@ func reachabilityHint(err error) error {
 	// answered was not STR: on a speaker whose agent is not up, the firmware's
 	// own listener replies with a bare status. So say that instead.
 	if answeredNotSTR(err) {
-		return fmt.Errorf("%w\n\nThe speaker answered, so this is not your firewall and not a Wi-Fi problem: something on the speaker replied to every request. What answered was not ST Reborn, which is what a speaker looks like while it is still starting up, or when its ST Reborn software did not come up at all. Unplug the speaker for ten seconds, plug it back in, wait about three minutes until it is fully up, and try the update again", err)
+		return fmt.Errorf("%w\n\n%s", err, answeredNotSTRAdvice)
 	}
-	return fmt.Errorf("%w\n\nThe app could not reach the speaker. This is usually a firewall or antivirus blocking ST Reborn, or this PC and the speaker being on different Wi-Fi networks. Allow ST Reborn through your firewall/antivirus (or turn it off briefly to test), and make sure both are on the same Wi-Fi network", err)
+	return fmt.Errorf("%w\n\n%s", err, firewallAdvice)
 }
+
+// The two closing paragraphs a user reads under a failed update. They are
+// constants because the update report has to be able to recognise the wrong one
+// and swap it for the right one (see stripWrongBlame): a copy of the text in
+// two places would drift and the swap would quietly stop working.
+const (
+	firewallAdvice = "The app could not reach the speaker. This is usually a firewall or antivirus blocking ST Reborn, or this PC and the speaker being on different Wi-Fi networks. Allow ST Reborn through your firewall/antivirus (or turn it off briefly to test), and make sure both are on the same Wi-Fi network"
+
+	answeredNotSTRAdvice = "The speaker answered, so this is not your firewall and not a Wi-Fi problem: something on the speaker replied to every request. What answered was not ST Reborn, which is what a speaker looks like while it is still starting up, or when its ST Reborn software did not come up at all. Unplug the speaker for ten seconds, plug it back in, wait about three minutes until it is fully up, and try the update again"
+)
 
 // answeredNotSTR reports whether the failure carries evidence that the speaker
 // replied: an HTTP status line rather than a connection that never completed.

--- a/desktop-app/app_transport_test.go
+++ b/desktop-app/app_transport_test.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// listenPort is the port half of an httptest server's address.
+func listenPort(t *testing.T, srv *httptest.Server) int {
+	t.Helper()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse %q: %v", srv.URL, err)
+	}
+	p, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("port of %q: %v", srv.URL, err)
+	}
+	return p
+}
+
+// newTestApp is an App with just enough wired up to make an agent HTTP call.
+func newTestApp() *App {
+	return &App{httpClient: &http.Client{}}
+}
+
+// deadPort returns a port nothing is listening on: a server is started and
+// immediately closed, so the number is real and certainly refused.
+func deadPort(t *testing.T) int {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	p := listenPort(t, srv)
+	srv.Close()
+	return p
+}
+
+func TestNotTheAgent(t *testing.T) {
+	body := func(status int, b string) *http.Response {
+		r := &http.Response{
+			StatusCode:    status,
+			Body:          io.NopCloser(strings.NewReader(b)),
+			ContentLength: int64(len(b)),
+		}
+		if b == "" {
+			r.ContentLength = 0
+		}
+		return r
+	}
+	cases := []struct {
+		name   string
+		resp   *http.Response
+		path   string
+		want   bool
+		reason string
+	}{
+		{"bare 400", body(400, ""), "/api/agent/version", true,
+			"the field report's shape: a firmware listener answering with a status and nothing else"},
+		{"400 with a reason is ours", body(400, "not an ELF binary\n"), "/api/agent/update", false,
+			"every refusal the agent writes goes through http.Error and carries text"},
+		{"404 on /api/ is the stock firmware", body(404, ""), "/api/agent/version", true,
+			"Bose on :8090 answers unknown /api/ paths with 404"},
+		{"404 with a body on /api/ is still not ours", body(404, "404 page not found\n"), "/api/agent/version", true,
+			"404 on our own namespace means the port does not serve our routes"},
+		{"200 is the agent", body(200, `{"version":"v0.9.35"}`), "/api/agent/version", false, "a real answer"},
+		{"bare 500 is the agent struggling", body(500, ""), "/api/agent/version", false,
+			"the agent does return bodiless 5xx; sending the app elsewhere then would be wrong"},
+		{"non-api paths are not ours to judge", body(400, ""), "/index.html", false,
+			"other software on the box legitimately serves those"},
+		{"nil response", nil, "/api/agent/version", false, "no evidence"},
+	}
+	for _, c := range cases {
+		if got := notTheAgent(c.resp, c.path); got != c.want {
+			t.Errorf("%s: notTheAgent = %v, want %v (%s)", c.name, got, c.want, c.reason)
+		}
+	}
+}
+
+// TestBodyIsEmptyLeavesTheBodyReadable guards the thing that would be silently
+// destructive: the fallback response is handed to the caller, so peeking at it
+// must not eat the first byte.
+func TestBodyIsEmptyLeavesTheBodyReadable(t *testing.T) {
+	resp := &http.Response{
+		StatusCode:    400,
+		Body:          io.NopCloser(strings.NewReader("not an ELF binary")),
+		ContentLength: -1, // unknown, the case that has to peek
+	}
+	if bodyIsEmpty(resp) {
+		t.Fatal("a body with content reported as empty")
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "not an ELF binary" {
+		t.Errorf("body after peek = %q, want it intact", got)
+	}
+}
+
+// TestBareStatusDoesNotCaptureTheHost is the field report of 2026-08-07: a
+// listener that is not the agent answers a bodiless 400, and from then on the
+// app talked to nothing else for two days across three app versions. The agent
+// was on the other port the whole time.
+func TestBareStatusDoesNotCaptureTheHost(t *testing.T) {
+	var strangerHits, agentHits int
+
+	stranger := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		strangerHits++
+		w.WriteHeader(http.StatusBadRequest) // no body, exactly as reported
+	}))
+	defer stranger.Close()
+
+	agent := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		agentHits++
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"version":"v0.9.35","nandFreeBytes":"22921216"}`)
+	}))
+	defer agent.Close()
+
+	agentPort := listenPort(t, agent)
+	old := altAgentPortFor
+	altAgentPortFor = func(int) int { return agentPort }
+	defer func() { altAgentPortFor = old }()
+
+	a := newTestApp()
+	resp, err := a.boxDo("127.0.0.1", listenPort(t, stranger), http.MethodGet, "/api/agent/version", "", "")
+	if err != nil {
+		t.Fatalf("boxDo: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: the bare 400 ended the search instead of moving to the next port", resp.StatusCode)
+	}
+	if agentHits != 1 {
+		t.Errorf("agent was asked %d times, want 1", agentHits)
+	}
+	if strangerHits != 1 {
+		t.Errorf("stranger was asked %d times, want 1", strangerHits)
+	}
+	if p, ok := a.cachedPort("127.0.0.1"); !ok || p != agentPort {
+		t.Errorf("cached port = %d (present=%v), want the agent's %d: caching the stranger is what made this last two days",
+			p, ok, agentPort)
+	}
+}
+
+// TestAgentRefusalIsNotMistakenForAStranger is the other half. The agent's own
+// 400 (the OTA upload checks produce one) must reach the caller unchanged, and
+// the agent's port must stay cached.
+func TestAgentRefusalIsNotMistakenForAStranger(t *testing.T) {
+	agent := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not an ELF binary", http.StatusBadRequest)
+	}))
+	defer agent.Close()
+
+	old := altAgentPortFor
+	altAgentPortFor = func(int) int { return deadPort(t) }
+	defer func() { altAgentPortFor = old }()
+
+	a := newTestApp()
+	port := listenPort(t, agent)
+	resp, err := a.boxDo("127.0.0.1", port, http.MethodGet, "/api/agent/update", "", "")
+	if err != nil {
+		t.Fatalf("boxDo: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want the agent's own 400 passed through", resp.StatusCode)
+	}
+	b, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(b), "not an ELF binary") {
+		t.Errorf("body = %q, want the agent's reason intact", b)
+	}
+	if p, ok := a.cachedPort("127.0.0.1"); !ok || p != port {
+		t.Errorf("cached port = %d (present=%v), want %d: a real agent refusal must not lose the port", p, ok, port)
+	}
+}
+
+// TestStrangerIsStillReturnedWhenNothingElseAnswers keeps the fallback honest:
+// skipping a port must not turn "the box said 400" into "the box said nothing",
+// which would put the firewall advice back in front of the user.
+func TestStrangerIsStillReturnedWhenNothingElseAnswers(t *testing.T) {
+	stranger := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer stranger.Close()
+
+	old := altAgentPortFor
+	altAgentPortFor = func(int) int { return deadPort(t) }
+	defer func() { altAgentPortFor = old }()
+
+	a := newTestApp()
+	resp, err := a.boxDo("127.0.0.1", listenPort(t, stranger), http.MethodGet, "/api/agent/version", "", "")
+	if err != nil {
+		t.Fatalf("boxDo returned an error instead of the only answer there was: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want the 400 surfaced", resp.StatusCode)
+	}
+	if _, ok := a.cachedPort("127.0.0.1"); ok {
+		t.Error("the stranger's port was cached even as a last resort; the next call would go straight back to it")
+	}
+}
+
+// TestAltAgentPortIsTheOtherRealPort runs without the seam installed, so the
+// shipped mapping itself is checked rather than the test's stand-in.
+func TestAltAgentPortIsTheOtherRealPort(t *testing.T) {
+	if got := altAgentPort(8888); got != 17008 {
+		t.Errorf("altAgentPort(8888) = %d, want 17008", got)
+	}
+	if got := altAgentPort(17008); got != 8888 {
+		t.Errorf("altAgentPort(17008) = %d, want 8888", got)
+	}
+	if altAgentPortFor(8888) != altAgentPort(8888) {
+		t.Error("the seam does not default to the real mapping")
+	}
+}

--- a/desktop-app/updatereport.go
+++ b/desktop-app/updatereport.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"strings"
@@ -32,6 +33,8 @@ func (a *App) UpdateFailureReport(host string, port int, phase, errMsg, targetVe
 	fmt.Fprintf(&b, "failed at     : %s\n", phase)
 	fmt.Fprintf(&b, "error         : %s\n\n", strings.TrimSpace(errMsg))
 
+	hist := a.otaHistoryTail(host, 25)
+
 	if ver, err := a.BoxAgentVersion(host, port); err == nil {
 		fmt.Fprintf(&b, "speaker reports now\n-------------------\n")
 		for _, k := range []string{
@@ -48,13 +51,39 @@ func (a *App) UpdateFailureReport(host string, port int, phase, errMsg, targetVe
 		}
 		b.WriteString("\n")
 	} else {
-		fmt.Fprintf(&b, "speaker reports now: NOT REACHABLE (%v)\n\n", err)
+		fmt.Fprintf(&b, "speaker reports now: NOT REACHABLE (%v)\n\n", stripWrongBlame(err, errMsg, hist))
 	}
 
-	if hist := a.otaHistoryTail(host, 25); hist != "" {
+	if hist != "" {
 		fmt.Fprintf(&b, "what the update did\n-------------------\n%s\n", hist)
 	}
 	b.WriteString("\nPlease send this text to str@sichtbar-app.de, together with the\n")
 	b.WriteString("diagnostic file if you were able to save one.\n")
 	return b.String()
+}
+
+// stripWrongBlame rewrites the closing probe's advice when the rest of the
+// report contradicts it.
+//
+// The probe that fills the "speaker reports now" line is a single request, and
+// its advice is chosen from that request alone. When it times out, the user is
+// told to go through their firewall and antivirus settings. That is the right
+// advice for a speaker that never answers, and the wrong advice for the case
+// this report was actually written for: field report 2026-08-07, where every
+// line of the journal above it reads `status 400 ... body=""`. The speaker was
+// answering all along, on the wrong port, and the closing probe simply happened
+// to end in a timeout. The user chased a firewall for two days.
+//
+// So the whole attempt decides, not the last request: if anything in the error
+// the update reported or in the journal shows the speaker returning an HTTP
+// status, the firewall paragraph is replaced. A missing journal changes
+// nothing, and a probe that already carries the right advice is left alone.
+func stripWrongBlame(probeErr error, errMsg, history string) error {
+	if probeErr == nil || !strings.Contains(probeErr.Error(), firewallAdvice) {
+		return probeErr
+	}
+	if !answeredNotSTR(errors.New(errMsg + "\n" + history)) {
+		return probeErr
+	}
+	return errors.New(strings.Replace(probeErr.Error(), firewallAdvice, answeredNotSTRAdvice, 1))
 }

--- a/desktop-app/updatereport_blame_test.go
+++ b/desktop-app/updatereport_blame_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// The journal as it reached us on 2026-08-07: every attempt over two days ends
+// in a bare 400, so the speaker demonstrably answered every single time.
+const fieldJournal = `time=2026-08-07T10:37:17+02:00 host=192.0.2.14 start: port=8888 bytes=13238434 app=v0.9.35
+time=2026-08-07T10:37:29+02:00 host=192.0.2.14 sidecar: delivered but could not verify (version read failed): status 400
+time=2026-08-07T10:39:29+02:00 host=192.0.2.14 preflight: speaker did not settle within the window, falling back to SSH: status 400 on 192.0.2.14 - body=""
+time=2026-08-07T10:44:41+02:00 host=192.0.2.14 outcome: reported failure: HTTP preflight rejected the listener at :8888`
+
+func TestStripWrongBlame(t *testing.T) {
+	// What the closing probe produced in the field report: it timed out, so on
+	// its own evidence the firewall advice was the correct choice.
+	timedOut := errors.New(`Get "http://192.0.2.14:8888/api/agent/version": context deadline exceeded` + "\n\n" + firewallAdvice)
+
+	t.Run("the journal overrules a probe that merely timed out last", func(t *testing.T) {
+		got := stripWrongBlame(timedOut, "HTTP preflight rejected the listener at :8888", fieldJournal)
+		if strings.Contains(got.Error(), firewallAdvice) {
+			t.Error("still tells the user to hunt through firewall and antivirus settings while the journal shows the speaker answering")
+		}
+		if !strings.Contains(got.Error(), answeredNotSTRAdvice) {
+			t.Error("did not put the right advice in its place")
+		}
+		if !strings.Contains(got.Error(), "context deadline exceeded") {
+			t.Error("dropped the underlying error the maintainer needs")
+		}
+	})
+
+	t.Run("a speaker that really never answered keeps the firewall advice", func(t *testing.T) {
+		quiet := `time=2026-08-07T10:37:17+02:00 host=192.0.2.14 start: port=8888 bytes=13238434
+time=2026-08-07T10:39:29+02:00 host=192.0.2.14 outcome: reported failure: dial tcp 192.0.2.14:8888: i/o timeout`
+		got := stripWrongBlame(timedOut, "dial tcp: i/o timeout", quiet)
+		if !strings.Contains(got.Error(), firewallAdvice) {
+			t.Error("removed advice that was correct: nothing on the speaker ever replied")
+		}
+	})
+
+	t.Run("no journal changes nothing", func(t *testing.T) {
+		if got := stripWrongBlame(timedOut, "dial tcp: i/o timeout", ""); !strings.Contains(got.Error(), firewallAdvice) {
+			t.Error("rewrote the advice with no evidence to justify it")
+		}
+	})
+
+	t.Run("a probe that already carries the right advice is left alone", func(t *testing.T) {
+		already := errors.New("status 400 on 192.0.2.14\n\n" + answeredNotSTRAdvice)
+		got := stripWrongBlame(already, "status 400", fieldJournal)
+		if got.Error() != already.Error() {
+			t.Errorf("changed an error that was already right:\n%s", got)
+		}
+	})
+
+	t.Run("nil stays nil", func(t *testing.T) {
+		if got := stripWrongBlame(nil, "", fieldJournal); got != nil {
+			t.Errorf("stripWrongBlame(nil) = %v, want nil", got)
+		}
+	})
+}


### PR DESCRIPTION
A speaker answered `status 400` with an empty body to every request for two
days, across three app versions, and the app told its owner to go through
their firewall and antivirus settings. Both halves of that were wrong.

The app reaches an agent on one of two ports and caches whichever answers.
Anything that was not a 404 counted as the agent, so the first bare 400 from
a listener that is not ours was cached as the agent's port, and because a real
HTTP response ends the search, every later call went straight back to that
same port and got the same 400. The agent was on the other port the whole
time. The 404 escape hatch existed for exactly this shape, but it was written
for the Bose firmware on :8090, which answers 404, and never covered a
listener that answers 400.

A refusal the agent itself writes always carries a reason, so a 4xx with no
body at all is not ours. Those no longer end the search and are never cached,
only kept as the answer of last resort so a genuine agent refusal still
reaches the caller unchanged. A bodiless 5xx is deliberately still treated as
the agent: a struggling agent is still the agent, and sending the app to the
other port at that moment would be the wrong move.

The advice under the failure was chosen from the closing probe alone. That one
request timed out, so it got the firewall paragraph, while every line of the
journal printed directly beneath it showed the speaker replying. The whole
attempt now decides.

Release-Note: fix(app): an update no longer fails forever against a speaker that is answering on its other port
Release-Note: fix(app): a failed update stops blaming your firewall when the speaker did answer

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W4ZJXsnpmJuazCKF6ijdcZ