### PR TITLE
Group follower no longer fights the group; a late certificate list is picked up

### DIFF
--- a/cmd/agent/bootstrap.go
+++ b/cmd/agent/bootstrap.go
@@ -75,13 +75,21 @@ func repairTrustStoreWhenBootstrapIsDone(ctx context.Context, caDir string, logg
 		case <-time.After(delay):
 		}
 		results := tlsgen.RepairTrustStore(tlsgen.ReadRootCAPEM(caDir), logger)
-		if anyStoreRepaired(results) {
-			restartForRepairedTrustStore(logger)
-			return
+		if !trustStoresHealthy(results) {
+			continue // still broken and unrepairable; the next attempt may find it settled
 		}
-		if trustStoresHealthy(results) {
-			return
+		// The store on disk is healthy. That is NOT the same as this process
+		// trusting those roots: Go caches the system store once per process,
+		// and the boot script mounts the overlay after the agent has already
+		// started and reached for TLS. A speaker in exactly that state reports
+		// both stores healthy and still fails every https station (ST20 field
+		// bundle, 2026-08-14, which is what "restart only when I changed
+		// something" missed: nothing needed changing, the cache was simply
+		// older than the store).
+		if effective, ok := tlsgen.RootsEffectiveInProcess(tlsgen.DefaultTrustStorePaths); ok && !effective {
+			restartForStaleTrustCache(logger)
 		}
+		return
 	}
 }
 
