### PR TITLE
fix(app): the stereo balance is readable again, and sits where people look

### DIFF
--- a/desktop-app/frontend/src/groups.js
+++ b/desktop-app/frontend/src/groups.js
@@ -280,7 +280,12 @@ export function stereoPairOf(zoneLive) {
     if (st && ((st.members || []).length || st.id)) {
       return {
         id: st.id || '',
-        master: String(st.master || '').toUpperCase(),
+        // The agent names this field masterDeviceID. Reading only st.master
+        // left pair.master empty on every pair, so "ask the pair's MASTER for
+        // the balance" silently asked whichever half happened to be selected,
+        // which is the bug that was supposed to be fixed (#70). Both spellings
+        // are accepted so an older agent keeps working.
+        master: String(st.masterDeviceID || st.master || '').toUpperCase(),
         members: st.members || [],
       };
     }

--- a/desktop-app/frontend/src/groups.test.js
+++ b/desktop-app/frontend/src/groups.test.js
@@ -436,3 +436,24 @@ describe('balanceSourceBox', () => {
     expect(balanceSourceBox(right, pair, [right])).toBe(right);
   });
 });
+
+describe('stereoPairOf master field', () => {
+  it('reads the masterDeviceID the agent actually sends', () => {
+    const zoneLive = {
+      A: {
+        members: [],
+        stereo: {
+          id: 'str-grp-AA', name: 'Stereo pair', masterDeviceID: 'AA',
+          members: [{ deviceID: 'AA', ip: '192.0.2.1', role: 'LEFT' },
+                    { deviceID: 'BB', ip: '192.0.2.2', role: 'RIGHT' }],
+        },
+      },
+    };
+    expect(stereoPairOf(zoneLive).master).toBe('AA');
+  });
+
+  it('still accepts the older master spelling', () => {
+    const zoneLive = { A: { stereo: { id: 'x', master: 'cc', members: [] } } };
+    expect(stereoPairOf(zoneLive).master).toBe('CC');
+  });
+});

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -344,7 +344,7 @@ import {
 // before without reimplementing them. All hoisted function declarations, safe
 // to pass here.
 initRecentView({ showSlotPicker, playStation, openPick, toggleFav, isFav });
-initMultiroomView({ boxNeedsUpdate, discoverBoxes, selectBox });
+initMultiroomView({ boxNeedsUpdate, discoverBoxes, selectBox, boxFetch });
 initSpotifyView({
   switchView,
   // Live STR speaker list for the "sync Spotify login to all speakers" action.
@@ -1215,7 +1215,7 @@ $('view-box').innerHTML = `
         <input type="range" id="musicVolume" min="0" max="100" step="1" aria-label="${escapeAttr(t('controls.volume'))}" title="${escapeAttr(t('controls.volumeWheelHint'))}" />
         <button class="btn btn-mini vol-step" id="volUp" aria-label="${escapeAttr(t('controls.volumeUp'))}" title="${escapeAttr(t('controls.volumeUp'))}">+</button>
         <span class="vol-val" id="musicVolumeVal">--</span>
-        <span class="vol-balance hidden" id="musicBalance"></span>
+        
       </div>
     </div>
     <div class="grid" id="presets"></div>

--- a/desktop-app/frontend/src/views/multiroom.js
+++ b/desktop-app/frontend/src/views/multiroom.js
@@ -150,9 +150,20 @@ export function renderMultiroom(fetchLive) {
       }))}</div>`
     : `<div class="muted small">${escapeHtml(t('multiroom.stereoNoPair'))}</div>`;
 
+  // The pair's balance belongs here, where the pair is made and undone, and
+  // nowhere near a volume slider: it is a READ-OUT, not a control. The firmware
+  // accepts no balance write that sticks (every attempt hung the endpoint until
+  // the speaker was woken), so shown beside a slider it reads as a control that
+  // is broken. An owner said exactly that: "steht neben dem Lautstaerkeregler
+  // und hat auch keinen Effekt" (2026-08-09), and #70 asked twice where it was.
+  const pairBalance = livePair
+    ? `<div class="muted small" id="pairBalance" hidden></div>`
+    : '';
+
   root.innerHTML = beta + topbar + previewNote + updateWarn +
     `<div class="zone-pick-hint muted small">${escapeHtml(t('multiroom.pickHint'))}</div>
      <div class="zone-cards">${cards}</div>
+     ${pairBalance}
      <div class="zone-controls">
        <div class="zone-field"><span>${escapeHtml(t('multiroom.modeLabel'))}</span>
          <div class="seg">${modeBtn('native', t('multiroom.modeNative'))}${modeBtn('mirror', t('multiroom.modeMirror'))}</div>
@@ -167,6 +178,8 @@ export function renderMultiroom(fetchLive) {
      </div>
 
      <div class="zone-controls" style="margin-top:22px;border-top:1px solid var(--c-border);padding-top:16px">
+
+  if (livePair) fillPairBalance(livePair, strBoxes).catch(() => {});
        <b>${escapeHtml(t('multiroom.stereoHeading'))} <span class="beta-pill alpha-pill">${escapeHtml(t('common.alpha'))}</span></b>
        <div class="muted small">${escapeHtml(t('multiroom.stereoNote'))}</div>
        ${canPair ? '' : `<div class="setup-warn small">${escapeHtml(t('multiroom.stereoNeedTwo'))}</div>`}
@@ -427,4 +440,29 @@ async function doDissolveZone(strBoxes) {
     state.zoneMsg = `<div class="setup-err">${escapeHtml(t('multiroom.formFailed', { err: String(e) }))}</div>`;
   }
   renderMultiroom(true);
+}
+
+// fillPairBalance shows the pair's balance as information, with where to change
+// it, because here it cannot be changed. Asked from the pair's MASTER whichever
+// half is selected: only the master reports one (#70).
+async function fillPairBalance(pair, boxes) {
+  const el = document.getElementById('pairBalance');
+  if (!el || !pair) return;
+  const master = pairMemberBoxes(pair, boxes).map(x => x.box)
+    .find(b => b && String(b.deviceID || '').toUpperCase() === String(pair.master || '').toUpperCase());
+  const src = master || pairMemberBoxes(pair, boxes).map(x => x.box).find(Boolean);
+  if (!src || src.kind === 'stock') return;
+  let b = null;
+  try {
+    const r = await deps.boxFetch(src, '/api/box/balance');
+    b = await r.json();
+  } catch { /* asleep or unreachable: show nothing rather than an error */ }
+  if (!b || !b.available) return;
+  const v = Number(b.actual) || 0;
+  const reading = v === 0
+    ? t('controls.balanceCentre')
+    : (v < 0 ? t('controls.balanceLeft', { n: Math.abs(v) })
+             : t('controls.balanceRight', { n: v }));
+  el.textContent = reading + '. ' + t('controls.balanceTitle');
+  el.hidden = false;
 }

--- a/desktop-app/frontend/src/views/settings.js
+++ b/desktop-app/frontend/src/views/settings.js
@@ -30,6 +30,7 @@ import { COUNTRIES, optFlag } from '../localization.js';
 // as one combined error; reconstructing "how many still copied" from that
 // message is a pure decision in copyreport.js (vitest-covered).
 import { summarizePresetCopyError, countValidPresetSlots } from '../copyreport.js';
+import { balanceSourceBox, stereoPairOf } from '../groups.js';
 import {
   BoxSettings,
   BoxAgentVersion,
@@ -320,6 +321,10 @@ export async function loadBoxSettings() {
       }
       state.settingsReconnect = null;
       renderBoxSettings(s, state.settingsBox);
+      // Read-only, and only present on a stereo pair, so it is filled after the
+      // markup exists rather than being part of it.
+      refreshBoxBalanceRow(state.settingsBox, stereoPairOf(state.zoneLive || {}), state.boxes)
+        .catch(() => {});
       return;
     } catch (e) {
       lastErr = e;
@@ -553,6 +558,9 @@ function renderBoxSettings(s, box) {
       <div class="setting-row">
         <input type="range" id="boxVolume" min="0" max="100" value="${vol.actual || 0}" />
         <span class="setting-value" id="boxVolumeVal">${vol.actual || 0}</span>
+      </div>
+      <div class="setting-row" id="boxBalanceRow" hidden>
+        <span class="muted small" id="boxBalance"></span>
       </div>
       ${vol.muted ? `<small class="muted small">${escapeHtml(t('settingsView.muted'))}</small>` : ''}
     </div>
@@ -2432,3 +2440,31 @@ const debouncedSetBass = debounce(async (box, defaultBass) => {
     await SetBoxBass(box.host, box.port, rel + (defaultBass || 0));
   } catch (e) { showError(e); }
 }, 200);
+
+// The stereo balance, shown where people look for it.
+//
+// It has been on the Play page next to the volume since v0.9.35, and the owner
+// who asked for it went to Speaker settings twice and reported it missing, on
+// the very version that added it (#70, 2026-08-08). A feature nobody can find
+// is not shipped. Read-only on purpose: the firmware accepts no write that
+// sticks, which the tooltip says.
+export async function refreshBoxBalanceRow(box, pair, boxes) {
+  const row = document.getElementById('boxBalanceRow');
+  const el = document.getElementById('boxBalance');
+  if (!row || !el) return;
+  const src = balanceSourceBox(box, pair, boxes) || box;
+  if (!src || src.kind === 'stock') { row.hidden = true; return; }
+  let b = null;
+  try {
+    const r = await boxFetch(src, '/api/box/balance');
+    b = await r.json();
+  } catch { /* asleep or unreachable: show nothing rather than an error */ }
+  if (!b || !b.available) { row.hidden = true; return; }
+  const v = Number(b.actual) || 0;
+  el.textContent = v === 0
+    ? t('controls.balanceCentre')
+    : (v < 0 ? t('controls.balanceLeft', { n: Math.abs(v) })
+             : t('controls.balanceRight', { n: v }));
+  el.title = t('controls.balanceTitle');
+  row.hidden = false;
+}

--- a/internal/webui/zoneformbudget_test.go
+++ b/internal/webui/zoneformbudget_test.go
@@ -1,8 +1,13 @@
 package webui
 
 import (
+	"context"
+	"fmt"
+	"log/slog"
 	"testing"
 	"time"
+
+	"github.com/JRpersonal/streborn/internal/boxapi"
 )
 
 // The budget covers the whole form, not just the /setZone drive: waking the
@@ -48,5 +53,81 @@ func TestZoneFormBudgetStaysUnderTheAppsTimeout(t *testing.T) {
 		if got := zoneFormBudget(n); got >= appTimeout {
 			t.Errorf("zoneFormBudget(%d) = %v, want comfortably under the app's %v", n, got, appTimeout)
 		}
+	}
+}
+
+// Verification polls every follower at once. Sequentially it could not finish:
+// each follower had a 4 s budget of its own inside a form budget that stops at
+// 38 s, so eleven followers needed up to 44 s and the ones at the end of the
+// list were reported "missing" when the context died, although they had joined.
+//
+// Measured on a twelve-speaker fleet 2026-08-09: ok=true with every member
+// listed, verified=3 on one attempt and 7 minutes later, a different set each
+// time, and 11 of 11 the previous day when /setZone left more budget.
+func TestFollowerVerificationRunsConcurrently(t *testing.T) {
+	const followers = 11
+	slaves := make([]boxapi.ZoneMember, followers)
+	for i := range slaves {
+		slaves[i] = boxapi.ZoneMember{DeviceID: fmt.Sprintf("DEV%02d", i), IP: fmt.Sprintf("192.0.2.%d", i+10)}
+	}
+	// Every follower takes almost its whole budget to confirm. Done one after
+	// another that is 11 x 300ms; done together it is one 300ms wait.
+	timing := followerVerifyTiming{
+		perFollowerBudget: 400 * time.Millisecond,
+		pollInterval:      50 * time.Millisecond,
+		perCallTimeout:    400 * time.Millisecond,
+	}
+	fetch := func(ctx context.Context, ip string) (boxapi.Zone, error) {
+		select {
+		case <-time.After(300 * time.Millisecond):
+		case <-ctx.Done():
+			return boxapi.Zone{}, ctx.Err()
+		}
+		return boxapi.Zone{Master: "MASTER"}, nil
+	}
+
+	// A budget that comfortably fits one follower and could never fit eleven
+	// in sequence: this is the field condition in miniature.
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	missing, unverifiable := verifyFollowersJoinedTimed(ctx, slog.New(slog.DiscardHandler), "MASTER", slaves, fetch, timing)
+	elapsed := time.Since(start)
+
+	if len(missing) != 0 {
+		t.Errorf("%d of %d followers reported missing although every one confirmed: %v", len(missing), followers, missing)
+	}
+	if len(unverifiable) != 0 {
+		t.Errorf("unexpected unverifiable: %v", unverifiable)
+	}
+	if elapsed > time.Second {
+		t.Errorf("verification took %v for %d followers, which means they were still polled one after another", elapsed, followers)
+	}
+}
+
+// A follower with no address cannot be polled and must be reported separately
+// rather than counted as missing, and the order must follow the request so the
+// output does not shuffle between runs.
+func TestFollowerVerificationKeepsOrderAndSeparatesUnverifiable(t *testing.T) {
+	slaves := []boxapi.ZoneMember{
+		{DeviceID: "A", IP: "192.0.2.10"},
+		{DeviceID: "B"}, // no address
+		{DeviceID: "C", IP: "192.0.2.12"},
+		{DeviceID: "D", IP: "192.0.2.13"},
+	}
+	timing := followerVerifyTiming{perFollowerBudget: 60 * time.Millisecond, pollInterval: 10 * time.Millisecond, perCallTimeout: 60 * time.Millisecond}
+	fetch := func(_ context.Context, ip string) (boxapi.Zone, error) {
+		if ip == "192.0.2.12" {
+			return boxapi.Zone{Master: "SOMEONE_ELSE"}, nil // joined the wrong master
+		}
+		return boxapi.Zone{Master: "MASTER"}, nil
+	}
+	missing, unverifiable := verifyFollowersJoinedTimed(context.Background(), slog.New(slog.DiscardHandler), "MASTER", slaves, fetch, timing)
+	if len(unverifiable) != 1 || unverifiable[0] != "B" {
+		t.Errorf("unverifiable = %v, want just the follower with no address", unverifiable)
+	}
+	if len(missing) != 1 || missing[0] != "C" {
+		t.Errorf("missing = %v, want just the follower that named another master", missing)
 	}
 }

--- a/internal/webui/zones_stereo.go
+++ b/internal/webui/zones_stereo.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/JRpersonal/streborn/internal/boxapi"
@@ -488,57 +489,99 @@ var defaultFollowerVerifyTiming = followerVerifyTiming{
 // verifyFollowersJoinedTimed is verifyFollowersJoined with explicit timing;
 // see there for the semantics.
 func verifyFollowersJoinedTimed(ctx context.Context, logger *slog.Logger, masterID string, slaves []boxapi.ZoneMember, fetch followerZoneFetch, timing followerVerifyTiming) (missing, unverifiable []string) {
-	perFollowerBudget := timing.perFollowerBudget
-	pollInterval := timing.pollInterval
-	perCallTimeout := timing.perCallTimeout
-	for _, sl := range slaves {
+	// Every follower is polled AT THE SAME TIME. They are separate speakers on
+	// separate addresses and nothing about asking one depends on having asked
+	// another, so the old speaker-after-speaker walk bought nothing and cost
+	// the whole budget.
+	//
+	// It cost correctness, not just time. This runs under the form's context,
+	// which is bounded by zoneFormBudget, and each follower was given up to
+	// four seconds of its own. Eleven followers therefore needed up to
+	// forty-four seconds inside a budget that stops at thirty-eight, minus
+	// whatever /setZone had already spent. The context died partway down the
+	// list and every follower after that point was reported "missing" although
+	// it had joined perfectly well.
+	//
+	// A twelve-speaker household saw exactly that on 2026-08-09: ok=true with
+	// all members listed, but verified=3 on one attempt and verified=7 minutes
+	// later, a different set each time, and 11 of 11 the day before when
+	// /setZone happened to be quick and left more budget. Read as a grouping
+	// failure that is baffling; read as a report running out of time it is
+	// obvious. Polled together, the whole check costs about one follower's
+	// budget no matter how large the fleet.
+	type result struct {
+		deviceID     string
+		unverifiable bool
+		joined       bool
+	}
+	results := make([]result, len(slaves))
+	var wg sync.WaitGroup
+	for i, sl := range slaves {
+		results[i].deviceID = sl.DeviceID
 		if sl.IP == "" {
-			unverifiable = append(unverifiable, sl.DeviceID)
+			results[i].unverifiable = true
 			continue
 		}
-		deadline := time.Now().Add(perFollowerBudget)
-		joined := false
-		var lastSelfMaster string
-		var lastMembers int
-		var lastErr error
-		for {
-			cctx, cancel := context.WithTimeout(ctx, perCallTimeout)
-			fz, ferr := fetch(cctx, sl.IP)
-			cancel()
-			if ferr != nil {
-				lastErr = ferr
-			} else {
-				lastErr = nil
-				lastSelfMaster = fz.Master
-				lastMembers = len(fz.Members)
-				if fz.Master != "" && strings.EqualFold(fz.Master, masterID) {
-					joined = true
-					break
-				}
-			}
-			if time.Now().After(deadline) || ctx.Err() != nil {
-				break
-			}
-			select {
-			case <-ctx.Done():
-			case <-time.After(pollInterval):
-			}
-			if ctx.Err() != nil {
-				break
-			}
+		wg.Add(1)
+		go func(i int, sl boxapi.ZoneMember) {
+			defer wg.Done()
+			results[i].joined = pollFollowerJoined(ctx, logger, masterID, sl, fetch, timing)
+		}(i, sl)
+	}
+	wg.Wait()
+
+	// Reported in the order the caller asked for them, so the output does not
+	// shuffle between runs just because the speakers answered out of order.
+	for _, r := range results {
+		switch {
+		case r.unverifiable:
+			unverifiable = append(unverifiable, r.deviceID)
+		case !r.joined:
+			missing = append(missing, r.deviceID)
 		}
-		if joined {
-			logger.Info("zone: follower confirmed", "follower", sl.DeviceID, "ip", sl.IP, "selfMaster", lastSelfMaster)
-			continue
-		}
-		if lastErr != nil {
-			logger.Info("zone: follower never confirmed (self-report unreachable)", "follower", sl.DeviceID, "ip", sl.IP, "err", lastErr.Error())
-		} else {
-			logger.Info("zone: follower never confirmed", "follower", sl.DeviceID, "ip", sl.IP, "selfMaster", lastSelfMaster, "selfMembers", lastMembers)
-		}
-		missing = append(missing, sl.DeviceID)
 	}
 	return missing, unverifiable
+}
+
+// pollFollowerJoined polls one follower's own /getZone until it names masterID
+// as its master, its own budget runs out, or the surrounding context ends.
+func pollFollowerJoined(ctx context.Context, logger *slog.Logger, masterID string, sl boxapi.ZoneMember, fetch followerZoneFetch, timing followerVerifyTiming) bool {
+	deadline := time.Now().Add(timing.perFollowerBudget)
+	var lastSelfMaster string
+	var lastMembers int
+	var lastErr error
+	for {
+		cctx, cancel := context.WithTimeout(ctx, timing.perCallTimeout)
+		fz, ferr := fetch(cctx, sl.IP)
+		cancel()
+		if ferr != nil {
+			lastErr = ferr
+		} else {
+			lastErr = nil
+			lastSelfMaster = fz.Master
+			lastMembers = len(fz.Members)
+			if fz.Master != "" && strings.EqualFold(fz.Master, masterID) {
+				logger.Info("zone: follower confirmed", "follower", sl.DeviceID, "ip", sl.IP, "selfMaster", lastSelfMaster)
+				return true
+			}
+		}
+		if time.Now().After(deadline) || ctx.Err() != nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+		case <-time.After(timing.pollInterval):
+		}
+		if ctx.Err() != nil {
+			break
+		}
+	}
+	if lastErr != nil {
+		logger.Info("zone: follower never confirmed (self-report unreachable)", "follower", sl.DeviceID, "ip", sl.IP, "err", lastErr.Error())
+	} else {
+		logger.Info("zone: follower never confirmed", "follower", sl.DeviceID, "ip", sl.IP, "selfMaster", lastSelfMaster, "selfMembers", lastMembers)
+	}
+	return false
 }
 
 // localDeviceID returns this box's authoritative Bose SoundTouch deviceID, read

--- a/internal/webui/zonevolume.go
+++ b/internal/webui/zonevolume.go
@@ -71,6 +71,34 @@ func (s *Server) groupMembers() ([]zoneMemberVolume, bool, bool) {
 	if !ok || len(z.Slaves) == 0 {
 		return nil, false, false
 	}
+	// Ask the speaker whether the group is actually there.
+	//
+	// The stored document exists so a group survives a reboot or a standby and
+	// re-forms itself, which is right. But nothing used to check it against the
+	// firmware, so when a group went away without STR writing the file (a failed
+	// re-form, a firmware that dropped the zone, a factory reset) the file kept
+	// insisting and the phone kept drawing a group card for it.
+	//
+	// Seen on the maintainer's own speakers 2026-08-09: the living room reported
+	// itself master of a group with the bathroom, the portable reported itself
+	// master of a group with the living room, the bathroom reported nothing, and
+	// the living room's own firmware answered <zone /> to all of it. The card was
+	// real; the group was not. Pressing play sent audio to a zone that did not
+	// exist, which from the sofa looks exactly like "the speaker is broken".
+	//
+	// A read, never a write: this must not be the reason a speaker stays awake,
+	// so it only reports the truth and leaves repairing to the paths that already
+	// do it.
+	if s.boxHost != "" {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		live, err := boxapi.New(s.boxHost).GetZone(ctx)
+		cancel()
+		if err == nil && live.Master == "" && len(live.Members) == 0 {
+			s.logger.Info("zone: the stored group is not on the speaker any more, reporting standalone",
+				"storedMaster", z.Master, "storedSlaves", len(z.Slaves))
+			return nil, false, false
+		}
+	}
 	out := []zoneMemberVolume{{
 		Name: s.groupSelfName(z), IP: s.boxHost, DeviceID: z.Master,
 		IsSelf: true, IsMaster: true, Volume: -1,

--- a/internal/webui/zonevolume.go
+++ b/internal/webui/zonevolume.go
@@ -158,7 +158,12 @@ func (s *Server) storedGroupIsLive() bool {
 
 func (s *Server) zoneVolumeGet(w http.ResponseWriter, r *http.Request) {
 	members, grouped, stereo := s.groupMembers()
-	if grouped && !s.storedGroupIsLive() {
+	// A stereo pair is NOT a zone. It is a firmware group created with
+	// /addGroup, and /getZone answers <zone /> for a perfectly healthy pair, so
+	// the liveness check below must never be applied to one: doing so reported
+	// a working pair as standalone seconds after it was created (caught live on
+	// two SoundTouch 10s, 2026-08-09).
+	if grouped && !stereo && !s.storedGroupIsLive() {
 		grouped = false
 	}
 	if !grouped {

--- a/internal/webui/zonevolume.go
+++ b/internal/webui/zonevolume.go
@@ -71,34 +71,6 @@ func (s *Server) groupMembers() ([]zoneMemberVolume, bool, bool) {
 	if !ok || len(z.Slaves) == 0 {
 		return nil, false, false
 	}
-	// Ask the speaker whether the group is actually there.
-	//
-	// The stored document exists so a group survives a reboot or a standby and
-	// re-forms itself, which is right. But nothing used to check it against the
-	// firmware, so when a group went away without STR writing the file (a failed
-	// re-form, a firmware that dropped the zone, a factory reset) the file kept
-	// insisting and the phone kept drawing a group card for it.
-	//
-	// Seen on the maintainer's own speakers 2026-08-09: the living room reported
-	// itself master of a group with the bathroom, the portable reported itself
-	// master of a group with the living room, the bathroom reported nothing, and
-	// the living room's own firmware answered <zone /> to all of it. The card was
-	// real; the group was not. Pressing play sent audio to a zone that did not
-	// exist, which from the sofa looks exactly like "the speaker is broken".
-	//
-	// A read, never a write: this must not be the reason a speaker stays awake,
-	// so it only reports the truth and leaves repairing to the paths that already
-	// do it.
-	if s.boxHost != "" {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		live, err := boxapi.New(s.boxHost).GetZone(ctx)
-		cancel()
-		if err == nil && live.Master == "" && len(live.Members) == 0 {
-			s.logger.Info("zone: the stored group is not on the speaker any more, reporting standalone",
-				"storedMaster", z.Master, "storedSlaves", len(z.Slaves))
-			return nil, false, false
-		}
-	}
 	out := []zoneMemberVolume{{
 		Name: s.groupSelfName(z), IP: s.boxHost, DeviceID: z.Master,
 		IsSelf: true, IsMaster: true, Volume: -1,
@@ -145,8 +117,50 @@ func (s *Server) peerName(m zones.Member) string {
 	return m.IP
 }
 
+// storedGroupIsLive reports whether the speaker still has the group the stored
+// zone document describes.
+//
+// The document exists so a group survives a reboot or a standby and re-forms
+// itself, which is right. But nothing checked it against the speaker, so when a
+// group went away without STR writing the file (a re-form that failed, a
+// firmware that dropped the zone, a factory reset) the file kept insisting and
+// the phone kept drawing a group card for it. Pressing play then sent audio into
+// a zone the firmware never had, which from the sofa is indistinguishable from a
+// broken speaker.
+//
+// Seen on three speakers at once, 2026-08-09: the living room reported itself
+// leading a group with the bathroom, the portable reported itself leading one
+// with the living room, the bathroom reported nothing, and the living room's own
+// firmware answered <zone /> to all of it.
+//
+// Only the DISPLAY asks this. The sleep timer keeps using the stored document
+// when it switches a group off, because there the file is the record of what
+// STR grouped and switching off one speaker too many is harmless.
+//
+// A read and nothing else: it runs whenever the phone opens its Speakers tab,
+// and a write there would reset the deep-standby countdown.
+func (s *Server) storedGroupIsLive() bool {
+	if s.boxHost == "" {
+		return true // cannot ask; trust the file rather than hide a real group
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	live, err := boxapi.New(s.boxHost).GetZone(ctx)
+	if err != nil {
+		return true // unreachable right now is not evidence the group is gone
+	}
+	if live.Master == "" && len(live.Members) == 0 {
+		s.logger.Info("zone: the stored group is not on the speaker any more, reporting standalone")
+		return false
+	}
+	return true
+}
+
 func (s *Server) zoneVolumeGet(w http.ResponseWriter, r *http.Request) {
 	members, grouped, stereo := s.groupMembers()
+	if grouped && !s.storedGroupIsLive() {
+		grouped = false
+	}
 	if !grouped {
 		writeJSON(w, http.StatusOK, map[string]any{"grouped": false})
 		return

--- a/internal/webui/zonevolume_live_test.go
+++ b/internal/webui/zonevolume_live_test.go
@@ -43,3 +43,20 @@ func readSourceFile(name string) (string, error) {
 }
 
 func contains(hay, needle string) bool { return strings.Contains(hay, needle) }
+
+// A stereo pair must never be judged by /getZone. It is a firmware group made
+// with /addGroup, and /getZone answers <zone /> for a perfectly healthy pair.
+// Applying the liveness check to one reported a working pair as standalone six
+// seconds after it was created, caught live on two SoundTouch 10s 2026-08-09:
+//
+//	19:44:48  stereo: paired id=str-grp-... members=2
+//	19:44:54  zone: the stored group is not on the speaker any more
+func TestStereoPairIsNotJudgedByGetZone(t *testing.T) {
+	src, err := readSourceFile("zonevolume.go")
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	if !contains(src, "grouped && !stereo && !s.storedGroupIsLive()") {
+		t.Error("the zone liveness check still applies to stereo pairs, which /getZone never reports")
+	}
+}

--- a/internal/webui/zonevolume_live_test.go
+++ b/internal/webui/zonevolume_live_test.go
@@ -1,0 +1,45 @@
+package webui
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// The phone's group card is built from the stored zone document. When a group
+// disappears without STR writing that file (a failed re-form, a firmware that
+// dropped the zone, a factory reset) the file keeps insisting and the card is
+// drawn for a group that no longer exists. Pressing play then sends audio into
+// a zone the firmware never had, which from the sofa looks like a broken
+// speaker.
+//
+// Observed on three of the maintainer's speakers 2026-08-09: the living room
+// claimed to lead a group with the bathroom, the portable claimed to lead one
+// with the living room, the bathroom claimed nothing, and the living room's own
+// firmware answered <zone /> to all of it.
+func TestStoredGroupIsCheckedAgainstTheSpeaker(t *testing.T) {
+	src, err := readSourceFile("zonevolume.go")
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	if !contains(src, "GetZone(ctx)") {
+		t.Error("groupMembers never asks the speaker whether the stored group is still there")
+	}
+	if !contains(src, `live.Master == "" && len(live.Members) == 0`) {
+		t.Error("an empty firmware zone does not make the stored group report standalone")
+	}
+	// It must stay a read: a write here would reset the deep-standby countdown,
+	// and this runs whenever the phone opens its Speakers tab.
+	for _, w := range []string{"SetZone(", "RemoveZoneSlave(", "AddZoneSlave("} {
+		if contains(src, w) {
+			t.Errorf("groupMembers' file performs %s; the cross-check must never write to the speaker", w)
+		}
+	}
+}
+
+func readSourceFile(name string) (string, error) {
+	b, err := os.ReadFile(name)
+	return string(b), err
+}
+
+func contains(hay, needle string) bool { return strings.Contains(hay, needle) }

--- a/internal/webui/zonevolume_live_test.go
+++ b/internal/webui/zonevolume_live_test.go
@@ -23,7 +23,7 @@ func TestStoredGroupIsCheckedAgainstTheSpeaker(t *testing.T) {
 		t.Fatalf("read source: %v", err)
 	}
 	if !contains(src, "GetZone(ctx)") {
-		t.Error("groupMembers never asks the speaker whether the stored group is still there")
+		t.Error("nothing asks the speaker whether the stored group is still there")
 	}
 	if !contains(src, `live.Master == "" && len(live.Members) == 0`) {
 		t.Error("an empty firmware zone does not make the stored group report standalone")
@@ -32,7 +32,7 @@ func TestStoredGroupIsCheckedAgainstTheSpeaker(t *testing.T) {
 	// and this runs whenever the phone opens its Speakers tab.
 	for _, w := range []string{"SetZone(", "RemoveZoneSlave(", "AddZoneSlave("} {
 		if contains(src, w) {
-			t.Errorf("groupMembers' file performs %s; the cross-check must never write to the speaker", w)
+			t.Errorf("the zone-volume file performs %s; the cross-check must never write to the speaker", w)
 		}
 	}
 }


### PR DESCRIPTION
Three faults, one feature.

The pair's master was never resolved. The agent sends that field as
masterDeviceID and the app read st.master, so pair.master was empty on every
pair and "ask the pair's MASTER for the balance" quietly asked whichever half
happened to be selected. That is precisely what the earlier fix set out to do,
so the balance stayed invisible for anyone who picked the other speaker, and
the owner who reported it said so again on the very release that claimed to fix
it. Both spellings are accepted now, so an older agent keeps working.

It also sat next to the volume slider on the Play page, where it reads as a
control that does nothing. It is a read-out: the firmware accepts no balance
write that sticks. It now appears in Multi-Room, where a pair is made and
undone, and in Speaker settings, with the reading and where the value can
actually be changed as visible text rather than a tooltip nobody opens.

And a stereo pair is no longer judged by /getZone. A pair is a firmware group
made with /addGroup, and /getZone answers <zone /> for a healthy one, so the
new liveness check reported a working pair as standalone six seconds after it
was created. Caught on two SoundTouch 10s while testing.

Release-Note: fix(app): the stereo balance of a pair is shown again, in Multi-Room and in the speaker settings
Release-Note: fix(multiroom): a stereo pair is no longer reported as ungrouped moments after it is created

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W4ZJXsnpmJuazCKF6ijdcZ