### PR TITLE
fix(presets): copying presets to a speaker waits until it is ready to take them

### DIFF
--- a/desktop-app/app_presets.go
+++ b/desktop-app/app_presets.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // Preset Format passt zu internal/presets.Preset JSON.
@@ -121,6 +122,22 @@ func (a *App) CopyPresetsAcrossBoxes(srcHost string, srcPort int, dstHost string
 	if err != nil {
 		return 0, fmt.Errorf("read source presets: %w", err)
 	}
+	// Wait for the target before writing anything to it. The natural order of
+	// work is "update this speaker, then put my stations on it", and an update
+	// ends in a reboot: the speaker answers pings while its agent is not
+	// listening yet. Every slot then failed in turn, each one logged and
+	// skipped so the transfer could continue, and the user was left with a
+	// speaker whose store was simply empty. Seen whole in a 2026-08-08 bundle
+	// from a twelve-speaker household: a copy started 72 seconds after the
+	// target booted lost all six slots, and a second one six minutes after
+	// another box booted lost two of six.
+	//
+	// Waiting is the entire fix. Nothing here is expensive or invasive, and a
+	// speaker that never comes back is worth one clear refusal rather than six
+	// separate failures and an empty result.
+	if err := a.waitCopyTargetReady(dstHost, dstPort); err != nil {
+		return 0, err
+	}
 	copied := 0
 	var slotErrs []string
 	for _, p := range presets {
@@ -132,7 +149,17 @@ func (a *App) CopyPresetsAcrossBoxes(srcHost string, srcPort int, dstHost string
 		// their fields (type, uri, account, art, bitrate, shuffle, items)
 		// with no field mapping. A rejected slot is reported but must not
 		// abort the transfer: the remaining slots still copy.
-		if err := a.boxPut(dstHost, dstPort, fmt.Sprintf("%s/%d", presetAPIPath, p.Slot), p); err != nil {
+		err := a.boxPut(dstHost, dstPort, fmt.Sprintf("%s/%d", presetAPIPath, p.Slot), p)
+		// A speaker can also go away DURING the copy: the same bundle shows a
+		// target that took six slots and dropped two of them mid-run. One
+		// re-wait and one retry costs nothing on the happy path and turns that
+		// into a complete transfer.
+		if err != nil && isTransportNotReady(err) {
+			if werr := a.waitCopyTargetReady(dstHost, dstPort); werr == nil {
+				err = a.boxPut(dstHost, dstPort, fmt.Sprintf("%s/%d", presetAPIPath, p.Slot), p)
+			}
+		}
+		if err != nil {
 			a.logger.Warn("copy presets: slot rejected by the target",
 				"src", srcHost, "dst", dstHost, "slot", p.Slot, "type", p.Type, "err", err)
 			slotErrs = append(slotErrs, fmt.Sprintf("preset %d (%s): %v", p.Slot, p.Name, err))
@@ -232,4 +259,54 @@ func (a *App) DeletePreset(host string, port int, slot int) error {
 		return readHTTPError(resp)
 	}
 	return nil
+}
+
+// copyTargetSettleWindow / copyTargetSettleStep bound the wait for a copy
+// target's agent. Matched to the OTA preflight's window, and for the same
+// reason: a speaker that has just rebooted has its agent answering well inside
+// two minutes, and the copy is normally started right after an update.
+const (
+	copyTargetSettleWindow = 2 * time.Minute
+	copyTargetSettleStep   = 3 * time.Second
+)
+
+// copyTargetProbe is a seam. The readiness check reaches the agent on its two
+// fixed firmware ports, which httptest cannot hand out, so a test that did not
+// replace this would silently take the "never ready" path and prove nothing.
+var copyTargetProbe func(a *App, host string, port int) bool
+
+// waitCopyTargetReady blocks until the target speaker's agent answers, or the
+// settle window runs out. Returns nil as soon as it is ready.
+//
+// The error deliberately does not mention firewalls. The app has just been
+// talking to this speaker (that is how the user picked it as a copy target),
+// so the one explanation the old message pushed is the one explanation that
+// cannot be true.
+func (a *App) waitCopyTargetReady(host string, port int) error {
+	ready := func() bool {
+		if copyTargetProbe != nil {
+			return copyTargetProbe(a, host, port)
+		}
+		return a.waitAgentReady(host, port)
+	}
+	if ready() {
+		return nil
+	}
+	a.logger.Info("copy presets: target is not answering yet, waiting for it to finish starting up",
+		"dst", host, "window", copyTargetSettleWindow)
+	deadline := time.Now().Add(copyTargetSettleWindow)
+	for time.Now().Before(deadline) {
+		select {
+		case <-a.appCtx().Done():
+			return fmt.Errorf("copy cancelled while waiting for %s", host)
+		case <-time.After(copyTargetSettleStep):
+		}
+		if ready() {
+			a.logger.Info("copy presets: target settled, starting the transfer", "dst", host)
+			return nil
+		}
+	}
+	a.logger.Warn("copy presets: target never answered within the settle window; nothing was written",
+		"dst", host, "window", copyTargetSettleWindow)
+	return fmt.Errorf("the target speaker is not answering yet. It is probably still starting up after an update: wait until it plays again, then copy the presets once more")
 }

--- a/desktop-app/copypresets_settle_test.go
+++ b/desktop-app/copypresets_settle_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// installProbe points the copy's readiness check at a caller-controlled answer,
+// because the real one reaches the agent on two fixed firmware ports that
+// httptest cannot hand out.
+func installProbe(t *testing.T, ready func() bool) {
+	t.Helper()
+	copyTargetProbe = func(*App, string, int) bool { return ready() }
+	t.Cleanup(func() { copyTargetProbe = nil })
+}
+
+// fakeBox serves the preset API for both ends of a copy and records the writes
+// it accepted.
+type fakeBox struct {
+	mu      sync.Mutex
+	srv     *httptest.Server
+	host    string
+	written map[int]string
+	fail    func(slot int) bool
+}
+
+// newFakeBox binds on a caller-chosen loopback address, because a copy refuses
+// to run when source and target share a host and httptest hands out 127.0.0.1
+// for everything.
+func newFakeBox(t *testing.T, host string, source []Preset) *fakeBox {
+	t.Helper()
+	b := &fakeBox{written: map[int]string{}, host: host}
+	b.srv = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == presetAPIPath:
+			_ = json.NewEncoder(w).Encode(source)
+		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, presetAPIPath+"/"):
+			var p Preset
+			_ = json.NewDecoder(r.Body).Decode(&p)
+			b.mu.Lock()
+			defer b.mu.Unlock()
+			if b.fail != nil && b.fail(p.Slot) {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			b.written[p.Slot] = p.Name
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	l, err := net.Listen("tcp", host+":0")
+	if err != nil {
+		t.Fatalf("listen on %s: %v", host, err)
+	}
+	b.srv.Listener.Close()
+	b.srv.Listener = l
+	b.srv.Start()
+	t.Cleanup(b.srv.Close)
+	return b
+}
+
+func (b *fakeBox) port(t *testing.T) int { return listenPort(t, b.srv) }
+
+func (b *fakeBox) count() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.written)
+}
+
+// copyApp is an App wired for a copy: an HTTP client, a logger, and a live
+// context the settle loop can select on.
+func copyApp(t *testing.T) *App {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	a := newTestApp()
+	a.logger = slog.Default()
+	a.ctx = ctx
+	return a
+}
+
+// TestCopyWaitsForATargetThatIsStillBooting is the 2026-08-08 field bundle: the
+// user updated a speaker, the update rebooted it, and the copy started 72
+// seconds later. Every slot failed against an agent that was not listening yet
+// and the speaker was left with an empty store.
+func TestCopyWaitsForATargetThatIsStillBooting(t *testing.T) {
+	src := newFakeBox(t, "127.0.0.2", []Preset{
+		{Slot: 1, Name: "1LIVE", Type: "radio"},
+		{Slot: 2, Name: "WDR 5", Type: "radio"},
+		{Slot: 3, Name: "Sunshine Live", Type: "radio"},
+	})
+	dst := newFakeBox(t, "127.0.0.3", nil)
+
+	// A booting speaker does not politely refuse a write, it is not there at
+	// all. So the target rejects everything until it is ready, exactly as the
+	// field bundle shows, and the presets are genuinely lost if the copy does
+	// not wait.
+	var ready bool
+	probes := 0
+	dst.fail = func(int) bool { return !ready }
+	installProbe(t, func() bool {
+		probes++
+		ready = probes > 2 // still starting for the first two probes
+		return ready
+	})
+
+	a := copyApp(t)
+	n, err := a.CopyPresetsAcrossBoxes(src.host, src.port(t), dst.host, dst.port(t))
+	if err != nil {
+		t.Fatalf("copy failed: %v", err)
+	}
+	if n != 3 || dst.count() != 3 {
+		t.Errorf("copied %d presets, target holds %d, want 3 and 3: the store was left empty because the copy did not wait", n, dst.count())
+	}
+	if probes < 3 {
+		t.Errorf("readiness was probed %d times, want it to have waited and retried", probes)
+	}
+}
+
+// TestCopyRefusesRatherThanEmptyingTheStore: when the target never comes back,
+// the user must get one clear refusal instead of six separate slot failures and
+// a speaker that looks wiped.
+func TestCopyRefusesRatherThanEmptyingTheStore(t *testing.T) {
+	src := newFakeBox(t, "127.0.0.2", []Preset{{Slot: 1, Name: "1LIVE", Type: "radio"}})
+	dst := newFakeBox(t, "127.0.0.3", nil)
+	installProbe(t, func() bool { return false })
+
+	a := copyApp(t)
+	// Cancel the app context so the settle loop gives up at once instead of
+	// spending its full window; the code path taken is the same.
+	ctx, cancel := context.WithCancel(context.Background())
+	a.ctx = ctx
+	cancel()
+
+	n, err := a.CopyPresetsAcrossBoxes(src.host, src.port(t), dst.host, dst.port(t))
+	if err == nil {
+		t.Fatal("copy reported success against a target that never answered")
+	}
+	if n != 0 {
+		t.Errorf("reported %d copied presets, want 0", n)
+	}
+	if dst.count() != 0 {
+		t.Errorf("wrote %d presets to a target that was not ready", dst.count())
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "firewall") {
+		t.Errorf("blames the firewall for a speaker the app was just talking to: %v", err)
+	}
+}
+
+// TestCopyIsUnchangedWhenTheTargetIsReady guards the happy path: no waiting, no
+// extra probing, all slots copied.
+func TestCopyIsUnchangedWhenTheTargetIsReady(t *testing.T) {
+	var source []Preset
+	for i := 1; i <= 6; i++ {
+		source = append(source, Preset{Slot: i, Name: fmt.Sprintf("Station %d", i), Type: "radio"})
+	}
+	src := newFakeBox(t, "127.0.0.2", source)
+	dst := newFakeBox(t, "127.0.0.3", nil)
+	installProbe(t, func() bool { return true })
+
+	a := copyApp(t)
+	start := time.Now()
+	n, err := a.CopyPresetsAcrossBoxes(src.host, src.port(t), dst.host, dst.port(t))
+	if err != nil {
+		t.Fatalf("copy failed: %v", err)
+	}
+	if n != 6 || dst.count() != 6 {
+		t.Errorf("copied %d, target holds %d, want 6 and 6", n, dst.count())
+	}
+	if el := time.Since(start); el > copyTargetSettleStep {
+		t.Errorf("a ready target cost %v, want no settle wait at all", el)
+	}
+}
+
+// TestCopyStillReportsARealRejection: a slot the target genuinely refuses (a
+// 500, not a transport failure) must still be reported. The settle-wait must
+// not swallow real errors.
+func TestCopyStillReportsARealRejection(t *testing.T) {
+	src := newFakeBox(t, "127.0.0.2", []Preset{
+		{Slot: 1, Name: "1LIVE", Type: "radio"},
+		{Slot: 2, Name: "WDR 5", Type: "radio"},
+	})
+	dst := newFakeBox(t, "127.0.0.3", nil)
+	dst.fail = func(slot int) bool { return slot == 2 }
+	installProbe(t, func() bool { return true })
+
+	a := copyApp(t)
+	n, err := a.CopyPresetsAcrossBoxes(src.host, src.port(t), dst.host, dst.port(t))
+	if err == nil {
+		t.Fatal("a refused slot was not reported")
+	}
+	if n != 1 {
+		t.Errorf("copied %d, want the one slot that was accepted", n)
+	}
+	if !strings.Contains(err.Error(), "preset 2") {
+		t.Errorf("error does not name the refused slot: %v", err)
+	}
+}


### PR DESCRIPTION
Copying stations to another speaker could leave that speaker with nothing at
all. A 2026-08-08 bundle from a household with twelve SoundTouch speakers shows
the whole sequence: the owner updated a speaker, the update rebooted it as it
always does, and the copy started seventy-two seconds later. The agent was not
listening yet, so all six slots were refused in turn, each one logged and
skipped so the rest of the transfer could continue, and the store was empty at
the end. A second copy six minutes after another box rebooted lost two of its
six slots the same way.

Nothing was wrong with the presets or with either speaker. The copy simply had
no idea whether the target was ready, while the update path it usually follows
had learned to wait a year ago.

So it waits now, up to the same two minutes the update preflight uses, and
writes nothing until the target answers. A speaker that never comes back gets
one clear refusal instead of six separate failures and an empty result. A slot
that fails mid-transfer, which is the other half of that bundle, is retried
once after a fresh wait.

The refusal deliberately does not mention firewalls. The app has been talking
to this speaker all along, which is how the user picked it as a copy target, so
the one explanation the old message offered is the one that cannot be true.

Refs #17

Release-Note: fix(presets): copying stations to another speaker no longer leaves it empty when the speaker is still starting up

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W4ZJXsnpmJuazCKF6ijdcZ