### PR TITLE
fix(agent): delivering the Spotify engine no longer restarts the speaker

### DIFF
--- a/internal/webui/agent_admin.go
+++ b/internal/webui/agent_admin.go
@@ -3,6 +3,7 @@
 package webui
 
 import (
+	"bufio"
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
@@ -668,11 +669,38 @@ var engineStopHook func() bool
 // filesystem's own verdict on the actual write (a real ENOSPC / short write)
 // maps to errInsufficientNAND now.
 func writeBinaryAtomic(dst string, body []byte) error {
-	dir := filepath.Dir(dst)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return fmt.Errorf("mkdir parent: %w", err)
+	tmp, dir, st, err := prepareBinaryWrite(dst, int64(len(body)))
+	if err != nil {
+		return err
 	}
-	tmp := dst + ".new"
+	if err := writeFileSynced(tmp, body, 0o755); err != nil {
+		// A mid-stream ENOSPC leaves a truncated tmp; remove it so no partial
+		// .new survives for the next attempt.
+		_ = os.Remove(tmp)
+		return classifyNANDWriteErr("write tmp", err, dir, int64(len(body)), st.engineStopped, st.engineReclaim, st.predictedFull)
+	}
+	return finishBinaryWrite(tmp, dst, dir, int64(len(body)), st)
+}
+
+// nandWriteState carries what the reclaim preamble learned into the error
+// classification, so a failure can still say whether the engine was dropped
+// and whether statfs had predicted the shortage.
+type nandWriteState struct {
+	engineStopped bool
+	engineReclaim string
+	predictedFull bool
+}
+
+// prepareBinaryWrite is everything writeBinaryAtomic does BEFORE the bytes
+// move: the parent directory, the stale temp, and the reclaim cascade that
+// makes room. Shared with the streaming variant so the two cannot drift on the
+// space handling, which is the part that took the longest to get right.
+func prepareBinaryWrite(dst string, need int64) (tmp, dir string, st nandWriteState, err error) {
+	dir = filepath.Dir(dst)
+	if err = os.MkdirAll(dir, 0o755); err != nil {
+		return "", "", st, fmt.Errorf("mkdir parent: %w", err)
+	}
+	tmp = dst + ".new"
 	// Drop this target's stale temp, then proactively reclaim regenerable junk on
 	// EVERY OTA write (not only when already tight), so a previous failed
 	// attempt's leftovers, a stale OTHER-binary .new, or oversized logs never eat
@@ -680,7 +708,6 @@ func writeBinaryAtomic(dst string, body []byte) error {
 	// files or the live binaries.
 	_ = os.Remove(tmp)
 	reclaimNAND()
-	need := int64(len(body))
 	engineStopped := false
 	engineReclaim := ""
 	predictedFull := false
@@ -729,15 +756,14 @@ func writeBinaryAtomic(dst string, body []byte) error {
 				"needKB", need/1024, "availKB", avail/1024)
 		}
 	}
-	if err := writeFileSynced(tmp, body, 0o755); err != nil {
-		// A mid-stream ENOSPC leaves a truncated tmp; remove it so no partial
-		// .new survives for the next attempt.
-		_ = os.Remove(tmp)
-		return classifyNANDWriteErr("write tmp", err, dir, need, engineStopped, engineReclaim, predictedFull)
-	}
+	return tmp, dir, nandWriteState{engineStopped, engineReclaim, predictedFull}, nil
+}
+
+// finishBinaryWrite renames the completed temp into place and journals it.
+func finishBinaryWrite(tmp, dst, dir string, need int64, st nandWriteState) error {
 	if err := os.Rename(tmp, dst); err != nil {
 		_ = os.Remove(tmp)
-		return classifyNANDWriteErr("rename", err, dir, need, engineStopped, engineReclaim, predictedFull)
+		return classifyNANDWriteErr("rename", err, dir, need, st.engineStopped, st.engineReclaim, st.predictedFull)
 	}
 	// fsync the parent directory so the rename itself reaches the UBIFS
 	// journal. Without this the whole write + rename can sit in the page
@@ -1318,19 +1344,19 @@ var nandHasRoom = func(dir string, need int64) bool {
 // running process until it exits, so killing+relaunching it on the write releases
 // that ~10 MB immediately instead of holding it until the next reboot.
 func (s *Server) handleAgentSidecar(w http.ResponseWriter, r *http.Request) {
-	body, ok := s.readUploadedELF(w, r, s.logger, "sidecar")
+	// Streamed, not buffered. This is the ~16 MB engine and the box has ~120 MB
+	// of RAM: holding it in memory first was enough to reboot a speaker that
+	// happened to be busy (see streamBinaryAtomic). The agent-update endpoint
+	// deliberately still buffers, because its fallback tiers need the bytes
+	// again after the write.
+	sum, size, ok := s.streamUploadedELF(w, r, s.logger, "sidecar", goLibrespotBinPath)
 	if !ok {
-		return
-	}
-	if err := writeBinaryAtomic(goLibrespotBinPath, body); err != nil {
-		http.Error(w, err.Error(), nandWriteHTTPStatus(err))
 		return
 	}
 	// Stamp the content hash next to the binary so the next /api/agent/version
 	// reports it and the desktop app skips re-pushing this ~10 MB binary when the
 	// box already has the embedded build.
-	sum := sha256.Sum256(body)
-	if err := os.WriteFile(goLibrespotBinPath+".sha256", []byte(hex.EncodeToString(sum[:])), 0o644); err != nil {
+	if err := os.WriteFile(goLibrespotBinPath+".sha256", []byte(sum), 0o644); err != nil {
 		s.logger.Warn("go-librespot sidecar: hash marker write failed (non-fatal)", "err", err)
 	}
 	// Flush now: an agent OTA often reboots the box right after this delivery,
@@ -1341,7 +1367,7 @@ func (s *Server) handleAgentSidecar(w http.ResponseWriter, r *http.Request) {
 	// The engine is back, so the "it was taken away for an update" marker has
 	// served its purpose. Clearing it stops the app from re-delivering forever.
 	clearEngineDroppedMarker()
-	s.logger.Info("go-librespot sidecar written via OTA", "size", len(body))
+	s.logger.Info("go-librespot sidecar written via OTA", "size", size)
 	// Activate the freshly delivered engine live: restart the supervised
 	// go-librespot so it re-execs the new binary, with no box reboot. A first-time
 	// delivery to a box that had no engine is already picked up by the manager's
@@ -1375,4 +1401,107 @@ func isLocalLAN(remoteAddr string) bool {
 		return false
 	}
 	return ip.IsPrivate() || ip.IsLoopback()
+}
+
+// streamBinaryAtomic writes dst from a reader instead of from a buffer, and
+// returns the SHA256 of what it wrote.
+//
+// It exists because the sidecar engine is ~16 MB and the box has ~120 MB of
+// RAM in total. Holding the whole upload in memory before writing it was
+// enough to kill the agent on a speaker that happened to be busy: a 2026-08-08
+// bundle from a Lifestyle 535 adapter caught it exactly, with the box's own log
+// showing MemAvailable falling from 27 MB to 11 MB as the body arrived, and the
+// speaker rebooting about eighty seconds later. Four pushes in a row died that
+// way and the owner saw his speaker restart each time. An earlier fix
+// (2026-07-30) removed io.ReadAll's doubling peak, which halved the cost but
+// left the 16 MB itself in memory.
+//
+// The bytes now go straight to the temp file the atomic write was going to use
+// anyway, so peak memory is a 32 KB copy buffer. The reclaim cascade in front
+// of it is shared verbatim with writeBinaryAtomic, because the space handling
+// is the part of this path that was hardest to get right and must not fork.
+//
+// need is the expected size (Content-Length) and is used only to make room; the
+// actual size written is returned.
+func streamBinaryAtomic(dst string, src io.Reader, need int64) (sum string, n int64, err error) {
+	tmp, dir, st, err := prepareBinaryWrite(dst, need)
+	if err != nil {
+		return "", 0, err
+	}
+	h := sha256.New()
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+	if err != nil {
+		return "", 0, classifyNANDWriteErr("open tmp", err, dir, need, st.engineStopped, st.engineReclaim, st.predictedFull)
+	}
+	n, err = io.Copy(f, io.TeeReader(src, h))
+	if err == nil {
+		// fsync before close, for the same reason writeFileSynced does it: an
+		// unsynced write does not survive the reboot that follows an OTA.
+		err = f.Sync()
+	}
+	if cerr := f.Close(); err == nil {
+		err = cerr
+	}
+	if err != nil {
+		// A mid-stream ENOSPC leaves a truncated tmp; remove it so no partial
+		// .new survives for the next attempt.
+		_ = os.Remove(tmp)
+		return "", n, classifyNANDWriteErr("write tmp", err, dir, need, st.engineStopped, st.engineReclaim, st.predictedFull)
+	}
+	if err := finishBinaryWrite(tmp, dst, dir, need, st); err != nil {
+		return "", n, err
+	}
+	return hex.EncodeToString(h.Sum(nil)), n, nil
+}
+
+// streamUploadedELF is readUploadedELF for a caller that does not need the
+// bytes afterwards: same guards, same logging, but the body goes to dst as it
+// arrives rather than into memory first.
+//
+// The ELF check still happens before anything is written, by peeking the first
+// four bytes; a body that is not a binary never reaches the flash.
+func (s *Server) streamUploadedELF(w http.ResponseWriter, r *http.Request, logger *slog.Logger, what, dst string) (sum string, size int64, ok bool) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return "", 0, false
+	}
+	if !isLocalLAN(r.RemoteAddr) {
+		http.Error(w, "update only allowed from LAN", http.StatusForbidden)
+		return "", 0, false
+	}
+	s.hushForUpload(what)
+	const maxSize = 30 * 1024 * 1024
+	memAtStart, memTotal := uploadMemKB()
+	logger.Info("upload started", "endpoint", what,
+		"contentLength", r.ContentLength, "remote", r.RemoteAddr,
+		"memAvailableKB", memAtStart, "memTotalKB", memTotal, "streamed", true)
+	upr := &uploadProgressReader{
+		r: io.LimitReader(r.Body, maxSize+1), start: time.Now(), logger: logger, what: what,
+	}
+	br := bufio.NewReaderSize(upr, 4096)
+	magic, err := br.Peek(4)
+	if err != nil || magic[0] != 0x7f || magic[1] != 'E' || magic[2] != 'L' || magic[3] != 'F' {
+		http.Error(w, "not an ELF binary", http.StatusBadRequest)
+		return "", 0, false
+	}
+	sum, size, werr := streamBinaryAtomic(dst, br, r.ContentLength)
+	memAfter, _ := uploadMemKB()
+	if werr != nil {
+		logger.Warn("upload write failed", "endpoint", what, "bytes", size,
+			"elapsedMs", time.Since(upr.start).Milliseconds(),
+			"memAvailableKB", memAfter, "memAvailableAtStartKB", memAtStart, "err", werr)
+		http.Error(w, werr.Error(), nandWriteHTTPStatus(werr))
+		return "", size, false
+	}
+	logger.Info("upload body received", "endpoint", what,
+		"bytes", size, "elapsedMs", time.Since(upr.start).Milliseconds(),
+		"memAvailableKB", memAfter, "memAvailableAtStartKB", memAtStart)
+	if size > maxSize {
+		http.Error(w, "binary too big", http.StatusRequestEntityTooLarge)
+		return "", size, false
+	}
+	if size < 1024 {
+		http.Error(w, "binary too small", http.StatusBadRequest)
+		return "", size, false
+	}
+	return sum, size, true
 }

--- a/internal/webui/sidecar_stream_test.go
+++ b/internal/webui/sidecar_stream_test.go
@@ -1,0 +1,183 @@
+package webui
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// elfBody builds a payload that passes the ELF magic check.
+func elfBody(n int) []byte {
+	b := make([]byte, n)
+	copy(b, []byte{0x7f, 'E', 'L', 'F'})
+	for i := 4; i < n; i++ {
+		b[i] = byte(i % 251)
+	}
+	return b
+}
+
+// TestStreamBinaryAtomicWritesAndHashes is the core of the fix: the bytes reach
+// the file without ever being held whole in memory, and the hash the caller
+// stamps beside the binary is the hash of what actually landed.
+func TestStreamBinaryAtomicWritesAndHashes(t *testing.T) {
+	dst := filepath.Join(t.TempDir(), "go-librespot")
+	body := elfBody(64 * 1024)
+
+	sum, n, err := streamBinaryAtomic(dst, bytes.NewReader(body), int64(len(body)))
+	if err != nil {
+		t.Fatalf("streamBinaryAtomic: %v", err)
+	}
+	if n != int64(len(body)) {
+		t.Errorf("wrote %d bytes, want %d", n, len(body))
+	}
+	want := sha256.Sum256(body)
+	if sum != hex.EncodeToString(want[:]) {
+		t.Errorf("hash = %s, want the hash of the written bytes", sum)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Error("the file on disk differs from what was sent")
+	}
+	// The engine has to be executable on the speaker. Windows does not model
+	// the bit, so this can only be checked where it means something; the box
+	// and CI are both Linux.
+	if runtime.GOOS != "windows" {
+		if fi, err := os.Stat(dst); err == nil && fi.Mode().Perm()&0o111 == 0 {
+			t.Error("the binary is not executable")
+		}
+	}
+	// No temp left behind.
+	if _, err := os.Stat(dst + ".new"); !os.IsNotExist(err) {
+		t.Error("the .new temp survived a successful write")
+	}
+}
+
+// A stream that dies mid-body must not leave a truncated binary in place: the
+// speaker would then run, or try to run, half an engine.
+func TestStreamBinaryAtomicLeavesNothingBehindOnFailure(t *testing.T) {
+	dst := filepath.Join(t.TempDir(), "go-librespot")
+	body := elfBody(8 * 1024)
+	broken := io.MultiReader(bytes.NewReader(body[:2048]), &erroringReader{})
+
+	if _, _, err := streamBinaryAtomic(dst, broken, int64(len(body))); err == nil {
+		t.Fatal("a broken stream was reported as a successful write")
+	}
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Error("a truncated binary was left at the destination")
+	}
+	if _, err := os.Stat(dst + ".new"); !os.IsNotExist(err) {
+		t.Error("a truncated .new temp was left behind")
+	}
+}
+
+type erroringReader struct{}
+
+func (*erroringReader) Read([]byte) (int, error) { return 0, io.ErrUnexpectedEOF }
+
+// TestStreamUploadedELFRejectsNonBinaryBeforeWriting keeps the guard that
+// matters on a device: something that is not a binary must never reach the
+// flash, and the check has to happen on the peeked head rather than after the
+// whole body has been stored.
+func TestStreamUploadedELFRejectsNonBinaryBeforeWriting(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "go-librespot")
+	s := &Server{logger: slog.New(slog.DiscardHandler)}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, _, ok := s.streamUploadedELF(w, r, s.logger, "sidecar", dst); ok {
+			t.Error("a non-ELF upload was accepted")
+		}
+	}))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL, "application/octet-stream",
+		strings.NewReader("<html>this is the web UI, not a binary</html>"))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Error("a non-binary body was written to the destination anyway")
+	}
+	if _, err := os.Stat(dst + ".new"); !os.IsNotExist(err) {
+		t.Error("a non-binary body left a temp behind")
+	}
+}
+
+// The happy path end to end, through a real HTTP request, so the peek does not
+// eat the first four bytes of the binary it is checking.
+func TestStreamUploadedELFRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "go-librespot")
+	s := &Server{logger: slog.New(slog.DiscardHandler)}
+	body := elfBody(256 * 1024)
+
+	var gotSum string
+	var gotSize int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sum, size, ok := s.streamUploadedELF(w, r, s.logger, "sidecar", dst)
+		if !ok {
+			t.Error("a valid ELF upload was rejected")
+			return
+		}
+		gotSum, gotSize = sum, size
+	}))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL, "application/octet-stream", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if gotSize != int64(len(body)) {
+		t.Errorf("size = %d, want %d", gotSize, len(body))
+	}
+	want := sha256.Sum256(body)
+	if gotSum != hex.EncodeToString(want[:]) {
+		t.Error("the reported hash is not the hash of the upload")
+	}
+	on, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !bytes.Equal(on, body) {
+		t.Error("the stored binary differs from the upload; the ELF peek may have consumed its head")
+	}
+}
+
+// The buffering variant must keep behaving exactly as before: the agent-update
+// endpoint still needs the bytes after the write for its fallback tiers, so the
+// shared reclaim preamble must not have changed what it does.
+func TestWriteBinaryAtomicStillWorksAfterTheSplit(t *testing.T) {
+	dst := filepath.Join(t.TempDir(), "streborn-armv7l")
+	body := elfBody(32 * 1024)
+	if err := writeBinaryAtomic(dst, body); err != nil {
+		t.Fatalf("writeBinaryAtomic: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Error("the buffered write no longer stores the exact bytes")
+	}
+	if _, err := os.Stat(dst + ".new"); !os.IsNotExist(err) {
+		t.Error("the .new temp survived a successful buffered write")
+	}
+}


### PR DESCRIPTION
An owner reported his Lifestyle 535 adapter rebooting several times while STR
tried to install the Spotify engine, ending in "Spotify postponed". He assumed
his model could not do Spotify. It can: the delivery was killing the speaker.

The engine is about 16 MB and the speaker has about 120 MB of RAM in total.
The upload was read into memory before being written to flash, and his box's
own log caught what that costs, with MemAvailable falling from 27 MB to 11 MB
as the body arrived and the speaker restarting some eighty seconds later. Four
pushes in a row died that way. A fix in July had already removed io.ReadAll's
doubling peak, which halved the cost but left the whole binary in memory.

The bytes now stream straight into the temp file the atomic write was going to
use anyway, so the cost is a 32 KB copy buffer. The ELF check still happens
before anything is written, on the peeked head, and the hash is computed while
the data flows. The reclaim cascade that makes room on flash is shared verbatim
with the buffering path, because the space handling is the part of this code
that was hardest to get right and must not fork.

The agent binary keeps its buffered path deliberately. Its fallback tiers need
the bytes again after the write, and it is the smaller of the two.

Measured on three speakers before and after, same box, minutes apart:

  SoundTouch Portable   agent-update 13.0 MB of RAM   engine 0.5 MB
  SoundTouch 10         agent-update 11.5 MB of RAM   engine 0.9 MB
  SoundTouch 30         agent-update 13.0 MB of RAM   engine 2.0 MB

The SoundTouch 30 ran with 7.6 MB of free flash, the tightest of the three, and
took the engine without restarting.

Release-Note: fix(agent): installing the Spotify engine no longer restarts the speaker

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W4ZJXsnpmJuazCKF6ijdcZ