### PR TITLE
An update no longer discards a Spotify engine delivered while it runs

### DIFF
--- a/desktop-app/ota.go
+++ b/desktop-app/ota.go
@@ -466,6 +466,15 @@ func (a *App) pushSidecarIfNeeded(host string, port int) (delivered bool, err er
 
 	a.recordOTA(host, fmt.Sprintf("sidecar: pushing go-librespot (%d bytes, sha %s)", len(bin), want[:12]))
 	if _, _, err := a.streamPostBinary(host, port, "/api/agent/sidecar", bin); err != nil {
+		// The speaker refuses the engine while its own update is running,
+		// because that update reclaims the engine's space and would delete what
+		// we just delivered. Not a failure: deliver it again once the new
+		// version reports itself. Anything else is a real problem.
+		if strings.Contains(err.Error(), "update-in-flight") {
+			a.recordOTA(host, "sidecar: the speaker is mid-update and would discard the engine; delivering it after the restart")
+			a.logger.Info("sidecar push deferred: the speaker reports an update in flight", "host", host)
+			return false, nil
+		}
 		a.recordOTA(host, "sidecar: push failed (agent OTA still proceeds): "+err.Error())
 		a.logger.Warn("sidecar push failed; agent OTA continues, Spotify may stay unavailable until next OTA", "host", host, "err", err)
 		return false, fmt.Errorf("sidecar upload failed: %w", err)

--- a/internal/webui/agent_admin.go
+++ b/internal/webui/agent_admin.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 )
@@ -348,11 +349,31 @@ func ensureSSHDRunning(logger *slog.Logger) bool {
 //
 // On success the stick still returns 200 OK and then exits. The
 // rc.local bootstrap starts the new agent.
+// updateInFlight is set while an agent update is writing the new binary and
+// heading for its restart.
+//
+// It exists because the update DELETES the Spotify engine when NAND is tight:
+// it stops the engine and reclaims its ~16 MB to make room for the new binary.
+// An engine delivered into that window is therefore thrown away moments later,
+// and the speaker comes back without one. That is not hypothetical, it cost a
+// SoundTouch 30 its engine twice in one day, both times because a client
+// pushed the engine while the update it had just started was still running.
+//
+// A client cannot see this from the outside: the old agent keeps answering
+// normally right up to the restart, so every check it can make says the
+// speaker is ready. So the agent has to say no.
+var updateInFlight atomic.Bool
+
 func (s *Server) handleAgentUpdate(w http.ResponseWriter, r *http.Request) {
 	body, ok := s.readUploadedELF(w, r, s.logger, "agent-update")
 	if !ok {
 		return
 	}
+	// From here the engine may be reclaimed at any moment and the process may
+	// exit. Cleared again only on the paths that give up WITHOUT restarting,
+	// so a failed update does not leave the speaker refusing engine deliveries
+	// until its next reboot.
+	updateInFlight.Store(true)
 	const dst = agentBinNANDPath
 	err := writeBinaryAtomic(dst, body)
 	// Tier 2 (#270): a NAND that UBIFS parked read-only fails the write (or,
@@ -363,6 +384,7 @@ func (s *Server) handleAgentUpdate(w http.ResponseWriter, r *http.Request) {
 		if remountNANDRW(s.logger) {
 			err = writeBinaryAtomic(dst, body)
 		} else {
+			updateInFlight.Store(false)
 			http.Error(w, errNANDReadOnly.Error(), http.StatusInsufficientStorage)
 			return
 		}
@@ -399,6 +421,7 @@ func (s *Server) handleAgentUpdate(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if err != nil {
+		updateInFlight.Store(false)
 		http.Error(w, err.Error(), nandWriteHTTPStatus(err))
 		return
 	}
@@ -417,6 +440,7 @@ func (s *Server) handleAgentUpdate(w http.ResponseWriter, r *http.Request) {
 		}
 		if verr = verifyBinaryOnFlash(dst, body); verr != nil {
 			s.logger.Error("agent update: flash verify failed twice, refusing to reboot", "err", verr)
+			updateInFlight.Store(false)
 			http.Error(w, "update did not persist to flash: "+verr.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -1415,6 +1439,20 @@ var nandHasRoom = func(dir string, need int64) bool {
 // running process until it exits, so killing+relaunching it on the write releases
 // that ~10 MB immediately instead of holding it until the next reboot.
 func (s *Server) handleAgentSidecar(w http.ResponseWriter, r *http.Request) {
+	// Refuse while an agent update is running. The update reclaims the engine's
+	// ~16 MB when NAND is tight, so an engine delivered now is deleted a moment
+	// later and the speaker restarts without one. The caller cannot see that
+	// from outside, because the old agent answers normally until the restart,
+	// so the answer has to come from here. Deliver it again once the new
+	// version reports itself, which is what the update flow already does.
+	if updateInFlight.Load() {
+		s.logger.Info("sidecar refused: an agent update is in flight, the engine would be reclaimed by it")
+		writeJSON(w, http.StatusConflict, map[string]string{
+			"code":  "update-in-flight",
+			"error": "An update is installing on this speaker. Deliver the Spotify engine again once the speaker reports the new version.",
+		})
+		return
+	}
 	// Streamed, not buffered. This is the ~16 MB engine and the box has ~120 MB
 	// of RAM: holding it in memory first was enough to reboot a speaker that
 	// happened to be busy (see streamBinaryAtomic). The agent-update endpoint

--- a/internal/webui/sidecarguard_test.go
+++ b/internal/webui/sidecarguard_test.go
@@ -1,0 +1,47 @@
+package webui
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// While an agent update is installing, the update itself may reclaim the
+// engine's ~16 MB to make room for the new binary. An engine delivered into
+// that window is deleted moments later and the speaker restarts without one.
+// A SoundTouch 30 lost its engine twice in one day this way, both times
+// because a client pushed the engine while the update it had just started was
+// still running.
+func TestSidecarIsRefusedWhileAnUpdateIsInstalling(t *testing.T) {
+	updateInFlight.Store(true)
+	t.Cleanup(func() { updateInFlight.Store(false) })
+
+	s := &Server{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	rec := httptest.NewRecorder()
+	s.handleAgentSidecar(rec, httptest.NewRequest(http.MethodPost, "/api/agent/sidecar", nil))
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d: the speaker must say no rather than accept an engine it is about to delete",
+			rec.Code, http.StatusConflict)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "update-in-flight") {
+		t.Errorf("body = %q, want a machine-readable code the app can act on", body)
+	}
+}
+
+// And it must not refuse the rest of the time, or every speaker loses its
+// engine delivery for good.
+func TestSidecarIsAcceptedWhenNoUpdateIsRunning(t *testing.T) {
+	updateInFlight.Store(false)
+
+	s := &Server{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	rec := httptest.NewRecorder()
+	s.handleAgentSidecar(rec, httptest.NewRequest(http.MethodPost, "/api/agent/sidecar", nil))
+
+	if rec.Code == http.StatusConflict {
+		t.Fatal("a speaker with no update running must not refuse the engine")
+	}
+}


### PR DESCRIPTION
## The race

`writeBinaryAtomic` reclaims the engine when NAND is tight: it stops
go-librespot and drops its ~16 MB so the new agent binary fits. An engine
delivered just before that is deleted by it, and the speaker comes back without
one.

Nothing outside can see the window. The old agent answers normally until it
restarts, so a client's "is the speaker ready" check says yes, the upload is
accepted, and the bytes are thrown away.

My own fleet tooling hit this twice in one day on the same SoundTouch 30. That
is the argument for fixing it in the speaker rather than in each client: the
information needed to avoid it only exists on the speaker.

## The fix

`POST /api/agent/sidecar` answers **409** with `code: update-in-flight` while an
update is installing. The desktop app treats that as a deferral, not a failure,
and delivers the engine once the new version reports itself, which its update
flow already does.

The flag is cleared on every give-up path in the update handler, so a failed
update cannot leave a speaker refusing engine deliveries until its next reboot.

## Tests

The refusal fires while an update is in flight and carries the machine-readable
code; the endpoint does not refuse the rest of the time, since that would cost
every speaker its engine delivery for good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)