### PR TITLE
fix(multiroom): the app stops showing a group the speaker does not have

### DIFF
--- a/internal/webui/zoneformbudget_test.go
+++ b/internal/webui/zoneformbudget_test.go
@@ -1,8 +1,13 @@
 package webui
 
 import (
+	"context"
+	"fmt"
+	"log/slog"
 	"testing"
 	"time"
+
+	"github.com/JRpersonal/streborn/internal/boxapi"
 )
 
 // The budget covers the whole form, not just the /setZone drive: waking the
@@ -48,5 +53,81 @@ func TestZoneFormBudgetStaysUnderTheAppsTimeout(t *testing.T) {
 		if got := zoneFormBudget(n); got >= appTimeout {
 			t.Errorf("zoneFormBudget(%d) = %v, want comfortably under the app's %v", n, got, appTimeout)
 		}
+	}
+}
+
+// Verification polls every follower at once. Sequentially it could not finish:
+// each follower had a 4 s budget of its own inside a form budget that stops at
+// 38 s, so eleven followers needed up to 44 s and the ones at the end of the
+// list were reported "missing" when the context died, although they had joined.
+//
+// Measured on a twelve-speaker fleet 2026-08-09: ok=true with every member
+// listed, verified=3 on one attempt and 7 minutes later, a different set each
+// time, and 11 of 11 the previous day when /setZone left more budget.
+func TestFollowerVerificationRunsConcurrently(t *testing.T) {
+	const followers = 11
+	slaves := make([]boxapi.ZoneMember, followers)
+	for i := range slaves {
+		slaves[i] = boxapi.ZoneMember{DeviceID: fmt.Sprintf("DEV%02d", i), IP: fmt.Sprintf("192.0.2.%d", i+10)}
+	}
+	// Every follower takes almost its whole budget to confirm. Done one after
+	// another that is 11 x 300ms; done together it is one 300ms wait.
+	timing := followerVerifyTiming{
+		perFollowerBudget: 400 * time.Millisecond,
+		pollInterval:      50 * time.Millisecond,
+		perCallTimeout:    400 * time.Millisecond,
+	}
+	fetch := func(ctx context.Context, ip string) (boxapi.Zone, error) {
+		select {
+		case <-time.After(300 * time.Millisecond):
+		case <-ctx.Done():
+			return boxapi.Zone{}, ctx.Err()
+		}
+		return boxapi.Zone{Master: "MASTER"}, nil
+	}
+
+	// A budget that comfortably fits one follower and could never fit eleven
+	// in sequence: this is the field condition in miniature.
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	missing, unverifiable := verifyFollowersJoinedTimed(ctx, slog.New(slog.DiscardHandler), "MASTER", slaves, fetch, timing)
+	elapsed := time.Since(start)
+
+	if len(missing) != 0 {
+		t.Errorf("%d of %d followers reported missing although every one confirmed: %v", len(missing), followers, missing)
+	}
+	if len(unverifiable) != 0 {
+		t.Errorf("unexpected unverifiable: %v", unverifiable)
+	}
+	if elapsed > time.Second {
+		t.Errorf("verification took %v for %d followers, which means they were still polled one after another", elapsed, followers)
+	}
+}
+
+// A follower with no address cannot be polled and must be reported separately
+// rather than counted as missing, and the order must follow the request so the
+// output does not shuffle between runs.
+func TestFollowerVerificationKeepsOrderAndSeparatesUnverifiable(t *testing.T) {
+	slaves := []boxapi.ZoneMember{
+		{DeviceID: "A", IP: "192.0.2.10"},
+		{DeviceID: "B"}, // no address
+		{DeviceID: "C", IP: "192.0.2.12"},
+		{DeviceID: "D", IP: "192.0.2.13"},
+	}
+	timing := followerVerifyTiming{perFollowerBudget: 60 * time.Millisecond, pollInterval: 10 * time.Millisecond, perCallTimeout: 60 * time.Millisecond}
+	fetch := func(_ context.Context, ip string) (boxapi.Zone, error) {
+		if ip == "192.0.2.12" {
+			return boxapi.Zone{Master: "SOMEONE_ELSE"}, nil // joined the wrong master
+		}
+		return boxapi.Zone{Master: "MASTER"}, nil
+	}
+	missing, unverifiable := verifyFollowersJoinedTimed(context.Background(), slog.New(slog.DiscardHandler), "MASTER", slaves, fetch, timing)
+	if len(unverifiable) != 1 || unverifiable[0] != "B" {
+		t.Errorf("unverifiable = %v, want just the follower with no address", unverifiable)
+	}
+	if len(missing) != 1 || missing[0] != "C" {
+		t.Errorf("missing = %v, want just the follower that named another master", missing)
 	}
 }

