### PR TITLE
fix(multiroom): a large group stops reporting speakers as missing when they joined

### DIFF
--- a/internal/webui/zoneformbudget_test.go
+++ b/internal/webui/zoneformbudget_test.go
@@ -1,8 +1,13 @@
 package webui
 
 import (
+	"context"
+	"fmt"
+	"log/slog"
 	"testing"
 	"time"
+
+	"github.com/JRpersonal/streborn/internal/boxapi"
 )
 
 // The budget covers the whole form, not just the /setZone drive: waking the
@@ -48,5 +53,81 @@ func TestZoneFormBudgetStaysUnderTheAppsTimeout(t *testing.T) {
 		if got := zoneFormBudget(n); got >= appTimeout {
 			t.Errorf("zoneFormBudget(%d) = %v, want comfortably under the app's %v", n, got, appTimeout)
 		}
+	}
+}
+
+// Verification polls every follower at once. Sequentially it could not finish:
+// each follower had a 4 s budget of its own inside a form budget that stops at
+// 38 s, so eleven followers needed up to 44 s and the ones at the end of the
+// list were reported "missing" when the context died, although they had joined.
+//
+// Measured on a twelve-speaker fleet 2026-08-09: ok=true with every member
+// listed, verified=3 on one attempt and 7 minutes later, a different set each
+// time, and 11 of 11 the previous day when /setZone left more budget.
+func TestFollowerVerificationRunsConcurrently(t *testing.T) {
+	const followers = 11
+	slaves := make([]boxapi.ZoneMember, followers)
+	for i := range slaves {
+		slaves[i] = boxapi.ZoneMember{DeviceID: fmt.Sprintf("DEV%02d", i), IP: fmt.Sprintf("192.0.2.%d", i+10)}
+	}
+	// Every follower takes almost its whole budget to confirm. Done one after
+	// another that is 11 x 300ms; done together it is one 300ms wait.
+	timing := followerVerifyTiming{
+		perFollowerBudget: 400 * time.Millisecond,
+		pollInterval:      50 * time.Millisecond,
+		perCallTimeout:    400 * time.Millisecond,
+	}
+	fetch := func(ctx context.Context, ip string) (boxapi.Zone, error) {
+		select {
+		case <-time.After(300 * time.Millisecond):
+		case <-ctx.Done():
+			return boxapi.Zone{}, ctx.Err()
+		}
+		return boxapi.Zone{Master: "MASTER"}, nil
+	}
+
+	// A budget that comfortably fits one follower and could never fit eleven
+	// in sequence: this is the field condition in miniature.
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	missing, unverifiable := verifyFollowersJoinedTimed(ctx, slog.New(slog.DiscardHandler), "MASTER", slaves, fetch, timing)
+	elapsed := time.Since(start)
+
+	if len(missing) != 0 {
+		t.Errorf("%d of %d followers reported missing although every one confirmed: %v", len(missing), followers, missing)
+	}
+	if len(unverifiable) != 0 {
+		t.Errorf("unexpected unverifiable: %v", unverifiable)
+	}
+	if elapsed > time.Second {
+		t.Errorf("verification took %v for %d followers, which means they were still polled one after another", elapsed, followers)
+	}
+}
+
+// A follower with no address cannot be polled and must be reported separately
+// rather than counted as missing, and the order must follow the request so the
+// output does not shuffle between runs.
+func TestFollowerVerificationKeepsOrderAndSeparatesUnverifiable(t *testing.T) {
+	slaves := []boxapi.ZoneMember{
+		{DeviceID: "A", IP: "192.0.2.10"},
+		{DeviceID: "B"}, // no address
+		{DeviceID: "C", IP: "192.0.2.12"},
+		{DeviceID: "D", IP: "192.0.2.13"},
+	}
+	timing := followerVerifyTiming{perFollowerBudget: 60 * time.Millisecond, pollInterval: 10 * time.Millisecond, perCallTimeout: 60 * time.Millisecond}
+	fetch := func(_ context.Context, ip string) (boxapi.Zone, error) {
+		if ip == "192.0.2.12" {
+			return boxapi.Zone{Master: "SOMEONE_ELSE"}, nil // joined the wrong master
+		}
+		return boxapi.Zone{Master: "MASTER"}, nil
+	}
+	missing, unverifiable := verifyFollowersJoinedTimed(context.Background(), slog.New(slog.DiscardHandler), "MASTER", slaves, fetch, timing)
+	if len(unverifiable) != 1 || unverifiable[0] != "B" {
+		t.Errorf("unverifiable = %v, want just the follower with no address", unverifiable)
+	}
+	if len(missing) != 1 || missing[0] != "C" {
+		t.Errorf("missing = %v, want just the follower that named another master", missing)
 	}
 }

