### PR TITLE
Donate rail stops overlapping the preset keys; speaker update offered without the extra wait

### DIFF
--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -961,6 +961,21 @@ async function renderFooter() {
   // app version is finally known.
   updateSettingsTabBadge();
   if (state.boxes.length) renderBoxSelect();
+  // Same race, and it was costing the user the better part of a minute right
+  // after they had updated the app, which is exactly when the speakers are
+  // behind and the prompt matters most.
+  //
+  // Both prompts need two facts: the app's version (this function, an await)
+  // and the speakers' versions (a discovery pass). They were only ever
+  // re-evaluated at the END of a discovery pass, so whenever appInfo lost that
+  // race the card was skipped and nothing looked at it again until the NEXT
+  // pass happened along. The delay was never a timer; it was a second sweep.
+  // Now that both facts are in hand, ask immediately. Both are idempotent and
+  // cheap, and both hide themselves when nothing is behind.
+  if (state.boxes.length) {
+    try { maybeShowSpeakerUpdateCard(); } catch {}
+    try { checkBoxUpdate(); } catch {}
+  }
 }
 
 // Donate sidebar — three branded buttons that open in the system

--- a/desktop-app/frontend/src/style.css
+++ b/desktop-app/frontend/src/style.css
@@ -111,7 +111,7 @@ body {
   min-height: 100vh;
 }
 
-/* ---------- Layout: App truly zentriert, Donate als Overlay ---------- */
+/* ---------- Layout: the app column is centred, the donate rail overlays ---------- */
 
 .layout {
   display: block;
@@ -241,10 +241,25 @@ body {
 .donate-side .share-trigger:hover { transform: translateY(-1px); background: color-mix(in srgb, var(--brand) 18%, transparent); }
 .donate-side .share-trigger .share-heart { color: var(--brand); }
 
-/* Bei zu schmalen Fenstern ueberlappt der Donate sonst die App
-   — dann ausblenden, der Footer Link bleibt als Backup. */
-@media (max-width: 1080px) {
-  .donate-side { display: none; }
+/* The donate rail is an overlay: it is position: fixed and reserves no space,
+   so the centered app column runs straight under it as soon as the window is
+   not wide enough for both. It is therefore HIDDEN BY DEFAULT and shown only
+   where there is provably room, rather than shown by default and hidden when
+   the window looks narrow.
+
+   That inversion is the fix. The old rule hid it below 1080px, and the app
+   column needs 720px with 170px of rail beside it, so the arithmetic left ten
+   pixels of slack. A macOS window with permanent scrollbars eats more than
+   that on its own, and a Mac user's screenshot showed the preset tiles drawn
+   straight over the rail (discussion #597). Ten pixels was never a margin, it
+   was a coincidence.
+
+   1200px keeps a real gap: 720 for the column, 186 for the rail and its
+   margin on each side, and about a hundred left over for scrollbars, zoom and
+   whatever the platform adds. Below that the footer donate link carries it. */
+.donate-side { display: none; }
+@media (min-width: 1200px) {
+  .donate-side { display: flex; }
 }
 
 /* Share modal: one tile per platform. Each tile opens the browser share on this
@@ -1011,8 +1026,8 @@ html.a11y-contrast .btn-warning:disabled {
 .actions-divider { grid-column: 1 / -1; margin: 4px 0; border: 0; border-top: 1px solid var(--c-surface-3); }
 
 /* ---------- Preset Grid ---------- */
-/* 3 Spalten passend zur Hardware (1 2 3 / 4 5 6). Auf schmalen Fenstern
-   fallen wir auf 2 Spalten zurueck. */
+/* Three columns, matching the hardware keys (1 2 3 / 4 5 6). Narrow windows
+   fall back to two. */
 .grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; margin-bottom: 10px; }
 @media (max-width: 560px) {
   .grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }


### PR DESCRIPTION
Both from a Mac user's screenshots in discussion #597.

## The donate rail overlapped the app

It is `position: fixed` and reserves no space, so the centred `#app` column
runs under it as soon as the window is not wide enough for both. His screenshot
shows the preset tiles drawn over the rail.

The old protection was a single breakpoint: hide below 1080px. The column needs
720px and the rail occupies 170px on the left, so the minimum is 1060px. Ten
pixels of slack, and a macOS window with permanent scrollbars eats more than
that.

Inverted: hidden by default, shown only at 1200px and up where there is
provably room. The failure mode flips from "content covered" to "panel absent
with the footer link still there".

## The speaker-update prompt waited for a second discovery pass

Reported as "about 15 seconds after the app updates before the speaker update
is offered". It is not a timer. The prompt needs the app version AND the
speaker versions, and it was only evaluated at the end of a discovery pass. The
app version comes from an await that regularly loses that race, so the prompt
was skipped and nothing re-checked it until the next sweep.

The badge and the speaker list were already re-rendered when the app version
lands, for exactly this reason. The two update prompts were left out of that
block; they are called there now.

Refs #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)