### PR TITLE
fix(radio): a station's own logo shows again instead of being replaced by ours

### DIFF
--- a/internal/webui/artproxy.go
+++ b/internal/webui/artproxy.go
@@ -115,11 +115,95 @@ func (s *Server) handleArt(w http.ResponseWriter, r *http.Request) {
 			"url", target, "contentType", ct, "status", resp.StatusCode)
 	}
 
-	w.Header().Set("Content-Type", ct)
-	w.Header().Set("Cache-Control", "public, max-age=86400")
 	// Bounded: a station logo is small, and an unbounded copy onto a speaker
 	// with little memory is not worth the risk.
-	_, _ = io.Copy(w, io.LimitReader(resp.Body, 2<<20))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	if err != nil || len(body) == 0 {
+		s.logger.Info("art proxy: image body could not be read", "url", target, "err", err)
+		http.Error(w, "image unreadable", http.StatusBadGateway)
+		return
+	}
+
+	out, outCT, note := drawableImage(body)
+	if note != "" && first {
+		s.logger.Info("art proxy: substituted the station logo", "url", target, "reason", note)
+	}
+	w.Header().Set("Content-Type", outCT)
+	w.Header().Set("Cache-Control", "public, max-age=86400")
+	_, _ = w.Write(out)
+}
+
+// drawableImage returns the bytes to serve for a fetched logo, their content
+// type, and a non-empty note when the original had to be replaced.
+//
+// The speaker's display draws ordinary raster formats and nothing else, so
+// something has to decide whether a logo is usable. That decision used to be
+// made from the URL's file extension, at preset-save time, because sniffing
+// each candidate would have meant a network round trip per station. It was
+// wrong often enough to matter: the icon service STR falls back to serves
+// PNG bytes under a .ico URL, so stations whose only logo came from it
+// (Sunshine Live among them) had a perfectly drawable picture thrown away and
+// replaced with STR's own logo. Reported 2026-08-07 by an owner who could
+// compare a not-yet-updated speaker side by side.
+//
+// The proxy already fetches the image, so the evidence is right here and costs
+// nothing extra. Deciding it from the bytes also holds the other way round: a
+// .png URL that actually serves an SVG no longer reaches the display as
+// something it cannot draw.
+func drawableImage(body []byte) (out []byte, contentType, note string) {
+	switch {
+	case len(body) >= 8 && string(body[:8]) == "\x89PNG\r\n\x1a\n":
+		return body, "image/png", ""
+	case len(body) >= 3 && body[0] == 0xFF && body[1] == 0xD8 && body[2] == 0xFF:
+		return body, "image/jpeg", ""
+	case len(body) >= 6 && (string(body[:6]) == "GIF87a" || string(body[:6]) == "GIF89a"):
+		return body, "image/gif", ""
+	case len(body) >= 2 && body[0] == 'B' && body[1] == 'M':
+		return body, "image/bmp", ""
+	case len(body) >= 12 && string(body[:4]) == "RIFF" && string(body[8:12]) == "WEBP":
+		return body, "image/webp", ""
+	}
+	// An .ico is a container, and since Vista its entries are very often whole
+	// PNGs. Handing the container to the display shows nothing; the PNG inside
+	// it draws fine, so unwrap it rather than give up on the station's own logo.
+	if png := pngInsideICO(body); png != nil {
+		return png, "image/png", ""
+	}
+	// SVG, an .ico holding only old-style bitmaps, or something unrecognised.
+	// STR's logo stands in, because an empty tile next to a station name reads
+	// as a fault rather than as a station having no picture.
+	return iconPNG, "image/png", "not a format the display can draw"
+}
+
+// pngInsideICO returns the largest PNG embedded in an ICO container, or nil.
+//
+// Layout: a 6-byte header (reserved, type=1, image count) followed by one
+// 16-byte directory entry per image, each ending in the entry's byte length
+// and offset. Entries are either a PNG or an old-style bitmap; only the former
+// is useful here, and there is no need to decode it, just to find it.
+func pngInsideICO(b []byte) []byte {
+	const hdr, entry = 6, 16
+	if len(b) < hdr || b[0] != 0 || b[1] != 0 || b[2] != 1 || b[3] != 0 {
+		return nil // not an ICO
+	}
+	count := int(b[4]) | int(b[5])<<8
+	if count <= 0 || len(b) < hdr+count*entry {
+		return nil
+	}
+	var best []byte
+	for i := 0; i < count; i++ {
+		e := b[hdr+i*entry:]
+		size := int(e[8]) | int(e[9])<<8 | int(e[10])<<16 | int(e[11])<<24
+		off := int(e[12]) | int(e[13])<<8 | int(e[14])<<16 | int(e[15])<<24
+		if size <= 0 || off < 0 || off > len(b) || off+size > len(b) {
+			continue
+		}
+		img := b[off : off+size]
+		if len(img) >= 8 && string(img[:8]) == "\x89PNG\r\n\x1a\n" && len(img) > len(best) {
+			best = img
+		}
+	}
+	return best
 }
 
 // The address check, and why this endpoint needs one.