@@ -90,47 +98,34 @@ func repairTrustStoreWhenBootstrapIsDone(ctx context.Context, caDir string, logg
 // broken overlay and legitimately earns another restart.
 const trustRestartStamp = "/tmp/streborn-trust-restarted"
 
-// restartForRepairedTrustStore exits so the boot script's watchdog respawns
-// the agent, and with it the Spotify engine.
+// restartForStaleTrustCache exits so the boot script's watchdog respawns the
+// agent, and with it the Spotify engine, on a trust store both can actually
+// read.
 //
-// Repairing the FILES is not enough, which a field bundle proved: the fixed
-// build reported both stores healthy and the speaker still failed every
-// handshake. Go reads the system trust store once per process and caches it,
-// so the agent and go-librespot were both started by a boot script that had
-// already mounted the broken overlay, and both went on using the poisoned copy
-// they had cached long before the repair touched the file. Nothing re-reads it,
-// so nothing changes until the processes are new.
+// This is the only lever there is. Go caches the system trust store once per
+// process, nothing re-reads it, and the Spotify engine is a separate process
+// STR does not control from the inside. Repairing the file changes what is on
+// disk and nothing about what either process trusts until both are new.
 //
-// Restarting is safe here in a way it would not be normally: a box that
-// reaches this path trusts nothing, so no stream is playing to interrupt.
-// Guarded to once per boot, because a restart that keeps repeating is worse
-// than a speaker that trusts nothing.
-func restartForRepairedTrustStore(logger *slog.Logger) {
+// Restarting is safe here in a way it would not be normally: a speaker that
+// reaches this path cannot reach anything over https, so there is no stream to
+// interrupt. Guarded to once per boot, because a restart that keeps repeating
+// is worse than a speaker that trusts nothing.
+func restartForStaleTrustCache(logger *slog.Logger) {
 	if _, err := os.Stat(trustRestartStamp); err == nil {
-		logger.Warn("trust store repaired again after a restart this boot, not restarting a second time (the boot script is rebuilding it)")
+		logger.Warn("the trust store still is not effective after a restart this boot, not restarting again (something is rebuilding it)")
 		return
 	}
 	if err := os.WriteFile(trustRestartStamp, []byte(time.Now().Format(time.RFC3339)+"\n"), 0o644); err != nil {
 		logger.Warn("trust store repair: cannot write the restart guard, staying up rather than risking a restart loop", "err", err)
 		return
 	}
-	logger.Warn("trust store repaired, restarting so this process and the Spotify engine read the fixed store (Go caches it once per process)")
+	logger.Warn("the trust store on disk is healthy but this process does not trust those roots, restarting so it and the Spotify engine read the current store (Go caches it once per process)")
 	// Flush before pulling the rug out, the same way every other exit path
 	// here does.
 	_ = exec.Command("sync").Run()
 	time.Sleep(500 * time.Millisecond)
 	os.Exit(0)
-}
-
-// anyStoreRepaired reports whether the pass actually rebuilt something, which
-// is what makes the cached-pool restart necessary.
-func anyStoreRepaired(results []tlsgen.TrustRepairResult) bool {
-	for _, r := range results {
-		if r.Outcome == tlsgen.TrustRepairRepaired {
-			return true
-		}
-	}
-	return false
 }
 
 // trustStoresHealthy reports whether every store either carries public roots

--- a/internal/tlsgen/trusteffective.go
+++ b/internal/tlsgen/trusteffective.go
@@ -1,0 +1,106 @@
+package tlsgen
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+)
+
+// Whether the trust store on disk is the trust store this PROCESS uses.
+//
+// These are not the same question, and a field bundle cost two releases to
+// teach that. Go reads the system trust store once per process and caches it.
+// The boot script mounts STR's overlay AFTER the agent has started, and the
+// agent reaches for TLS within seconds of starting (the Spotify engine
+// launches almost immediately). So a speaker can hold a perfectly healthy
+// store on disk while every handshake in the running process still fails
+// against the copy it cached at startup.
+//
+// The first version of the repair only restarted when it had CHANGED a file.
+// On the reporter's ST20 nothing needed changing at the moment it looked: the
+// store it reads was already healthy, the other one was beyond saving, and the
+// agent went on failing every https station with a diagnostic that said both
+// stores were fine. Nothing in the file state could have revealed that. Only
+// asking the process itself can.
+//
+// The check is deliberately network-free. A handshake against some public host
+// would answer the same question, but it would also fail for a speaker with no
+// route, a captive portal or a slow DNS, and turn every one of those into a
+// spurious restart.
+
+// maxRootsProbed bounds the work: a store holds well over a hundred roots and
+// parsing all of them on a speaker CPU buys nothing. Several are tried rather
+// than one because an individual root may legitimately be expired, which would
+// make a single sample say "stale cache" when the cache is fine.
+const maxRootsProbed = 10
+
+// systemPool is x509.SystemCertPool, behind a seam so the tests can drive the
+// direction that actually carries risk: proving a HEALTHY speaker is never
+// restarted needs a pool that provably contains the roots on disk, and on a
+// dev host the real system pool contains neither them nor anything we can
+// place there.
+var systemPool = x509.SystemCertPool
+
+// RootsEffectiveInProcess reports whether the roots currently on disk are the
+// roots this process would actually trust.
+//
+// checked is false when the question could not be put: no readable store, or
+// nothing in it that parses as a certificate. Callers must not read that as
+// either answer.
+func RootsEffectiveInProcess(paths []string) (effective, checked bool) {
+	pool, err := systemPool()
+	if err != nil || pool == nil {
+		return false, false
+	}
+	for _, path := range paths {
+		body, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		for _, root := range parseRoots(body, maxRootsProbed) {
+			// A self-signed root verifies against a pool that contains it and
+			// fails with "unknown authority" against one that does not, which
+			// is exactly the distinction being drawn. One success is enough:
+			// it proves the process is reading the same material as the disk.
+			if _, err := root.Verify(x509.VerifyOptions{
+				Roots:     pool,
+				KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+			}); err == nil {
+				return true, true
+			}
+		}
+	}
+	// Something was readable but nothing in it verified. Report it as a real
+	// answer only if a certificate was actually parsed, so an empty or
+	// unreadable store does not masquerade as a stale cache.
+	for _, path := range paths {
+		if body, err := os.ReadFile(path); err == nil && len(parseRoots(body, 1)) > 0 {
+			return false, true
+		}
+	}
+	return false, false
+}
+
+// parseRoots decodes up to max certificates from a PEM bundle, skipping
+// entries that do not parse. A trust store with one unreadable block in it is
+// still a trust store.
+func parseRoots(body []byte, max int) []*x509.Certificate {
+	var out []*x509.Certificate
+	rest := body
+	for len(out) < max {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			continue
+		}
+		out = append(out, cert)
+	}
+	return out
+}

