### PR TITLE
fix(presets): a preset key that lost its station logo gets it back by itself

### DIFF
--- a/cmd/agent/reconcile.go
+++ b/cmd/agent/reconcile.go
@@ -418,13 +418,29 @@ func reconcileOnce(store *presets.Store, boxHost string, logger *slog.Logger, fo
 		// would point a hardware key at a source the box cannot enter, which is a
 		// DEAD key - strictly worse than the UPnP form it replaced. Put it back.
 		stale := boxHasNative && native == ""
+		// A slot the box already holds natively is otherwise left alone, and
+		// that is right: every write wakes the speaker and restarts its standby
+		// countdown. One case has to be an exception. Until v0.9.36 a station
+		// logo was judged by the file extension of its URL, so stations whose
+		// logo came from the icon fallback (it answers .ico URLs with PNG bytes)
+		// had STR's stand-in written into the slot. The judgement is fixed, but
+		// the slot keeps what it was given, and the owner sees one station with
+		// a picture and the next without and cannot tell why.
+		//
+		// So: repair a slot that carries our stand-in when the preset now
+		// resolves to a real picture. The condition stops holding as soon as the
+		// rewrite lands, so this is one write per affected slot, once, and never
+		// a recurring one.
+		relogo := boxHasNative && native != "" &&
+			webui.StationLocationCarriesStandInLogo(loc) &&
+			!webui.StationLocationCarriesStandInLogo(native)
 		switch {
 		case upgradable:
 			migrated++
 		case stale:
 			reverted++
 		}
-		if forceFull || !onBox || upgradable || stale {
+		if forceFull || !onBox || upgradable || stale || relogo {
 			missing = append(missing, boxcli.PresetSpec{
 				Slot: p.Slot, Name: p.Name, StreamURL: boxPresetURL(p),
 				NativeLocation: native,

--- a/internal/webui/lir.go
+++ b/internal/webui/lir.go
@@ -171,6 +171,43 @@ func OrionStationLocation(streamURL, name, art string) string {
 	return "/station?data=" + base64.RawURLEncoding.EncodeToString(payload)
 }
 
+// StationLocationCarriesStandInLogo reports whether an already-stored station
+// location tells the display to draw STR's own logo rather than the station's.
+//
+// It exists so a slot written by an older agent can be recognised and put
+// right. A preset the box already holds in native form is never rewritten,
+// which is correct (a write wakes the speaker and resets its standby
+// countdown, and rewriting on every boot for nothing would be a bug of its
+// own). But it means a slot that lost its logo to the old extension check
+// keeps STR's stand-in for good, and the owner has no way to tell why one
+// station has a picture and the next one does not.
+//
+// Deliberately answers only this one question. Comparing whole locations would
+// rewrite slots for any harmless difference and could ping-pong; "the stored
+// one is our stand-in" is a condition that stops being true the moment the
+// rewrite lands, so the repair happens once per slot and then never again.
+func StationLocationCarriesStandInLogo(loc string) bool {
+	const p = "/station?data="
+	i := strings.Index(loc, p)
+	if i < 0 {
+		return false
+	}
+	raw := loc[i+len(p):]
+	dec, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		if dec, err = base64.URLEncoding.DecodeString(raw); err != nil {
+			return false // unreadable: leave it alone rather than guess
+		}
+	}
+	var st struct {
+		ImageURL string `json:"imageUrl"`
+	}
+	if err := json.Unmarshal(dec, &st); err != nil {
+		return false
+	}
+	return strings.HasSuffix(st.ImageURL, strLogoPath)
+}
+
 // strLogoPath is the STR icon the agent already serves, 192x192 PNG over plain
 // http from the speaker itself: raster, right-sized, no external fetch and no
 // https the firmware cannot do.

--- a/internal/webui/lir_standinlogo_test.go
+++ b/internal/webui/lir_standinlogo_test.go
@@ -1,0 +1,84 @@
+package webui
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// locWith builds a station location carrying a given imageUrl, the way an agent
+// of any vintage would have written it.
+func locWith(imageURL string) string {
+	payload, _ := json.Marshal(map[string]any{
+		"streamUrl": "http://box/stream/1", "name": "Sunshine Live",
+		"imageUrl": imageURL, "streamType": "liveRadio", "isRealtime": true,
+	})
+	return "/station?data=" + base64.RawURLEncoding.EncodeToString(payload)
+}
+
+// The repair has to recognise exactly one thing: a slot already carrying STR's
+// stand-in logo. Anything wider would rewrite presets for harmless differences,
+// and every rewrite wakes the speaker and restarts its standby countdown.
+func TestStationLocationCarriesStandInLogo(t *testing.T) {
+	cases := []struct {
+		name string
+		loc  string
+		want bool
+	}{
+		{"our stand-in, the slot to repair", locWith("http://127.0.0.1:8888" + strLogoPath), true},
+		{"stand-in on some other authority", locWith("http://192.0.2.9:17008" + strLogoPath), true},
+		{"a real logo through the proxy", locWith("http://127.0.0.1:8888/art?u=aHR0cHM6Ly94L2xvZ28ucG5n"), false},
+		{"a plain http logo passed straight through", locWith("http://cdn.example/logo.png"), false},
+		{"no image at all", locWith(""), false},
+
+		// Anything unreadable must be left alone rather than guessed at: a
+		// false positive here is a needless write to a sleeping speaker.
+		{"not a station location", "/upnp/whatever", false},
+		{"station location with unreadable payload", "/station?data=@@@not-base64@@@", false},
+		{"station location with non-JSON payload", "/station?data=" + base64.RawURLEncoding.EncodeToString([]byte("nonsense")), false},
+		{"empty", "", false},
+	}
+	for _, c := range cases {
+		if got := StationLocationCarriesStandInLogo(c.loc); got != c.want {
+			t.Errorf("%s: got %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// The freshly built location for a station that HAS a logo must not itself look
+// like a slot needing repair, or the reconcile would rewrite the same slot on
+// every boot and hold the speaker out of deep standby.
+func TestRepairConvergesInsteadOfLooping(t *testing.T) {
+	before := locWith("http://127.0.0.1:8888" + strLogoPath)
+	after := OrionStationLocation("http://box/stream/1", "Sunshine Live",
+		"https://icons.duckduckgo.com/ip3/www.sunshine-live.de.ico")
+
+	if !StationLocationCarriesStandInLogo(before) {
+		t.Fatal("the slot written by the old agent is not recognised as needing repair")
+	}
+	if StationLocationCarriesStandInLogo(after) {
+		t.Fatal("the repaired slot still looks like it needs repair: this would rewrite on every boot")
+	}
+	if !strings.Contains(after, "data=") {
+		t.Error("the rewritten location is not a station payload")
+	}
+
+	// A station that genuinely has no logo keeps the stand-in for ever, and so
+	// keeps matching the first half of the condition. It must never be
+	// rewritten, which is why the reconcile also requires the FRESH location to
+	// have a real picture. Both halves, as the reconcile evaluates them:
+	none := OrionStationLocation("http://box/stream/2", "1LIVE", "")
+	repair := func(onBox, fresh string) bool {
+		return StationLocationCarriesStandInLogo(onBox) && !StationLocationCarriesStandInLogo(fresh)
+	}
+	if repair(none, none) {
+		t.Error("a station that simply has no logo would be rewritten on every boot")
+	}
+	if !repair(before, after) {
+		t.Error("the slot that lost its logo would not be repaired")
+	}
+	if repair(after, after) {
+		t.Error("an already-repaired slot would be rewritten again")
+	}
+}


### PR DESCRIPTION
v0.9.36 stopped throwing away station logos, but only for presets saved after
it. A slot the speaker already holds as a native radio station is deliberately
never rewritten, because every write wakes the speaker and restarts its standby
countdown. So the keys that lost their picture kept STR's stand-in, and their
owner still saw one station with a logo and the next one without, with no way
to tell why and nothing to do about it short of saving every affected preset
again.

The reconcile now repairs exactly that slot: one whose stored location carries
our stand-in logo while the preset resolves to a real picture today. Both
halves are required, which is what keeps it safe. A station that genuinely has
no logo keeps the stand-in in the freshly built location too, so it never
matches and is never rewritten. And the condition stops being true the moment
the repair lands, so this is one write per affected slot, once, not a write on
every boot. Deep standby is untouched.

Recognising the slot reads the imageUrl back out of the stored location rather
than comparing whole locations, which would rewrite for any harmless
difference and could ping-pong between two agents. Anything unreadable is left
alone instead of guessed at: a false positive here is a pointless write to a
sleeping speaker.

Release-Note: fix(presets): a preset key that lost its station logo gets it back on its own, without saving the station again

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W4ZJXsnpmJuazCKF6ijdcZ