--- a/internal/webui/artproxy_drawable_test.go
+++ b/internal/webui/artproxy_drawable_test.go
@@ -1,0 +1,131 @@
+package webui
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+var (
+	pngMagic  = []byte("\x89PNG\r\n\x1a\n")
+	jpegMagic = []byte{0xFF, 0xD8, 0xFF, 0xE0}
+)
+
+func pad(head []byte, n int) []byte {
+	b := make([]byte, 0, len(head)+n)
+	b = append(b, head...)
+	return append(b, bytes.Repeat([]byte{0x11}, n)...)
+}
+
+// buildICO wraps payloads in an ICO container the way a real favicon does.
+func buildICO(payloads ...[]byte) []byte {
+	const hdr, entry = 6, 16
+	out := make([]byte, hdr+entry*len(payloads))
+	out[2] = 1 // type: icon
+	binary.LittleEndian.PutUint16(out[4:], uint16(len(payloads)))
+	off := len(out)
+	for i, p := range payloads {
+		e := out[hdr+i*entry:]
+		binary.LittleEndian.PutUint32(e[8:], uint32(len(p)))
+		binary.LittleEndian.PutUint32(e[12:], uint32(off))
+		off += len(p)
+	}
+	for _, p := range payloads {
+		out = append(out, p...)
+	}
+	return out
+}
+
+// TestDrawableImagePassesRealPicturesThrough is the reported bug: the icon
+// service answers a .ico URL with PNG bytes, and those must reach the display
+// untouched instead of being swapped for STR's own logo.
+func TestDrawableImagePassesRealPicturesThrough(t *testing.T) {
+	cases := []struct {
+		name string
+		body []byte
+		ct   string
+	}{
+		{"PNG served under a .ico URL (Sunshine Live)", pad(pngMagic, 64), "image/png"},
+		{"JPEG", pad(jpegMagic, 64), "image/jpeg"},
+		{"GIF", pad([]byte("GIF89a"), 64), "image/gif"},
+		{"BMP", pad([]byte("BM"), 64), "image/bmp"},
+		{"WEBP (MANGORADIO)", append([]byte("RIFF\x00\x00\x00\x00WEBP"), bytes.Repeat([]byte{1}, 32)...), "image/webp"},
+	}
+	for _, c := range cases {
+		out, ct, note := drawableImage(c.body)
+		if note != "" {
+			t.Errorf("%s: was substituted (%s), want it served as-is", c.name, note)
+		}
+		if !bytes.Equal(out, c.body) {
+			t.Errorf("%s: body was altered", c.name)
+		}
+		if ct != c.ct {
+			t.Errorf("%s: content type = %q, want %q", c.name, ct, c.ct)
+		}
+	}
+}
+
+// TestDrawableImageUnwrapsAnICO keeps a station's own favicon.ico usable: the
+// container shows nothing on the display, the PNG inside it draws fine.
+func TestDrawableImageUnwrapsAnICO(t *testing.T) {
+	small := pad(pngMagic, 16)
+	large := pad(pngMagic, 200)
+	out, ct, note := drawableImage(buildICO(small, large))
+	if note != "" {
+		t.Fatalf("an ICO carrying PNGs was substituted (%s)", note)
+	}
+	if ct != "image/png" {
+		t.Errorf("content type = %q, want image/png", ct)
+	}
+	if !bytes.Equal(out, large) {
+		t.Error("did not pick the largest embedded PNG")
+	}
+}
+
+// TestDrawableImageSubstitutesWhatCannotBeDrawn keeps the 2026-08-05 fix alive
+// at its new home: an SVG, or an ICO holding only old-style bitmaps, would
+// leave the display blank, which reads as a fault rather than as a station
+// without a picture.
+func TestDrawableImageSubstitutesWhatCannotBeDrawn(t *testing.T) {
+	cases := []struct {
+		name string
+		body []byte
+	}{
+		{"SVG", []byte(`<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>`)},
+		{"SVG served under a .png URL", []byte("<?xml version=\"1.0\"?><svg></svg>")},
+		{"ICO with no PNG inside", buildICO(pad([]byte("BM"), 40))},
+		{"something unrecognised", []byte("not an image at all")},
+	}
+	for _, c := range cases {
+		out, ct, note := drawableImage(c.body)
+		if note == "" {
+			t.Errorf("%s: served as-is, want STR's logo in its place", c.name)
+		}
+		if !bytes.Equal(out, iconPNG) {
+			t.Errorf("%s: did not fall back to the STR logo", c.name)
+		}
+		if ct != "image/png" {
+			t.Errorf("%s: content type = %q, want image/png", c.name, ct)
+		}
+	}
+}
+
+// TestPNGInsideICORejectsRubbish guards the parser against a malformed or
+// hostile container: the offsets come straight off the wire, and a speaker must
+// not be crashed by a station logo.
+func TestPNGInsideICORejectsRubbish(t *testing.T) {
+	bad := [][]byte{
+		nil,
+		{},
+		{0, 0, 1, 0},       // header cut short
+		{0, 0, 1, 0, 5, 0}, // claims 5 entries, has none
+		{0, 0, 2, 0, 1, 0}, // type 2 is a cursor, not an icon
+		append([]byte{0, 0, 1, 0, 1, 0}, // offset past the end of the buffer
+			bytes.Repeat([]byte{0xFF}, 16)...),
+	}
+	for i, b := range bad {
+		if got := pngInsideICO(b); got != nil {
+			t.Errorf("case %d: returned %d bytes, want nil", i, len(got))
+		}
+	}
+}

