### PR TITLE
A refused update says which address was turned away

### DIFF
--- a/internal/webui/agent_admin.go
+++ b/internal/webui/agent_admin.go
@@ -1685,13 +1685,33 @@ func (s *Server) refuseNonLAN(w http.ResponseWriter, r *http.Request, what strin
 	if host, _, err := net.SplitHostPort(caller); err == nil {
 		caller = host
 	}
-	local := localSubnets()
+	local := localSubnetsFn()
+	// "I cannot tell" is not "you are not local", and saying the second when
+	// the first is true sends the owner looking at his router for a problem
+	// that is on the speaker. A speaker that cannot enumerate its own
+	// interfaces refuses EVERY caller, including the one standing next to it.
+	//
+	// It still refuses: this endpoint writes a binary and runs it as root, so
+	// the unknown case is not one to wave through. What changes is that it says
+	// which of the two happened, and that a restart is the thing to try.
+	if len(local) == 0 {
+		s.logger.Warn("refused: this speaker cannot read its own network configuration, so it cannot tell whether the caller is local",
+			"endpoint", what, "caller", caller)
+		http.Error(w, fmt.Sprintf(
+			"update refused: this speaker cannot read its own network configuration right now, so it cannot tell whether %s is on its network. Restart the speaker and try again.",
+			caller), http.StatusForbidden)
+		return
+	}
 	s.logger.Warn("refused: the caller is not on any network this speaker has an address in",
 		"endpoint", what, "caller", caller, "speakerNetworks", strings.Join(local, ","))
 	http.Error(w, fmt.Sprintf(
 		"update only allowed from LAN: this speaker sees the request coming from %s, which is not on any network it has an address in (%s)",
 		caller, strings.Join(local, ", ")), http.StatusForbidden)
 }
+
+// localSubnetsFn is localSubnets behind a seam, so the "cannot tell" branch
+// can be tested without breaking the machine running the tests.
+var localSubnetsFn = localSubnets
 
 // localSubnets lists the networks the speaker has an address in, for the
 // refusal message. Best effort: an empty list is itself informative, since a

--- a/internal/webui/agent_admin.go
+++ b/internal/webui/agent_admin.go
@@ -538,7 +538,7 @@ func (s *Server) readUploadedELF(w http.ResponseWriter, r *http.Request, logger 
 		return nil, false
 	}
 	if !isLocalLAN(r.RemoteAddr) {
-		http.Error(w, "update only allowed from LAN", http.StatusForbidden)
+		s.refuseNonLAN(w, r, what)
 		return nil, false
 	}
 	// Quieten the speaker before the transfer starts, not after: the audio and
@@ -1628,7 +1628,7 @@ func (s *Server) streamUploadedELF(w http.ResponseWriter, r *http.Request, logge
 		return "", 0, false
 	}
 	if !isLocalLAN(r.RemoteAddr) {
-		http.Error(w, "update only allowed from LAN", http.StatusForbidden)
+		s.refuseNonLAN(w, r, what)
 		return "", 0, false
 	}
 	s.hushForUpload(what)
@@ -1667,4 +1667,56 @@ func (s *Server) streamUploadedELF(w http.ResponseWriter, r *http.Request, logge
 		return "", size, false
 	}
 	return sum, size, true
+}
+
+// refuseNonLAN answers a request the LAN gate turned away, and records WHY.
+//
+// The refusal used to be silent: http.Error and nothing else. A user whose
+// update was refused therefore sent a diagnostic bundle containing no trace of
+// it at all, so the only way to work out what happened was to ask him to try
+// again and describe it. One reporter went through ten attempts and a mail
+// exchange before his Wave updated (2026-08-15), and his bundle could not say
+// which address had been turned away or what the speaker considered local.
+//
+// Both figures are in the answer as well as the log, because the person who
+// needs them is usually reading the app's error message rather than a bundle.
+func (s *Server) refuseNonLAN(w http.ResponseWriter, r *http.Request, what string) {
+	caller := r.RemoteAddr
+	if host, _, err := net.SplitHostPort(caller); err == nil {
+		caller = host
+	}
+	local := localSubnets()
+	s.logger.Warn("refused: the caller is not on any network this speaker has an address in",
+		"endpoint", what, "caller", caller, "speakerNetworks", strings.Join(local, ","))
+	http.Error(w, fmt.Sprintf(
+		"update only allowed from LAN: this speaker sees the request coming from %s, which is not on any network it has an address in (%s)",
+		caller, strings.Join(local, ", ")), http.StatusForbidden)
+}
+
+// localSubnets lists the networks the speaker has an address in, for the
+// refusal message. Best effort: an empty list is itself informative, since a
+// speaker whose interfaces cannot be read refuses everything.
+func localSubnets() []string {
+	var out []string
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return out
+	}
+	for _, ifi := range ifaces {
+		if ifi.Flags&net.FlagUp == 0 {
+			continue
+		}
+		addrs, err := ifi.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, a := range addrs {
+			n, ok := a.(*net.IPNet)
+			if !ok || n.IP.IsLoopback() {
+				continue
+			}
+			out = append(out, n.String())
+		}
+	}
+	return out
 }

