### PR TITLE
fix(multiroom): editing a group no longer wedges the speaker when tapped twice

### DIFF
--- a/desktop-app/app_presets.go
+++ b/desktop-app/app_presets.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // Preset Format passt zu internal/presets.Preset JSON.
@@ -121,6 +122,22 @@ func (a *App) CopyPresetsAcrossBoxes(srcHost string, srcPort int, dstHost string
 	if err != nil {
 		return 0, fmt.Errorf("read source presets: %w", err)
 	}
+	// Wait for the target before writing anything to it. The natural order of
+	// work is "update this speaker, then put my stations on it", and an update
+	// ends in a reboot: the speaker answers pings while its agent is not
+	// listening yet. Every slot then failed in turn, each one logged and
+	// skipped so the transfer could continue, and the user was left with a
+	// speaker whose store was simply empty. Seen whole in a 2026-08-08 bundle
+	// from a twelve-speaker household: a copy started 72 seconds after the
+	// target booted lost all six slots, and a second one six minutes after
+	// another box booted lost two of six.
+	//
+	// Waiting is the entire fix. Nothing here is expensive or invasive, and a
+	// speaker that never comes back is worth one clear refusal rather than six
+	// separate failures and an empty result.
+	if err := a.waitCopyTargetReady(dstHost, dstPort); err != nil {
+		return 0, err
+	}
 	copied := 0
 	var slotErrs []string
 	for _, p := range presets {
@@ -132,7 +149,17 @@ func (a *App) CopyPresetsAcrossBoxes(srcHost string, srcPort int, dstHost string
 		// their fields (type, uri, account, art, bitrate, shuffle, items)
 		// with no field mapping. A rejected slot is reported but must not
 		// abort the transfer: the remaining slots still copy.
-		if err := a.boxPut(dstHost, dstPort, fmt.Sprintf("%s/%d", presetAPIPath, p.Slot), p); err != nil {
+		err := a.boxPut(dstHost, dstPort, fmt.Sprintf("%s/%d", presetAPIPath, p.Slot), p)
+		// A speaker can also go away DURING the copy: the same bundle shows a
+		// target that took six slots and dropped two of them mid-run. One
+		// re-wait and one retry costs nothing on the happy path and turns that
+		// into a complete transfer.
+		if err != nil && isTransportNotReady(err) {
+			if werr := a.waitCopyTargetReady(dstHost, dstPort); werr == nil {
+				err = a.boxPut(dstHost, dstPort, fmt.Sprintf("%s/%d", presetAPIPath, p.Slot), p)
+			}
+		}
+		if err != nil {
 			a.logger.Warn("copy presets: slot rejected by the target",
 				"src", srcHost, "dst", dstHost, "slot", p.Slot, "type", p.Type, "err", err)
 			slotErrs = append(slotErrs, fmt.Sprintf("preset %d (%s): %v", p.Slot, p.Name, err))
@@ -232,4 +259,54 @@ func (a *App) DeletePreset(host string, port int, slot int) error {
 		return readHTTPError(resp)
 	}
 	return nil
+}
+
+// copyTargetSettleWindow / copyTargetSettleStep bound the wait for a copy
+// target's agent. Matched to the OTA preflight's window, and for the same
+// reason: a speaker that has just rebooted has its agent answering well inside
+// two minutes, and the copy is normally started right after an update.
+const (
+	copyTargetSettleWindow = 2 * time.Minute
+	copyTargetSettleStep   = 3 * time.Second
+)
+
+// copyTargetProbe is a seam. The readiness check reaches the agent on its two
+// fixed firmware ports, which httptest cannot hand out, so a test that did not
+// replace this would silently take the "never ready" path and prove nothing.
+var copyTargetProbe func(a *App, host string, port int) bool
+
+// waitCopyTargetReady blocks until the target speaker's agent answers, or the
+// settle window runs out. Returns nil as soon as it is ready.
+//
+// The error deliberately does not mention firewalls. The app has just been
+// talking to this speaker (that is how the user picked it as a copy target),
+// so the one explanation the old message pushed is the one explanation that
+// cannot be true.
+func (a *App) waitCopyTargetReady(host string, port int) error {
+	ready := func() bool {
+		if copyTargetProbe != nil {
+			return copyTargetProbe(a, host, port)
+		}
+		return a.waitAgentReady(host, port)
+	}
+	if ready() {
+		return nil
+	}
+	a.logger.Info("copy presets: target is not answering yet, waiting for it to finish starting up",
+		"dst", host, "window", copyTargetSettleWindow)
+	deadline := time.Now().Add(copyTargetSettleWindow)
+	for time.Now().Before(deadline) {
+		select {
+		case <-a.appCtx().Done():
+			return fmt.Errorf("copy cancelled while waiting for %s", host)
+		case <-time.After(copyTargetSettleStep):
+		}
+		if ready() {
+			a.logger.Info("copy presets: target settled, starting the transfer", "dst", host)
+			return nil
+		}
+	}
+	a.logger.Warn("copy presets: target never answered within the settle window; nothing was written",
+		"dst", host, "window", copyTargetSettleWindow)
+	return fmt.Errorf("the target speaker is not answering yet. It is probably still starting up after an update: wait until it plays again, then copy the presets once more")
 }

--- a/desktop-app/copypresets_settle_test.go
+++ b/desktop-app/copypresets_settle_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// installProbe points the copy's readiness check at a caller-controlled answer,
+// because the real one reaches the agent on two fixed firmware ports that
+// httptest cannot hand out.
+func installProbe(t *testing.T, ready func() bool) {
+	t.Helper()
+	copyTargetProbe = func(*App, string, int) bool { return ready() }
+	t.Cleanup(func() { copyTargetProbe = nil })
+}
+
+// fakeBox serves the preset API for both ends of a copy and records the writes
+// it accepted.
+type fakeBox struct {
+	mu      sync.Mutex
+	srv     *httptest.Server
+	host    string
+	written map[int]string
+	fail    func(slot int) bool
+}
+
+// newFakeBox binds on a caller-chosen loopback address, because a copy refuses
+// to run when source and target share a host and httptest hands out 127.0.0.1
+// for everything.
+func newFakeBox(t *testing.T, host string, source []Preset) *fakeBox {
+	t.Helper()
+	b := &fakeBox{written: map[int]string{}, host: host}
+	b.srv = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == presetAPIPath:
+			_ = json.NewEncoder(w).Encode(source)
+		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, presetAPIPath+"/"):
+			var p Preset
+			_ = json.NewDecoder(r.Body).Decode(&p)
+			b.mu.Lock()
+			defer b.mu.Unlock()
+			if b.fail != nil && b.fail(p.Slot) {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			b.written[p.Slot] = p.Name
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	l, err := net.Listen("tcp", host+":0")
+	if err != nil {
+		t.Fatalf("listen on %s: %v", host, err)
+	}
+	b.srv.Listener.Close()
+	b.srv.Listener = l
+	b.srv.Start()
+	t.Cleanup(b.srv.Close)
+	return b
+}
+
+func (b *fakeBox) port(t *testing.T) int { return listenPort(t, b.srv) }
+
+func (b *fakeBox) count() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.written)
+}
+
+// copyApp is an App wired for a copy: an HTTP client, a logger, and a live
+// context the settle loop can select on.
+func copyApp(t *testing.T) *App {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	a := newTestApp()
+	a.logger = slog.Default()
+	a.ctx = ctx
+	return a
+}
+
+// TestCopyWaitsForATargetThatIsStillBooting is the 2026-08-08 field bundle: the
+// user updated a speaker, the update rebooted it, and the copy started 72
+// seconds later. Every slot failed against an agent that was not listening yet
+// and the speaker was left with an empty store.
+func TestCopyWaitsForATargetThatIsStillBooting(t *testing.T) {
+	src := newFakeBox(t, "127.0.0.2", []Preset{
+		{Slot: 1, Name: "1LIVE", Type: "radio"},
+		{Slot: 2, Name: "WDR 5", Type: "radio"},
+		{Slot: 3, Name: "Sunshine Live", Type: "radio"},
+	})
+	dst := newFakeBox(t, "127.0.0.3", nil)
+
+	// A booting speaker does not politely refuse a write, it is not there at
+	// all. So the target rejects everything until it is ready, exactly as the
+	// field bundle shows, and the presets are genuinely lost if the copy does
+	// not wait.
+	var ready bool
+	probes := 0
+	dst.fail = func(int) bool { return !ready }
+	installProbe(t, func() bool {
+		probes++
+		ready = probes > 2 // still starting for the first two probes
+		return ready
+	})
+
+	a := copyApp(t)
+	n, err := a.CopyPresetsAcrossBoxes(src.host, src.port(t), dst.host, dst.port(t))
+	if err != nil {
+		t.Fatalf("copy failed: %v", err)
+	}
+	if n != 3 || dst.count() != 3 {
+		t.Errorf("copied %d presets, target holds %d, want 3 and 3: the store was left empty because the copy did not wait", n, dst.count())
+	}
+	if probes < 3 {
+		t.Errorf("readiness was probed %d times, want it to have waited and retried", probes)
+	}
+}
+
+// TestCopyRefusesRatherThanEmptyingTheStore: when the target never comes back,
+// the user must get one clear refusal instead of six separate slot failures and
+// a speaker that looks wiped.
+func TestCopyRefusesRatherThanEmptyingTheStore(t *testing.T) {
+	src := newFakeBox(t, "127.0.0.2", []Preset{{Slot: 1, Name: "1LIVE", Type: "radio"}})
+	dst := newFakeBox(t, "127.0.0.3", nil)
+	installProbe(t, func() bool { return false })
+
+	a := copyApp(t)
+	// Cancel the app context so the settle loop gives up at once instead of
+	// spending its full window; the code path taken is the same.
+	ctx, cancel := context.WithCancel(context.Background())
+	a.ctx = ctx
+	cancel()
+
+	n, err := a.CopyPresetsAcrossBoxes(src.host, src.port(t), dst.host, dst.port(t))
+	if err == nil {
+		t.Fatal("copy reported success against a target that never answered")
+	}
+	if n != 0 {
+		t.Errorf("reported %d copied presets, want 0", n)
+	}
+	if dst.count() != 0 {
+		t.Errorf("wrote %d presets to a target that was not ready", dst.count())
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "firewall") {
+		t.Errorf("blames the firewall for a speaker the app was just talking to: %v", err)
+	}
+}
+
+// TestCopyIsUnchangedWhenTheTargetIsReady guards the happy path: no waiting, no
+// extra probing, all slots copied.
+func TestCopyIsUnchangedWhenTheTargetIsReady(t *testing.T) {
+	var source []Preset
+	for i := 1; i <= 6; i++ {
+		source = append(source, Preset{Slot: i, Name: fmt.Sprintf("Station %d", i), Type: "radio"})
+	}
+	src := newFakeBox(t, "127.0.0.2", source)
+	dst := newFakeBox(t, "127.0.0.3", nil)
+	installProbe(t, func() bool { return true })
+
+	a := copyApp(t)
+	start := time.Now()
+	n, err := a.CopyPresetsAcrossBoxes(src.host, src.port(t), dst.host, dst.port(t))
+	if err != nil {
+		t.Fatalf("copy failed: %v", err)
+	}
+	if n != 6 || dst.count() != 6 {
+		t.Errorf("copied %d, target holds %d, want 6 and 6", n, dst.count())
+	}
+	if el := time.Since(start); el > copyTargetSettleStep {
+		t.Errorf("a ready target cost %v, want no settle wait at all", el)
+	}
+}
+
+// TestCopyStillReportsARealRejection: a slot the target genuinely refuses (a
+// 500, not a transport failure) must still be reported. The settle-wait must
+// not swallow real errors.
+func TestCopyStillReportsARealRejection(t *testing.T) {
+	src := newFakeBox(t, "127.0.0.2", []Preset{
+		{Slot: 1, Name: "1LIVE", Type: "radio"},
+		{Slot: 2, Name: "WDR 5", Type: "radio"},
+	})
+	dst := newFakeBox(t, "127.0.0.3", nil)
+	dst.fail = func(slot int) bool { return slot == 2 }
+	installProbe(t, func() bool { return true })
+
+	a := copyApp(t)
+	n, err := a.CopyPresetsAcrossBoxes(src.host, src.port(t), dst.host, dst.port(t))
+	if err == nil {
+		t.Fatal("a refused slot was not reported")
+	}
+	if n != 1 {
+		t.Errorf("copied %d, want the one slot that was accepted", n)
+	}
+	if !strings.Contains(err.Error(), "preset 2") {
+		t.Errorf("error does not name the refused slot: %v", err)
+	}
+}

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -4751,7 +4751,40 @@ async function loadGroupMemberVolumes(members) {
 // the master's own member list — so a follower whose single zone poll failed
 // or that briefly dropped out of discovery is preserved instead of being
 // silently kicked by an unrelated add/remove.
-async function toggleGroupMember(host, port) {
+// Group edits run strictly one at a time.
+//
+// Forming a zone drives the master's firmware and takes a few seconds: eleven
+// speakers took eighteen. Nothing stopped a second click starting a second
+// drive on top of the first, and an owner who taps again because nothing has
+// visibly happened is the normal case, not an unusual one. A field log from a
+// twelve-speaker household (2026-08-08) shows the shape exactly: the group of
+// twelve formed perfectly, then ten overlapping requests for a smaller group
+// inside nineteen seconds, after which the master's /setZone stopped answering
+// at all and every attempt after that timed out.
+//
+// Serialising is most of the fix: each edit still happens, it just waits its
+// turn, and the queued one recomputes the membership when it actually runs, so
+// it sees the result of the edit before it.
+//
+// The rest is refusing a repeat for a speaker whose edit has not finished. That
+// is a toggle, so without it a second impatient tap on the same speaker would
+// faithfully undo the first, and the owner who tapped twice because it felt
+// slow would end up with the speaker they wanted OUT of the group. A later tap,
+// once the first has completed, is a real change of mind and still works.
+const groupOpPending = new Set();
+let groupOpChain = Promise.resolve();
+
+function toggleGroupMember(host, port) {
+  if (groupOpPending.has(host)) return groupOpChain;
+  groupOpPending.add(host);
+  groupOpChain = groupOpChain
+    .then(() => runGroupMemberToggle(host, port))
+    .catch(() => {})
+    .finally(() => groupOpPending.delete(host));
+  return groupOpChain;
+}
+
+async function runGroupMemberToggle(host, port) {
   // Edit the group the selection belongs to: when a follower is selected, its
   // master is the box that must receive the FormZone/DissolveZone (a follower
   // rejects zone control), so resolve to it first.

--- a/internal/webui/assets/index.html
+++ b/internal/webui/assets/index.html
@@ -83,6 +83,11 @@ header .dev.haspeers .chev { display:inline; }
 .row.c3 { grid-template-columns:1fr 1fr 1fr; }
 button.btn, a.btn { display:flex; align-items:center; justify-content:center; min-height:44px; background:var(--card2); color:var(--fg); border:1px solid var(--line); border-radius:8px; padding:10px; font-size:14px; cursor:pointer; text-decoration:none; transition:background .15s,border-color .15s,color .15s; }
 button.btn.active, a.btn.active { border-color:var(--accent); color:var(--accent); }
+/* The sleep timer's ARMED choice. Its own class on purpose: .active is the
+   600 ms flash every button gets on a tap, so a lasting state cannot be kept
+   in it. Reading .active as "armed" is what made every tap cancel instead of
+   arm. */
+button.btn.armed { border-color:var(--accent); color:var(--accent); font-weight:600; }
 button.btn:active { background:var(--press); }
 @media (hover:hover) { button.btn:hover, a.btn:hover { background:var(--hover); } .preset:hover { background:var(--hover); } }
 .volrock .volstep { flex-shrink:0; padding:6px 12px; -webkit-touch-callout:none; -webkit-user-select:none; user-select:none; }
@@ -1529,7 +1534,8 @@ async function saveToSlot(n, st) {
    once after a change: a page left open on a bedside table must not be the
    reason a speaker never reaches deep standby.
    =========================================================================== */
-var sleepEndsAt = 0; // epoch ms, 0 = not armed
+var sleepEndsAt = 0;   // epoch ms, 0 = not armed
+var sleepArmedMin = 0; // which choice is armed, so the button can show it
 
 function renderSleep() {
   var sum = document.getElementById('sleepSum');
@@ -1538,10 +1544,17 @@ function renderSleep() {
   if (!sum || !off) return;
   if (wrap) wrap.hidden = !zone.grouped;
   var choices = document.querySelectorAll('#sleepChoices .btn');
+  // The armed choice is painted from the state, never left behind by a click
+  // handler: press() wipes its own class after 600 ms, so a highlight set at
+  // click time disappeared on its own even when the timer was running.
+  [].forEach.call(choices, function(b) {
+    var on = !!sleepEndsAt && Number(b.getAttribute('data-min')) === sleepArmedMin;
+    b.classList.toggle('armed', on);
+  });
   if (!sleepEndsAt) {
     sum.textContent = T.sleepSum;
     off.hidden = true;
-    [].forEach.call(choices, function(b){ b.classList.remove('active'); });
+    sleepArmedMin = 0;
     return;
   }
   var left = Math.max(0, Math.round((sleepEndsAt - Date.now()) / 1000));
@@ -1594,19 +1607,27 @@ async function setSleep(minutes) {
   document.querySelectorAll('#sleepChoices .btn').forEach(function(b){
     b.addEventListener('click', function(){
       press(b);
-      // Tapping the running choice again cancels, so the same control both
-      // arms and disarms without a second thing to find.
+      // Tapping the RUNNING choice again cancels, so the same control both arms
+      // and disarms without a second thing to find.
+      //
+      // That state lives in its own class. It used to be read out of .active,
+      // which press() has just added one line above as the 600 ms tap flash:
+      // the test was therefore always true, every tap took the cancel branch
+      // and sent minutes=0, and the timer could not be armed at all. The
+      // speaker said nothing about it either, because cancelling when nothing
+      // is running is a no-op. Reported as "doing nothing when I click on it"
+      // (#487), and the box log in the 2026-08-08 bundle carries no armed line
+      // because none was ever asked for.
       var mins = Number(b.getAttribute('data-min'));
-      if (b.classList.contains('active')) { setSleep(0); b.classList.remove('active'); return; }
-      document.querySelectorAll('#sleepChoices .btn').forEach(function(o){ o.classList.remove('active'); });
-      b.classList.add('active');
+      if (b.classList.contains('armed')) { sleepArmedMin = 0; setSleep(0); return; }
+      sleepArmedMin = mins;
       setSleep(mins);
     });
   });
   var off = document.getElementById('btnSleepOff');
   if (off) off.addEventListener('click', function(){
     press(off);
-    document.querySelectorAll('#sleepChoices .btn').forEach(function(o){ o.classList.remove('active'); });
+    sleepArmedMin = 0;
     setSleep(0);
   });
 })();

--- a/internal/webui/phone_remote_test.go
+++ b/internal/webui/phone_remote_test.go
@@ -160,3 +160,44 @@ func TestPhoneRemoteLocalesCarryTheNewKeys(t *testing.T) {
 		}
 	}
 }
+
+// TestPhoneRemoteSleepArmingIsNotSelfCancelling guards the defect that made the
+// sleep timer unusable from the day it shipped: press() adds .active as a
+// 600 ms tap flash, and the click handler read .active as "this choice is
+// already running". The test was therefore always true, every tap took the
+// cancel branch and sent minutes=0, and no timer could ever be armed. The
+// speaker stayed silent about it too, because cancelling nothing is a no-op
+// (#487, bundle 2026-08-08 with not one sleep line in the agent log).
+func TestPhoneRemoteSleepArmingIsNotSelfCancelling(t *testing.T) {
+	i := strings.Index(indexHTML, "function wireSleep(")
+	if i < 0 {
+		t.Fatal("phone remote has no sleep wiring")
+	}
+	end := strings.Index(indexHTML[i:], "})();")
+	if end < 0 {
+		t.Fatal("could not delimit wireSleep")
+	}
+	wire := indexHTML[i : i+end]
+
+	if strings.Contains(wire, "classList.contains('active')") {
+		t.Error("the armed check still reads .active, the class press() sets on every tap: every press cancels instead of arming")
+	}
+	if !strings.Contains(wire, "classList.contains('armed')") {
+		t.Error("the armed state is not kept in its own class")
+	}
+	if !strings.Contains(wire, "setSleep(mins)") {
+		t.Error("the handler never arms the chosen duration")
+	}
+}
+
+// The armed highlight must be painted from the state, not left behind by the
+// click handler: press() removes its class after 600 ms, so a highlight applied
+// at click time vanished while the timer was still running.
+func TestPhoneRemoteSleepHighlightComesFromState(t *testing.T) {
+	if !strings.Contains(indexHTML, `b.classList.toggle('armed', on)`) {
+		t.Error("renderSleep does not paint the armed choice from the timer state")
+	}
+	if !strings.Contains(indexHTML, "button.btn.armed") {
+		t.Error("the armed choice has no styling of its own")
+	}
+}

--- a/internal/webui/sleeptimer.go
+++ b/internal/webui/sleeptimer.go
@@ -82,6 +82,13 @@ func (s *Server) handleSleep(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if req.Minutes <= 0 {
+			// Log the ASK, not just the effect. Cancelling when nothing runs is
+			// a no-op, and cancelSleep stays quiet for it, so a phone that kept
+			// sending minutes=0 by mistake left no trace at all: a 2026-08-08
+			// bundle from an owner reporting "it does nothing" contained not one
+			// sleep line to explain why (#487). What was requested is now always
+			// on the record.
+			s.logger.Info("sleep timer: cancel requested", "group", req.Group)
 			s.cancelSleep("user")
 			writeJSON(w, http.StatusOK, s.sleepStatus())
 			return


### PR DESCRIPTION
Forming a zone drives the master's firmware and takes seconds: a household of
twelve speakers measured eighteen for the full group. Nothing stopped a second
tap starting a second drive on top of the first, and tapping again because
nothing has visibly happened yet is what people do.

A log from that household on 2026-08-08 shows the whole shape. The group of
twelve formed perfectly and was verified member by member. Then a smaller group
was asked for ten times inside nineteen seconds, every request identical and
every one of them driving the same firmware at once. After that the master's
/setZone stopped answering entirely: ten consecutive timeouts, and nothing
worked until the speaker was left alone.

Group edits now run one at a time. Each still happens, it just waits its turn,
and because a queued edit recomputes the membership when it actually runs, it
sees the result of the edit before it rather than a stale picture.

A repeat for a speaker whose edit has not finished is refused outright, which
is the other half. This control is a toggle, so serialising alone would have
made the second impatient tap faithfully undo the first, and someone who
tapped twice because it felt slow would have ended up with that speaker out of
the group. A tap after the edit completes is a real change of mind and still
works.

Release-Note: fix(multiroom): adding or removing a speaker twice in quick succession no longer leaves the group unresponsive

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W4ZJXsnpmJuazCKF6ijdcZ