--- a/internal/webui/lir.go
+++ b/internal/webui/lir.go
@@ -189,44 +189,17 @@ const strLogoPath = "/icon.png"
 // draw (.svg, .ico). A URL with no extension at all keeps its place, because
 // plenty of perfectly drawable logos are served without one and replacing those
 // would take a working picture away.
+// Which candidate to point at is still an extension question, because choosing
+// among URLs without fetching them is all that can be done cheaply. Whether the
+// chosen one is actually drawable is NOT: that is settled from the bytes, in
+// the art proxy, which is fetching the image anyway (see drawableImage). The
+// veto that used to sit here judged by extension and threw away real pictures,
+// most visibly the PNGs the fallback icon service serves under a .ico URL.
 func stationImageURL(art string) string {
-	if u := ArtProxyURL("http://"+boxurl.Authority, firstArtURL(art)); u != "" && !onlyUndrawableArt(art) {
+	if u := ArtProxyURL("http://"+boxurl.Authority, firstArtURL(art)); u != "" {
 		return u
 	}
 	return "http://" + boxurl.Authority + strLogoPath
-}
-
-// onlyUndrawableArt reports whether every entry in the fallback chain is a
-// format a speaker display cannot render. Extension-based like
-// isRasterImageURL, and for the same reason: sniffing each candidate would turn
-// saving a preset into a series of network round trips.
-func onlyUndrawableArt(art string) bool {
-	seen := false
-	for _, p := range strings.Split(art, "|") {
-		p = strings.TrimSpace(p)
-		if p == "" {
-			continue
-		}
-		seen = true
-		if isRasterImageURL(p) || !hasUndrawableExt(p) {
-			return false
-		}
-	}
-	return seen
-}
-
-func hasUndrawableExt(raw string) bool {
-	u := strings.TrimSpace(raw)
-	if i := strings.IndexAny(u, "?#"); i >= 0 {
-		u = u[:i]
-	}
-	u = strings.ToLower(u)
-	for _, ext := range []string{".svg", ".svgz", ".ico"} {
-		if strings.HasSuffix(u, ext) {
-			return true
-		}
-	}
-	return false
 }
 
 // firstArtURL picks ONE logo out of STR's pipe-separated fallback chain, the

--- a/internal/webui/lir_fallbackart_test.go
+++ b/internal/webui/lir_fallbackart_test.go
@@ -67,39 +67,26 @@ func TestStationWithARealLogoKeepsIt(t *testing.T) {
 	}
 }
 