--- a/internal/webui/zones_stereo.go
+++ b/internal/webui/zones_stereo.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/JRpersonal/streborn/internal/boxapi"
@@ -488,57 +489,99 @@ var defaultFollowerVerifyTiming = followerVerifyTiming{
 // verifyFollowersJoinedTimed is verifyFollowersJoined with explicit timing;
 // see there for the semantics.
 func verifyFollowersJoinedTimed(ctx context.Context, logger *slog.Logger, masterID string, slaves []boxapi.ZoneMember, fetch followerZoneFetch, timing followerVerifyTiming) (missing, unverifiable []string) {
-	perFollowerBudget := timing.perFollowerBudget
-	pollInterval := timing.pollInterval
-	perCallTimeout := timing.perCallTimeout
-	for _, sl := range slaves {
+	// Every follower is polled AT THE SAME TIME. They are separate speakers on
+	// separate addresses and nothing about asking one depends on having asked
+	// another, so the old speaker-after-speaker walk bought nothing and cost
+	// the whole budget.
+	//
+	// It cost correctness, not just time. This runs under the form's context,
+	// which is bounded by zoneFormBudget, and each follower was given up to
+	// four seconds of its own. Eleven followers therefore needed up to
+	// forty-four seconds inside a budget that stops at thirty-eight, minus
+	// whatever /setZone had already spent. The context died partway down the
+	// list and every follower after that point was reported "missing" although
+	// it had joined perfectly well.
+	//
+	// A twelve-speaker household saw exactly that on 2026-08-09: ok=true with
+	// all members listed, but verified=3 on one attempt and verified=7 minutes
+	// later, a different set each time, and 11 of 11 the day before when
+	// /setZone happened to be quick and left more budget. Read as a grouping
+	// failure that is baffling; read as a report running out of time it is
+	// obvious. Polled together, the whole check costs about one follower's
+	// budget no matter how large the fleet.
+	type result struct {
+		deviceID     string
+		unverifiable bool
+		joined       bool
+	}
+	results := make([]result, len(slaves))
+	var wg sync.WaitGroup
+	for i, sl := range slaves {
+		results[i].deviceID = sl.DeviceID
 		if sl.IP == "" {
-			unverifiable = append(unverifiable, sl.DeviceID)
+			results[i].unverifiable = true
 			continue
 		}
-		deadline := time.Now().Add(perFollowerBudget)
-		joined := false
-		var lastSelfMaster string
-		var lastMembers int
-		var lastErr error
-		for {
-			cctx, cancel := context.WithTimeout(ctx, perCallTimeout)
-			fz, ferr := fetch(cctx, sl.IP)
-			cancel()
-			if ferr != nil {
-				lastErr = ferr
-			} else {
-				lastErr = nil
-				lastSelfMaster = fz.Master
-				lastMembers = len(fz.Members)
-				if fz.Master != "" && strings.EqualFold(fz.Master, masterID) {
-					joined = true
-					break
-				}
-			}
-			if time.Now().After(deadline) || ctx.Err() != nil {
-				break
-			}
-			select {
-			case <-ctx.Done():
-			case <-time.After(pollInterval):
-			}
-			if ctx.Err() != nil {
-				break
-			}
+		wg.Add(1)
+		go func(i int, sl boxapi.ZoneMember) {
+			defer wg.Done()
+			results[i].joined = pollFollowerJoined(ctx, logger, masterID, sl, fetch, timing)
+		}(i, sl)
+	}
+	wg.Wait()
+
+	// Reported in the order the caller asked for them, so the output does not
+	// shuffle between runs just because the speakers answered out of order.
+	for _, r := range results {
+		switch {
+		case r.unverifiable:
+			unverifiable = append(unverifiable, r.deviceID)
+		case !r.joined:
+			missing = append(missing, r.deviceID)
 		}
-		if joined {
-			logger.Info("zone: follower confirmed", "follower", sl.DeviceID, "ip", sl.IP, "selfMaster", lastSelfMaster)
-			continue
-		}
-		if lastErr != nil {
-			logger.Info("zone: follower never confirmed (self-report unreachable)", "follower", sl.DeviceID, "ip", sl.IP, "err", lastErr.Error())
-		} else {
-			logger.Info("zone: follower never confirmed", "follower", sl.DeviceID, "ip", sl.IP, "selfMaster", lastSelfMaster, "selfMembers", lastMembers)
-		}
-		missing = append(missing, sl.DeviceID)
 	}
 	return missing, unverifiable
+}
+
+// pollFollowerJoined polls one follower's own /getZone until it names masterID
+// as its master, its own budget runs out, or the surrounding context ends.
+func pollFollowerJoined(ctx context.Context, logger *slog.Logger, masterID string, sl boxapi.ZoneMember, fetch followerZoneFetch, timing followerVerifyTiming) bool {
+	deadline := time.Now().Add(timing.perFollowerBudget)
+	var lastSelfMaster string
+	var lastMembers int
+	var lastErr error
+	for {
+		cctx, cancel := context.WithTimeout(ctx, timing.perCallTimeout)
+		fz, ferr := fetch(cctx, sl.IP)
+		cancel()
+		if ferr != nil {
+			lastErr = ferr
+		} else {
+			lastErr = nil
+			lastSelfMaster = fz.Master
+			lastMembers = len(fz.Members)
+			if fz.Master != "" && strings.EqualFold(fz.Master, masterID) {
+				logger.Info("zone: follower confirmed", "follower", sl.DeviceID, "ip", sl.IP, "selfMaster", lastSelfMaster)
+				return true
+			}
+		}
+		if time.Now().After(deadline) || ctx.Err() != nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+		case <-time.After(timing.pollInterval):
+		}
+		if ctx.Err() != nil {
+			break
+		}
+	}
+	if lastErr != nil {
+		logger.Info("zone: follower never confirmed (self-report unreachable)", "follower", sl.DeviceID, "ip", sl.IP, "err", lastErr.Error())
+	} else {
+		logger.Info("zone: follower never confirmed", "follower", sl.DeviceID, "ip", sl.IP, "selfMaster", lastSelfMaster, "selfMembers", lastMembers)
+	}
+	return false
 }
 
 // localDeviceID returns this box's authoritative Bose SoundTouch deviceID, read


### PR DESCRIPTION
A twelve-speaker household formed the same group twice within two minutes and
got ok=true both times with every member listed, but verified=3 on one attempt
and verified=7 on the next, naming a different set of speakers each time. The
day before, the same fleet verified 11 of 11. Read as a grouping failure that
is baffling. It was not one: the speakers joined, the report ran out of time.

Verification polls each follower's own /getZone until it names the master, and
it did so one speaker after another, four seconds allowed for each. That runs
inside the form's context, which stops at thirty-eight seconds, so eleven
followers needed up to forty-four seconds of a budget /setZone had already
spent part of. The context ended partway down the list and everything after
that point was reported missing. Which speakers those were depended entirely on
how quick the firmware had been that minute, which is why the number moved and
why it was fine the day before.

They are separate speakers on separate addresses and asking one never depended
on having asked another, so they are polled together now. The whole check costs
about one follower's budget regardless of fleet size, and the result is ordered
by request rather than by who answered first, so the output does not shuffle
between runs.

Each goroutine writes only its own slot in a pre-sized slice and the read
happens after Wait, so no lock is needed.

Release-Note: fix(multiroom): a large group no longer reports speakers as missing when they actually joined

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W4ZJXsnpmJuazCKF6ijdcZ