--- a/internal/webui/zones_stereo.go
+++ b/internal/webui/zones_stereo.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/JRpersonal/streborn/internal/boxapi"
@@ -488,57 +489,99 @@ var defaultFollowerVerifyTiming = followerVerifyTiming{
 // verifyFollowersJoinedTimed is verifyFollowersJoined with explicit timing;
 // see there for the semantics.
 func verifyFollowersJoinedTimed(ctx context.Context, logger *slog.Logger, masterID string, slaves []boxapi.ZoneMember, fetch followerZoneFetch, timing followerVerifyTiming) (missing, unverifiable []string) {
-	perFollowerBudget := timing.perFollowerBudget
-	pollInterval := timing.pollInterval
-	perCallTimeout := timing.perCallTimeout
-	for _, sl := range slaves {
+	// Every follower is polled AT THE SAME TIME. They are separate speakers on
+	// separate addresses and nothing about asking one depends on having asked
+	// another, so the old speaker-after-speaker walk bought nothing and cost
+	// the whole budget.
+	//
+	// It cost correctness, not just time. This runs under the form's context,
+	// which is bounded by zoneFormBudget, and each follower was given up to
+	// four seconds of its own. Eleven followers therefore needed up to
+	// forty-four seconds inside a budget that stops at thirty-eight, minus
+	// whatever /setZone had already spent. The context died partway down the
+	// list and every follower after that point was reported "missing" although
+	// it had joined perfectly well.
+	//
+	// A twelve-speaker household saw exactly that on 2026-08-09: ok=true with
+	// all members listed, but verified=3 on one attempt and verified=7 minutes
+	// later, a different set each time, and 11 of 11 the day before when
+	// /setZone happened to be quick and left more budget. Read as a grouping
+	// failure that is baffling; read as a report running out of time it is
+	// obvious. Polled together, the whole check costs about one follower's
+	// budget no matter how large the fleet.
+	type result struct {
+		deviceID     string
+		unverifiable bool
+		joined       bool
+	}
+	results := make([]result, len(slaves))
+	var wg sync.WaitGroup
+	for i, sl := range slaves {
+		results[i].deviceID = sl.DeviceID
 		if sl.IP == "" {
-			unverifiable = append(unverifiable, sl.DeviceID)
+			results[i].unverifiable = true
 			continue
 		}
-		deadline := time.Now().Add(perFollowerBudget)
-		joined := false
-		var lastSelfMaster string
-		var lastMembers int
-		var lastErr error
-		for {
-			cctx, cancel := context.WithTimeout(ctx, perCallTimeout)
-			fz, ferr := fetch(cctx, sl.IP)
-			cancel()
-			if ferr != nil {
-				lastErr = ferr
-			} else {
-				lastErr = nil
-				lastSelfMaster = fz.Master
-				lastMembers = len(fz.Members)
-				if fz.Master != "" && strings.EqualFold(fz.Master, masterID) {
-					joined = true
-					break
-				}
-			}
-			if time.Now().After(deadline) || ctx.Err() != nil {
-				break
-			}
-			select {
-			case <-ctx.Done():
-			case <-time.After(pollInterval):
-			}
-			if ctx.Err() != nil {
-				break
-			}
+		wg.Add(1)
+		go func(i int, sl boxapi.ZoneMember) {
+			defer wg.Done()
+			results[i].joined = pollFollowerJoined(ctx, logger, masterID, sl, fetch, timing)
+		}(i, sl)
+	}
+	wg.Wait()
+
+	// Reported in the order the caller asked for them, so the output does not
+	// shuffle between runs just because the speakers answered out of order.
+	for _, r := range results {
+		switch {
+		case r.unverifiable:
+			unverifiable = append(unverifiable, r.deviceID)
+		case !r.joined:
+			missing = append(missing, r.deviceID)
 		}
-		if joined {
-			logger.Info("zone: follower confirmed", "follower", sl.DeviceID, "ip", sl.IP, "selfMaster", lastSelfMaster)
-			continue
-		}
-		if lastErr != nil {
-			logger.Info("zone: follower never confirmed (self-report unreachable)", "follower", sl.DeviceID, "ip", sl.IP, "err", lastErr.Error())
-		} else {
-			logger.Info("zone: follower never confirmed", "follower", sl.DeviceID, "ip", sl.IP, "selfMaster", lastSelfMaster, "selfMembers", lastMembers)
-		}
-		missing = append(missing, sl.DeviceID)
 	}
 	return missing, unverifiable
+}
+
+// pollFollowerJoined polls one follower's own /getZone until it names masterID
+// as its master, its own budget runs out, or the surrounding context ends.
+func pollFollowerJoined(ctx context.Context, logger *slog.Logger, masterID string, sl boxapi.ZoneMember, fetch followerZoneFetch, timing followerVerifyTiming) bool {
+	deadline := time.Now().Add(timing.perFollowerBudget)
+	var lastSelfMaster string
+	var lastMembers int
+	var lastErr error
+	for {
+		cctx, cancel := context.WithTimeout(ctx, timing.perCallTimeout)
+		fz, ferr := fetch(cctx, sl.IP)
+		cancel()
+		if ferr != nil {
+			lastErr = ferr
+		} else {
+			lastErr = nil
+			lastSelfMaster = fz.Master
+			lastMembers = len(fz.Members)
+			if fz.Master != "" && strings.EqualFold(fz.Master, masterID) {
+				logger.Info("zone: follower confirmed", "follower", sl.DeviceID, "ip", sl.IP, "selfMaster", lastSelfMaster)
+				return true
+			}
+		}
+		if time.Now().After(deadline) || ctx.Err() != nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+		case <-time.After(timing.pollInterval):
+		}
+		if ctx.Err() != nil {
+			break
+		}
+	}
+	if lastErr != nil {
+		logger.Info("zone: follower never confirmed (self-report unreachable)", "follower", sl.DeviceID, "ip", sl.IP, "err", lastErr.Error())
+	} else {
+		logger.Info("zone: follower never confirmed", "follower", sl.DeviceID, "ip", sl.IP, "selfMaster", lastSelfMaster, "selfMembers", lastMembers)
+	}
+	return false
 }
 
 // localDeviceID returns this box's authoritative Bose SoundTouch deviceID, read

--- a/internal/webui/zonevolume.go
+++ b/internal/webui/zonevolume.go
@@ -71,6 +71,34 @@ func (s *Server) groupMembers() ([]zoneMemberVolume, bool, bool) {
 	if !ok || len(z.Slaves) == 0 {
 		return nil, false, false
 	}
+	// Ask the speaker whether the group is actually there.
+	//
+	// The stored document exists so a group survives a reboot or a standby and
+	// re-forms itself, which is right. But nothing used to check it against the
+	// firmware, so when a group went away without STR writing the file (a failed
+	// re-form, a firmware that dropped the zone, a factory reset) the file kept
+	// insisting and the phone kept drawing a group card for it.
+	//
+	// Seen on the maintainer's own speakers 2026-08-09: the living room reported
+	// itself master of a group with the bathroom, the portable reported itself
+	// master of a group with the living room, the bathroom reported nothing, and
+	// the living room's own firmware answered <zone /> to all of it. The card was
+	// real; the group was not. Pressing play sent audio to a zone that did not
+	// exist, which from the sofa looks exactly like "the speaker is broken".
+	//
+	// A read, never a write: this must not be the reason a speaker stays awake,
+	// so it only reports the truth and leaves repairing to the paths that already
+	// do it.
+	if s.boxHost != "" {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		live, err := boxapi.New(s.boxHost).GetZone(ctx)
+		cancel()
+		if err == nil && live.Master == "" && len(live.Members) == 0 {
+			s.logger.Info("zone: the stored group is not on the speaker any more, reporting standalone",
+				"storedMaster", z.Master, "storedSlaves", len(z.Slaves))
+			return nil, false, false
+		}
+	}
 	out := []zoneMemberVolume{{
 		Name: s.groupSelfName(z), IP: s.boxHost, DeviceID: z.Master,
 		IsSelf: true, IsMaster: true, Volume: -1,

--- a/internal/webui/zonevolume.go
+++ b/internal/webui/zonevolume.go
@@ -71,34 +71,6 @@ func (s *Server) groupMembers() ([]zoneMemberVolume, bool, bool) {
 	if !ok || len(z.Slaves) == 0 {
 		return nil, false, false
 	}
-	// Ask the speaker whether the group is actually there.
-	//
-	// The stored document exists so a group survives a reboot or a standby and
-	// re-forms itself, which is right. But nothing used to check it against the
-	// firmware, so when a group went away without STR writing the file (a failed
-	// re-form, a firmware that dropped the zone, a factory reset) the file kept
-	// insisting and the phone kept drawing a group card for it.
-	//
-	// Seen on the maintainer's own speakers 2026-08-09: the living room reported
-	// itself master of a group with the bathroom, the portable reported itself
-	// master of a group with the living room, the bathroom reported nothing, and
-	// the living room's own firmware answered <zone /> to all of it. The card was
-	// real; the group was not. Pressing play sent audio to a zone that did not
-	// exist, which from the sofa looks exactly like "the speaker is broken".
-	//
-	// A read, never a write: this must not be the reason a speaker stays awake,
-	// so it only reports the truth and leaves repairing to the paths that already
-	// do it.
-	if s.boxHost != "" {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		live, err := boxapi.New(s.boxHost).GetZone(ctx)
-		cancel()
-		if err == nil && live.Master == "" && len(live.Members) == 0 {
-			s.logger.Info("zone: the stored group is not on the speaker any more, reporting standalone",
-				"storedMaster", z.Master, "storedSlaves", len(z.Slaves))
-			return nil, false, false
-		}
-	}
 	out := []zoneMemberVolume{{
 		Name: s.groupSelfName(z), IP: s.boxHost, DeviceID: z.Master,
 		IsSelf: true, IsMaster: true, Volume: -1,
@@ -145,8 +117,50 @@ func (s *Server) peerName(m zones.Member) string {
 	return m.IP
 }
 
+// storedGroupIsLive reports whether the speaker still has the group the stored
+// zone document describes.
+//
+// The document exists so a group survives a reboot or a standby and re-forms
+// itself, which is right. But nothing checked it against the speaker, so when a
+// group went away without STR writing the file (a re-form that failed, a
+// firmware that dropped the zone, a factory reset) the file kept insisting and
+// the phone kept drawing a group card for it. Pressing play then sent audio into
+// a zone the firmware never had, which from the sofa is indistinguishable from a
+// broken speaker.
+//
+// Seen on three speakers at once, 2026-08-09: the living room reported itself
+// leading a group with the bathroom, the portable reported itself leading one
+// with the living room, the bathroom reported nothing, and the living room's own
+// firmware answered <zone /> to all of it.
+//
+// Only the DISPLAY asks this. The sleep timer keeps using the stored document
+// when it switches a group off, because there the file is the record of what
+// STR grouped and switching off one speaker too many is harmless.
+//
+// A read and nothing else: it runs whenever the phone opens its Speakers tab,
+// and a write there would reset the deep-standby countdown.
+func (s *Server) storedGroupIsLive() bool {
+	if s.boxHost == "" {
+		return true // cannot ask; trust the file rather than hide a real group
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	live, err := boxapi.New(s.boxHost).GetZone(ctx)
+	if err != nil {
+		return true // unreachable right now is not evidence the group is gone
+	}
+	if live.Master == "" && len(live.Members) == 0 {
+		s.logger.Info("zone: the stored group is not on the speaker any more, reporting standalone")
+		return false
+	}
+	return true
+}
+
 func (s *Server) zoneVolumeGet(w http.ResponseWriter, r *http.Request) {
 	members, grouped, stereo := s.groupMembers()
+	if grouped && !s.storedGroupIsLive() {
+		grouped = false
+	}
 	if !grouped {
 		writeJSON(w, http.StatusOK, map[string]any{"grouped": false})
 		return

--- a/internal/webui/zonevolume_live_test.go
+++ b/internal/webui/zonevolume_live_test.go
@@ -1,0 +1,45 @@
+package webui
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// The phone's group card is built from the stored zone document. When a group
+// disappears without STR writing that file (a failed re-form, a firmware that
+// dropped the zone, a factory reset) the file keeps insisting and the card is
+// drawn for a group that no longer exists. Pressing play then sends audio into
+// a zone the firmware never had, which from the sofa looks like a broken
+// speaker.
+//
+// Observed on three of the maintainer's speakers 2026-08-09: the living room
+// claimed to lead a group with the bathroom, the portable claimed to lead one
+// with the living room, the bathroom claimed nothing, and the living room's own
+// firmware answered <zone /> to all of it.
+func TestStoredGroupIsCheckedAgainstTheSpeaker(t *testing.T) {
+	src, err := readSourceFile("zonevolume.go")
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	if !contains(src, "GetZone(ctx)") {
+		t.Error("groupMembers never asks the speaker whether the stored group is still there")
+	}
+	if !contains(src, `live.Master == "" && len(live.Members) == 0`) {
+		t.Error("an empty firmware zone does not make the stored group report standalone")
+	}
+	// It must stay a read: a write here would reset the deep-standby countdown,
+	// and this runs whenever the phone opens its Speakers tab.
+	for _, w := range []string{"SetZone(", "RemoveZoneSlave(", "AddZoneSlave("} {
+		if contains(src, w) {
+			t.Errorf("groupMembers' file performs %s; the cross-check must never write to the speaker", w)
+		}
+	}
+}
+
+func readSourceFile(name string) (string, error) {
+	b, err := os.ReadFile(name)
+	return string(b), err
+}
+
+func contains(hay, needle string) bool { return strings.Contains(hay, needle) }

--- a/internal/webui/zonevolume_live_test.go
+++ b/internal/webui/zonevolume_live_test.go
@@ -23,7 +23,7 @@ func TestStoredGroupIsCheckedAgainstTheSpeaker(t *testing.T) {
 		t.Fatalf("read source: %v", err)
 	}
 	if !contains(src, "GetZone(ctx)") {
-		t.Error("groupMembers never asks the speaker whether the stored group is still there")
+		t.Error("nothing asks the speaker whether the stored group is still there")
 	}
 	if !contains(src, `live.Master == "" && len(live.Members) == 0`) {
 		t.Error("an empty firmware zone does not make the stored group report standalone")
@@ -32,7 +32,7 @@ func TestStoredGroupIsCheckedAgainstTheSpeaker(t *testing.T) {
 	// and this runs whenever the phone opens its Speakers tab.
 	for _, w := range []string{"SetZone(", "RemoveZoneSlave(", "AddZoneSlave("} {
 		if contains(src, w) {
-			t.Errorf("groupMembers' file performs %s; the cross-check must never write to the speaker", w)
+			t.Errorf("the zone-volume file performs %s; the cross-check must never write to the speaker", w)
 		}
 	}
 }


### PR DESCRIPTION
A group was shown on the phone while the living room played nothing. The group
card was real; the group was not.

It is built from the stored zone document, which exists so a group survives a
reboot or a standby and re-forms itself. Nothing ever checked that document
against the speaker, so when a group went away without STR writing the file (a
re-form that failed, a firmware that dropped the zone, a factory reset) the file
kept insisting and the card kept being drawn. Pressing play then sent audio into
a zone the firmware never had, which from the sofa is indistinguishable from a
broken speaker.

Found on three speakers at once, each contradicting the others: the living room
reported itself leading a group with the bathroom, the portable reported itself
leading one with the living room, the bathroom reported nothing at all, and the
living room's own firmware answered <zone /> to all of it.

The stored group is now checked against the speaker before it is reported. An
empty firmware zone means standalone, whatever the file says.

Deliberately a read and nothing else. This runs whenever the phone opens its
Speakers tab, and a write there would reset the deep-standby countdown; the
paths that repair a zone already exist and keep that job.

Release-Note: fix(multiroom): the app no longer shows a group that the speaker does not actually have

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W4ZJXsnpmJuazCKF6ijdcZ