-// A chain made only of formats a display cannot draw is the same blank screen
-// as no logo at all, so it gets the same treatment.
-func TestStationWithOnlyUndrawableLogosFallsBack(t *testing.T) {
+// A logo whose URL merely LOOKS undrawable is still handed to the proxy, which
+// is fetching it anyway and can see what it really is. Judging this by
+// extension here threw away real pictures: the icon service STR falls back to
+// answers .ico URLs with PNG bytes, so Sunshine Live lost its logo while
+// MANGORADIO, whose logo happens to end in .webp, kept one (reported
+// 2026-08-07). What a display cannot draw is now decided in drawableImage.
+func TestUndrawableLookingURLsStillReachTheProxy(t *testing.T) {
 	for _, art := range []string{
-		"https://cdn.example/logo.svg",
+		"https://icons.duckduckgo.com/ip3/www.sunshine-live.de.ico",
 		"https://cdn.example/favicon.ico",
 		"https://cdn.example/logo.svg|https://cdn.example/favicon.ico",
 		"https://cdn.example/logo.SVG?v=2",
 	} {
 		loc := OrionStationLocation("http://box/stream/1", "Test", art)
 		got, _ := decodeStation(t, loc)["imageUrl"].(string)
-		if !strings.HasSuffix(got, strLogoPath) {
-			t.Errorf("art %q gave imageUrl %q, want the STR logo", art, got)
+		if strings.HasSuffix(got, strLogoPath) {
+			t.Errorf("art %q was replaced by the STR logo before anything looked at the image", art)
 		}
-	}
-}
-
-func TestOnlyUndrawableArt(t *testing.T) {
-	cases := []struct {
-		art  string
-		want bool
-	}{
-		{"", false}, // nothing at all is handled by the empty path, not here
-		{"https://x/logo.svg", true},
-		{"https://x/logo.ico", true},
-		{"https://x/logo.png", false},
-		{"https://x/logo", false},
-		{"https://x/a.svg|https://x/b.png", false},
-		{"https://x/a.svg|https://x/b.ico", true},
-	}
-	for _, tc := range cases {
-		if got := onlyUndrawableArt(tc.art); got != tc.want {
-			t.Errorf("onlyUndrawableArt(%q) = %v, want %v", tc.art, got, tc.want)
+		if !strings.Contains(got, artProxyPath+"?u=") {
+			t.Errorf("art %q gave imageUrl %q, want it routed through the art proxy", art, got)
 		}
 	}
 }


### PR DESCRIPTION
An owner with several SoundTouch 10s could compare an updated speaker against
one still on an older STR and found that some presets had lost their station
logo. Sunshine Live came back as STR's own icon while MANGORADIO kept its
picture, and the stream itself was fine in both cases.

The difference was the file extension. Whether a display can draw a logo was
decided when the preset was saved, from the URL alone, because sniffing every
candidate would have meant a network round trip per station. Anything ending in
.svg or .ico was treated as undrawable and swapped for STR's logo. But the icon
service STR falls back to when a station has no logo of its own answers those
.ico URLs with PNG bytes: Sunshine Live's logo is a perfectly ordinary 1597-byte
PNG that was thrown away for the name it is served under. MANGORADIO's happens
to end in .webp, which is why it survived.

The proxy that hands the image to the speaker is already fetching it, so the
evidence is there and costs nothing extra. Drawability is now decided from the
bytes: a real picture is passed through whatever its URL looked like, and STR's
logo stands in only when what arrives genuinely cannot be drawn. That holds the
other way round too, where the extension check could not help at all: a .png URL
that actually serves an SVG no longer reaches the display as something it cannot
render.

An .ico that really is a container is now unwrapped rather than given up on,
since since Vista its entries are usually whole PNGs. The parser takes its
offsets straight off the wire, so it is written to reject a malformed or
hostile container rather than trust it.

Release-Note: fix(radio): a station's own logo shows again instead of being replaced by the STR logo

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W4ZJXsnpmJuazCKF6ijdcZ