--- a/internal/tlsgen/trusteffective_test.go
+++ b/internal/tlsgen/trusteffective_test.go
@@ -1,0 +1,118 @@
+package tlsgen
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// The whole point of this check is that a HEALTHY FILE is not proof. The store
+// on the reporter's ST20 held 158 roots and every handshake still failed,
+// because the process had cached an older copy. So: roots that are on disk but
+// not in the process's pool must read as "not effective".
+func TestRootsOnDiskThatTheProcessDoesNotTrustAreNotEffective(t *testing.T) {
+	dir := t.TempDir()
+	store := filepath.Join(dir, "ca-bundle.crt")
+	// A self-signed root the system pool cannot possibly contain.
+	rootPEM := makeSelfSignedRootPEM(t)
+	if err := os.WriteFile(store, rootPEM, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	effective, checked := RootsEffectiveInProcess([]string{store})
+
+	if !checked {
+		t.Fatal("a store holding a parseable certificate must produce an answer")
+	}
+	if effective {
+		t.Error("a root the process does not trust must not count as effective")
+	}
+}
+
+// And the other direction, which is the one that carries the risk: a store
+// whose roots ARE what the process trusts must read as effective, because a
+// false negative here restarts a perfectly healthy speaker.
+func TestRootsTheProcessTrustsAreEffective(t *testing.T) {
+	dir := t.TempDir()
+	store := filepath.Join(dir, "ca-bundle.crt")
+	rootPEM := makeSelfSignedRootPEM(t)
+	if err := os.WriteFile(store, rootPEM, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A pool that DOES contain the root on disk, i.e. a process reading the
+	// same material as the file.
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(rootPEM) {
+		t.Fatal("could not seed the test pool")
+	}
+	prev := systemPool
+	systemPool = func() (*x509.CertPool, error) { return pool, nil }
+	t.Cleanup(func() { systemPool = prev })
+
+	effective, checked := RootsEffectiveInProcess([]string{store})
+
+	if !checked || !effective {
+		t.Errorf("effective=%v checked=%v, want both true: a healthy speaker must never be restarted", effective, checked)
+	}
+}
+
+// An unreadable or empty store is not evidence of a stale cache and must not
+// be reported as an answer, or every speaker missing one of the two paths
+// would restart itself.
+func TestAnEmptyStoreProducesNoAnswer(t *testing.T) {
+	dir := t.TempDir()
+	empty := filepath.Join(dir, "empty.crt")
+	if err := os.WriteFile(empty, []byte("not a certificate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, checked := RootsEffectiveInProcess([]string{empty}); checked {
+		t.Error("a store with no parseable certificate must not produce a verdict")
+	}
+	if _, checked := RootsEffectiveInProcess([]string{filepath.Join(dir, "missing.crt")}); checked {
+		t.Error("a missing store must not produce a verdict")
+	}
+}
+
+func TestParseRootsSkipsJunkAndHonoursTheLimit(t *testing.T) {
+	blob := append([]byte("garbage\n-----BEGIN NOTACERT-----\nx\n-----END NOTACERT-----\n"), makeSelfSignedRootPEM(t)...)
+	got := parseRoots(blob, 10)
+	if len(got) != 1 {
+		t.Fatalf("parsed %d certificates, want the 1 real one", len(got))
+	}
+	if n := len(parseRoots(append(blob, makeSelfSignedRootPEM(t)...), 1)); n != 1 {
+		t.Errorf("limit ignored: parsed %d, want 1", n)
+	}
+}
+
+// makeSelfSignedRootPEM builds a throwaway self-signed CA, which by
+// construction is not in any real system trust store.
+func makeSelfSignedRootPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "STR test root"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}

--- a/internal/webui/resume_standby.go
+++ b/internal/webui/resume_standby.go
@@ -547,6 +547,72 @@ func (s *Server) displayTrackText(streamTitle string) string {
 // false (treat as standalone): a missing zone read should not silently disable
 // the feature for the standalone majority, and the per-box opt-out is the
 // backstop for the rare paired box that also fails the read.
+// zoneRoleFromMaster decides this speaker's role in a zone by comparing the
+// zone's master against the speaker's own id.
+//
+// The deviceIDs are compared rather than the firmware's own senderIsMaster
+// attribute, and that is deliberate. On the Lifestyle/ST20 pair in the field
+// report the attribute reads the opposite way round to its name: the speaker
+// that FORMED the zone and leads it logs senderIsMaster=false, and the
+// follower logs true. Whatever the firmware means by "sender" there, the
+// master's deviceID is unambiguous and every chassis agrees on it.
+//
+// known is false when the answer cannot be trusted: no zone, or either id
+// missing. Callers must decide their own safe direction rather than reading
+// an unknown as "standalone".
+func zoneRoleFromMaster(masterID, selfID string) (follower, known bool) {
+	masterID = strings.TrimSpace(masterID)
+	selfID = strings.TrimSpace(selfID)
+	if masterID == "" {
+		return false, false // not in a zone at all
+	}
+	if selfID == "" {
+		return false, false // in a zone, but we cannot tell which end
+	}
+	return !strings.EqualFold(masterID, selfID), true
+}
+
+// zonePushWouldFightGroup reports whether pushing this speaker a stream of its
+// own would fight a group, and why. The policy lives here rather than at the
+// call site, because the two failure directions are not symmetrical and the
+// choice between them is the whole point.
+//
+// The distinction boxInZone cannot make: a MASTER that loses its stream still
+// has to recover it, and the whole group is listening to that one, so it must
+// keep its watchdog. A FOLLOWER must never be handed a stream of its own,
+// because the firmware is already playing what the master sends.
+//
+// Where the answer is uncertain the direction depends on what is uncertain:
+//
+//   - The zone cannot be read at all: treat as standalone and allow the push.
+//     Most speakers are standalone, and a momentary /getZone failure must not
+//     quietly disable stream recovery for them. Same reasoning as boxInZone.
+//   - The speaker IS in a zone but its own id cannot be established: stand
+//     down. Being in a group is already the risky state, and here the choice
+//     is only between a station the user restarts and a push that fights a
+//     group that is currently playing.
+func (s *Server) zonePushWouldFightGroup() (standDown bool, reason string) {
+	if s.boxHost == "" {
+		return false, ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+	c := boxapi.New(s.boxHost)
+	z, err := c.GetZone(ctx)
+	if err != nil {
+		return false, "" // unreadable: the standalone majority keeps recovery
+	}
+	follower, known := zoneRoleFromMaster(z.Master, s.localDeviceID(ctx, c, ""))
+	switch {
+	case !known && strings.TrimSpace(z.Master) != "":
+		return true, "in a group but cannot tell whether this speaker leads or follows"
+	case follower:
+		return true, "this speaker is a group follower, its audio comes from the master"
+	default:
+		return false, ""
+	}
+}
+
 func (s *Server) boxInZone() bool {
 	if s.boxHost == "" {
 		return false
@@ -1398,6 +1464,27 @@ func (s *Server) maybeRePush() {
 			s.lastPlay.rePushes = 0
 		}
 		s.lastPlayMu.Unlock()
+		return
+	}
+
+	// A speaker that has just JOINED a group looks exactly like one whose
+	// stream dropped: it leaves its own source, the proxy connection ends, and
+	// this watchdog arms. It is not a drop. The follower's audio now comes from
+	// the master, and pushing it its own previous station fights the group. The
+	// firmware says so plainly, and a field report caught it a second after the
+	// group formed (Lifestyle 535 with an ST20, 2026-08-14):
+	//
+	//   source changed  LOCAL_INTERNET_RADIO -> UPNP
+	//   re-push: box dropped the stream while idle, resuming  url=.../stream/3
+	//   re-push failed: SetURI: soap SetAVTransportURI status 500
+	//
+	// Only the FOLLOWER stands down. A master that loses its stream still has
+	// to recover it, and the whole group is listening to that one. An
+	// indeterminate answer also stands down: this runs on a speaker that is
+	// idle, so the cost of not pushing is a station the user restarts, while
+	// the cost of pushing into a group is the fight above.
+	if standDown, why := s.zonePushWouldFightGroup(); standDown {
+		s.logger.Info("re-push: not resuming, " + why)
 		return
 	}
 

--- a/internal/webui/zonerole_test.go
+++ b/internal/webui/zonerole_test.go
@@ -1,0 +1,49 @@
+package webui
+
+import "testing"
+
+// The role decision is what keeps a group working. Getting it backwards would
+// silence the master (the one speaker the whole group is listening to) while
+// leaving the follower being fought, so it is worth pinning down directly.
+func TestZoneRoleFromMaster(t *testing.T) {
+	const self = "EC24B8B790CC"
+
+	tests := []struct {
+		name         string
+		master, id   string
+		wantFollower bool
+		wantKnown    bool
+	}{
+		{"master leads its own zone", self, self, false, true},
+		{"master id in another case still leads", "ec24b8b790cc", self, false, true},
+		{"a different master means we follow", "000C8A96488D", self, true, true},
+		{"no zone at all", "", self, false, false},
+		{"in a zone but our own id is unknown", "000C8A96488D", "", false, false},
+		{"whitespace is not an id", "  ", self, false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			follower, known := zoneRoleFromMaster(tc.master, tc.id)
+			if follower != tc.wantFollower || known != tc.wantKnown {
+				t.Errorf("zoneRoleFromMaster(%q, %q) = (follower=%v, known=%v), want (%v, %v)",
+					tc.master, tc.id, follower, known, tc.wantFollower, tc.wantKnown)
+			}
+		})
+	}
+}
+
+// The firmware's own senderIsMaster attribute reads the opposite way round to
+// its name on the chassis in the field report: the speaker that formed and
+// leads the zone logs false, the follower logs true. This test exists to state
+// why the role is derived from the deviceIDs instead, so nobody "simplifies"
+// it back to the attribute.
+func TestZoneRoleIgnoresTheFirmwareSenderFlag(t *testing.T) {
+	const master, follower = "852F08E8AAAA", "C4FC5074BBBB"
+
+	if isFollower, known := zoneRoleFromMaster(master, master); !known || isFollower {
+		t.Error("the speaker whose id IS the master must not be treated as a follower, whatever senderIsMaster says")
+	}
+	if isFollower, known := zoneRoleFromMaster(master, follower); !known || !isFollower {
+		t.Error("a speaker whose id differs from the master must be treated as a follower")
+	}
+}


### PR DESCRIPTION
From a Lifestyle 535 grouped with an ST20 (mail report, 2026-08-14).

## What happens

A speaker that joins a group looks exactly like one whose stream dropped: it
leaves its own source, the proxy connection ends, and the re-push watchdog
arms. One second after the group formed:

```
10:10:07  source changed  LOCAL_INTERNET_RADIO -> UPNP
10:10:08  re-push: box dropped the stream while idle, resuming  url=.../stream/3
10:10:09  re-push failed: SetURI: soap SetAVTransportURI status 500
```

The speaker refusing the push is the correct answer. The watchdog counted the
attempt and stood ready to try again.

## Only the follower stands down

`boxInZone` already exists but is true for both ends, so using it here would
silence the **master**, which is the one speaker the whole group is listening
to and the one whose recovery matters most.

The role is decided by comparing the zone's master against the speaker's own
deviceID, deliberately **not** by the firmware's `senderIsMaster` attribute. On
this chassis that attribute reads the opposite way round to its name: the
speaker that formed and leads the zone logs `senderIsMaster=false`, the
follower logs `true`. A test states this so it cannot be "simplified" back.

## The two uncertain cases are not alike

- Zone unreadable: treat as standalone and keep recovery. Most speakers are
  standalone and a momentary `/getZone` failure must not quietly disable
  stream recovery for them.
- In a zone but own id unestablishable: stand down. The choice there is only
  between a station the user restarts and a push into a group that is playing.

Still open on the same report: the Lifestyle switching itself fully off when
the group is DISSOLVED. That needs a diagnostic saved right after a
dissolution, which the reporter's current file stops one minute short of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)