### PR TITLE
feat(phone): every input the speaker has is now offered, not just two

### DIFF
--- a/internal/webui/assets/index.html
+++ b/internal/webui/assets/index.html
@@ -788,11 +788,97 @@ async function togglePower() {
   setTimeout(refreshStatus, 1500); setTimeout(refreshStatus, 4000);
 }
 // setSource selects an input and keeps that button highlighted until another is chosen.
-async function setSource(s, btn) {
+async function setSource(s, btn, account) {
   document.querySelectorAll('#inputs .btn').forEach(function(e){ e.classList.remove('active'); });
   if (btn) btn.classList.add('active');
-  await api('/api/box/source','PUT',{source:s});
+  await api('/api/box/source','PUT',{source:s, sourceAccount: account || ''});
   setTimeout(refreshStatus, 1200);
+}
+
+// STR's own sources and the firmware's bookkeeping entries are not inputs a
+// person can switch to, so they never become buttons. Everything else the box
+// reports as local IS one: the names differ per model and cannot be listed
+// ahead of time (a CineMate calls its analogue input LOCAL where a SoundTouch
+// 10 says AUX, and a soundbar's sockets arrive as PRODUCT with the socket in
+// sourceAccount), so this is a list of what we know is NOT an input rather
+// than a guess at what is.
+var NOT_AN_INPUT = {
+  UPNP:1, LOCAL_INTERNET_RADIO:1, STORED_MUSIC:1, STORED_MUSIC_MEDIA_SERVER:1,
+  STORED_MUSIC_MEDIA_RENDERER:1, STANDBY:1, INVALID_SOURCE:1, NOTIFICATION:1,
+  UPDATE:1, SETUP:1
+};
+
+// isPhysicalInput decides what becomes a button, and both halves were measured
+// on real speakers (2026-08-09, Portable + SoundTouch 10 + SoundTouch 30)
+// rather than assumed:
+//
+//   - isLocal alone is NOT enough. QPlay reports isLocal=true on every one of
+//     those boxes and is a network protocol, not a socket; taking isLocal at
+//     face value would have put two buttons labelled "QPlay1UserName" under
+//     everybody's inputs.
+//   - status is NOT a filter. The SoundTouch 10's Bluetooth is a real input
+//     reporting UNAVAILABLE simply because nothing is paired to it, and an
+//     HDMI socket with the television off can be expected to look the same.
+//     Filtering on status would hide exactly the input the user wants back.
+//
+// What separates them cleanly is the account: the firmware gives every service
+// slot an account ending in "UserName" (QPlay1UserName, UPnPUserName,
+// SpotifyConnectUserName, StoredMusicUserName), and a physical socket never
+// has one. That rule needs no list of input names, which matters because the
+// input names are the part we cannot know in advance.
+function isPhysicalInput(x) {
+  var name = String((x && x.source) || '').toUpperCase();
+  if (!name || !x.isLocal || NOT_AN_INPUT[name]) return false;
+  return !/UserName$/.test(String(x.sourceAccount || ''));
+}
+
+// renderInputs builds one button per physical input the speaker actually has.
+//
+// It used to be two fixed buttons, Bluetooth and AUX, which is every input a
+// speaker has and no input a soundbar has. A CineMate 130 owner reported the
+// consequence on 2026-08-08: his box has TV, CBL-Sat, BD-DVD, Game and Aux on
+// the back, and once he switched to radio he had to reach for the infrared
+// remote to get his television sound back, because STR offered him no way
+// back. The SoundTouch 300 has the same shape of inputs.
+//
+// The label comes from the speaker, not from us: the box's own display name is
+// what the owner named that socket, so "CBL-Sat" stays "CBL-Sat".
+function renderInputs(sources) {
+  var card = document.getElementById('inputs');
+  if (!card) return;
+  var inputs = (sources || []).filter(isPhysicalInput);
+  var wrap = card.parentElement;
+  if (!inputs.length) {
+    card.innerHTML = '';
+    if (wrap) wrap.style.display = 'none';
+    return;
+  }
+  if (wrap) wrap.style.display = '';
+  card.innerHTML = '';
+  inputs.forEach(function(x) {
+    var b = document.createElement('button');
+    b.className = 'btn';
+    b.type = 'button';
+    b.textContent = inputLabel(x);
+    b.addEventListener('click', function(){ setSource(x.source, b, x.sourceAccount); });
+    card.appendChild(b);
+  });
+  // Two per row reads well up to four inputs; a soundbar with five or six
+  // needs the narrower grid or the labels wrap to two lines each.
+  card.className = inputs.length > 4 ? 'row c3' : 'row c2';
+}
+
+// inputLabel prefers what the speaker calls the socket, because that is what
+// its owner named it: a CineMate reports "CBL-Sat" and it should say CBL-Sat.
+// Bluetooth and AUX stay untranslated deliberately, like the other brand names
+// on this page.
+function inputLabel(x) {
+  var src = String(x.source || '').toUpperCase();
+  if (src === 'BLUETOOTH') return 'Bluetooth';
+  var shown = String(x.displayName || '').trim();
+  if (shown) return shown;
+  if (x.sourceAccount) return String(x.sourceAccount);
+  return src === 'LOCAL' ? 'AUX' : src;
 }
 
 async function loadSettings() {
@@ -801,15 +887,7 @@ async function loadSettings() {
   // Hide input buttons for sources this box does not offer (#417/#418: the
   // Wave pedestal has no selectable AUX, some models no Bluetooth). The box's
   // own source list is authoritative; an empty/missing list changes nothing.
-  if (Array.isArray(s.sources) && s.sources.length) {
-    var have = {};
-    s.sources.forEach(function(x){ have[String(x.source||'').toUpperCase()] = true; });
-    var bt = document.getElementById('btnSrcBt'), ax = document.getElementById('btnSrcAux');
-    if (bt) bt.style.display = have.BLUETOOTH ? '' : 'none';
-    if (ax) ax.style.display = have.AUX ? '' : 'none';
-    var card = document.getElementById('inputs');
-    if (card && card.parentElement) card.parentElement.style.display = (have.BLUETOOTH || have.AUX) ? '' : 'none';
-  }
+  if (Array.isArray(s.sources)) renderInputs(s.sources);
   if (s.info && s.info.name) {
     var dn = document.getElementById('devName');
     if (dn && dn.textContent !== s.info.name) { dn.textContent = s.info.name; renderDevMenu(); }

--- a/internal/webui/boxsettings_http.go
+++ b/internal/webui/boxsettings_http.go
@@ -5,6 +5,7 @@ package webui
 import (
 	"context"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"io"
 	"net/http"
@@ -368,7 +369,8 @@ func (s *Server) handleBoxSource(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req struct {
-		Source string `json:"source"`
+		Source        string `json:"source"`
+		SourceAccount string `json:"sourceAccount"`
 	}
 	if !decodeJSONRequest(w, r, 256, &req) {
 		return
@@ -404,20 +406,8 @@ func (s *Server) handleBoxSource(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var body string
-	switch src {
-	case "AUX":
-		body = `<ContentItem source="AUX" sourceAccount="AUX"></ContentItem>`
-	case "LOCAL":
-		// The same analogue input under the name a Cinemate uses for it. Note
-		// there is no sourceAccount: that is how the speaker itself describes
-		// the source when it is playing through it, and it is the reason the
-		// AUX form cannot simply be reused here (#491, taken from the owner's
-		// own diagnostic: <ContentItem source="LOCAL" isPresetable="true" />).
-		body = `<ContentItem source="LOCAL"></ContentItem>`
-	case "BLUETOOTH", "BT":
-		body = `<ContentItem source="BLUETOOTH" sourceAccount=""></ContentItem>`
-	default:
+	body, ok := s.contentItemForSource(r.Context(), src, req.SourceAccount)
+	if !ok {
 		http.Error(w, "unsupported source: "+src, http.StatusBadRequest)
 		return
 	}
@@ -762,4 +752,76 @@ func writeFlagFile(path, val string) error {
 		return err
 	}
 	return os.Rename(tmp, path)
+}
+
+// contentItemForSource builds the /select ContentItem for a source the user
+// picked, and reports false for anything this speaker does not actually offer.
+//
+// It used to be a switch over AUX, LOCAL and BLUETOOTH, which is every input a
+// speaker has and no input a soundbar has. A CineMate 130 owner (2026-08-08)
+// has TV, CBL-Sat, BD-DVD, Game and Aux on the back of his box and could reach
+// none of them from STR: once he switched to radio he had to get up and use the
+// infrared remote to get his television sound back. The SoundTouch 300 has the
+// same shape of inputs.
+//
+// The names cannot be hardcoded, and that is the whole lesson of the source
+// handling elsewhere in this codebase: a CineMate calls its analogue input
+// LOCAL where a SoundTouch 10 says AUX, an SA-5 answers AUX with sourceAccount
+// AUX1 to AUX3, and a soundbar's HDMI inputs arrive as PRODUCT with the socket
+// in sourceAccount. So the box's own /sources list decides.
+//
+// Validating against that list is also what makes this safe to accept from a
+// client at all: source and sourceAccount end up inside an XML attribute, and
+// echoing an arbitrary string there would let a caller write the ContentItem.
+// Only values the speaker itself reported are ever used, and they are taken
+// from the speaker's copy rather than from the request.
+func (s *Server) contentItemForSource(ctx context.Context, src, account string) (string, bool) {
+	item := func(source, acct string) string {
+		if acct == "" {
+			// No sourceAccount at all, which is how a CineMate describes its
+			// own analogue input and the reason the AUX form cannot simply be
+			// reused for it (#491).
+			return `<ContentItem source="` + xmlAttr(source) + `"></ContentItem>`
+		}
+		return `<ContentItem source="` + xmlAttr(source) + `" sourceAccount="` + xmlAttr(acct) + `"></ContentItem>`
+	}
+
+	sctx, cancel := context.WithTimeout(ctx, 4*time.Second)
+	defer cancel()
+	if settings, err := boxapi.New(s.boxHost).LoadSettings(sctx); err == nil && len(settings.Sources) > 0 {
+		for _, have := range settings.Sources {
+			if !strings.EqualFold(have.Source, src) {
+				continue
+			}
+			// An empty account in the request matches the box's entry for this
+			// source, whatever it is: the phone sends what it was given, and a
+			// source with exactly one account needs no disambiguation.
+			if account != "" && !strings.EqualFold(have.SourceAccount, account) {
+				continue
+			}
+			return item(have.Source, have.SourceAccount), true
+		}
+		// The box answered with a list and this source was not in it.
+		return "", false
+	}
+
+	// The box's list could not be read. Fall back to the three forms that were
+	// hardcoded before, so a speaker that is slow to answer /sources keeps the
+	// inputs it has always had rather than losing them to a timeout.
+	switch strings.ToUpper(src) {
+	case "AUX":
+		return `<ContentItem source="AUX" sourceAccount="AUX"></ContentItem>`, true
+	case "LOCAL":
+		return `<ContentItem source="LOCAL"></ContentItem>`, true
+	case "BLUETOOTH", "BT":
+		return `<ContentItem source="BLUETOOTH" sourceAccount=""></ContentItem>`, true
+	}
+	return "", false
+}
+
+// xmlAttr escapes a value for use inside a double-quoted XML attribute.
+func xmlAttr(v string) string {
+	var b strings.Builder
+	_ = xml.EscapeText(&b, []byte(v))
+	return strings.ReplaceAll(b.String(), `"`, "&#34;")
 }

--- a/internal/webui/boxsource_inputs_test.go
+++ b/internal/webui/boxsource_inputs_test.go
@@ -1,0 +1,143 @@
+package webui
+
+import (
+	"strings"
+	"testing"
+)
+
+// A soundbar's inputs cannot be hardcoded: a CineMate calls its analogue input
+// LOCAL where a SoundTouch 10 says AUX, an SA-5 answers AUX with sourceAccount
+// AUX1..AUX3, and a soundbar's sockets arrive as PRODUCT with the socket name
+// in sourceAccount. The phone therefore builds its buttons from the box's own
+// list, and this guards the shape of that.
+func TestPhoneRemoteBuildsInputsFromTheBoxsOwnList(t *testing.T) {
+	if strings.Contains(indexHTML, `if (bt) bt.style.display = have.BLUETOOTH`) {
+		t.Error("the phone still only shows the two hardcoded inputs; a soundbar's TV/HDMI sockets can never appear")
+	}
+	for _, want := range []string{
+		"function renderInputs(",
+		"function isPhysicalInput(",
+		"UserName$/.test",
+		"function inputLabel(",
+		"NOT_AN_INPUT",
+		"x.isLocal",
+	} {
+		if !strings.Contains(indexHTML, want) {
+			t.Errorf("phone input rendering is missing %q", want)
+		}
+	}
+	// The label must come from the speaker, not from a table of ours.
+	if !strings.Contains(indexHTML, "x.displayName") {
+		t.Error("the input button ignores the name the speaker gives the socket")
+	}
+	// STR's own sources must never be offered as physical inputs.
+	for _, ours := range []string{"UPNP", "LOCAL_INTERNET_RADIO", "STORED_MUSIC"} {
+		if !strings.Contains(indexHTML, ours+":1") {
+			t.Errorf("%s is not excluded from the input buttons", ours)
+		}
+	}
+	// The account has to travel with the request or a soundbar's sockets are
+	// indistinguishable from one another.
+	if !strings.Contains(indexHTML, "sourceAccount: account") {
+		t.Error("setSource does not send the sourceAccount, so PRODUCT sockets cannot be told apart")
+	}
+}
+
+// contentItemForSource takes a source name from the client and puts it inside
+// an XML attribute. Anything not reported by the speaker itself must be
+// refused, both because it cannot work and because echoing an arbitrary string
+// there would let a caller write the ContentItem.
+func TestSourceSelectionIsBoundedByWhatTheBoxReports(t *testing.T) {
+	if strings.Contains(xmlAttr(`x" evil="1`), `evil="1`) {
+		t.Error("xmlAttr does not neutralise a quote, so a source name can break out of the attribute")
+	}
+	for _, in := range []string{`a"b`, "a<b", "a&b", "a'b"} {
+		got := xmlAttr(in)
+		if strings.ContainsAny(got, `"<>`) {
+			t.Errorf("xmlAttr(%q) = %q still carries a character that changes the markup", in, got)
+		}
+	}
+}
+
+// The fallback matters: a speaker slow to answer /sources must keep the inputs
+// it has always had rather than losing them to a timeout. contentItemForSource
+// is exercised here through the fallback branch only (no box to reach), which
+// is exactly the case that must not regress.
+func TestSourceFallbackKeepsTheClassicInputs(t *testing.T) {
+	s := &Server{boxHost: "127.0.0.1:1"} // nothing listening: forces the fallback
+	for _, tc := range []struct {
+		src  string
+		want string
+	}{
+		{"AUX", `source="AUX" sourceAccount="AUX"`},
+		{"BLUETOOTH", `source="BLUETOOTH"`},
+		{"LOCAL", `<ContentItem source="LOCAL"></ContentItem>`},
+	} {
+		body, ok := s.contentItemForSource(t.Context(), tc.src, "")
+		if !ok {
+			t.Errorf("%s was refused when the box could not be asked", tc.src)
+			continue
+		}
+		if !strings.Contains(body, tc.want) {
+			t.Errorf("%s built %q, want it to contain %q", tc.src, body, tc.want)
+		}
+	}
+	if _, ok := s.contentItemForSource(t.Context(), "SOMETHING_INVENTED", ""); ok {
+		t.Error("an unknown source was accepted even though the box could not confirm it")
+	}
+}
+
+// The filter that decides what becomes a button, checked against source lists
+// captured from three real speakers on 2026-08-09. Both rules here exist
+// because the obvious ones were wrong on hardware.
+func TestOnlyPhysicalSocketsBecomeInputButtons(t *testing.T) {
+	// Verbatim from the boxes: a Portable, a SoundTouch 10 and a SoundTouch 30.
+	cases := []struct {
+		source, account, status string
+		local, want             bool
+		why                     string
+	}{
+		{"AUX", "AUX", "READY", true, true, "the analogue socket, on all three boxes"},
+		{"BLUETOOTH", "", "UNAVAILABLE", true, true,
+			"a real input on the ST10 that reports UNAVAILABLE because nothing is paired: status must not filter"},
+		{"QPLAY", "QPlay1UserName", "UNAVAILABLE", true, false,
+			"reports isLocal=true on every box but is a network protocol, not a socket"},
+		{"QPLAY", "QPlay2UserName", "UNAVAILABLE", true, false, "the second QPlay slot"},
+		{"UPNP", "UPnPUserName", "UNAVAILABLE", false, false, "STR's own playback source"},
+		{"SPOTIFY", "SpotifyConnectUserName", "UNAVAILABLE", false, false, "a service"},
+		{"STORED_MUSIC_MEDIA_RENDERER", "StoredMusicUserName", "UNAVAILABLE", false, false, "a service"},
+		{"LOCAL_INTERNET_RADIO", "", "READY", false, false, "STR's own radio source"},
+		{"AIRPLAY", "", "READY", false, false, "a service"},
+		{"ALEXA", "", "READY", false, false, "a service"},
+		{"NOTIFICATION", "", "UNAVAILABLE", false, false, "firmware bookkeeping"},
+
+		// What a soundbar is expected to report. Not captured from hardware, so
+		// these encode the intent rather than a measurement.
+		{"PRODUCT", "TV", "UNAVAILABLE", true, true, "a soundbar socket with the television off"},
+		{"PRODUCT", "BD-DVD", "READY", true, true, "a soundbar socket"},
+		{"LOCAL", "", "READY", true, true, "what a CineMate calls its analogue input"},
+	}
+	for _, c := range cases {
+		got := phoneKeepsAsInput(c.source, c.account, c.local)
+		if got != c.want {
+			t.Errorf("%s/%s: kept=%v, want %v (%s)", c.source, c.account, got, c.want, c.why)
+		}
+	}
+}
+
+// phoneKeepsAsInput mirrors isPhysicalInput in the phone page. Kept in step by
+// TestPhoneRemoteBuildsInputsFromTheBoxsOwnList, which fails if the page stops
+// using the same two rules.
+func phoneKeepsAsInput(source, account string, isLocal bool) bool {
+	notAnInput := map[string]bool{
+		"UPNP": true, "LOCAL_INTERNET_RADIO": true, "STORED_MUSIC": true,
+		"STORED_MUSIC_MEDIA_SERVER": true, "STORED_MUSIC_MEDIA_RENDERER": true,
+		"STANDBY": true, "INVALID_SOURCE": true, "NOTIFICATION": true,
+		"UPDATE": true, "SETUP": true,
+	}
+	up := strings.ToUpper(source)
+	if up == "" || !isLocal || notAnInput[up] {
+		return false
+	}
+	return !strings.HasSuffix(account, "UserName")
+}

--- a/internal/webui/phone_remote_test.go
+++ b/internal/webui/phone_remote_test.go
@@ -99,14 +99,22 @@ func TestPhoneRemoteLocalesHavePlayLabel(t *testing.T) {
 	}
 }
 
-// TestPhoneRemoteHidesUnavailableSources guards #417/#418: the input buttons
-// must be gated on the box's own /sources list so a Wave (no selectable AUX
-// through the pedestal) does not offer a dead AUX button.
+// TestPhoneRemoteHidesUnavailableSources guards #417/#418: a speaker must never
+// be offered an input it does not have, such as the Wave whose pedestal has no
+// selectable AUX.
+//
+// The mechanism changed when soundbar inputs arrived: instead of two fixed
+// buttons whose visibility was toggled, the buttons ARE the box's own list, so
+// an input that is absent from that list cannot be rendered in the first place.
+// The guarantee is the same and stronger, so this test now guards the source of
+// the buttons rather than the old visibility toggles.
 func TestPhoneRemoteHidesUnavailableSources(t *testing.T) {
-	for _, tok := range []string{`id="btnSrcAux"`, `id="btnSrcBt"`, "have.AUX", "have.BLUETOOTH", "s.sources"} {
-		if !strings.Contains(indexHTML, tok) {
-			t.Fatalf("phone remote missing source-availability gating token %q (#417/#418)", tok)
-		}
+	if !strings.Contains(indexHTML, "s.sources") || !strings.Contains(indexHTML, "renderInputs(s.sources)") {
+		t.Fatal("the input buttons are no longer built from the box's own source list (#417/#418)")
+	}
+	// Nothing may render an input that is not in the list the box reported.
+	if strings.Contains(indexHTML, `id="btnSrcAux"`) && !strings.Contains(indexHTML, "card.innerHTML = ''") {
+		t.Fatal("the static fallback buttons are never replaced by the box's real list (#417/#418)")
 	}
 }
 


### PR DESCRIPTION
A CineMate 130 owner has TV, CBL-Sat, BD-DVD, Game and Aux on the back of his
box and could reach none of them from STR. Once he switched to radio he had to
get up and use the infrared remote to get his television sound back. The
SoundTouch 300 has the same shape of inputs.

The phone offered exactly two buttons, Bluetooth and AUX, and only decided
whether to show them. That is every input a speaker has and no input a soundbar
has. The agent matched it: a switch over AUX, LOCAL and BLUETOOTH that refused
anything else.

Both sides now follow the speaker's own source list. The buttons ARE that list,
and the label is the name the box gives the socket, so "CBL-Sat" stays
CBL-Sat rather than becoming something we invented. Selecting one is validated
against the same list, which also makes it safe to accept a source name from a
client at all: it ends up inside an XML attribute, and only values the speaker
itself reported are ever used.

Two rules decide what counts as an input, and both are there because the
obvious answer was wrong on real speakers (measured on a Portable, a
SoundTouch 10 and a SoundTouch 30):

  isLocal alone is not enough. QPlay reports isLocal=true on all three and is a
  network protocol, not a socket, so trusting it would have put two buttons
  labelled "QPlay1UserName" under everyone's inputs.

  status must not filter. The SoundTouch 10's Bluetooth is a real input
  reporting UNAVAILABLE because nothing is paired to it, and an HDMI socket
  with the television off can be expected to look the same. Filtering on status
  would hide exactly the input the owner wants back.

What separates them is the account: the firmware gives every service slot one
ending in "UserName" and a physical socket never has one. That needs no list of
input names, which matters because the input names are the part we cannot know
in advance.

Verified on hardware: a SoundTouch 10 now offers "AUX IN" and "Bluetooth" and
nothing else, and the switch to AUX is accepted by the box.

Refs #577

Release-Note: feat(phone): a soundbar's inputs (TV, HDMI, Aux) can be switched from the phone remote, not just Bluetooth and AUX

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W4ZJXsnpmJuazCKF6ijdcZ