### PR TITLE
Trust store self-repair, preset sync between phone and computer, group join while waking

### DIFF
--- a/cmd/agent/bootstrap.go
+++ b/cmd/agent/bootstrap.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/JRpersonal/streborn/internal/boxapi"
+	"github.com/JRpersonal/streborn/internal/tlsgen"
 	usbstick "github.com/JRpersonal/streborn/usb-stick"
 )
 
@@ -51,6 +52,47 @@ func loadRegion(path string, logger *slog.Logger) string {
 	}
 	logger.Info("region loaded", "country", out)
 	return out
+}
+
+// trustRepairAttempts are the delays after agent start at which the trust
+// store is checked. The boot script mounts its own overlay AFTER starting the
+// agent: it waits for the root CA (up to 20s) and then mounts, so checking
+// before that would inspect a store the script is about to replace. The first
+// delay clears that window with room to spare; the second covers a boot slow
+// enough to miss it. Two bounded attempts, not a poll: this corruption is
+// created at boot and never mid-run.
+var trustRepairAttempts = []time.Duration{60 * time.Second, 5 * time.Minute}
+
+// repairTrustStoreWhenBootstrapIsDone checks the box's trust stores once the
+// boot script has finished with them and rebuilds any that lost the vendor's
+// public roots. Stops as soon as every store is healthy, which on a healthy
+// box is the first look.
+func repairTrustStoreWhenBootstrapIsDone(ctx context.Context, caDir string, logger *slog.Logger) {
+	for _, delay := range trustRepairAttempts {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(delay):
+		}
+		results := tlsgen.RepairTrustStore(tlsgen.ReadRootCAPEM(caDir), logger)
+		if trustStoresHealthy(results) {
+			return
+		}
+	}
+}
+
+// trustStoresHealthy reports whether every store either carries public roots
+// or does not exist on this chassis. A store we could not fix keeps the
+// retry alive; one we did fix ends it.
+func trustStoresHealthy(results []tlsgen.TrustRepairResult) bool {
+	for _, r := range results {
+		switch r.Outcome {
+		case tlsgen.TrustRepairHealthy, tlsgen.TrustRepairAbsent, tlsgen.TrustRepairRepaired:
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // syncRunOverrideFromStick keeps the NAND run-override.sh in sync with

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -482,8 +482,15 @@ func run() error {
 	// "certificate signed by unknown authority". Without this section a
 	// bundle shows only that terse error and it reads like a station
 	// problem.
+	// "repair" says whether the agent had to rebuild a store and whether that
+	// worked, which "stores" alone cannot show: a repaired box and a box that
+	// was never broken both read healthy afterwards.
 	webui.RegisterDebugSection("tls_trust", func() any {
-		return tlsgen.TrustStoreSnapshot(tlsgen.ReadRootCAPEM(*tlsDir))
+		root := tlsgen.ReadRootCAPEM(*tlsDir)
+		return map[string]any{
+			"stores": tlsgen.TrustStoreSnapshot(root),
+			"repair": tlsgen.LastTrustRepair(),
+		}
 	})
 	bmxSrv := bmx.New(logger.With("comp", "bmx"))
 	// The AutoPair manager is created up here so it can also be used in the
@@ -1124,6 +1131,17 @@ func run() error {
 	// the old run-override.sh from the very first setup runs forever and new
 	// setup wizard configs are ignored.
 	go syncRunOverrideFromStick(logger)
+
+	// Repair a trust store that lost the vendor's public roots, which kills
+	// every https station AND the Spotify engine with the same terse
+	// "certificate signed by unknown authority". The boot script no longer
+	// produces that state, but it is the only thing that ever did and an
+	// over-the-air update cannot deliver a boot script: it replaces the agent
+	// binary, and the NAND copy of run-override.sh is refreshed from a USB
+	// stick alone. Without this the affected speakers would re-break at every
+	// boot for good, however many updates they took. See
+	// internal/tlsgen/trustrepair.go.
+	go repairTrustStoreWhenBootstrapIsDone(ctx, *tlsDir, logger.With("comp", "tlsgen"))
 
 	// TLS termination for marge on 8443. iptables redirects the real box
 	// request from 443 to it. Skip when TLS is disabled.

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -475,6 +475,16 @@ func run() error {
 			"default_gateway": dnsboot.DefaultGateway(),
 		}
 	})
+	// tls_trust is the counterpart for the fault class dns_status cannot
+	// see: the box resolves and connects fine, but its overlaid trust
+	// store no longer carries the vendor's public roots, so every https
+	// station AND the Spotify engine die with the same
+	// "certificate signed by unknown authority". Without this section a
+	// bundle shows only that terse error and it reads like a station
+	// problem.
+	webui.RegisterDebugSection("tls_trust", func() any {
+		return tlsgen.TrustStoreSnapshot(tlsgen.ReadRootCAPEM(*tlsDir))
+	})
 	bmxSrv := bmx.New(logger.With("comp", "bmx"))
 	// The AutoPair manager is created up here so it can also be used in the
 	// WS and webui handlers.

--- a/desktop-app/app_discovery.go
+++ b/desktop-app/app_discovery.go
@@ -1375,8 +1375,21 @@ func probeSTR(ctx context.Context, ip string) (BoxInfo, bool) {
 		if info.Model != "" {
 			box.Model = info.Model
 		}
-		box.DeviceID = info.DeviceID
-		box.SerialNumber = info.SerialNumber
+		// Same guard as the two fields above, which these two lacked: a
+		// /info that answers but carries no deviceID blanked the one the
+		// agent had just reported, and a box with an empty deviceID drops
+		// out of every zone operation (the members are addressed by it).
+		// The stock deviceID is still preferred whenever it HAS a value:
+		// it is the SoundTouch ID the firmware's zone protocol keys on,
+		// while the agent may report its wlan0 MAC, which on a two-chip
+		// chassis is a different address (#544, Wave in a zone with an
+		// ST20 master: the master formed a zone the Wave never joined).
+		if info.DeviceID != "" {
+			box.DeviceID = info.DeviceID
+		}
+		if info.SerialNumber != "" {
+			box.SerialNumber = info.SerialNumber
+		}
 	}
 	return box, true
 }

--- a/desktop-app/app_playback.go
+++ b/desktop-app/app_playback.go
@@ -15,15 +15,26 @@ import (
 )
 
 // PlaySlot triggert POST /api/play/<slot>.
+//
+// Every exit is logged. A slot recall used to be the only play path that
+// wrote nothing at all to the app log, so a failed one left no trace on
+// either side: the box log shows no incoming request (the app never got
+// that far) and the app log shows nothing either. A bundle taken right
+// after a failing preset press was therefore unreadable (#582, shorty310:
+// two tiles showing "speaker is still starting" with an idle box log).
 func (a *App) PlaySlot(host string, port int, slot int) error {
 	resp, err := a.playPost(host, port, fmt.Sprintf("/api/play/%d", slot), "")
 	if err != nil {
+		a.logger.Info("play: slot failed", "host", host, "port", port, "slot", slot, "err", err)
 		return err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("%s", friendlyError(resp))
+		msg := friendlyError(resp)
+		a.logger.Info("play: slot rejected", "host", host, "slot", slot, "status", resp.StatusCode, "err", msg)
+		return fmt.Errorf("%s", msg)
 	}
+	a.logger.Info("play: slot accepted", "host", host, "slot", slot)
 	return nil
 }
 
@@ -85,6 +96,13 @@ func (a *App) playPost(host string, port int, path, body string) (*http.Response
 // if it stays unreachable within the budget.
 func (a *App) waitAgentReady(host string, port int) bool {
 	deadline := time.Now().Add(4 * time.Second)
+	started := time.Now()
+	// Kept for the give-up log line: without them a "box_not_ready" is a
+	// dead end in a bundle, because it names neither the ports that were
+	// tried nor why they did not answer (#582).
+	var tried []int
+	var lastErr error
+	var lastBody string
 	for {
 		// Try each candidate port; the one that answers is cached so the
 		// subsequent play (and every later call) goes straight to it. This
@@ -98,8 +116,20 @@ func (a *App) waitAgentReady(host string, port int) bool {
 				a.rememberPort(host, p)
 				return true
 			}
+			tried = append(tried, p)
+			lastErr = err
+			if err == nil {
+				// Answered, but not with an agent version: a bare 400 from the
+				// box's own :17008 listener while the agent is not up yet, or a
+				// stock-firmware 404. The body separates the two.
+				lastBody = string(body)
+			}
 		}
 		if !time.Now().Before(deadline) {
+			a.logger.Warn("play: agent readiness probe gave up, reporting the box as not ready",
+				"host", host, "port", port, "portsTried", tried,
+				"elapsedMs", time.Since(started).Milliseconds(),
+				"lastErr", lastErr, "lastBody", truncForLog(lastBody, 120))
 			return false
 		}
 		select {

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -4167,6 +4167,49 @@ function updateBoxUiVisibility() {
 }
 
 let loadedPresetsBoxKey = null;
+// presetSignature reduces the preset list to what a tile actually draws, so a
+// re-read that returns the same thing costs one comparison and no redraw.
+function presetSignature(list) {
+  return (list || [])
+    .map(p => [p.slot, p.type || '', p.name || '', p.stream_url || '', p.art || ''].join(''))
+    .join('');
+}
+
+let _lastPresetCheck = 0;
+// How often the preset list is re-read from the speaker. Deliberately slower
+// than the status poll: this only has to catch a change made somewhere else,
+// which is a human pressing save on their phone, and nothing here is worth
+// another request per status tick.
+const PRESET_RECHECK_MS = 15000;
+
+// refreshPresetsIfChanged re-reads the presets and redraws only when they
+// differ from what is on screen. Fired from the status poll, never awaited.
+//
+// It reads the agent's own preset store, not the Bose firmware, so it does not
+// add to the :8090 load that keeps the status cadence deliberately slow.
+async function refreshPresetsIfChanged() {
+  const box = state.currentBox;
+  if (!box || state.view !== 'box') return;
+  if (Date.now() - _lastPresetCheck < PRESET_RECHECK_MS) return;
+  _lastPresetCheck = Date.now();
+  let fresh;
+  try {
+    fresh = await GetPresets(box.host, box.port) || [];
+  } catch {
+    return; // a missed poll changes nothing; the next one tries again
+  }
+  if (state.currentBox !== box) return; // speaker switched while we were reading
+  // Same transient-empty guard loadPresets uses: a busy speaker can answer
+  // with zero presets while its store reloads, and taking that at face value
+  // is what used to make the whole grid vanish.
+  if (fresh.length === 0 && state.presets.length > 0) return;
+  if (presetSignature(fresh) === presetSignature(state.presets)) return;
+  state.presets = fresh;
+  renderPresets();
+  healPresetLogos();
+  loadBoxPresets();
+}
+
 async function loadPresets(retry = 0) {
   if (!state.currentBox) return;
   // Drop another box's box-native presets the moment we switch, so a Deezer tile
@@ -4193,6 +4236,9 @@ async function loadPresets(retry = 0) {
       return;
     }
     state.presets = fresh;
+    // This IS a fresh read, so the background re-check starts its interval
+    // from here instead of firing again right after a box switch or a save.
+    _lastPresetCheck = Date.now();
     renderPresets();
     healPresetLogos();
     loadBoxPresets();
@@ -5869,6 +5915,11 @@ async function refreshStatus() {
   // Track position rides the same cadence, not awaited so a slow AVTransport
   // read cannot delay the status poll.
   pollTrackPosition();
+  // This app is not the only thing that writes presets: the phone remote saves
+  // to the same speaker, and until now the tiles here kept whatever they were
+  // loaded with, so a key reassigned from the phone showed the old station
+  // until the speaker was reselected.
+  refreshPresetsIfChanged();
   try {
     const xml = await Status(state.currentBox.host, state.currentBox.port);
     _statusFailCount = 0; // the box answered: it is reachable at its current IP

--- a/internal/tlsgen/trustrepair.go
+++ b/internal/tlsgen/trustrepair.go
@@ -1,0 +1,291 @@
+package tlsgen
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+)
+
+// The trust store overlay and how it breaks.
+//
+// The boot script copies the firmware's own CA bundle to /tmp, appends STR's
+// root and bind-mounts the result over the original. When it copied while an
+// overlay from an earlier run was still mounted, source and destination were
+// the same inode: the copy read and wrote one file and could leave it empty.
+// What then got mounted was STR's root and nothing else, and the box stopped
+// trusting every public certificate. Every https station and the Spotify
+// engine die seconds apart on the identical "x509: certificate signed by
+// unknown authority" (ST20 field bundle, 2026-08-13).
+//
+// setup/run.sh and usb-stick/run.sh no longer produce that state. That fix
+// alone does not reach a speaker that is already installed: an over-the-air
+// update replaces the agent binary and nothing else, and the NAND copy of the
+// boot script is only ever refreshed from a physical USB stick. A box that
+// entered the broken state would keep re-entering it at every boot, forever,
+// no matter how many updates it received.
+//
+// So the agent repairs it. Reading the pristine firmware bundle means taking
+// the broken overlay off first, which is also the rollback: if anything below
+// fails, the firmware's own bundle is what stays live. That is the safe
+// direction. A box that trusts the internet but not STR still plays radio and
+// Spotify, and RefreshTrustStore re-appends our root; the reverse leaves the
+// speaker unable to reach anything.
+
+// overlayDir is where the overlay files that get bind-mounted over the trust
+// store live. tmpfs on the box, so this costs no NAND and starts empty after
+// every boot. A variable only so the tests can put it somewhere that exists
+// on a dev host.
+var overlayDir = "/tmp"
+
+// TrustRepairOutcome is the verdict for one trust store path.
+type TrustRepairOutcome string
+
+const (
+	// TrustRepairHealthy means the store still carries public roots. The
+	// overwhelmingly common case and the only one that touches nothing.
+	TrustRepairHealthy TrustRepairOutcome = "healthy"
+	// TrustRepairAbsent means the firmware has no bundle at that path.
+	TrustRepairAbsent TrustRepairOutcome = "absent"
+	// TrustRepairRepaired means the store had lost its public roots and now
+	// carries them again.
+	TrustRepairRepaired TrustRepairOutcome = "repaired"
+	// TrustRepairNotOverlaid means the store is broken but nothing is
+	// mounted over it, so the emptiness is the firmware's own file. Taking
+	// a mount off cannot fix that and there is nothing to roll back to.
+	TrustRepairNotOverlaid TrustRepairOutcome = "not-overlaid"
+	// TrustRepairFirmwareEmpty means the pristine bundle underneath the
+	// overlay carries no public roots either. The overlay was put back.
+	TrustRepairFirmwareEmpty TrustRepairOutcome = "firmware-bundle-empty"
+	// TrustRepairFailed means the repair could not be completed. Which step
+	// gave up is in Err; the firmware bundle is live unless Err says the
+	// unmount itself failed, in which case nothing changed at all.
+	TrustRepairFailed TrustRepairOutcome = "failed"
+)
+
+// TrustRepairResult records what happened to one trust store path, so a
+// diagnostic bundle answers "did the speaker notice, and did it help?"
+// without anyone having to reproduce the boot.
+type TrustRepairResult struct {
+	Path    string             `json:"path"`
+	Outcome TrustRepairOutcome `json:"outcome"`
+	// RootsBefore / RootsAfter are PEM certificate counts as read THROUGH
+	// any mount, i.e. what the box's TLS clients actually see. A healthy
+	// box shows a three-digit count; 1 is the broken state.
+	RootsBefore int `json:"roots_before"`
+	RootsAfter  int `json:"roots_after"`
+	// FirmwareRoots is what the pristine bundle underneath held, counted
+	// while the overlay was off. Zero unless the overlay came off.
+	FirmwareRoots int `json:"firmware_roots,omitempty"`
+	// Overlay is the file that ended up mounted, when one did.
+	Overlay string `json:"overlay,omitempty"`
+	Err     string `json:"err,omitempty"`
+}
+
+// mountOps is the platform boundary. The repair logic is identical
+// everywhere; only these three calls are Linux-only, and injecting them keeps
+// the logic testable on a dev host that cannot mount anything.
+type mountOps struct {
+	isMountPoint func(path string) bool
+	unmount      func(path string) error
+	bindMount    func(src, dst string) error
+}
+
+var (
+	lastRepairMu sync.Mutex
+	lastRepair   []TrustRepairResult
+)
+
+// LastTrustRepair returns the most recent repair pass, or nil if none has run
+// yet. Reported through /api/debug/state next to the trust store snapshot.
+func LastTrustRepair() []TrustRepairResult {
+	lastRepairMu.Lock()
+	defer lastRepairMu.Unlock()
+	return append([]TrustRepairResult(nil), lastRepair...)
+}
+
+// RepairTrustStore inspects the overlaid trust stores and rebuilds any that
+// have lost the vendor's public roots. rootCAPEM is STR's own root, appended
+// to the rebuilt store so the box keeps accepting our Bose-domain server
+// cert; pass nil when it is not available yet and the rebuild restores the
+// public roots alone.
+//
+// Returns one result per configured path. Never returns an error: no single
+// store's fate should stop the other from being looked at, and a speaker that
+// cannot repair itself must still start.
+func RepairTrustStore(rootCAPEM []byte, logger *slog.Logger) []TrustRepairResult {
+	return repairTrustStorePaths(DefaultTrustStorePaths, rootCAPEM, platformMountOps(), logger)
+}
+
+func repairTrustStorePaths(paths []string, rootCAPEM []byte, ops mountOps, logger *slog.Logger) []TrustRepairResult {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	results := make([]TrustRepairResult, 0, len(paths))
+	for i, path := range paths {
+		// The slot number keeps the two overlays in separate files. They
+		// shared one once, because the previous name carried a single hex
+		// digit of an md5 and one collision in sixteen is not rare enough.
+		results = append(results, repairOne(path, i+1, rootCAPEM, ops, logger))
+	}
+	lastRepairMu.Lock()
+	lastRepair = append([]TrustRepairResult(nil), results...)
+	lastRepairMu.Unlock()
+	return results
+}
+
+func repairOne(path string, slot int, rootCAPEM []byte, ops mountOps, logger *slog.Logger) TrustRepairResult {
+	res := TrustRepairResult{Path: path}
+
+	before, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			res.Outcome = TrustRepairAbsent
+			return res
+		}
+		res.Outcome = TrustRepairFailed
+		res.Err = fmt.Sprintf("read: %v", err)
+		logger.Warn("trust store repair: cannot read the store", "path", path, "err", err)
+		return res
+	}
+	res.RootsBefore = publicRootCount(before, rootCAPEM)
+	res.RootsAfter = res.RootsBefore
+	if res.RootsBefore > 0 {
+		res.Outcome = TrustRepairHealthy
+		return res
+	}
+
+	// Broken. Everything past here changes the box's trust set, so say so
+	// before touching anything: if the repair wedges the speaker, the log
+	// still shows what it was about to do.
+	logger.Warn("trust store lost its public roots, repairing",
+		"path", path, "bytes", len(before), "certificates", strings.Count(string(before), pemCertHeader))
+
+	if !ops.isMountPoint(path) {
+		// Nothing mounted: this emptiness is the firmware's own file, on a
+		// read-only rootfs. Not ours to fix, and not ours to have caused.
+		res.Outcome = TrustRepairNotOverlaid
+		logger.Error("trust store is empty but not overlaid by STR, leaving it alone", "path", path)
+		return res
+	}
+
+	if err := ops.unmount(path); err != nil {
+		res.Outcome = TrustRepairFailed
+		res.Err = fmt.Sprintf("unmount: %v", err)
+		logger.Error("trust store repair: unmount failed, the broken overlay stays live", "path", path, "err", err)
+		return res
+	}
+
+	// The overlay is off, so this reads the pristine firmware bundle.
+	firmware, err := os.ReadFile(path)
+	if err != nil {
+		res.Outcome = TrustRepairFailed
+		res.Err = fmt.Sprintf("read firmware bundle: %v", err)
+		logger.Error("trust store repair: firmware bundle unreadable after unmount", "path", path, "err", err)
+		return res
+	}
+	res.FirmwareRoots = strings.Count(string(firmware), pemCertHeader)
+	if publicRootCount(firmware, rootCAPEM) == 0 {
+		// Nothing to rebuild from. The broken overlay at least carried our
+		// root, so put it back rather than leave the speaker with less than
+		// it started with.
+		res.Outcome = TrustRepairFirmwareEmpty
+		if err := restoreOverlay(path, before, slot, ops); err != nil {
+			res.Err = fmt.Sprintf("restore: %v", err)
+		}
+		res.RootsAfter = publicRootCountAt(path, rootCAPEM)
+		logger.Error("trust store repair: the firmware bundle holds no public roots either",
+			"path", path, "restoreErr", res.Err)
+		return res
+	}
+
+	overlay := overlayPath(slot)
+	rebuilt := appendRootBlock(firmware, rootCAPEM)
+	if err := os.WriteFile(overlay, rebuilt, 0o644); err != nil {
+		res.Outcome = TrustRepairFailed
+		res.Err = fmt.Sprintf("write overlay: %v", err)
+		res.RootsAfter = publicRootCountAt(path, rootCAPEM)
+		logger.Error("trust store repair: cannot write the overlay, the firmware bundle stays live",
+			"path", path, "overlay", overlay, "err", err)
+		return res
+	}
+	res.Overlay = overlay
+	if err := ops.bindMount(overlay, path); err != nil {
+		res.Outcome = TrustRepairFailed
+		res.Err = fmt.Sprintf("bind mount: %v", err)
+		res.RootsAfter = publicRootCountAt(path, rootCAPEM)
+		logger.Error("trust store repair: bind mount failed, the firmware bundle stays live",
+			"path", path, "overlay", overlay, "err", err)
+		return res
+	}
+
+	// Confirm through the mount, the same way the box's TLS clients will.
+	res.RootsAfter = publicRootCountAt(path, rootCAPEM)
+	if res.RootsAfter == 0 {
+		res.Outcome = TrustRepairFailed
+		res.Err = "the rebuilt overlay still shows no public roots"
+		logger.Error("trust store repair: rebuilt overlay reads back empty", "path", path, "overlay", overlay)
+		return res
+	}
+	res.Outcome = TrustRepairRepaired
+	logger.Warn("trust store repaired", "path", path, "overlay", overlay,
+		"publicRoots", res.RootsAfter, "firmwareRoots", res.FirmwareRoots)
+	return res
+}
+
+// restoreOverlay puts the original overlay content back over path, used when
+// the pristine bundle turns out to be no better than what we took off.
+func restoreOverlay(path string, original []byte, slot int, ops mountOps) error {
+	overlay := overlayPath(slot)
+	if err := os.WriteFile(overlay, original, 0o644); err != nil {
+		return err
+	}
+	return ops.bindMount(overlay, path)
+}
+
+func overlayPath(slot int) string {
+	return fmt.Sprintf("%s/streborn-trust%d.crt", overlayDir, slot)
+}
+
+// appendRootBlock returns bundle with rootCAPEM appended in the same marked
+// form the boot script writes, so `cat` on the box reads the same either way.
+// A nil or blank root yields the bundle unchanged.
+func appendRootBlock(bundle, rootCAPEM []byte) []byte {
+	var b bytes.Buffer
+	b.Write(bundle)
+	if len(bundle) > 0 && bundle[len(bundle)-1] != '\n' {
+		b.WriteByte('\n')
+	}
+	if len(bytes.TrimSpace(rootCAPEM)) == 0 {
+		return b.Bytes()
+	}
+	b.WriteString("\n# >>> STR Root CA >>>\n")
+	b.Write(rootCAPEM)
+	if rootCAPEM[len(rootCAPEM)-1] != '\n' {
+		b.WriteByte('\n')
+	}
+	b.WriteString("# <<< STR Root CA <<<\n")
+	return b.Bytes()
+}
+
+// publicRootCount counts the certificates in bundle that are not STR's own
+// root. That is the figure that decides whether the box can reach the
+// internet: a store holding only our root passes a naive "is it empty" check
+// and still fails every public handshake.
+func publicRootCount(bundle, rootCAPEM []byte) int {
+	n := strings.Count(string(bundle), pemCertHeader)
+	if n > 0 && len(bytes.TrimSpace(rootCAPEM)) > 0 && bytes.Contains(bundle, bytes.TrimSpace(rootCAPEM)) {
+		n--
+	}
+	return n
+}
+
+func publicRootCountAt(path string, rootCAPEM []byte) int {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	return publicRootCount(b, rootCAPEM)
+}

--- a/internal/tlsgen/trustrepair_linux.go
+++ b/internal/tlsgen/trustrepair_linux.go
@@ -1,0 +1,88 @@
+//go:build linux
+
+package tlsgen
+
+import (
+	"os"
+	"strings"
+	"syscall"
+)
+
+// platformMountOps are the real mount operations on the speaker.
+func platformMountOps() mountOps {
+	return mountOps{
+		isMountPoint: isMountPoint,
+		unmount:      unmountOverlay,
+		bindMount:    bindMountFile,
+	}
+}
+
+// isMountPoint reports whether something is mounted exactly at path. The
+// mount point is the SECOND field of /proc/mounts and has to match exactly:
+// a prefix match would confuse the trust store with a neighbouring file.
+// An unreadable /proc/mounts answers false, which routes the repair into
+// "not overlaid" and makes it change nothing.
+func isMountPoint(path string) bool {
+	b, err := os.ReadFile("/proc/mounts")
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && unescapeMountField(fields[1]) == path {
+			return true
+		}
+	}
+	return false
+}
+
+// unescapeMountField undoes the octal escaping /proc/mounts applies to
+// spaces, tabs, newlines and backslashes. The trust store paths contain none
+// of those, but a field left escaped would silently never match.
+func unescapeMountField(f string) string {
+	if !strings.Contains(f, `\`) {
+		return f
+	}
+	var b strings.Builder
+	for i := 0; i < len(f); i++ {
+		if f[i] == '\\' && i+3 < len(f) {
+			var v int
+			ok := true
+			for _, c := range []byte(f[i+1 : i+4]) {
+				if c < '0' || c > '7' {
+					ok = false
+					break
+				}
+				v = v*8 + int(c-'0')
+			}
+			if ok {
+				b.WriteByte(byte(v))
+				i += 3
+				continue
+			}
+		}
+		b.WriteByte(f[i])
+	}
+	return b.String()
+}
+
+// unmountOverlay takes the overlay off path. Bose's libcurl and openssl open
+// the bundle per handshake rather than holding it, so a plain unmount is
+// normally enough; a lazy detach covers the moment one of them happens to be
+// mid-read. MNT_DETACH leaves already-open descriptors on the old file and
+// points every new open at what is underneath, which is exactly what the
+// rebuild needs.
+func unmountOverlay(path string) error {
+	err := syscall.Unmount(path, 0)
+	if err == nil {
+		return nil
+	}
+	if lazyErr := syscall.Unmount(path, syscall.MNT_DETACH); lazyErr == nil {
+		return nil
+	}
+	return err
+}
+
+func bindMountFile(src, dst string) error {
+	return syscall.Mount(src, dst, "", syscall.MS_BIND, "")
+}

--- a/internal/tlsgen/trustrepair_other.go
+++ b/internal/tlsgen/trustrepair_other.go
@@ -1,0 +1,18 @@
+//go:build !linux
+
+package tlsgen
+
+import "errors"
+
+// platformMountOps has no mounts off-Linux. The agent only ever runs on the
+// speaker's ARM Linux; these stubs exist so the package builds and its tests
+// run on a dev host. isMountPoint answering false makes the repair report
+// "not overlaid" and change nothing, which is the same conservative answer
+// the Linux build gives when /proc/mounts cannot be read.
+func platformMountOps() mountOps {
+	return mountOps{
+		isMountPoint: func(string) bool { return false },
+		unmount:      func(string) error { return errors.New("unmount: not supported on this platform") },
+		bindMount:    func(string, string) error { return errors.New("bind mount: not supported on this platform") },
+	}
+}

--- a/internal/tlsgen/trustrepair_test.go
+++ b/internal/tlsgen/trustrepair_test.go
@@ -1,0 +1,279 @@
+package tlsgen
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+const (
+	testSTRRoot = "-----BEGIN CERTIFICATE-----\nSTRROOTCA\n-----END CERTIFICATE-----\n"
+	testPublic  = "-----BEGIN CERTIFICATE-----\nDIGICERTG2\n-----END CERTIFICATE-----\n" +
+		"-----BEGIN CERTIFICATE-----\nISRGROOTX1\n-----END CERTIFICATE-----\n"
+)
+
+// fakeMounts models a bind mount over a single file: the "mounted" content
+// shadows the pristine file, and unmounting reveals it again. That is the
+// whole mechanism the repair depends on, so the test drives it directly
+// instead of needing a real kernel mount.
+type fakeMounts struct {
+	t         *testing.T
+	path      string
+	pristine  []byte
+	mounted   bool
+	unmounts  int
+	binds     int
+	failUmnt  error
+	failBind  error
+	lastBound string
+}
+
+func newFakeMounts(t *testing.T, pristine, overlay string) *fakeMounts {
+	t.Helper()
+	// /tmp is the box's tmpfs and does not exist on a dev host.
+	prev := overlayDir
+	overlayDir = t.TempDir()
+	t.Cleanup(func() { overlayDir = prev })
+
+	f := &fakeMounts{t: t, path: filepath.Join(t.TempDir(), "ca-bundle.crt"), pristine: []byte(pristine)}
+	if overlay != "" {
+		f.mounted = true
+		writeFile(t, f.path, overlay)
+	} else {
+		writeFile(t, f.path, pristine)
+	}
+	return f
+}
+
+func (f *fakeMounts) ops() mountOps {
+	return mountOps{
+		isMountPoint: func(string) bool { return f.mounted },
+		unmount: func(p string) error {
+			if f.failUmnt != nil {
+				return f.failUmnt
+			}
+			f.unmounts++
+			f.mounted = false
+			writeFile(f.t, p, string(f.pristine))
+			return nil
+		},
+		bindMount: func(src, dst string) error {
+			if f.failBind != nil {
+				return f.failBind
+			}
+			f.binds++
+			f.lastBound = src
+			b, err := os.ReadFile(src)
+			if err != nil {
+				return err
+			}
+			f.mounted = true
+			writeFile(f.t, dst, string(b))
+			return nil
+		},
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+// TestRepairRebuildsAStoreThatHoldsOnlyOurOwnRoot is the field case: the
+// ST20 whose overlay carried STR's root and nothing else, so Deutschlandfunk
+// and the Spotify engine both died on "certificate signed by unknown
+// authority" (support mail 2026-08-13).
+func TestRepairRebuildsAStoreThatHoldsOnlyOurOwnRoot(t *testing.T) {
+	f := newFakeMounts(t, testPublic, testSTRRoot)
+
+	res := repairTrustStorePaths([]string{f.path}, []byte(testSTRRoot), f.ops(), quietLogger())
+
+	if len(res) != 1 {
+		t.Fatalf("want one result, got %d", len(res))
+	}
+	if res[0].Outcome != TrustRepairRepaired {
+		t.Fatalf("outcome = %q (err %q), want %q", res[0].Outcome, res[0].Err, TrustRepairRepaired)
+	}
+	if res[0].RootsBefore != 0 {
+		t.Errorf("RootsBefore = %d, want 0 public roots before the repair", res[0].RootsBefore)
+	}
+	if res[0].RootsAfter != 2 {
+		t.Errorf("RootsAfter = %d, want the 2 public roots back", res[0].RootsAfter)
+	}
+	// The box has to trust the internet AND us: dropping our root would
+	// break the Bose-domain server cert instead.
+	live := readFile(t, f.path)
+	if !strings.Contains(live, "DIGICERTG2") || !strings.Contains(live, "ISRGROOTX1") {
+		t.Error("repaired store lost the firmware's public roots")
+	}
+	if !strings.Contains(live, "STRROOTCA") {
+		t.Error("repaired store lost STR's own root")
+	}
+	if f.unmounts != 1 || f.binds != 1 {
+		t.Errorf("unmounts=%d binds=%d, want exactly one of each", f.unmounts, f.binds)
+	}
+}
+
+func TestRepairLeavesAHealthyStoreUntouched(t *testing.T) {
+	f := newFakeMounts(t, testPublic, testPublic+testSTRRoot)
+
+	res := repairTrustStorePaths([]string{f.path}, []byte(testSTRRoot), f.ops(), quietLogger())
+
+	if res[0].Outcome != TrustRepairHealthy {
+		t.Fatalf("outcome = %q, want %q", res[0].Outcome, TrustRepairHealthy)
+	}
+	if f.unmounts != 0 || f.binds != 0 {
+		t.Errorf("unmounts=%d binds=%d, a healthy store must not be touched", f.unmounts, f.binds)
+	}
+}
+
+// TestRepairRestoresTheOverlayWhenTheFirmwareBundleIsEmptyToo guards against
+// making things worse: if the pristine bundle has no public roots either, the
+// box should end up with at least what it had, not less.
+func TestRepairRestoresTheOverlayWhenTheFirmwareBundleIsEmptyToo(t *testing.T) {
+	f := newFakeMounts(t, "", testSTRRoot)
+
+	res := repairTrustStorePaths([]string{f.path}, []byte(testSTRRoot), f.ops(), quietLogger())
+
+	if res[0].Outcome != TrustRepairFirmwareEmpty {
+		t.Fatalf("outcome = %q, want %q", res[0].Outcome, TrustRepairFirmwareEmpty)
+	}
+	if !strings.Contains(readFile(t, f.path), "STRROOTCA") {
+		t.Error("the rollback must put STR's root back, the box had it before")
+	}
+	if f.binds != 1 {
+		t.Errorf("binds=%d, want the overlay remounted once", f.binds)
+	}
+}
+
+// TestRepairLeavesTheFirmwareBundleLiveWhenRemountFails encodes the safe
+// direction: a box that trusts the internet but not STR still plays radio and
+// Spotify, while the reverse leaves it unable to reach anything.
+func TestRepairLeavesTheFirmwareBundleLiveWhenRemountFails(t *testing.T) {
+	f := newFakeMounts(t, testPublic, testSTRRoot)
+	f.failBind = errors.New("mount: operation not permitted")
+
+	res := repairTrustStorePaths([]string{f.path}, []byte(testSTRRoot), f.ops(), quietLogger())
+
+	if res[0].Outcome != TrustRepairFailed {
+		t.Fatalf("outcome = %q, want %q", res[0].Outcome, TrustRepairFailed)
+	}
+	if res[0].RootsAfter != 2 {
+		t.Errorf("RootsAfter = %d, want the firmware's 2 public roots live", res[0].RootsAfter)
+	}
+	if strings.Contains(readFile(t, f.path), "STRROOTCA") {
+		t.Error("expected the pristine firmware bundle, not the broken overlay")
+	}
+}
+
+// TestRepairKeepsTheBrokenOverlayWhenUnmountFails: if we cannot take the
+// overlay off we have not changed anything, and the result has to say so
+// rather than claim a repair.
+func TestRepairKeepsTheBrokenOverlayWhenUnmountFails(t *testing.T) {
+	f := newFakeMounts(t, testPublic, testSTRRoot)
+	f.failUmnt = errors.New("umount: device or resource busy")
+
+	res := repairTrustStorePaths([]string{f.path}, []byte(testSTRRoot), f.ops(), quietLogger())
+
+	if res[0].Outcome != TrustRepairFailed {
+		t.Fatalf("outcome = %q, want %q", res[0].Outcome, TrustRepairFailed)
+	}
+	if !strings.Contains(res[0].Err, "unmount") {
+		t.Errorf("Err = %q, want it to name the unmount", res[0].Err)
+	}
+	if f.binds != 0 {
+		t.Error("nothing may be mounted when the unmount failed")
+	}
+}
+
+// TestRepairDoesNotTouchAnEmptyStoreThatIsNotOverlaid: an empty bundle with
+// no mount over it is the firmware's own file on a read-only rootfs. Not ours
+// to have caused and not ours to fix.
+func TestRepairDoesNotTouchAnEmptyStoreThatIsNotOverlaid(t *testing.T) {
+	f := newFakeMounts(t, "", "")
+	f.mounted = false
+
+	res := repairTrustStorePaths([]string{f.path}, []byte(testSTRRoot), f.ops(), quietLogger())
+
+	if res[0].Outcome != TrustRepairNotOverlaid {
+		t.Fatalf("outcome = %q, want %q", res[0].Outcome, TrustRepairNotOverlaid)
+	}
+	if f.unmounts != 0 || f.binds != 0 {
+		t.Error("a store STR does not overlay must not be touched")
+	}
+}
+
+func TestRepairReportsAnAbsentBundle(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "no-such-bundle.crt")
+
+	res := repairTrustStorePaths([]string{missing}, []byte(testSTRRoot), platformMountOps(), quietLogger())
+
+	if res[0].Outcome != TrustRepairAbsent {
+		t.Fatalf("outcome = %q, want %q", res[0].Outcome, TrustRepairAbsent)
+	}
+}
+
+// TestRepairGivesEachStoreItsOwnOverlayFile guards the collision that put
+// both trust stores on one file: a shared overlay is how the empty-copy bug
+// hit both at once.
+func TestRepairGivesEachStoreItsOwnOverlayFile(t *testing.T) {
+	if a, b := overlayPath(1), overlayPath(2); a == b {
+		t.Fatalf("slot 1 and 2 share the overlay file %q", a)
+	}
+}
+
+// TestRepairWithoutOurRootStillRestoresThePublicRoots: on a box whose CA is
+// not generated yet, radio and Spotify still matter.
+func TestRepairWithoutOurRootStillRestoresThePublicRoots(t *testing.T) {
+	f := newFakeMounts(t, testPublic, "")
+	f.mounted = true
+	writeFile(t, f.path, "")
+
+	res := repairTrustStorePaths([]string{f.path}, nil, f.ops(), quietLogger())
+
+	if res[0].Outcome != TrustRepairRepaired {
+		t.Fatalf("outcome = %q (err %q), want %q", res[0].Outcome, res[0].Err, TrustRepairRepaired)
+	}
+	if res[0].RootsAfter != 2 {
+		t.Errorf("RootsAfter = %d, want 2", res[0].RootsAfter)
+	}
+}
+
+func TestLastTrustRepairReportsTheMostRecentPass(t *testing.T) {
+	f := newFakeMounts(t, testPublic, testSTRRoot)
+
+	repairTrustStorePaths([]string{f.path}, []byte(testSTRRoot), f.ops(), quietLogger())
+
+	last := LastTrustRepair()
+	if len(last) != 1 || last[0].Outcome != TrustRepairRepaired {
+		t.Fatalf("LastTrustRepair() = %+v, want one repaired entry", last)
+	}
+	// A copy, so a caller rendering it into a diagnostic bundle cannot
+	// mutate what the next pass compares against.
+	last[0].Outcome = TrustRepairFailed
+	if LastTrustRepair()[0].Outcome != TrustRepairRepaired {
+		t.Error("LastTrustRepair must hand out a copy")
+	}
+}
+
+func TestAppendRootBlockSeparatesTheMarkerFromABundleWithoutATrailingNewline(t *testing.T) {
+	out := string(appendRootBlock([]byte("-----END CERTIFICATE-----"), []byte(testSTRRoot)))
+	if strings.Contains(out, "-----END CERTIFICATE----- ") || !strings.Contains(out, "-----END CERTIFICATE-----\n") {
+		t.Errorf("marker glued to the last line:\n%s", out)
+	}
+	if !strings.Contains(out, "# >>> STR Root CA >>>") || !strings.Contains(out, "# <<< STR Root CA <<<") {
+		t.Errorf("missing the markers the boot script writes:\n%s", out)
+	}
+}

--- a/internal/tlsgen/truststatus.go
+++ b/internal/tlsgen/truststatus.go
@@ -1,0 +1,102 @@
+package tlsgen
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ReadRootCAPEM returns the persisted root CA of the given CA dir, or
+// nil when it is not there yet (first boot, before EnsureBundle ran).
+// Callers that only need it to enrich a status report treat nil as
+// "unknown", never as an error.
+func ReadRootCAPEM(caDir string) []byte {
+	b, err := os.ReadFile(filepath.Join(caDir, rootCAFile))
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+// TrustStoreStatus describes one system trust store file as the agent
+// sees it at runtime.
+//
+// Why this exists: a box whose overlaid trust store lost the vendor's
+// public roots fails EVERY outbound TLS handshake with the same terse
+// "x509: certificate signed by unknown authority" — https radio streams
+// and the Spotify engine alike (support mail 2026-08-13, ST20 on
+// v0.9.42: Deutschlandfunk and apresolve.spotify.com both refused, both
+// chaining to DigiCert Global Root G2, which every healthy box trusts).
+// From a diagnostic bundle that error is indistinguishable from a
+// station-side problem, because nothing reported what the box actually
+// trusts. RootCount does exactly that in one number.
+type TrustStoreStatus struct {
+	Path string `json:"path"`
+	// Exists is false when the firmware has no such bundle at all
+	// (the two paths serve libcurl and openssl and not every chassis
+	// carries both).
+	Exists bool `json:"exists"`
+	// Bytes is the size the agent reads THROUGH any bind mount, i.e.
+	// the overlay's size, not the pristine firmware bundle's.
+	Bytes int64 `json:"bytes"`
+	// RootCount is the number of PEM certificates in the file. A
+	// healthy box shows a three-digit count; 1 means the overlay
+	// contains STR's own root and nothing else, which is the broken
+	// state described above.
+	RootCount int `json:"root_count"`
+	// HasSTRRoot reports whether STR's own root CA made it in. It has
+	// to be there for the box to accept our Bose-domain server cert.
+	HasSTRRoot bool `json:"has_str_root"`
+	// PublicRootsMissing is the verdict, so a bundle can be triaged
+	// without counting certificates by hand.
+	PublicRootsMissing bool `json:"public_roots_missing"`
+	// Err carries a read failure verbatim (a missing file is reported
+	// via Exists instead).
+	Err string `json:"err,omitempty"`
+}
+
+// pemCertHeader is what we count. Counting headers rather than parsing
+// every certificate keeps this cheap enough to run on every
+// /api/debug/state call on a speaker CPU.
+const pemCertHeader = "-----BEGIN CERTIFICATE-----"
+
+// TrustStoreSnapshot inspects the trust store paths STR overlays and
+// returns one entry per path, in the order of DefaultTrustStorePaths.
+// rootCAPEM is STR's own root; pass nil if it is not loaded yet, then
+// HasSTRRoot stays false without changing the rest of the verdict.
+func TrustStoreSnapshot(rootCAPEM []byte) []TrustStoreStatus {
+	return trustStoreSnapshotPaths(DefaultTrustStorePaths, rootCAPEM)
+}
+
+func trustStoreSnapshotPaths(paths []string, rootCAPEM []byte) []TrustStoreStatus {
+	out := make([]TrustStoreStatus, 0, len(paths))
+	for _, p := range paths {
+		s := TrustStoreStatus{Path: p}
+		body, err := os.ReadFile(p)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				s.Err = err.Error()
+				s.Exists = true
+			}
+			out = append(out, s)
+			continue
+		}
+		s.Exists = true
+		s.Bytes = int64(len(body))
+		s.RootCount = strings.Count(string(body), pemCertHeader)
+		if len(bytes.TrimSpace(rootCAPEM)) > 0 {
+			s.HasSTRRoot = bytes.Contains(body, bytes.TrimSpace(rootCAPEM))
+		}
+		// The public roots are what a stream or the Spotify engine needs.
+		// Subtracting STR's own root avoids calling a store healthy just
+		// because we put one certificate in it.
+		public := s.RootCount
+		if s.HasSTRRoot && public > 0 {
+			public--
+		}
+		s.PublicRootsMissing = public == 0
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/tlsgen/truststatus_test.go
+++ b/internal/tlsgen/truststatus_test.go
@@ -1,0 +1,73 @@
+package tlsgen
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const fakeRoot = "-----BEGIN CERTIFICATE-----\nSFRSUk9PVA==\n-----END CERTIFICATE-----\n"
+const fakePublic = "-----BEGIN CERTIFICATE-----\nUFVCTElD\n-----END CERTIFICATE-----\n"
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// The whole point of the section: tell a store that lost the vendor's
+// public roots apart from a healthy one, because on the box both fail
+// with the identical "unknown authority" error.
+func TestTrustStoreSnapshotFlagsAStoreWithOnlyOurOwnRoot(t *testing.T) {
+	dir := t.TempDir()
+	healthy := filepath.Join(dir, "healthy.crt")
+	broken := filepath.Join(dir, "broken.crt")
+	writeFile(t, healthy, fakePublic+fakePublic+fakeRoot)
+	writeFile(t, broken, fakeRoot)
+
+	got := trustStoreSnapshotPaths([]string{healthy, broken}, []byte(fakeRoot))
+	if len(got) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(got))
+	}
+	if got[0].RootCount != 3 || got[0].PublicRootsMissing || !got[0].HasSTRRoot {
+		t.Errorf("healthy store misreported: %+v", got[0])
+	}
+	if got[1].RootCount != 1 || !got[1].PublicRootsMissing || !got[1].HasSTRRoot {
+		t.Errorf("broken store misreported: %+v", got[1])
+	}
+}
+
+// A store that never got our root is a different fault (Bose rejects our
+// server cert) and must not be reported as the one above.
+func TestTrustStoreSnapshotSeparatesMissingSTRRootFromMissingPublicRoots(t *testing.T) {
+	dir := t.TempDir()
+	noSTR := filepath.Join(dir, "nostr.crt")
+	writeFile(t, noSTR, fakePublic)
+
+	got := trustStoreSnapshotPaths([]string{noSTR}, []byte(fakeRoot))
+	if got[0].HasSTRRoot {
+		t.Errorf("STR root reported present although it is not: %+v", got[0])
+	}
+	if got[0].PublicRootsMissing {
+		t.Errorf("public roots reported missing although one is there: %+v", got[0])
+	}
+}
+
+func TestTrustStoreSnapshotMarksAnAbsentBundle(t *testing.T) {
+	got := trustStoreSnapshotPaths([]string{filepath.Join(t.TempDir(), "nope.crt")}, []byte(fakeRoot))
+	if got[0].Exists || got[0].Err != "" {
+		t.Errorf("absent bundle should read as not existing without an error: %+v", got[0])
+	}
+}
+
+func TestReadRootCAPEMReturnsNilWithoutACA(t *testing.T) {
+	if b := ReadRootCAPEM(t.TempDir()); b != nil {
+		t.Errorf("want nil for a dir without a CA, got %d bytes", len(b))
+	}
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, rootCAFile), fakeRoot)
+	if b := ReadRootCAPEM(dir); string(b) != fakeRoot {
+		t.Errorf("root CA not read back verbatim: %q", string(b))
+	}
+}

--- a/internal/webui/assets/index.html
+++ b/internal/webui/assets/index.html
@@ -1137,9 +1137,32 @@ async function refreshWedge() {
   } catch (e) {}
 }
 
+// presetSig reduces the list to what a tile shows, so a re-read that returns
+// the same thing does not rebuild the grid underneath the user's finger.
+function presetSig(list) {
+  return (list || []).map(function (p) { return p.slot + ' ' + (p.name || ''); }).join('');
+}
+var lastPresetSig = null;
+
 async function loadPresets() {
-  const list = await api('/api/presets') || [];
+  const raw = await api('/api/presets');
+  const list = raw || [];
   const grid = document.getElementById('presets');
+  // A failed read (api returns null) must not blank a grid that is already
+  // showing presets. That matters now the list is re-read in the background:
+  // one timed-out poll would otherwise wipe the tiles until the next one.
+  if (!raw && grid.children.length) return;
+  const sig = presetSig(list);
+  if (sig === lastPresetSig && grid.children.length) return;
+  lastPresetSig = sig;
+  // The tapped tile keeps its highlight across a rebuild: the grid is redrawn
+  // whenever the desktop app changes a preset, and losing the marker then
+  // would look like the speaker forgot what it is playing.
+  const activeSlot = (function () {
+    const tiles = grid.querySelectorAll('.preset');
+    for (let i = 0; i < tiles.length; i++) if (tiles[i].classList.contains('active')) return i + 1;
+    return 0;
+  })();
   grid.innerHTML = '';
   for (let i = 1; i <= 6; i++) {
     const p = list.find(x => x.slot === i);
@@ -1153,6 +1176,7 @@ async function loadPresets() {
       div.innerHTML = '<div class="num">#' + i + '</div><div class="name">' + escapeHtml(nm) + '</div>';
     }
     else { div.innerHTML = '<div class="num">#' + i + '</div><div class="name">' + escapeHtml(T.empty) + '</div>'; }
+    if (i === activeSlot) div.classList.add('active');
     grid.appendChild(div);
   }
 }
@@ -2108,6 +2132,12 @@ setInterval(function(){ refreshStatus(); refreshWedge(); }, 5000);
 // somebody forms or dissolves one, not second by second, and every poll costs
 // the speaker a round trip to each member.
 setInterval(function(){ if (!document.getElementById('panelSpeakers').hidden || zone.grouped) loadZone(); }, 15000);
+// Presets change from the desktop app too, and this page used to keep whatever
+// it loaded on open. Re-read on the same slow cadence as the group: it only has
+// to catch somebody pressing save elsewhere, and the grid is left alone unless
+// the names actually differ. The read hits the agent's own store, not the Bose
+// firmware, so it adds nothing to the load the transport poll is rationed for.
+setInterval(function(){ loadPresets().catch(function(){}); }, 15000);
 </script>
 </body>
 </html>

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -43,6 +43,16 @@ type Server struct {
 	// after reboot/standby (#70). nil when not wired; zone write endpoints
 	// then still drive the box but do not persist.
 	zones *zones.Store
+	// memberIDs remembers, per member IP, the SoundTouch deviceID that
+	// speaker's own firmware reported. Zone forming corrects the caller's
+	// deviceID from a live /info read, because a two-chip chassis announces
+	// its wlan0 MAC over mDNS and that is not the ID /setZone keys on. When
+	// that read times out (a member waking, or busy right after an OTA) the
+	// correction used to be skipped and the wrong ID went into the group, so
+	// a phantom member was enrolled that never joined. This cache carries the
+	// answer from the last successful read across such a moment.
+	memberIDs   map[string]string
+	memberIDsMu sync.RWMutex
 	// mediaServers remembers which DLNA/UPnP media servers the user turned into
 	// native music sources, because the speaker forgets them on reboot. nil when
 	// not wired; the endpoints then still drive the box but nothing is restored

--- a/internal/webui/zone_memberid_cache_test.go
+++ b/internal/webui/zone_memberid_cache_test.go
@@ -1,0 +1,59 @@
+package webui
+
+import "testing"
+
+// A member speaker that is waking or busy right after an OTA does not answer
+// its firmware /info in time. Zone forming used to fall back to the deviceID
+// the caller supplied, which on a two-chip chassis is the wlan0 MAC rather than
+// the SoundTouch ID /setZone keys on, so a member was enrolled that never
+// joined. These tests pin the cache that carries the firmware's own answer
+// across such a moment (#544, and a 7-speaker fleet on the same day where the
+// correction fired for one speaker and then not for the same speaker 25s
+// later).
+func TestMemberDeviceIDCache(t *testing.T) {
+	t.Run("a firmware answer is remembered per IP", func(t *testing.T) {
+		s := &Server{}
+		s.rememberMemberDeviceID("192.0.2.26", "SOUNDTOUCHID26")
+		s.rememberMemberDeviceID("192.0.2.31", "SOUNDTOUCHID31")
+
+		got, ok := s.cachedMemberDeviceID("192.0.2.26")
+		if !ok || got != "SOUNDTOUCHID26" {
+			t.Errorf("got (%q, %v), want (\"SOUNDTOUCHID26\", true)", got, ok)
+		}
+		got, ok = s.cachedMemberDeviceID("192.0.2.31")
+		if !ok || got != "SOUNDTOUCHID31" {
+			t.Errorf("got (%q, %v), want (\"SOUNDTOUCHID31\", true)", got, ok)
+		}
+	})
+
+	t.Run("a speaker never seen answering reports no entry", func(t *testing.T) {
+		s := &Server{}
+		if got, ok := s.cachedMemberDeviceID("192.0.2.99"); ok {
+			t.Errorf("got (%q, true), want no entry", got)
+		}
+	})
+
+	t.Run("a later answer replaces the earlier one", func(t *testing.T) {
+		s := &Server{}
+		s.rememberMemberDeviceID("192.0.2.26", "OLDID")
+		s.rememberMemberDeviceID("192.0.2.26", "NEWID")
+		if got, _ := s.cachedMemberDeviceID("192.0.2.26"); got != "NEWID" {
+			t.Errorf("got %q, want NEWID", got)
+		}
+	})
+
+	// The cache exists to hold FIRMWARE answers only. An empty id would make a
+	// later lookup hand out nothing while claiming a hit, and an empty IP has
+	// no member to belong to.
+	t.Run("empty values are not stored", func(t *testing.T) {
+		s := &Server{}
+		s.rememberMemberDeviceID("192.0.2.26", "")
+		s.rememberMemberDeviceID("", "SOUNDTOUCHID")
+		if _, ok := s.cachedMemberDeviceID("192.0.2.26"); ok {
+			t.Error("an empty deviceID was cached")
+		}
+		if _, ok := s.cachedMemberDeviceID(""); ok {
+			t.Error("an entry under an empty IP was cached")
+		}
+	})
+}

--- a/internal/webui/zones_stereo.go
+++ b/internal/webui/zones_stereo.go
@@ -195,6 +195,20 @@ func (s *Server) handleZoneForm(w http.ResponseWriter, r *http.Request) {
 	// never ambiguous. Sequential rather than parallel on purpose: this runs
 	// inside the form budget, /info answers in milliseconds on a reachable box,
 	// and a fleet-wide fan-out on a speaker with 120 MB of RAM buys nothing.
+	// Falling back to the caller's value when that read fails is not safe, and
+	// two field bundles on the same day showed why (#544 and a 7-speaker fleet,
+	// both 2026-08-13). A member that is waking or busy right after an OTA
+	// answers :8090 a few seconds late, the correction was skipped, and the
+	// wrong id went into /setZone: the master enrolls a member nobody answers
+	// for, its own zone reads back one member short, and the speaker sits there
+	// showing "Select a source". In the 7-speaker log the correction is visible
+	// firing for .26 at 18:38:10 and then NOT firing for the very same speaker
+	// 25 seconds later, when its :8090 timed out, which put both that box and
+	// one other into the group under their wlan0 MAC.
+	//
+	// So remember what a speaker's firmware said last time and use that when it
+	// cannot be asked right now. The map is keyed by IP, the same identifier the
+	// read uses, and it is only ever written from a firmware answer.
 	for i := range slaves {
 		if slaves[i].IP == "" {
 			continue
@@ -202,11 +216,30 @@ func (s *Server) handleZoneForm(w http.ResponseWriter, r *http.Request) {
 		ictx, icancel := context.WithTimeout(ctx, 2*time.Second)
 		info, err := boxapi.New(slaves[i].IP).GetInfo(ictx)
 		icancel()
-		if err != nil {
-			continue // unreachable right now: keep what the caller supplied
+		real := ""
+		if err == nil {
+			real = strings.TrimSpace(info.DeviceID)
+			if real != "" {
+				s.rememberMemberDeviceID(slaves[i].IP, real)
+			}
 		}
-		real := strings.TrimSpace(info.DeviceID)
-		if real == "" || strings.EqualFold(real, slaves[i].DeviceID) {
+		if real == "" {
+			cached, ok := s.cachedMemberDeviceID(slaves[i].IP)
+			if !ok {
+				// Never seen this speaker answer: the caller's value is all
+				// there is, and refusing the member outright would break the
+				// common case where it is already correct.
+				continue
+			}
+			if strings.EqualFold(cached, slaves[i].DeviceID) {
+				continue
+			}
+			s.logger.Warn("zone: member did not answer its firmware /info, using the deviceID it reported earlier instead of the caller's",
+				"ip", slaves[i].IP, "supplied", slaves[i].DeviceID, "cached", cached, "err", err)
+			slaves[i].DeviceID = cached
+			continue
+		}
+		if strings.EqualFold(real, slaves[i].DeviceID) {
 			continue
 		}
 		s.logger.Info("zone: corrected a member's deviceID from its own firmware /info (the caller had the chassis wlan0/SMSC MAC, not the SoundTouch ID)",
@@ -605,6 +638,32 @@ func (s *Server) localDeviceID(ctx context.Context, c *boxapi.Client, supplied s
 			"supplied", supplied, "firmware", real)
 	}
 	return real
+}
+
+// rememberMemberDeviceID records what a member speaker's own firmware answered
+// for its deviceID, keyed by the IP it was asked on. Only ever called with a
+// firmware answer, so the cache cannot be poisoned by a caller-supplied value.
+func (s *Server) rememberMemberDeviceID(ip, deviceID string) {
+	if ip == "" || deviceID == "" {
+		return
+	}
+	s.memberIDsMu.Lock()
+	defer s.memberIDsMu.Unlock()
+	if s.memberIDs == nil {
+		s.memberIDs = make(map[string]string)
+	}
+	s.memberIDs[ip] = deviceID
+}
+
+// cachedMemberDeviceID returns the last deviceID a speaker at this IP reported
+// for itself, and whether there was one. Used when its /info does not answer in
+// time during zone forming, so a busy member is still enrolled under the ID its
+// firmware actually keys on.
+func (s *Server) cachedMemberDeviceID(ip string) (string, bool) {
+	s.memberIDsMu.RLock()
+	defer s.memberIDsMu.RUnlock()
+	v, ok := s.memberIDs[ip]
+	return v, ok
 }
 
 // formStereoPair drives POST /addGroup to make a real left/right stereo pair

--- a/setup/run.sh
+++ b/setup/run.sh
@@ -139,16 +139,45 @@ done
 if [ -r "$ROOT_CA" ]; then
     log "Root CA present after ${WAIT}s, setting up the bind mount"
 
+    # Unmount an overlay from an earlier run BEFORE copying: while it is
+    # mounted, "$target" and "$bundle" are the same inode, so the copy reads
+    # and writes one file and can leave it empty. The box would then trust our
+    # root CA and nothing else, and every https station plus the Spotify
+    # engine would fail with "certificate signed by unknown authority". Same
+    # reason for the plain counter in the name: one hex digit of an md5
+    # collides one time in sixteen and made both targets share one overlay.
+    # Install the overlay only once it still carries the firmware's own roots.
+    ca_slot=0
     for target in /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt; do
-        if [ ! -f "$target" ]; then continue; fi
-        bundle="/tmp/streborn-bundle$(echo "$target" | md5sum | head -c 1).crt"
-        cp "$target" "$bundle" 2>/dev/null
-        cat "$ROOT_CA" >> "$bundle"
-        echo "# <<< STR Root CA <<<" >> "$bundle"
-        if mount | grep -q "$target"; then
+        ca_slot=$((ca_slot+1))
+        [ -f "$target" ] || continue
+        bundle="/tmp/streborn-bundle$ca_slot.crt"
+        if mount | grep -q " $target "; then
             umount "$target" 2>/dev/null
         fi
-        mount --bind "$bundle" "$target" 2>/dev/null && echo "bind mount active: $bundle -> $target"
+        rm -f "$bundle"
+        if ! cp "$target" "$bundle" 2>/dev/null; then
+            log "trust store: cannot copy $target, leaving the firmware bundle in place"
+            continue
+        fi
+        roots=$(grep -c "BEGIN CERTIFICATE" "$bundle" 2>/dev/null)
+        [ -n "$roots" ] || roots=0
+        if [ "$roots" -lt 1 ]; then
+            log "trust store: copy of $target holds no certificate, leaving the firmware bundle in place"
+            rm -f "$bundle"
+            continue
+        fi
+        {
+            echo ""
+            echo "# >>> STR Root CA >>>"
+            cat "$ROOT_CA"
+            echo "# <<< STR Root CA <<<"
+        } >> "$bundle"
+        if mount --bind "$bundle" "$target" 2>/dev/null; then
+            log "trust store: overlay active on $target ($roots public roots plus STR)"
+        else
+            log "trust store: bind mount on $target failed, firmware bundle still in place"
+        fi
     done
 fi
 

--- a/usb-stick/rc.local
+++ b/usb-stick/rc.local
@@ -96,21 +96,21 @@ if [ -f /media/sda1/run.sh ]; then
     echo "$(date): /mnt/nv/streborn/run-override.sh redeployed from stick (effective this boot)" >> "$LOGDIR/boot.log"
 fi
 
-# NAND Override hat Prioritaet. Damit koennen Updates ueberleben auch
-# wenn die SD Karte read only ist oder eine alte run.sh hat.
+# The NAND override wins. That is what lets an update survive an SD card
+# that is read only or still carries an old run.sh.
 NAND_OVERRIDE="/mnt/nv/streborn/run-override.sh"
 if [ -x "$NAND_OVERRIDE" ]; then
-    echo "$(date): NAND override aktiv, nutze $NAND_OVERRIDE" >> "$LOGDIR/boot.log"
+    echo "$(date): NAND override active, using $NAND_OVERRIDE" >> "$LOGDIR/boot.log"
     nohup "$NAND_OVERRIDE" > "$LOGDIR/run.out" 2>&1 &
     exit 0
 fi
 
-# Fallback ohne NAND override: stick run.sh direkt starten falls da.
+# Fallback without a NAND override: start the stick's run.sh directly if present.
 if [ -x /media/sda1/run.sh ]; then
-    echo "$(date): kein NAND override, nutze /media/sda1/run.sh" >> "$LOGDIR/boot.log"
+    echo "$(date): no NAND override, using /media/sda1/run.sh" >> "$LOGDIR/boot.log"
     nohup /media/sda1/run.sh > "$LOGDIR/run.out" 2>&1 &
     exit 0
 fi
 
-echo "$(date): weder NAND override noch /media/sda1/run.sh — USB Stick fehlt" >> "$LOGDIR/boot.log"
+echo "$(date): neither a NAND override nor /media/sda1/run.sh, USB stick missing" >> "$LOGDIR/boot.log"
 exit 1

--- a/usb-stick/run.sh
+++ b/usb-stick/run.sh
@@ -4197,16 +4197,52 @@ done
 if [ -r "$ROOT_CA" ]; then
     log "root CA available after ${WAIT}s, applying bind mount"
 
+    # Order matters: an overlay left over from an earlier run has to be
+    # unmounted BEFORE the copy. While it is still mounted, "$target" and
+    # "$bundle" are the same inode, so the copy reads and writes one file and
+    # can leave it empty; what then gets mounted is our own root CA and
+    # nothing else, and the box stops trusting every public certificate. Both
+    # https stations and the Spotify engine then fail with the same
+    # "certificate signed by unknown authority" (ST20 field report,
+    # 2026-08-13). The name is a plain counter for the same reason: one hex
+    # digit of an md5 collides one time in sixteen, and a collision made both
+    # targets share one overlay file.
+    #
+    # The overlay is installed only once it demonstrably still carries the
+    # firmware's own roots. A box that trusts the public internet but not us
+    # is far less broken than the reverse: it plays radio and Spotify, and the
+    # agent re-appends its root to the live overlay anyway.
+    ca_slot=0
     for target in /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt; do
-        if [ ! -f "$target" ]; then continue; fi
-        bundle="/tmp/streborn-bundle$(echo "$target" | md5sum | head -c 1).crt"
-        cp "$target" "$bundle" 2>/dev/null
-        cat "$ROOT_CA" >> "$bundle"
-        echo "# <<< STR Root CA <<<" >> "$bundle"
-        if mount | grep -q "$target"; then
+        ca_slot=$((ca_slot+1))
+        [ -f "$target" ] || continue
+        bundle="/tmp/streborn-bundle$ca_slot.crt"
+        if mount | grep -q " $target "; then
             umount "$target" 2>/dev/null
         fi
-        mount --bind "$bundle" "$target" 2>/dev/null && echo "bind mount active: $bundle -> $target"
+        rm -f "$bundle"
+        if ! cp "$target" "$bundle" 2>/dev/null; then
+            log "trust store: cannot copy $target, leaving the firmware bundle in place"
+            continue
+        fi
+        roots=$(grep -c "BEGIN CERTIFICATE" "$bundle" 2>/dev/null)
+        [ -n "$roots" ] || roots=0
+        if [ "$roots" -lt 1 ]; then
+            log "trust store: copy of $target holds no certificate, leaving the firmware bundle in place"
+            rm -f "$bundle"
+            continue
+        fi
+        {
+            echo ""
+            echo "# >>> STR Root CA >>>"
+            cat "$ROOT_CA"
+            echo "# <<< STR Root CA <<<"
+        } >> "$bundle"
+        if mount --bind "$bundle" "$target" 2>/dev/null; then
+            log "trust store: overlay active on $target ($roots public roots plus STR)"
+        else
+            log "trust store: bind mount on $target failed, firmware bundle still in place"
+        fi
     done
 fi
 


### PR DESCRIPTION
Sweep of the day's mail and GitHub reports.

## A speaker that stopped trusting the internet

An ST20 field bundle had every https station and the Spotify engine dying
seconds apart on the identical `x509: certificate signed by unknown authority`,
both hosts chaining to a root every healthy box trusts. The bootstrap builds
the box's trust store by copying the firmware's bundle to /tmp, appending STR's
root and bind-mounting the result. It copied BEFORE unmounting an overlay left
by an earlier run, and with that mount active source and destination are the
same inode, so the copy could leave the file empty. What got mounted was STR's
root and nothing else.

Two commits, because the boot-script fix cannot reach the speakers already in
that state: an update replaces the agent binary and nothing else, and the NAND
copy of the boot script is only refreshed from a physical USB stick.

- `6daccad` stops the boot script producing it, on both install paths.
- `df3a351` makes the agent repair it, which is what an update can deliver.
  Every failure path leaves the firmware's own bundle live rather than the
  broken overlay, and if the firmware bundle is empty too the overlay goes
  back, so a box never ends up with less than it had.
- `8202845` reports what the box actually trusts in the diagnostic, since
  from a bundle this was indistinguishable from a station-side problem.

Verified on an ST10: field state reproduced exactly (one certificate, every
handshake refused), agent restarted, store rebuilt 0 -> 158 public roots, and
both hosts from the reporter's log answered again. A natural boot afterwards
reports both stores healthy and touches neither.

## Presets out of step between the phone and the computer

Reported on discussion #597 with a screenshot: tile 4 shows the station it used
to hold and says it is playing, while the line above it plays the one just
assigned from the phone. Both screens read the presets once and kept them.
Both now re-read in the background and redraw only on an actual difference, at
a cadence deliberately slower than the transport poll and against the agent's
own store rather than the Bose firmware.

## Also here

- `d8dc69b` a speaker that is waking still joins the group it was added to.
- `463e460` a preset press that fails leaves a trace, so the next bundle can
  say why (follow-up to #582, where the app reached the speaker with nothing
  written anywhere).
- `04ccc6e` the boot log speaks English like the rest of the repo.

Refs #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)