--- a/internal/webui/lanrefusal_test.go
+++ b/internal/webui/lanrefusal_test.go
@@ -53,3 +53,35 @@ func TestTheRefusalReportsTheAddressWithoutThePort(t *testing.T) {
 		t.Errorf("the source port has no business in the message: %q", rec.Body.String())
 	}
 }
+
+// A speaker that cannot enumerate its own interfaces refuses everyone,
+// including the owner standing next to it. Telling him "you are not local"
+// sends him to his router for a problem that is on the speaker, so the two
+// cases have to read differently.
+func TestARefusalSaysWhenTheSpeakerCannotTell(t *testing.T) {
+	var logged bytes.Buffer
+	s := &Server{logger: slog.New(slog.NewTextHandler(&logged, nil))}
+	prev := localSubnetsFn
+	localSubnetsFn = func() []string { return nil }
+	t.Cleanup(func() { localSubnetsFn = prev })
+
+	req := httptest.NewRequest(http.MethodPost, "/api/agent/update", nil)
+	req.RemoteAddr = "192.168.1.5:5000"
+	rec := httptest.NewRecorder()
+
+	s.refuseNonLAN(rec, req, "agent-update")
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: the unknown case still refuses, it writes a binary and runs it as root", rec.Code)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "not on any network") {
+		t.Errorf("must not claim the caller is remote when the speaker simply cannot tell: %q", body)
+	}
+	if !strings.Contains(body, "cannot read its own network configuration") {
+		t.Errorf("must say which of the two happened: %q", body)
+	}
+	if !strings.Contains(logged.String(), "cannot tell whether the caller is local") {
+		t.Errorf("the bundle needs the distinction too: %q", logged.String())
+	}
+}

--- a/internal/webui/lanrefusal_test.go
+++ b/internal/webui/lanrefusal_test.go
@@ -1,0 +1,55 @@
+package webui
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// A refused update used to say only "update only allowed from LAN", and said
+// it nowhere else: no log line, so the diagnostic bundle from a user whose
+// update was refused carried no trace of it. One reporter went through ten
+// attempts and a mail exchange over this. The refusal has to name the address
+// it turned away.
+func TestALANRefusalNamesTheAddressItTurnedAway(t *testing.T) {
+	var logged bytes.Buffer
+	s := &Server{logger: slog.New(slog.NewTextHandler(&logged, nil))}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/agent/update", nil)
+	req.RemoteAddr = "203.0.113.9:51234"
+	rec := httptest.NewRecorder()
+
+	s.refuseNonLAN(rec, req, "agent-update")
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "203.0.113.9") {
+		t.Errorf("the answer must name the refused address, got %q", body)
+	}
+	if !strings.Contains(logged.String(), "203.0.113.9") {
+		t.Errorf("the refusal must be logged so a bundle carries it, got %q", logged.String())
+	}
+	if !strings.Contains(logged.String(), "agent-update") {
+		t.Error("the log line must say which endpoint refused")
+	}
+}
+
+// The port must not end up in the message: it is noise, and it changes on
+// every attempt, which makes two identical refusals look different.
+func TestTheRefusalReportsTheAddressWithoutThePort(t *testing.T) {
+	s := &Server{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	req := httptest.NewRequest(http.MethodPost, "/api/agent/sidecar", nil)
+	req.RemoteAddr = "198.51.100.4:44321"
+	rec := httptest.NewRecorder()
+
+	s.refuseNonLAN(rec, req, "sidecar")
+
+	if strings.Contains(rec.Body.String(), "44321") {
+		t.Errorf("the source port has no business in the message: %q", rec.Body.String())
+	}
+}


### PR DESCRIPTION
From a Wave owner's report: ten update attempts refused with `403 update only
allowed from LAN`, then one that worked, with no explanation for either.

## The forensic hole

The gate refused silently: `http.Error` and no log line. So the bundle from a
speaker that had just refused an update carried **nothing** about it. Neither
the address turned away nor what the speaker considers local was recorded.

His bundle shows the refusal only as an absence. The app's report has the 403;
the speaker's log has a Wi-Fi switch confirmed four minutes earlier, which is
exactly the kind of event that moves a speaker out of the caller's subnet.
Whether that caused it cannot be decided from what was recorded, which is the
argument for recording it.

## The change

The refusal names the caller and lists the networks the speaker has an address
in, in the log and in the response body. The body matters because the person
who needs this is usually reading the app's error message, not a bundle.

The source port is dropped: it changes on every attempt and makes two identical
refusals look different.

🤖 Generated with [Claude Code](https://claude.com/claude-code)