### PR TITLE
fix(multiroom): a group of more than six speakers can be formed again

### DIFF
--- a/internal/webui/zoneformbudget_test.go
+++ b/internal/webui/zoneformbudget_test.go
@@ -1,0 +1,52 @@
+package webui
+
+import (
+	"testing"
+	"time"
+)
+
+// The budget covers the whole form, not just the /setZone drive: waking the
+// master, reading the live zone, removing dropped members, forming, and the
+// confirming read. A flat ten seconds was therefore a ceiling on group size.
+//
+// Measured on a twelve-speaker fleet, 2026-08-08, one speaker added at a time:
+// up to five slaves formed in 4 to 8 s, six took 22 s, and seven failed five
+// times in a row with "setZone: context deadline exceeded". The same fleet had
+// formed a group of twelve earlier the same afternoon, so nothing was wrong
+// with the eighth speaker.
+func TestZoneFormBudgetGrowsWithTheGroup(t *testing.T) {
+	// The sizes that used to work must not become slower to fail.
+	if got := zoneFormBudget(0); got < 10*time.Second {
+		t.Errorf("zoneFormBudget(0) = %v, want at least the old 10s", got)
+	}
+
+	// The size that failed in the field must now have room. Six slaves were
+	// measured at 22 s, so seven needs comfortably more than that.
+	if got := zoneFormBudget(7); got <= 22*time.Second {
+		t.Errorf("zoneFormBudget(7) = %v, want more than the 22s six slaves measured", got)
+	}
+
+	// Strictly increasing up to the ceiling, so a bigger group never gets less
+	// time than a smaller one.
+	prev := time.Duration(0)
+	for n := 0; n <= 20; n++ {
+		got := zoneFormBudget(n)
+		if got < prev {
+			t.Errorf("zoneFormBudget(%d) = %v is less than for %d slaves (%v)", n, got, n-1, prev)
+		}
+		prev = got
+	}
+}
+
+// The agent must never answer after the desktop app has stopped listening: the
+// app would report a failure for a group the firmware went on to build, which
+// is the confusing half of this bug rather than the slow half. The app's own
+// budget for this call is 45 s.
+func TestZoneFormBudgetStaysUnderTheAppsTimeout(t *testing.T) {
+	const appTimeout = 45 * time.Second
+	for _, n := range []int{0, 1, 6, 7, 11, 50, 1000} {
+		if got := zoneFormBudget(n); got >= appTimeout {
+			t.Errorf("zoneFormBudget(%d) = %v, want comfortably under the app's %v", n, got, appTimeout)
+		}
+	}
+}

--- a/internal/webui/zones_stereo.go
+++ b/internal/webui/zones_stereo.go
@@ -158,7 +158,7 @@ func (s *Server) handleZoneForm(w http.ResponseWriter, r *http.Request) {
 	s.logger.Info("zone: forming (beta)", "mode", mode, "master", master.DeviceID, "masterIP", master.IP,
 		"slaves", len(slaves), "stereo", req.Stereo, "name", req.Name)
 
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), zoneFormBudget(len(slaves)))
 	defer cancel()
 	c := boxapi.New(s.boxHost)
 
@@ -1295,4 +1295,43 @@ func (s *Server) handleMargeGroupDoc(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Allow", "GET, POST, DELETE")
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
+}
+
+// zoneFormBudget is how long the whole form is allowed to take, as a function
+// of how many speakers are joining.
+//
+// It used to be a flat ten seconds, and that one budget covers everything the
+// form does: waking the master, reading the live zone, removing members the
+// user dropped, the /setZone drive itself, and the read that confirms it. The
+// firmware gets slower as the group grows, so the fixed budget turned into a
+// ceiling on group size rather than a safety net.
+//
+// A twelve-speaker household measured it exactly on 2026-08-08, adding one
+// speaker at a time and waiting between each:
+//
+//	1 to 5 slaves   formed in 4 to 8 seconds
+//	6 slaves        formed, but took 22 seconds
+//	7 slaves        failed every time, always "setZone: context deadline
+//	                exceeded", five attempts in a row
+//
+// Nothing was wrong with the eighth speaker: the same fleet had formed a group
+// of twelve earlier that afternoon, when the box happened to answer quickly.
+// The owner's conclusion was that STR cannot do more than six, which is exactly
+// what a fixed budget looks like from outside.
+//
+// So the budget grows with the group. The ceiling stays below the desktop
+// app's own 45 s call timeout, because an agent that answers after the app has
+// given up is worse than one that fails: the app would report failure for a
+// group the firmware went on to build.
+func zoneFormBudget(slaves int) time.Duration {
+	const (
+		base    = 10 * time.Second
+		perSlve = 4 * time.Second
+		ceiling = 38 * time.Second // the app gives up at 45 s
+	)
+	d := base + time.Duration(slaves)*perSlve
+	if d > ceiling {
+		return ceiling
+	}
+	return d
 }


### PR DESCRIPTION
An owner with twelve SoundTouch speakers could not get more than six into a
group. Every attempt beyond that failed the same way, five times in a row:

  Error: status 502: setZone: Post "http://127.0.0.1:8090/setZone": context
  deadline exceeded

He measured it himself, adding one speaker at a time and waiting in between,
and the log is unusually clear about it:

  1 to 5 slaves   formed in 4 to 8 seconds
  6 slaves        formed, but took 22 seconds
  7 slaves        failed every time

Nothing is wrong with the eighth speaker. The same fleet had formed a group of
all twelve earlier the same afternoon, when the firmware happened to answer
quickly.

The form ran under one flat ten-second budget, and that budget covers
everything it does: waking the master, reading the live zone, removing members
the user dropped, the /setZone drive itself, and the read that confirms it. The
firmware gets slower as the group grows, so a fixed budget was not a safety net
but a ceiling on how many speakers a group could hold, and it presented itself
as a hard limit at six.

The budget now grows with the group, four seconds per speaker on top of the old
ten. It stops below the desktop app's own 45 second timeout for this call on
purpose: an agent that answers after the app has given up is worse than one
that fails, because the app then reports failure for a group the firmware went
on to build.

Release-Note: fix(multiroom): a group of more than six speakers can be formed again

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W4ZJXsnpmJuazCKF6ijdcZ