### PR TITLE
Four fixes: a group-wide crash, the phone's group volume, and two certificate blind spots

### DIFF
--- a/cmd/agent/peers.go
+++ b/cmd/agent/peers.go
@@ -251,22 +251,8 @@ func probeStalePeers(logger *slog.Logger) {
 		return
 	}
 	peersProbing = true
-	type cand struct {
-		ip   string
-		seen time.Time
-	}
-	var stale []cand
-	now := time.Now()
-	for ip, e := range peersByIP {
-		if now.Sub(e.lastSeen) > 30*time.Second {
-			stale = append(stale, cand{ip: ip, seen: e.lastSeen})
-		}
-	}
+	stale := probeCandidatesLocked()
 	peersMu.Unlock()
-	sort.Slice(stale, func(i, j int) bool { return stale[i].seen.Before(stale[j].seen) })
-	if len(stale) > 8 {
-		stale = stale[:8]
-	}
 	go func() {
 		defer func() {
 			peersMu.Lock()
@@ -274,7 +260,7 @@ func probeStalePeers(logger *slog.Logger) {
 			peersMu.Unlock()
 		}()
 		for _, c := range stale {
-			port := reachableWebPort(c.ip)
+			port := reachableWebPort(c)
 			if port == 0 {
 				continue
 			}
@@ -286,12 +272,18 @@ func probeStalePeers(logger *slog.Logger) {
 			// where a name belongs (#494, seen live 2026-07-28).
 			var friendly string
 			peersMu.Lock()
-			if e := peersByIP[c.ip]; e != nil && placeholderPeerName(e.name) {
+			// An EMPTY name counts too, and used to be the worse case of the
+			// two: a nameless entry is skipped by the listing further down, so
+			// the speaker was not merely shown badly, it was not shown at all,
+			// and nothing ever came back to fix it. Live on 2026-08-15: after a
+			// reboot one speaker restored five peers from NAND and offered four,
+			// and the missing one was up, reachable and named the whole time.
+			if e := peersByIP[c]; e != nil && (e.name == "" || placeholderPeerName(e.name)) {
 				peersMu.Unlock()
-				friendly = peerFriendlyName(c.ip)
+				friendly = peerFriendlyName(c)
 				peersMu.Lock()
 			}
-			if e := peersByIP[c.ip]; e != nil {
+			if e := peersByIP[c]; e != nil {
 				e.lastSeen = time.Now()
 				e.reachable = true
 				e.port = port
@@ -615,4 +607,37 @@ func dialable(ip string, port int) bool {
 		}
 	}
 	return false
+}
+
+// probeCandidates picks the peers worth asking. A nameless one is included
+// whatever its age: the listing skips an entry with no name, and this is the
+// only path that ever learns one, so leaving it out hides the speaker for good.
+// Capped, because this runs on a speaker with 120 MB of RAM.
+func probeCandidates() []string {
+	peersMu.Lock()
+	defer peersMu.Unlock()
+	return probeCandidatesLocked()
+}
+
+func probeCandidatesLocked() []string {
+	type cand struct {
+		ip   string
+		seen time.Time
+	}
+	var out []cand
+	now := time.Now()
+	for ip, e := range peersByIP {
+		if e.name == "" || now.Sub(e.lastSeen) > 30*time.Second {
+			out = append(out, cand{ip: ip, seen: e.lastSeen})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].seen.Before(out[j].seen) })
+	if len(out) > 8 {
+		out = out[:8]
+	}
+	ips := make([]string, 0, len(out))
+	for _, c := range out {
+		ips = append(ips, c.ip)
+	}
+	return ips
 }

--- a/cmd/agent/peers_nameless_test.go
+++ b/cmd/agent/peers_nameless_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// A peer restored from NAND without a name was invisible forever: the listing
+// skips a nameless entry, and the only code that asks a speaker its name asked
+// only when the name was a "str-..." placeholder. Live on 2026-08-15, one
+// speaker offered four of the five peers it had restored, and the missing one
+// was up and reachable the whole time.
+func TestANamelessPeerIsProbedForItsName(t *testing.T) {
+	peersMu.Lock()
+	peersByIP = map[string]*peerEntry{
+		"192.0.2.11": {name: "", lastSeen: time.Now()},                     // nameless and fresh
+		"192.0.2.12": {name: "Kitchen", lastSeen: time.Now()},              // named and fresh
+		"192.0.2.13": {name: "str-192.0.2.13", lastSeen: time.Now()},       // placeholder, fresh
+		"192.0.2.14": {name: "Bath", lastSeen: time.Now().Add(-time.Hour)}, // named but stale
+	}
+	peersMu.Unlock()
+	t.Cleanup(func() {
+		peersMu.Lock()
+		peersByIP = map[string]*peerEntry{}
+		peersProbing = false
+		peersMu.Unlock()
+	})
+
+	got := probeCandidates()
+	in := func(ip string) bool {
+		for _, c := range got {
+			if c == ip {
+				return true
+			}
+		}
+		return false
+	}
+	if !in("192.0.2.11") {
+		t.Error("a nameless peer must be probed however fresh it is: nothing else will ever name it")
+	}
+	if !in("192.0.2.14") {
+		t.Error("a stale peer is still a candidate, that was the original purpose")
+	}
+	if in("192.0.2.12") {
+		t.Error("a named, fresh peer needs nothing")
+	}
+}

--- a/desktop-app/app.go
+++ b/desktop-app/app.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/JRpersonal/streborn/dlna"
 	"github.com/JRpersonal/streborn/sticksetup"
+	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
 // App is the central state struct.
@@ -178,6 +179,75 @@ func (a *App) startup(ctx context.Context) {
 		"build", appBuild,
 		"logFile", LogFilePath(),
 		"agentbinAvailable", agentbin.Available())
+	a.fitWindowToScreen()
+}
+
+// fitWindowToScreen keeps the title bar reachable.
+//
+// The configured window size is in device-independent pixels, and a scaled
+// display has far fewer of them than its resolution suggests: 1920x1080 at
+// 150% leaves 1280x720, minus the taskbar. A window taller than that, centred
+// by the platform, ends up with its top edge above the screen, and then it
+// cannot be dragged, moved or maximised, because the bar you would grab is
+// off-screen (live 2026-08-15, caused by raising the default height to 820).
+//
+// So the window is measured against the screen it is on and, when it does not
+// fit, shrunk to fit and pinned to the top edge. Pinning to the top rather
+// than centring is deliberate: losing a strip at the bottom costs content,
+// losing the strip at the top costs control of the window.
+//
+// Entirely best-effort. A screen the runtime cannot report leaves the window
+// exactly as the platform placed it.
+func (a *App) fitWindowToScreen() {
+	defer func() {
+		if r := recover(); r != nil {
+			a.logger.Warn("could not fit the window to the screen", "panic", r)
+		}
+	}()
+	screens, err := runtime.ScreenGetAll(a.ctx)
+	if err != nil || len(screens) == 0 {
+		return
+	}
+	screen := screens[0]
+	for _, s := range screens {
+		if s.IsCurrent {
+			screen = s
+			break
+		}
+	}
+	if screen.Width <= 0 || screen.Height <= 0 {
+		return
+	}
+	w, h := runtime.WindowGetSize(a.ctx)
+	// Leave room for the taskbar and the window frame. ScreenGetAll reports
+	// the full screen rather than the work area, and on Windows it reports
+	// PHYSICAL pixels while the window is sized in device-independent ones,
+	// so on a scaled display this comparison is generous and the shrink
+	// rarely triggers. The pinning below is what actually saves the window
+	// there, which is why the opening height is kept modest as well.
+	const chrome = 80
+	maxH := screen.Height - chrome
+	maxW := screen.Width
+	newW, newH := w, h
+	if newH > maxH {
+		newH = maxH
+	}
+	if newW > maxW {
+		newW = maxW
+	}
+	if newW != w || newH != h {
+		runtime.WindowSetSize(a.ctx, newW, newH)
+		a.logger.Info("window shrunk to fit the screen",
+			"screenW", screen.Width, "screenH", screen.Height,
+			"fromW", w, "fromH", h, "toW", newW, "toH", newH)
+	}
+	x, _ := runtime.WindowGetPosition(a.ctx)
+	if x < 0 {
+		x = 0
+	}
+	// Top edge on the screen edge, always. This is the whole point of the
+	// function: the title bar has to be grabbable.
+	runtime.WindowSetPosition(a.ctx, x, 0)
 }
 
 // LogClientError records an error the frontend caught (a global

--- a/desktop-app/frontend/src/groups.js
+++ b/desktop-app/frontend/src/groups.js
@@ -126,16 +126,53 @@ export function resolvePlayTarget(box, zoneLive, boxes) {
 //     next chip toggle silently kick the follower from the zone,
 //   - boxes absent from this round's list are dropped,
 //   - a box that has never answered stays absent (unknown, not standalone).
-export function mergeZoneLive(prev, boxes, results) {
+// ZONE_CARRY_MS is how long a speaker's last known zone survives while the
+// speaker itself does not answer. Carrying it over covers a poll that lost a
+// race or a speaker that is briefly busy; carrying it forever is how a group
+// outlived the speakers in it (live 2026-08-15: a speaker had been offline for
+// hours and the app still showed it grouped with another, complete with a
+// group volume slider and no frames, because its entry was renewed from itself
+// on every round). Ninety seconds is several poll rounds, well past any
+// transient, and far short of "all evening".
+export const ZONE_CARRY_MS = 90 * 1000;
+
+// zoneSaysNoGroup reports whether an answer means "this speaker is in no
+// group". A speaker that ANSWERED is the authority on the group it supposedly
+// leads, which is what makes it safe to drop the stale entries pointing at it.
+function zoneSaysNoGroup(z) {
+  if (!z) return false;
+  return !String(z.master || '') && !((z.members || []).length);
+}
+
+export function mergeZoneLive(prev, boxes, results, now = Date.now()) {
   const map = {};
+  const answeredEmpty = new Set();
   (boxes || []).forEach((b, i) => {
     const r = results && results[i];
     if (r && r.status === 'fulfilled' && r.value) {
+      // A fresh answer is stored exactly as it came, with no bookkeeping added.
       map[b.deviceID] = r.value;
-    } else if (prev && Object.prototype.hasOwnProperty.call(prev, b.deviceID)) {
-      map[b.deviceID] = prev[b.deviceID];
+      if (zoneSaysNoGroup(r.value)) answeredEmpty.add(String(b.deviceID).toUpperCase());
+      return;
     }
+    if (!prev || !Object.prototype.hasOwnProperty.call(prev, b.deviceID)) return;
+    const carried = prev[b.deviceID];
+    // A null entry means "known standalone" and is set deliberately by
+    // applyOptimisticZone. It says something, so it is kept as it is.
+    if (!carried) { map[b.deviceID] = carried; return; }
+    // The clock starts at the first round this speaker missed, not at the last
+    // one it answered: that is the moment the entry stopped being observed.
+    const staleSince = typeof carried.staleSince === 'number' ? carried.staleSince : now;
+    if (now - staleSince < ZONE_CARRY_MS) map[b.deviceID] = { ...carried, staleSince };
   });
+  // Drop what the speakers themselves contradict: an entry naming a master
+  // that just told us it has no group describes a group that no longer exists.
+  if (answeredEmpty.size) {
+    for (const id of Object.keys(map)) {
+      const e = map[id];
+      if (e && answeredEmpty.has(String(e.master || '').toUpperCase())) delete map[id];
+    }
+  }
   return map;
 }
 

--- a/desktop-app/frontend/src/groups.test.js
+++ b/desktop-app/frontend/src/groups.test.js
@@ -198,7 +198,11 @@ describe('mergeZoneLive', () => {
       { status: 'fulfilled', value: prev[boxB.deviceID] },
     ];
     const merged = mergeZoneLive(prev, [master, boxA, boxB], results);
-    expect(merged[boxA.deviceID]).toBe(prev[boxA.deviceID]);
+    // Equality, not identity: a carried entry now records WHEN the speaker
+    // stopped answering, so it can be dropped once that is no longer a gap but
+    // an absence. The membership it carries is what matters here.
+    expect(merged[boxA.deviceID]).toMatchObject(prev[boxA.deviceID]);
+    expect(typeof merged[boxA.deviceID].staleSince).toBe('number');
   });
   it('keeps an optimistic null through a failed poll (known standalone)', () => {
     const prev = { [boxA.deviceID]: null };

--- a/desktop-app/frontend/src/i18n/bundles/ar.json
+++ b/desktop-app/frontend/src/i18n/bundles/ar.json
@@ -1293,5 +1293,8 @@
   "settingsView.phoneAndroid4": "أكّد بالضغط على <b>تثبيت</b>.",
   "settingsView.phoneAndroidNote": "بعض الكاميرات تفتح الرابط في متصفح آخر، وChrome وحده يعرض التثبيت.",
   "settingsView.phoneShotIos": "آيفون: أيقونة خاصة، ويفتح بدون شريط المتصفح.",
-  "settingsView.phoneShotAndroid": "أندرويد: يُثبَّت عبر Chrome، فيظهر أيضاً في قائمة التطبيقات."
+  "settingsView.phoneShotAndroid": "أندرويد: يُثبَّت عبر Chrome، فيظهر أيضاً في قائمة التطبيقات.",
+  "banner.checkForAppUpdate": "البحث عن تحديثات التطبيق",
+  "banner.checkingForAppUpdate": "جارٍ البحث…",
+  "banner.appIsCurrent": "تطبيقك محدَّث."
 }

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -1293,5 +1293,8 @@
   "settingsView.phoneAndroid4": "Mit <b>Installieren</b> bestätigen.",
   "settingsView.phoneAndroidNote": "Manche Kameras öffnen den Link in einem anderen Browser. Nur Chrome bietet die Installation an.",
   "settingsView.phoneShotIos": "iPhone: eigenes Symbol, öffnet ohne Browserleiste.",
-  "settingsView.phoneShotAndroid": "Android: über Chrome installiert, damit auch in der App-Übersicht."
+  "settingsView.phoneShotAndroid": "Android: über Chrome installiert, damit auch in der App-Übersicht.",
+  "banner.checkForAppUpdate": "Nach App-Updates suchen",
+  "banner.checkingForAppUpdate": "Suche…",
+  "banner.appIsCurrent": "Deine App ist aktuell."
 }

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -1293,5 +1293,8 @@
   "settingsView.phoneAndroid4": "Confirm with <b>Install</b>.",
   "settingsView.phoneAndroidNote": "Some cameras open the link in another browser. Only Chrome offers the install.",
   "settingsView.phoneShotIos": "iPhone: its own icon, opens with no browser bar.",
-  "settingsView.phoneShotAndroid": "Android: installed through Chrome, so it is in the app drawer too."
+  "settingsView.phoneShotAndroid": "Android: installed through Chrome, so it is in the app drawer too.",
+  "banner.checkForAppUpdate": "Check for app updates",
+  "banner.checkingForAppUpdate": "Checking…",
+  "banner.appIsCurrent": "Your app is up to date."
 }

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -1293,5 +1293,8 @@
   "settingsView.phoneAndroid4": "Confirma con <b>Instalar</b>.",
   "settingsView.phoneAndroidNote": "Algunas cámaras abren el enlace en otro navegador. Solo Chrome ofrece la instalación.",
   "settingsView.phoneShotIos": "iPhone: icono propio, se abre sin barra del navegador.",
-  "settingsView.phoneShotAndroid": "Android: instalada con Chrome, así que también está en el cajón de aplicaciones."
+  "settingsView.phoneShotAndroid": "Android: instalada con Chrome, así que también está en el cajón de aplicaciones.",
+  "banner.checkForAppUpdate": "Buscar actualizaciones de la app",
+  "banner.checkingForAppUpdate": "Buscando…",
+  "banner.appIsCurrent": "Tu aplicación está actualizada."
 }

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -1293,5 +1293,8 @@
   "settingsView.phoneAndroid4": "Confirmez avec <b>Installer</b>.",
   "settingsView.phoneAndroidNote": "Certains appareils photo ouvrent le lien dans un autre navigateur. Seul Chrome propose l'installation.",
   "settingsView.phoneShotIos": "iPhone : icône dédiée, s'ouvre sans barre de navigateur.",
-  "settingsView.phoneShotAndroid": "Android : installée via Chrome, donc présente aussi dans la liste des applications."
+  "settingsView.phoneShotAndroid": "Android : installée via Chrome, donc présente aussi dans la liste des applications.",
+  "banner.checkForAppUpdate": "Rechercher des mises à jour",
+  "banner.checkingForAppUpdate": "Recherche…",
+  "banner.appIsCurrent": "Votre application est à jour."
 }

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -1293,5 +1293,8 @@
   "settingsView.phoneAndroid4": "<b>インストール</b>で確定します。",
   "settingsView.phoneAndroidNote": "カメラによっては別のブラウザで開きます。インストールを提案するのはChromeだけです。",
   "settingsView.phoneShotIos": "iPhone: 専用アイコンで、ブラウザのバーなしで開きます。",
-  "settingsView.phoneShotAndroid": "Android: Chromeでインストールするので、アプリ一覧にも並びます。"
+  "settingsView.phoneShotAndroid": "Android: Chromeでインストールするので、アプリ一覧にも並びます。",
+  "banner.checkForAppUpdate": "アプリの更新を確認",
+  "banner.checkingForAppUpdate": "確認中…",
+  "banner.appIsCurrent": "アプリは最新です。"
 }

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -1293,5 +1293,8 @@
   "settingsView.phoneAndroid4": "Patvirtinkite mygtuku <b>Įdiegti</b>.",
   "settingsView.phoneAndroidNote": "Kai kurios kameros atidaro nuorodą kitoje naršyklėje. Įdiegimą siūlo tik Chrome.",
   "settingsView.phoneShotIos": "iPhone: sava piktograma, atsidaro be naršyklės juostos.",
-  "settingsView.phoneShotAndroid": "Android: įdiegta per Chrome, todėl matoma ir programų sąraše."
+  "settingsView.phoneShotAndroid": "Android: įdiegta per Chrome, todėl matoma ir programų sąraše.",
+  "banner.checkForAppUpdate": "Ieškoti programos naujinių",
+  "banner.checkingForAppUpdate": "Ieškoma…",
+  "banner.appIsCurrent": "Programa yra naujausia."
 }

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -1293,5 +1293,8 @@
   "settingsView.phoneAndroid4": "Apstiprini ar <b>Instalēt</b>.",
   "settingsView.phoneAndroidNote": "Dažas kameras atver saiti citā pārlūkā. Instalēšanu piedāvā tikai Chrome.",
   "settingsView.phoneShotIos": "iPhone: sava ikona, atveras bez pārlūka joslas.",
-  "settingsView.phoneShotAndroid": "Android: instalēta ar Chrome, tāpēc redzama arī lietotņu sarakstā."
+  "settingsView.phoneShotAndroid": "Android: instalēta ar Chrome, tāpēc redzama arī lietotņu sarakstā.",
+  "banner.checkForAppUpdate": "Meklēt lietotnes atjauninājumus",
+  "banner.checkingForAppUpdate": "Meklē…",
+  "banner.appIsCurrent": "Lietotne ir aktuāla."
 }

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -1293,5 +1293,8 @@
   "settingsView.phoneAndroid4": "Bevestig met <b>Installeren</b>.",
   "settingsView.phoneAndroidNote": "Sommige camera's openen de link in een andere browser. Alleen Chrome biedt de installatie aan.",
   "settingsView.phoneShotIos": "iPhone: eigen pictogram, opent zonder browserbalk.",
-  "settingsView.phoneShotAndroid": "Android: via Chrome geïnstalleerd, dus ook in de app-lade."
+  "settingsView.phoneShotAndroid": "Android: via Chrome geïnstalleerd, dus ook in de app-lade.",
+  "banner.checkForAppUpdate": "Zoeken naar app-updates",
+  "banner.checkingForAppUpdate": "Zoeken…",
+  "banner.appIsCurrent": "Je app is up-to-date."
 }

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -1293,5 +1293,8 @@
   "settingsView.phoneAndroid4": "Potwierdź przyciskiem <b>Zainstaluj</b>.",
   "settingsView.phoneAndroidNote": "Niektóre aparaty otwierają link w innej przeglądarce. Instalację oferuje tylko Chrome.",
   "settingsView.phoneShotIos": "iPhone: własna ikona, otwiera się bez paska przeglądarki.",
-  "settingsView.phoneShotAndroid": "Android: zainstalowana przez Chrome, więc jest też w szufladzie aplikacji."
+  "settingsView.phoneShotAndroid": "Android: zainstalowana przez Chrome, więc jest też w szufladzie aplikacji.",
+  "banner.checkForAppUpdate": "Sprawdź aktualizacje aplikacji",
+  "banner.checkingForAppUpdate": "Sprawdzanie…",
+  "banner.appIsCurrent": "Aplikacja jest aktualna."
 }

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -1293,5 +1293,8 @@
   "settingsView.phoneAndroid4": "<b>Yükle</b> ile onayla.",
   "settingsView.phoneAndroidNote": "Bazı kameralar bağlantıyı başka bir tarayıcıda açar. Kurulumu yalnızca Chrome sunar.",
   "settingsView.phoneShotIos": "iPhone: kendi simgesi, tarayıcı çubuğu olmadan açılır.",
-  "settingsView.phoneShotAndroid": "Android: Chrome ile kurulur, uygulama çekmecesinde de görünür."
+  "settingsView.phoneShotAndroid": "Android: Chrome ile kurulur, uygulama çekmecesinde de görünür.",
+  "banner.checkForAppUpdate": "Uygulama güncellemelerini denetle",
+  "banner.checkingForAppUpdate": "Denetleniyor…",
+  "banner.appIsCurrent": "Uygulamanız güncel."
 }

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -1293,5 +1293,8 @@
   "settingsView.phoneAndroid4": "Підтвердьте кнопкою <b>Встановити</b>.",
   "settingsView.phoneAndroidNote": "Деякі камери відкривають посилання в іншому браузері. Встановлення пропонує лише Chrome.",
   "settingsView.phoneShotIos": "iPhone: власна іконка, відкривається без панелі браузера.",
-  "settingsView.phoneShotAndroid": "Android: встановлено через Chrome, тому є і в списку застосунків."
+  "settingsView.phoneShotAndroid": "Android: встановлено через Chrome, тому є і в списку застосунків.",
+  "banner.checkForAppUpdate": "Перевірити оновлення застосунку",
+  "banner.checkingForAppUpdate": "Перевірка…",
+  "banner.appIsCurrent": "Ваш застосунок актуальний."
 }

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -201,6 +201,7 @@ import {
   noticeDismissed,
   activeSlotFromLocation,
   orionStationPayload,
+  clearNoticeDismissal,
 } from './utils.js';
 
 // Group membership (who follows master X) and the shared zoneLive poll live
@@ -1032,14 +1033,44 @@ function renderDonateSidebar() {
   if (shareBtn) shareBtn.onclick = openShareModal;
 }
 
-async function checkAppUpdate() {
+// renderAppUpdateCheckLink leaves a quiet way back to the update notice in the
+// place the banner would occupy.
+//
+// Dismissing the notice used to be one-way. The version check ran 8 s after
+// start and then every twelve hours, and a dismissal was remembered for that
+// version, so somebody who clicked it away, or who went back to an older
+// build, had nothing left to press and no way to be offered the update again
+// (discussion #597: "How do I force it to check for updates?"). A manual
+// check also ignores the stored dismissal, because a person pressing this has
+// just answered the question the dismissal was standing in for.
+function renderAppUpdateCheckLink(banner, note) {
+  if (!banner) return;
+  banner.classList.add('app-update-quiet');
+  banner.classList.remove('hidden');
+  banner.innerHTML = `<a href="#" id="appUpdateCheckLink" class="footer-link">${escapeHtml(t('banner.checkForAppUpdate'))}</a>`
+    + (note ? `<span class="app-update-quiet-note">${escapeHtml(note)}</span>` : '');
+  const link = $('appUpdateCheckLink');
+  if (link) link.onclick = (e) => {
+    e.preventDefault();
+    link.textContent = t('banner.checkingForAppUpdate');
+    try { clearNoticeDismissal('appUpdate'); } catch {}
+    checkAppUpdate(true);
+  };
+}
+
+async function checkAppUpdate(manual) {
   // Entirely best-effort: an unreachable endpoint or a garbage payload
   // must never break the UI. Validate every field defensively and stay
   // silent on any failure.
+  const banner = $('appUpdateBanner');
   try {
     const m = await CheckAppUpdate();
-    if (!m || typeof m !== 'object' || typeof m.version !== 'string' || !m.version) return;
-    const banner = $('appUpdateBanner');
+    if (!m || typeof m !== 'object' || typeof m.version !== 'string' || !m.version) {
+      // Nothing newer. Say so when the user asked; otherwise just leave the
+      // way back on screen.
+      renderAppUpdateCheckLink(banner, manual ? t('banner.appIsCurrent') : '');
+      return;
+    }
     if (!banner) return;
     // An app update outranks the speaker updates and hides their prompts (see
     // speakerUpdateCardMuted). Set before the dismissal check: the ORDER
@@ -1047,9 +1078,10 @@ async function checkAppUpdate() {
     // stopped needing the app first.
     state.appUpdateVersion = m.version;
     if (noticeDismissed('appUpdate', m.version)) {
-      banner.classList.add('hidden');
+      renderAppUpdateCheckLink(banner, '');
       return;
     }
+    banner.classList.remove('app-update-quiet');
     // Keep the banner discreet: version, a single "What's new" LINK to
     // the release notes (not the notes inline, which took too much space
     // and does not interest every user), and the download button.
@@ -1098,13 +1130,16 @@ async function checkAppUpdate() {
     const x = $('appUpdateDismiss');
     if (x) x.onclick = () => {
       dismissNotice('appUpdate', m.version);
-      banner.classList.add('hidden');
+      // Not hidden: the quiet link stays so the notice can be brought back.
+      renderAppUpdateCheckLink(banner, '');
       // The speaker prompts stay muted: the app is still the thing to do first.
       // They return once the app is current.
       maybeShowSpeakerUpdateCard();
     };
   } catch (e) {
     try { console.warn('checkAppUpdate failed', e); } catch {}
+    // A check that could not run must not swallow the control that triggers it.
+    try { renderAppUpdateCheckLink(banner, ''); } catch {}
   }
 }
 
@@ -1295,7 +1330,17 @@ $('searchOrder').value = state.searchOrder;
 $('searchOnlyOK').checked = state.searchOnlyOK;
 $('searchOnlyBose').checked = state.searchOnlyBose;
 
-$('refreshBtn').onclick = discoverBoxes;
+// The refresh button also re-asks whether a newer app exists, and forgets any
+// earlier dismissal while doing so. Until now the app version was only checked
+// 8 s after start and then every 12 hours, so a user who had put the notice
+// away, or who moved back to an older build, had no way to be offered the
+// update again and pressing refresh appeared to do nothing at all (discussion
+// #597: "How do I force it to check for updates?"). Somebody pressing refresh
+// is asking, so a stored "not now" must not answer for them.
+$('refreshBtn').onclick = () => {
+  try { clearNoticeDismissal('appUpdate'); checkAppUpdate(); } catch {}
+  discoverBoxes();
+};
 
 // Globaler Security Reboot Knopf (im Top Banner)
 const gsb = $('globalSecurityRebootBtn');

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -1047,7 +1047,12 @@ function renderAppUpdateCheckLink(banner, note) {
   if (!banner) return;
   banner.classList.add('app-update-quiet');
   banner.classList.remove('hidden');
-  banner.innerHTML = `<a href="#" id="appUpdateCheckLink" class="footer-link">${escapeHtml(t('banner.checkForAppUpdate'))}</a>`
+  // Name the version next to the link. On its own the link was a stray line
+  // above everything else with nothing to explain why it was there; with the
+  // installed version in front of it, the line says what it is about.
+  const cur = (state.appInfo && state.appInfo.version) ? String(state.appInfo.version) : '';
+  banner.innerHTML = (cur ? `<span class="app-update-quiet-ver">${escapeHtml(t('setup.versionLabel', { version: cur }))}</span>` : '')
+    + `<a href="#" id="appUpdateCheckLink" class="footer-link">${escapeHtml(t('banner.checkForAppUpdate'))}</a>`
     + (note ? `<span class="app-update-quiet-note">${escapeHtml(note)}</span>` : '');
   const link = $('appUpdateCheckLink');
   if (link) link.onclick = (e) => {

--- a/desktop-app/frontend/src/style.css
+++ b/desktop-app/frontend/src/style.css
@@ -1990,6 +1990,23 @@ select option { background-color: var(--c-bg); color: var(--c-text); }
 .box-wedge-banner { background: #fdba74; color: #431407; }
 .box-wedge-banner b { color: #431407; }
 .app-update-text { display: flex; align-items: center; gap: 8px; min-width: 0; }
+/* The quiet state of the same slot: no banner, just a way back to the update
+   notice for anyone who dismissed it or moved back to an older build. It has
+   to be findable and must not compete with the speaker list, so it keeps the
+   page background and footer-link sizing. */
+.app-update-banner.app-update-quiet {
+  background: none;
+  color: var(--c-text-dim);
+  border: none;
+  box-shadow: none;
+  animation: none;
+  padding: 6px 18px;
+  justify-content: flex-end;
+  gap: 10px;
+  font-size: 12px;
+}
+.app-update-banner.app-update-quiet .footer-link { font-size: 12px; }
+.app-update-quiet-note { color: var(--c-text-dim); }
 .app-update-icon { font-size: 18px; font-weight: 700; line-height: 1; flex: 0 0 auto; }
 /* Dismiss control: a plain close cross at the far end of the banner, sized to
    be an easy target without competing with the install button next to it. */

--- a/desktop-app/frontend/src/style.css
+++ b/desktop-app/frontend/src/style.css
@@ -120,10 +120,14 @@ body {
 }
 .donate-side {
   position: fixed;
-  left: 10px;
+  left: 0.625rem;
   top: 50%;
   transform: translateY(-50%);
-  width: 160px;
+  /* rem, not px: at a larger text size the same words need more room, and a
+     fixed 160px made the buttons spill out of the panel and over the column
+     (reported for "Large" and "Extra Large", discussion #597). */
+  width: 10rem;
+  box-sizing: border-box;
   padding: 14px 10px;
   display: flex;
   flex-direction: column;
@@ -258,8 +262,16 @@ body {
    margin on each side, and about a hundred left over for scrollbars, zoom and
    whatever the platform adds. Below that the footer donate link carries it. */
 .donate-side { display: none; }
-@media (min-width: 1200px) {
+/* The rail is an overlay, so nothing used to stop the centred column sliding
+   under it; the 1200px threshold was the margin that made that unlikely rather
+   than impossible. Now the layout RESERVES the rail's width, so an overlap
+   cannot happen and the rail fits a much smaller window. That matters because
+   it disappeared as soon as the window was pulled down to its minimum.
+   Threshold and widths are in em/rem, so both grow with the text size instead
+   of leaving the same pixels to hold larger words. */
+@media (min-width: 62em) {
   .donate-side { display: flex; }
+  .layout { padding-left: 11.5rem; }
 }
 
 /* Share modal: one tile per platform. Each tile opens the browser share on this
@@ -2000,9 +2012,13 @@ select option { background-color: var(--c-bg); color: var(--c-text); }
   border: none;
   box-shadow: none;
   animation: none;
+  /* Aligned with the content column rather than flush against the window
+     edge, where it read as a stray line above the page. */
   padding: 6px 18px;
-  justify-content: flex-end;
-  gap: 10px;
+  max-width: 720px;
+  margin: 0 auto;
+  justify-content: flex-start;
+  gap: 8px;
   font-size: 12px;
 }
 .app-update-banner.app-update-quiet .footer-link { font-size: 12px; }

--- a/desktop-app/main.go
+++ b/desktop-app/main.go
@@ -70,9 +70,20 @@ func main() {
 
 	// Create application with options
 	err := wails.Run(&options.App{
-		Title:  "ST Reborn " + appVersion,
-		Width:  1100,
-		Height: 780,
+		Title: "ST Reborn " + appVersion,
+		// The window opens wide enough for the donate rail, and cannot be
+		// dragged narrower than it needs.
+		//
+		// The rail is an overlay pinned to the left edge and appears from
+		// 1200 CSS px, which the layout needs for a 720 px column plus the
+		// 160 px rail and its margins. The window used to open at 1100, i.e.
+		// below its own threshold, so a fresh install never showed the rail at
+		// all and users only met it after widening the window by hand
+		// (discussion #597).
+		Width:     1240,
+		Height:    820,
+		MinWidth:  1200,
+		MinHeight: 720,
 		AssetServer: &assetserver.Options{
 			Assets: assets,
 		},

--- a/desktop-app/main.go
+++ b/desktop-app/main.go
@@ -80,10 +80,15 @@ func main() {
 		// below its own threshold, so a fresh install never showed the rail at
 		// all and users only met it after widening the window by hand
 		// (discussion #597).
+		// The minimums stay well below the opening size. A minimum is a trap
+		// on a scaled display, where 1920x1080 at 150% leaves 1280x720 device
+		// independent pixels: a window that cannot be made smaller than the
+		// screen cannot be moved back onto it either. fitWindowToScreen in
+		// app.go is the second half of this, and pins the top edge.
 		Width:     1240,
-		Height:    820,
-		MinWidth:  1200,
-		MinHeight: 720,
+		Height:    740,
+		MinWidth:  1000,
+		MinHeight: 600,
 		AssetServer: &assetserver.Options{
 			Assets: assets,
 		},

--- a/internal/spotify/manager.go
+++ b/internal/spotify/manager.go
@@ -205,6 +205,19 @@ type Manager struct {
 	// playlist) the box is re-pointed at the stream so it drops its buffer and
 	// plays the new playlist promptly instead of finishing the old buffer.
 	lastContext string
+	// pendingRepointFrom/To hold a context change announced by will_play that
+	// has not been acted on yet.
+	//
+	// will_play says what the engine is going to play NEXT, which on a
+	// generated radio playlist arrives while the current song is still
+	// running. Re-pointing there tore the box off the stream mid-song, and
+	// the engine then started the announced track: the song the listener was
+	// hearing was cut off BY the re-point, which reads as the speaker
+	// skipping on its own (live 2026-08-15 17:40:52, reported as "the
+	// previous track was not over yet"). The re-point now waits for that
+	// track to actually start.
+	pendingRepointFrom string
+	pendingRepointTo   string
 	// headerPages holds the current track's Ogg header pages (the BOS page
 	// with the Vorbis identification header plus the comment/setup pages).
 	// The drain captures them as they stream past; ServeOgg replays them to

--- a/internal/spotify/pendingrepoint_test.go
+++ b/internal/spotify/pendingrepoint_test.go
@@ -65,3 +65,25 @@ func waitFor(t *testing.T, got *atomic.Int32, want int32, what string) {
 	}
 	t.Fatalf("%s: got %d, want %d", what, got.Load(), want)
 }
+
+// The first track of every recall was cut off, and only the first: Play stores
+// the unwrapped playlist while the engine announces the station wrapper for
+// the same context, so the two strings differed and a re-point was armed.
+func TestTheStationWrapperIsNotAPlaylistChange(t *testing.T) {
+	cases := []struct {
+		stored, announced string
+		same              bool
+	}{
+		{"spotify:playlist:6xKB", "spotify:station:playlist:6xKB", true},
+		{"spotify:station:playlist:6xKB", "spotify:playlist:6xKB", true},
+		{"spotify:playlist:6xKB", "spotify:playlist:6xKB", true},
+		{"spotify:playlist:6xKB", "spotify:playlist:OTHER", false},
+		{"spotify:album:1", "spotify:playlist:1", false},
+	}
+	for _, c := range cases {
+		got := normalizeContextURI(c.stored) == normalizeContextURI(c.announced)
+		if got != c.same {
+			t.Errorf("%q vs %q: same=%v, want %v", c.stored, c.announced, got, c.same)
+		}
+	}
+}

--- a/internal/spotify/pendingrepoint_test.go
+++ b/internal/spotify/pendingrepoint_test.go
@@ -1,0 +1,67 @@
+package spotify
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func repointRecorder(t *testing.T) (*Manager, *atomic.Int32) {
+	t.Helper()
+	var fired atomic.Int32
+	m := &Manager{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	m.onActivate = func(context.Context) { fired.Add(1) }
+	return m, &fired
+}
+
+// will_play announces the NEXT track. On a generated radio playlist that
+// arrives while the current song still has time to run, and re-pointing there
+// tore the box off the stream and made the engine start the announced track
+// early: the speaker appeared to skip on its own while the previous track was
+// not over (live 2026-08-15 17:40:52). Holding the re-point until that track
+// actually starts is the whole fix, so the held state must not act on its own.
+func TestAHeldRepointDoesNothingUntilTheTrackStarts(t *testing.T) {
+	m, fired := repointRecorder(t)
+	m.pendingRepointFrom, m.pendingRepointTo = "spotify:playlist:old", "spotify:playlist:new"
+
+	if fired.Load() != 0 {
+		t.Fatal("holding a re-point must not fire it")
+	}
+	m.repointForPendingContext()
+	waitFor(t, fired, 1, "the held re-point fires once the track starts")
+
+	// The second event of the same track (playing then metadata) must not
+	// re-point again.
+	m.repointForPendingContext()
+	if got := fired.Load(); got != 1 {
+		t.Errorf("re-points = %d, want exactly 1: the second event of the same track must find nothing held", got)
+	}
+	if m.pendingRepointTo != "" {
+		t.Errorf("the held re-point was not cleared: %q", m.pendingRepointTo)
+	}
+}
+
+// Called on every playing/metadata event, so the common case is that nothing
+// is held and nothing must happen.
+func TestNothingHeldMeansNoRepoint(t *testing.T) {
+	m, fired := repointRecorder(t)
+	m.repointForPendingContext()
+	m.repointForPendingContext()
+	if got := fired.Load(); got != 0 {
+		t.Errorf("re-points = %d, want 0 when no context change was announced", got)
+	}
+}
+
+func waitFor(t *testing.T, got *atomic.Int32, want int32, what string) {
+	t.Helper()
+	for i := 0; i < 200; i++ {
+		if got.Load() == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("%s: got %d, want %d", what, got.Load(), want)
+}

--- a/internal/spotify/recall.go
+++ b/internal/spotify/recall.go
@@ -510,3 +510,27 @@ func (m *Manager) repointBox(from, to string) {
 		"fromContext", from, "toContext", to)
 	go cb(context.Background())
 }
+
+// repointForPendingContext performs a re-point that will_play announced
+// earlier, now that the announced track is actually playing.
+//
+// The split exists because will_play describes the NEXT track. On a generated
+// radio playlist that announcement arrives while the current song still has
+// time to run, and re-pointing there tore the box off the stream and made the
+// engine start the announced track early: the listener heard the speaker skip
+// on its own (live 2026-08-15 17:40:52). Acting on "playing" / "metadata"
+// instead keeps a deliberate playlist switch from the app just as prompt,
+// because those follow it within moments, while a prefetch announcement now
+// costs nothing until the track really begins.
+//
+// Safe to call on every event: it does nothing when no re-point is held.
+func (m *Manager) repointForPendingContext() {
+	m.mu.Lock()
+	from, to := m.pendingRepointFrom, m.pendingRepointTo
+	m.pendingRepointFrom, m.pendingRepointTo = "", ""
+	m.mu.Unlock()
+	if to == "" {
+		return
+	}
+	m.repointBox(from, to)
+}

--- a/internal/spotify/recall.go
+++ b/internal/spotify/recall.go
@@ -13,6 +13,22 @@ import (
 	"time"
 )
 
+// normalizeContextURI unwraps an ephemeral autoplay STATION context
+// (spotify:station:playlist:X -> spotify:playlist:X).
+//
+// Play stores the unwrapped form, and go-librespot then announces the wrapped
+// one for the very same context. Comparing the two raw strings therefore read
+// as "the playlist changed" on the FIRST track of every recall, which armed a
+// re-point that cut that track off (reported live 2026-08-15: "the last track
+// ends too early to play the next one, and only on the very first track").
+func normalizeContextURI(uri string) string {
+	u := strings.TrimSpace(uri)
+	if rest, ok := strings.CutPrefix(u, "spotify:station:"); ok && rest != "" {
+		return "spotify:" + rest
+	}
+	return u
+}
+
 // PlayOptions tunes a Spotify context recall.
 type PlayOptions struct {
 	// Shuffle starts the context on a random track with shuffle enabled, the

--- a/internal/spotify/recall.go
+++ b/internal/spotify/recall.go
@@ -475,7 +475,7 @@ func (m *Manager) maybeActivate() {
 // repointBox re-points the box at the Spotify stream even if it is already
 // attached, so a playlist switch from the app flushes the box buffer and plays
 // the new stream promptly. Debounced and shares lastActivate with maybeActivate.
-func (m *Manager) repointBox() {
+func (m *Manager) repointBox(from, to string) {
 	m.mu.Lock()
 	cb := m.onActivate
 	if cb == nil || time.Since(m.lastActivate) < 5*time.Second ||
@@ -499,6 +499,14 @@ func (m *Manager) repointBox() {
 		m.engineHotUntil = t
 	}
 	m.mu.Unlock()
-	m.logger.Info("spotify: playlist context changed, re-pointing box to play the new stream")
+	// Name both contexts. This re-point tears the box's Ogg fetch down and
+	// opens a new one, which the listener hears as the next song arriving
+	// abruptly, so the first question about it is always "switched from what
+	// to what?" and the line could not answer it. A generated radio playlist
+	// running out and Spotify continuing under an autoplay context looks
+	// identical here to somebody picking a new playlist in the app; the two
+	// URIs tell them apart (live 2026-08-15 17:40:52).
+	m.logger.Info("spotify: playlist context changed, re-pointing box to play the new stream",
+		"fromContext", from, "toContext", to)
 	go cb(context.Background())
 }

--- a/internal/spotify/serve.go
+++ b/internal/spotify/serve.go
@@ -6,6 +6,7 @@ package spotify
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -230,6 +231,11 @@ func (m *Manager) ServeOgg(w http.ResponseWriter, r *http.Request) {
 
 	done := make(chan struct{})
 	cw := &closeNotifyWriter{w: w, done: done}
+	// Hand the ResponseWriter back before returning, and wait for any write
+	// the engine goroutine has in flight. Without this the handler can return
+	// while a write is still running, which is a segfault rather than an
+	// error. See the type's comment.
+	defer cw.retire()
 	m.mu.Lock()
 	oldSink, _ := m.sink.(*closeNotifyWriter) // previous consumer, if any
 	reattach := m.sink != nil                 // a consumer was already attached = box re-fetched
@@ -355,20 +361,56 @@ func (m *Manager) ServeOgg(w http.ResponseWriter, r *http.Request) {
 		"firstAudioAfterMs", firstAudioMs, "kbps", kbps)
 }
 
+// errSinkRetired is returned by a writer whose handler has gone. forward()
+// treats any write error as "this box is gone", which is exactly right here.
+var errSinkRetired = errors.New("spotify: the box's stream connection is gone")
+
 // closeNotifyWriter signals done on the first failed write so ServeOgg
 // returns when the box drops the connection.
+//
+// It also owns the lifetime of the underlying http.ResponseWriter. That
+// matters more than it sounds: the pages are written by the ENGINE goroutine,
+// not by the HTTP handler, and net/http hands the response's buffered writer
+// back to a pool and nils its destination the moment the handler returns.
+// A write arriving after that is not an error, it is a segfault, and it takes
+// the whole agent down. On 2026-08-15 16:51:03 a box detached mid-track, the
+// handler returned, the engine wrote one more batch, and the agent died,
+// which stopped the music on all five speakers in the group at once.
 type closeNotifyWriter struct {
 	w    io.Writer
 	done chan struct{}
 	once sync.Once
+
+	// wmu serialises writes against retirement, so a write is either
+	// completely before the handler returns or refused outright. It is held
+	// across the write itself on purpose: retire() has to WAIT for a write in
+	// flight, not merely set a flag it might race with.
+	wmu     sync.Mutex
+	retired bool
 }
 
 func (c *closeNotifyWriter) Write(p []byte) (int, error) {
+	c.wmu.Lock()
+	defer c.wmu.Unlock()
+	if c.retired {
+		return 0, errSinkRetired
+	}
 	n, err := c.w.Write(p)
 	if err != nil {
 		c.once.Do(func() { close(c.done) })
 	}
 	return n, err
+}
+
+// retire gives the http.ResponseWriter back. It blocks until any write in
+// flight has finished and refuses every write after it, so ServeOgg MUST call
+// it before returning: past that point the writer belongs to net/http again
+// and touching it is undefined.
+func (c *closeNotifyWriter) retire() {
+	c.wmu.Lock()
+	c.retired = true
+	c.wmu.Unlock()
+	c.once.Do(func() { close(c.done) })
 }
 
 // closeConn tears the connection down from the manager side, used to enforce
@@ -378,6 +420,11 @@ func (c *closeNotifyWriter) closeConn() {
 }
 
 func (c *closeNotifyWriter) Flush() {
+	c.wmu.Lock()
+	defer c.wmu.Unlock()
+	if c.retired {
+		return
+	}
 	if f, ok := c.w.(http.Flusher); ok {
 		f.Flush()
 	}

--- a/internal/spotify/serve_retire_test.go
+++ b/internal/spotify/serve_retire_test.go
@@ -1,0 +1,106 @@
+package spotify
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// handoverWriter stands in for net/http's response writer. After the handler
+// returns, net/http puts the buffered writer back in a pool and nils its
+// destination, so a late write is a segfault rather than an error. Here that
+// same moment is a recorded test failure instead of a dead speaker.
+type handoverWriter struct {
+	mu       sync.Mutex
+	returned bool
+	late     atomic.Int32
+	writes   atomic.Int32
+}
+
+func (h *handoverWriter) Write(p []byte) (int, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.returned {
+		h.late.Add(1)
+		return 0, errors.New("write after the handler returned: this is a segfault on the box")
+	}
+	h.writes.Add(1)
+	return len(p), nil
+}
+
+func (h *handoverWriter) handlerReturned() {
+	h.mu.Lock()
+	h.returned = true
+	h.mu.Unlock()
+}
+
+// The crash of 2026-08-15 16:51:03: a box detached mid-track, ServeOgg
+// returned, and the engine goroutine wrote one more batch into a writer
+// net/http had already recycled. The agent died and took the audio on all
+// five speakers of the group with it.
+//
+// retire() must therefore be a barrier, not a flag: once it returns, no write
+// can be in flight and no later write may reach the ResponseWriter.
+func TestNoPageReachesTheResponseWriterAfterRetire(t *testing.T) {
+	for attempt := 0; attempt < 200; attempt++ {
+		h := &handoverWriter{}
+		cw := &closeNotifyWriter{w: h, done: make(chan struct{})}
+
+		var engine sync.WaitGroup
+		engine.Add(1)
+		go func() { // the engine goroutine, writing Ogg pages
+			defer engine.Done()
+			for i := 0; i < 50; i++ {
+				if _, err := cw.Write([]byte("ogg-page")); err != nil {
+					return
+				}
+			}
+		}()
+
+		cw.retire()         // what ServeOgg defers
+		h.handlerReturned() // what net/http does the instant the handler is done
+		engine.Wait()
+
+		if h.late.Load() != 0 {
+			t.Fatalf("attempt %d: %d write(s) reached the writer after it was handed back; on the box that is the SIGSEGV that killed the agent",
+				attempt, h.late.Load())
+		}
+	}
+}
+
+// A retired writer has to report the failure, not swallow it: forward() drops
+// the sink on a write error, which is how the engine learns the box is gone.
+func TestARetiredWriterRefusesAndSaysSo(t *testing.T) {
+	h := &handoverWriter{}
+	cw := &closeNotifyWriter{w: h, done: make(chan struct{})}
+	cw.retire()
+
+	n, err := cw.Write([]byte("ogg-page"))
+	if err == nil {
+		t.Fatal("a retired writer must report an error so the engine drops the sink")
+	}
+	if !errors.Is(err, errSinkRetired) {
+		t.Errorf("err = %v, want errSinkRetired", err)
+	}
+	if n != 0 {
+		t.Errorf("n = %d, want 0: nothing was written", n)
+	}
+	if h.writes.Load() != 0 {
+		t.Errorf("the underlying writer was touched %d time(s) after retirement", h.writes.Load())
+	}
+}
+
+// retire has to be safe to call more than once: ServeOgg defers it and the
+// single-connection invariant may already have closed the same writer.
+func TestRetireIsIdempotent(t *testing.T) {
+	cw := &closeNotifyWriter{w: &handoverWriter{}, done: make(chan struct{})}
+	cw.retire()
+	cw.retire() // must not panic on a second close of done
+	cw.closeConn()
+	select {
+	case <-cw.done:
+	default:
+		t.Error("retire must also release ServeOgg's wait")
+	}
+}

--- a/internal/spotify/volume.go
+++ b/internal/spotify/volume.go
@@ -230,6 +230,7 @@ func (m *Manager) volumeStream(ctx context.Context, url string) error {
 			}
 			if json.Unmarshal(ev.Data, &wp) == nil && wp.ContextURI != "" {
 				m.mu.Lock()
+				prevContext := m.lastContext
 				changed := m.lastContext != "" && wp.ContextURI != m.lastContext
 				m.lastContext = wp.ContextURI
 				if changed {
@@ -240,7 +241,7 @@ func (m *Manager) volumeStream(ctx context.Context, url string) error {
 				}
 				m.mu.Unlock()
 				if changed {
-					m.repointBox()
+					m.repointBox(prevContext, wp.ContextURI)
 				}
 			}
 		case "metadata":

--- a/internal/spotify/volume.go
+++ b/internal/spotify/volume.go
@@ -216,6 +216,7 @@ func (m *Manager) volumeStream(ctx context.Context, url string) error {
 		case "playing":
 			m.maybeActivate()
 			m.handleEnginePlaybackStart()
+			m.repointForPendingContext()
 		case "paused", "stopped", "inactive":
 			// The Spotify app paused/stopped playback on this box, or moved it
 			// to another device. Forward as deliberate intent (guarded against
@@ -231,8 +232,12 @@ func (m *Manager) volumeStream(ctx context.Context, url string) error {
 			if json.Unmarshal(ev.Data, &wp) == nil && wp.ContextURI != "" {
 				m.mu.Lock()
 				prevContext := m.lastContext
+				playingNow := m.curName
 				changed := m.lastContext != "" && wp.ContextURI != m.lastContext
 				m.lastContext = wp.ContextURI
+				if changed {
+					m.pendingRepointFrom, m.pendingRepointTo = prevContext, wp.ContextURI
+				}
 				if changed {
 					// New context: drop the previous track so noteResume cannot
 					// pair this context with the old track before its own
@@ -241,7 +246,12 @@ func (m *Manager) volumeStream(ctx context.Context, url string) error {
 				}
 				m.mu.Unlock()
 				if changed {
-					m.repointBox(prevContext, wp.ContextURI)
+					// Deliberately not re-pointing here: see
+					// pendingRepointFrom. Record what the engine announced,
+					// including what is playing right now, so a bundle shows
+					// whether the announcement arrived mid-song.
+					m.logger.Info("spotify: the engine announced a different playlist for the next track, holding the re-point until it starts",
+						"fromContext", prevContext, "toContext", wp.ContextURI, "playingNow", playingNow)
 				}
 			}
 		case "metadata":
@@ -264,6 +274,10 @@ func (m *Manager) volumeStream(ctx context.Context, url string) error {
 			}
 			m.mu.Unlock()
 			m.notifyTrack()
+			// metadata arrives for the track that is actually playing, so it
+			// is the second place a held re-point becomes due. Whichever of
+			// the two events lands first wins; the other finds nothing left.
+			m.repointForPendingContext()
 			// Remember this track as the resume point for its context, so a
 			// later default recall continues here instead of restarting the
 			// playlist (the events stream covers the no-desktop-app case).

--- a/internal/spotify/volume.go
+++ b/internal/spotify/volume.go
@@ -233,10 +233,22 @@ func (m *Manager) volumeStream(ctx context.Context, url string) error {
 				m.mu.Lock()
 				prevContext := m.lastContext
 				playingNow := m.curName
-				changed := m.lastContext != "" && wp.ContextURI != m.lastContext
+				// Compare the NORMALIZED contexts: a recall stores the
+				// unwrapped playlist and the engine announces the station
+				// wrapper for the same thing.
+				changed := prevContext != "" &&
+					normalizeContextURI(wp.ContextURI) != normalizeContextURI(prevContext)
+				// A recall drives the box itself, and the re-point it would
+				// otherwise trigger used to be suppressed by the debounce in
+				// repointBox. Holding the announcement outlives that window, so
+				// the recall has to be excluded here instead of there.
+				inRecall := time.Since(m.lastActivate) < 5*time.Second
 				m.lastContext = wp.ContextURI
-				if changed {
+				if changed && !inRecall {
 					m.pendingRepointFrom, m.pendingRepointTo = prevContext, wp.ContextURI
+				}
+				if changed && inRecall {
+					changed = false
 				}
 				if changed {
 					// New context: drop the previous track so noteResume cannot

--- a/internal/streamproxy/chainlog_test.go
+++ b/internal/streamproxy/chainlog_test.go
@@ -1,0 +1,97 @@
+package streamproxy
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"log/slog"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+)
+
+func issuedCert(t *testing.T, cn, issuerCN string) *x509.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		Issuer:       pkix.Name{CommonName: issuerCN},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("certificate: %v", err)
+	}
+	c, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	// CreateCertificate self-signs, so the parsed issuer is the subject. The
+	// log only reads the field, so set it to the name under test.
+	c.Issuer = pkix.Name{CommonName: issuerCN}
+	return c
+}
+
+// "certificate signed by unknown authority" reads identically whether the
+// speaker lacks one authority, has a broken trust store, or sits behind
+// something on the owner's network that substitutes certificates. Three
+// releases went to the wrong one of those. The issuer name is what separates
+// them, so it has to be in the bundle.
+func TestARefusedStationIsLoggedWithTheAuthorityThatSignedIt(t *testing.T) {
+	var logged bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logged, nil))
+
+	leaf := issuedCert(t, "*.rndfnk.com", "DigiCert Global G2 TLS RSA SHA256 2020 CA1")
+	inter := issuedCert(t, "DigiCert Global G2 TLS RSA SHA256 2020 CA1", "DigiCert Global Root G2")
+
+	logRejectedChain(logger, "f131.rndfnk.com", []*x509.Certificate{leaf, inter},
+		x509.NewCertPool(), errors.New("x509: certificate signed by unknown authority"))
+
+	out := logged.String()
+	for _, want := range []string{
+		"f131.rndfnk.com",
+		"*.rndfnk.com",
+		"DigiCert Global G2 TLS RSA SHA256 2020 CA1",
+		"DigiCert Global Root G2", // the authority that decides the case
+		"rootsInPool=0",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the failure line must carry %q, got: %s", want, out)
+		}
+	}
+}
+
+// A speaker whose system pool could not be built at all is a different fault
+// from one missing a single authority, and the line has to say which.
+func TestAnUnavailableRootPoolIsReportedAsSuch(t *testing.T) {
+	var logged bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logged, nil))
+
+	logRejectedChain(logger, "example.invalid",
+		[]*x509.Certificate{issuedCert(t, "leaf", "some-ca")}, nil, errors.New("boom"))
+
+	if !strings.Contains(logged.String(), "rootsInPool=-1") {
+		t.Errorf("a missing system pool must be distinguishable from an empty one: %s", logged.String())
+	}
+}
+
+// A handshake that fails before any certificate arrives has nothing to report,
+// and must not add a line that looks like a rejected chain.
+func TestNothingIsLoggedWithoutAChain(t *testing.T) {
+	var logged bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logged, nil))
+	logRejectedChain(logger, "example.invalid", nil, x509.NewCertPool(), errors.New("boom"))
+	if logged.Len() != 0 {
+		t.Errorf("want no line without peer certificates, got: %s", logged.String())
+	}
+}

--- a/internal/streamproxy/streamproxy.go
+++ b/internal/streamproxy/streamproxy.go
@@ -178,7 +178,7 @@ func New(store *presets.Store, logger *slog.Logger) *Server {
 		}
 		hctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
-		conn := tls.Client(raw, clockTolerantTLSConfig(host))
+		conn := tls.Client(raw, clockTolerantTLSConfig(host, logger))
 		if err := conn.HandshakeContext(hctx); err != nil {
 			_ = raw.Close()
 			return nil, err

--- a/internal/streamproxy/tlsclock.go
+++ b/internal/streamproxy/tlsclock.go
@@ -7,6 +7,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"log/slog"
+	"strings"
 	"time"
 )
 
@@ -37,7 +39,7 @@ func clockUntrustworthy() bool { return time.Now().Before(minPlausibleClock) }
 // weaken MITM protection. host is passed explicitly (not read from
 // ConnectionState.ServerName) so a bare-IP upstream, which sends no SNI, is
 // still verified against the certificate's IP SANs.
-func clockTolerantTLSConfig(host string) *tls.Config {
+func clockTolerantTLSConfig(host string, logger *slog.Logger) *tls.Config {
 	return &tls.Config{
 		ServerName: host, // SNI for a hostname; ignored on the wire for an IP literal
 		// h2 stays available (DialTLSContext otherwise defaults to HTTP/1.1 only).
@@ -47,9 +49,49 @@ func clockTolerantTLSConfig(host string) *tls.Config {
 		InsecureSkipVerify: true, //nolint:gosec // VerifyConnection re-implements chain+host verification below.
 		VerifyConnection: func(cs tls.ConnectionState) error {
 			roots, _ := x509.SystemCertPool()
-			return verifyChainClockTolerant(cs.PeerCertificates, host, roots, time.Now(), clockUntrustworthy())
+			err := verifyChainClockTolerant(cs.PeerCertificates, host, roots, time.Now(), clockUntrustworthy())
+			if err != nil {
+				logRejectedChain(logger, host, cs.PeerCertificates, roots, err)
+			}
+			return err
 		},
 	}
+}
+
+// logRejectedChain records WHICH certificate a rejected station presented.
+//
+// Without it, "x509: certificate signed by unknown authority" is the same
+// sentence whatever the cause, and a support bundle cannot tell three very
+// different situations apart:
+//
+//   - the speaker is missing one specific certificate authority (a support
+//     case where two stations under DigiCert Global Root G2 failed while a
+//     station under Amazon Root CA 1 played on the same box, same minute),
+//   - the speaker's trust store is broken as a whole,
+//   - something on the owner's network hands out its own certificate, in
+//     which case no change we ship will ever help and we should stop trying.
+//
+// The issuer name on the failure line separates all three. Failure path only,
+// so a healthy speaker pays nothing.
+func logRejectedChain(logger *slog.Logger, host string, certs []*x509.Certificate, roots *x509.CertPool, cause error) {
+	if logger == nil || len(certs) == 0 {
+		return
+	}
+	chain := make([]string, 0, len(certs))
+	for _, c := range certs {
+		chain = append(chain, c.Subject.CommonName+" <- "+c.Issuer.CommonName)
+	}
+	poolSize := -1 // -1 = the system pool was unavailable, which is itself the finding
+	if roots != nil {
+		poolSize = len(roots.Subjects()) //nolint:staticcheck // the only way to count a pool, failure path only
+	}
+	logger.Warn("this speaker refused a station's certificate, here is what the station presented",
+		"host", host,
+		"leaf", certs[0].Subject.CommonName,
+		"issuer", certs[0].Issuer.CommonName,
+		"chain", strings.Join(chain, " | "),
+		"rootsInPool", poolSize,
+		"reason", cause.Error())
 }
 
 // verifyChainClockTolerant verifies leaf (certs[0]) against roots and host at

--- a/internal/tlsgen/trustrepair.go
+++ b/internal/tlsgen/trustrepair.go
@@ -161,7 +161,7 @@ func repairOne(path string, slot int, rootCAPEM []byte, ops mountOps, logger *sl
 	// before touching anything: if the repair wedges the speaker, the log
 	// still shows what it was about to do.
 	logger.Warn("trust store lost its public roots, repairing",
-		"path", path, "bytes", len(before), "certificates", strings.Count(string(before), pemCertHeader))
+		"path", path, "bytes", len(before), "certificateHeaders", strings.Count(string(before), pemCertHeader), "usableCertificates", usableRoots(before))
 
 	if !ops.isMountPoint(path) {
 		// Nothing mounted: this emptiness is the firmware's own file, on a
@@ -186,7 +186,7 @@ func repairOne(path string, slot int, rootCAPEM []byte, ops mountOps, logger *sl
 		logger.Error("trust store repair: firmware bundle unreadable after unmount", "path", path, "err", err)
 		return res
 	}
-	res.FirmwareRoots = strings.Count(string(firmware), pemCertHeader)
+	res.FirmwareRoots = usableRoots(firmware)
 	if publicRootCount(firmware, rootCAPEM) < minPlausiblePublicRoots {
 		// Nothing to rebuild from. The broken overlay at least carried our
 		// root, so put it back rather than leave the speaker with less than
@@ -283,12 +283,15 @@ func appendRootBlock(bundle, rootCAPEM []byte) []byte {
 // broken box gets told it is fine.
 const minPlausiblePublicRoots = 10
 
-// publicRootCount counts the certificates in bundle that are not STR's own
-// root. That is the figure that decides whether the box can reach the
+// publicRootCount counts the USABLE certificates in bundle that are not STR's
+// own root. That is the figure that decides whether the box can reach the
 // internet: a store holding only our root passes a naive "is it empty" check
-// and still fails every public handshake.
+// and still fails every public handshake, and so does a store full of text
+// that merely looks like certificates. Counting headers here would also let
+// the repair rebuild a store from a firmware bundle Go cannot read and then
+// report that as repaired.
 func publicRootCount(bundle, rootCAPEM []byte) int {
-	n := strings.Count(string(bundle), pemCertHeader)
+	n := usableRoots(bundle)
 	if n > 0 && len(bytes.TrimSpace(rootCAPEM)) > 0 && bytes.Contains(bundle, bytes.TrimSpace(rootCAPEM)) {
 		n--
 	}

--- a/internal/tlsgen/trustrepair_test.go
+++ b/internal/tlsgen/trustrepair_test.go
@@ -15,18 +15,21 @@ func quietLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
-const testSTRRoot = "-----BEGIN CERTIFICATE-----\nSTRROOTCA\n-----END CERTIFICATE-----\n"
+var testSTRRoot = mustRoot("str-root-ca")
 
 // wantPublic is how many public roots testPublic carries. It has to clear
 // minPlausiblePublicRoots, because the repair judges a store by whether it
 // holds a believable NUMBER of public roots rather than merely one.
 const wantPublic = minPlausiblePublicRoots + 2
 
-// testPublic stands in for a real firmware bundle.
+// testPublic stands in for a real firmware bundle. These are real
+// certificates: the repair now judges a store by what crypto/x509 can parse
+// out of it, so certificate-shaped placeholder text would make every fixture
+// here look like the corruption it is meant to model.
 var testPublic = func() string {
 	out := ""
 	for i := 0; i < wantPublic; i++ {
-		out += fmt.Sprintf("-----BEGIN CERTIFICATE-----\nPUBLICROOT%02d\n-----END CERTIFICATE-----\n", i)
+		out += mustRoot(fmt.Sprintf("public-root-%02d", i))
 	}
 	return out
 }()
@@ -126,11 +129,14 @@ func TestRepairRebuildsAStoreThatHoldsOnlyOurOwnRoot(t *testing.T) {
 	// The box has to trust the internet AND us: dropping our root would
 	// break the Bose-domain server cert instead.
 	live := readFile(t, f.path)
-	if !strings.Contains(live, "PUBLICROOT00") || !strings.Contains(live, "PUBLICROOT05") {
+	if !strings.Contains(live, testPublic) {
 		t.Error("repaired store lost the firmware's public roots")
 	}
-	if !strings.Contains(live, "STRROOTCA") {
+	if !strings.Contains(live, testSTRRoot) {
 		t.Error("repaired store lost STR's own root")
+	}
+	if got := usableRoots([]byte(live)); got != wantPublic+1 {
+		t.Errorf("usable roots = %d, want the %d firmware roots plus ours", got, wantPublic)
 	}
 	if f.unmounts != 1 || f.binds != 1 {
 		t.Errorf("unmounts=%d binds=%d, want exactly one of each", f.unmounts, f.binds)
@@ -161,7 +167,7 @@ func TestRepairRestoresTheOverlayWhenTheFirmwareBundleIsEmptyToo(t *testing.T) {
 	if res[0].Outcome != TrustRepairFirmwareEmpty {
 		t.Fatalf("outcome = %q, want %q", res[0].Outcome, TrustRepairFirmwareEmpty)
 	}
-	if !strings.Contains(readFile(t, f.path), "STRROOTCA") {
+	if !strings.Contains(readFile(t, f.path), testSTRRoot) {
 		t.Error("the rollback must put STR's root back, the box had it before")
 	}
 	if f.binds != 1 {
@@ -184,7 +190,7 @@ func TestRepairLeavesTheFirmwareBundleLiveWhenRemountFails(t *testing.T) {
 	if res[0].RootsAfter != wantPublic {
 		t.Errorf("RootsAfter = %d, want the firmware's %d public roots live", res[0].RootsAfter, wantPublic)
 	}
-	if strings.Contains(readFile(t, f.path), "STRROOTCA") {
+	if strings.Contains(readFile(t, f.path), testSTRRoot) {
 		t.Error("expected the pristine firmware bundle, not the broken overlay")
 	}
 }
@@ -295,7 +301,7 @@ func TestAppendRootBlockSeparatesTheMarkerFromABundleWithoutATrailingNewline(t *
 // healthy, the file was left alone, and the speaker went on failing every
 // handshake while the diagnostic said it was fine.
 func TestRepairRebuildsAStoreLeftWithASingleSurvivingRoot(t *testing.T) {
-	const oneSurvivor = "-----BEGIN CERTIFICATE-----\nLONESURVIVOR\n-----END CERTIFICATE-----\n"
+	oneSurvivor := mustRoot("lone-survivor")
 	f := newFakeMounts(t, testPublic, oneSurvivor+testSTRRoot)
 
 	res := repairTrustStorePaths([]string{f.path}, []byte(testSTRRoot), f.ops(), quietLogger())

--- a/internal/tlsgen/truststatus.go
+++ b/internal/tlsgen/truststatus.go
@@ -2,6 +2,8 @@ package tlsgen
 
 import (
 	"bytes"
+	"crypto/x509"
+	"encoding/pem"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,11 +42,22 @@ type TrustStoreStatus struct {
 	// Bytes is the size the agent reads THROUGH any bind mount, i.e.
 	// the overlay's size, not the pristine firmware bundle's.
 	Bytes int64 `json:"bytes"`
-	// RootCount is the number of PEM certificates in the file. A
-	// healthy box shows a three-digit count; 1 means the overlay
-	// contains STR's own root and nothing else, which is the broken
-	// state described above.
+	// RootCount is the number of PEM certificate HEADERS in the file. It
+	// says how much looks like a certificate, not how much is one, so
+	// never triage on it alone: see UsableRootCount.
 	RootCount int `json:"root_count"`
+	// UsableRootCount is the number of certificates Go actually accepts
+	// out of this file, parsed the same way crypto/x509 parses it when
+	// it builds the system pool.
+	//
+	// The two numbers came apart on a support case and cost three
+	// releases (ST20, 2026-08-15). The bundle reported 158 roots and was
+	// read as healthy, so all three fixes went looking elsewhere, while
+	// every TLS handshake on that speaker kept failing. A count of PEM
+	// headers cannot distinguish a working store from a file full of
+	// certificate-shaped text, and the failing store is exactly the one
+	// where that distinction decides the case.
+	UsableRootCount int `json:"usable_root_count"`
 	// HasSTRRoot reports whether STR's own root CA made it in. It has
 	// to be there for the box to accept our Bose-domain server cert.
 	HasSTRRoot bool `json:"has_str_root"`
@@ -56,10 +69,33 @@ type TrustStoreStatus struct {
 	Err string `json:"err,omitempty"`
 }
 
-// pemCertHeader is what we count. Counting headers rather than parsing
-// every certificate keeps this cheap enough to run on every
-// /api/debug/state call on a speaker CPU.
 const pemCertHeader = "-----BEGIN CERTIFICATE-----"
+
+// usableRoots counts the certificates crypto/x509 would take out of this
+// file when it builds the system pool. AppendCertsFromPEM does exactly
+// this walk and silently drops whatever fails to parse, so counting the
+// same way is the only number that predicts whether a handshake works.
+//
+// It parses on every call. On a speaker CPU a full 166-root bundle costs
+// single-digit milliseconds, which the earlier header count was not worth
+// saving.
+func usableRoots(body []byte) int {
+	n := 0
+	for rest := body; len(rest) > 0; {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
+			continue
+		}
+		if _, err := x509.ParseCertificate(block.Bytes); err == nil {
+			n++
+		}
+	}
+	return n
+}
 
 // TrustStoreSnapshot inspects the trust store paths STR overlays and
 // returns one entry per path, in the order of DefaultTrustStorePaths.
@@ -85,17 +121,22 @@ func trustStoreSnapshotPaths(paths []string, rootCAPEM []byte) []TrustStoreStatu
 		s.Exists = true
 		s.Bytes = int64(len(body))
 		s.RootCount = strings.Count(string(body), pemCertHeader)
+		s.UsableRootCount = usableRoots(body)
 		if len(bytes.TrimSpace(rootCAPEM)) > 0 {
 			s.HasSTRRoot = bytes.Contains(body, bytes.TrimSpace(rootCAPEM))
 		}
-		// The public roots are what a stream or the Spotify engine needs.
-		// Subtracting STR's own root avoids calling a store healthy just
-		// because we put one certificate in it.
-		public := s.RootCount
+		// The public roots are what a stream or the Spotify engine needs,
+		// and only the ones that parse count. Subtracting STR's own root
+		// avoids calling a store healthy just because we put one
+		// certificate in it.
+		public := s.UsableRootCount
 		if s.HasSTRRoot && public > 0 {
 			public--
 		}
-		s.PublicRootsMissing = public == 0
+		// Same threshold the repair uses. The two disagreed until now, so
+		// a store the repair considered broken was reported as fine in the
+		// bundle, which is the worst of both.
+		s.PublicRootsMissing = public < minPlausiblePublicRoots
 		out = append(out, s)
 	}
 	return out

--- a/internal/tlsgen/truststatus_test.go
+++ b/internal/tlsgen/truststatus_test.go
@@ -1,13 +1,66 @@
 package tlsgen
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
-const fakeRoot = "-----BEGIN CERTIFICATE-----\nSFRSUk9PVA==\n-----END CERTIFICATE-----\n"
-const fakePublic = "-----BEGIN CERTIFICATE-----\nUFVCTElD\n-----END CERTIFICATE-----\n"
+// realRoot mints an actual self-signed certificate. The fixtures used to be
+// certificate-SHAPED text, which is precisely the state that made a broken
+// speaker read as healthy in a bundle, so the tests now use certificates a
+// TLS stack would accept.
+func realRoot(t *testing.T, cn string) string {
+	t.Helper()
+	return mustRoot(cn)
+}
+
+// mustRoot is the same thing for package-level fixtures, which have no
+// *testing.T to fail on.
+func mustRoot(cn string) string {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		panic(err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+// publicRoots returns enough real roots to clear minPlausiblePublicRoots, so
+// a test store looks like a firmware bundle rather than like a repair that
+// only put our own root back.
+func publicRoots(t *testing.T, n int) string {
+	t.Helper()
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		b.WriteString(realRoot(t, "public-"+strings.Repeat("x", i+1)))
+	}
+	return b.String()
+}
+
+// certificateShapedText parses as PEM but not as a certificate. This is what
+// a header count cannot tell from a working trust store.
+const certificateShapedText = "-----BEGIN CERTIFICATE-----\nUFVCTElD\n-----END CERTIFICATE-----\n"
 
 func writeFile(t *testing.T, path, body string) {
 	t.Helper()
@@ -21,20 +74,42 @@ func writeFile(t *testing.T, path, body string) {
 // with the identical "unknown authority" error.
 func TestTrustStoreSnapshotFlagsAStoreWithOnlyOurOwnRoot(t *testing.T) {
 	dir := t.TempDir()
+	strRoot := realRoot(t, "str")
 	healthy := filepath.Join(dir, "healthy.crt")
 	broken := filepath.Join(dir, "broken.crt")
-	writeFile(t, healthy, fakePublic+fakePublic+fakeRoot)
-	writeFile(t, broken, fakeRoot)
+	writeFile(t, healthy, publicRoots(t, minPlausiblePublicRoots)+strRoot)
+	writeFile(t, broken, strRoot)
 
-	got := trustStoreSnapshotPaths([]string{healthy, broken}, []byte(fakeRoot))
+	got := trustStoreSnapshotPaths([]string{healthy, broken}, []byte(strRoot))
 	if len(got) != 2 {
 		t.Fatalf("want 2 entries, got %d", len(got))
 	}
-	if got[0].RootCount != 3 || got[0].PublicRootsMissing || !got[0].HasSTRRoot {
+	if got[0].UsableRootCount != minPlausiblePublicRoots+1 || got[0].PublicRootsMissing || !got[0].HasSTRRoot {
 		t.Errorf("healthy store misreported: %+v", got[0])
 	}
-	if got[1].RootCount != 1 || !got[1].PublicRootsMissing || !got[1].HasSTRRoot {
+	if got[1].UsableRootCount != 1 || !got[1].PublicRootsMissing || !got[1].HasSTRRoot {
 		t.Errorf("broken store misreported: %+v", got[1])
+	}
+}
+
+// The support case that cost three releases: a store full of text that looks
+// like certificates counted as healthy while every handshake on that speaker
+// failed. The header count and the usable count have to disagree here, and
+// the verdict has to follow the usable one.
+func TestAStoreOfCertificateShapedTextIsNotHealthy(t *testing.T) {
+	dir := t.TempDir()
+	junk := filepath.Join(dir, "junk.crt")
+	writeFile(t, junk, strings.Repeat(certificateShapedText, 158))
+
+	got := trustStoreSnapshotPaths([]string{junk}, nil)
+	if got[0].RootCount != 158 {
+		t.Errorf("header count should still report what is in the file: %+v", got[0])
+	}
+	if got[0].UsableRootCount != 0 {
+		t.Errorf("none of this parses, so nothing is usable: %+v", got[0])
+	}
+	if !got[0].PublicRootsMissing {
+		t.Errorf("a store Go cannot use must read as broken, this is the bug that cost three releases: %+v", got[0])
 	}
 }
 
@@ -43,19 +118,36 @@ func TestTrustStoreSnapshotFlagsAStoreWithOnlyOurOwnRoot(t *testing.T) {
 func TestTrustStoreSnapshotSeparatesMissingSTRRootFromMissingPublicRoots(t *testing.T) {
 	dir := t.TempDir()
 	noSTR := filepath.Join(dir, "nostr.crt")
-	writeFile(t, noSTR, fakePublic)
+	writeFile(t, noSTR, publicRoots(t, minPlausiblePublicRoots))
 
-	got := trustStoreSnapshotPaths([]string{noSTR}, []byte(fakeRoot))
+	got := trustStoreSnapshotPaths([]string{noSTR}, []byte(realRoot(t, "str")))
 	if got[0].HasSTRRoot {
 		t.Errorf("STR root reported present although it is not: %+v", got[0])
 	}
 	if got[0].PublicRootsMissing {
-		t.Errorf("public roots reported missing although one is there: %+v", got[0])
+		t.Errorf("public roots reported missing although they are there: %+v", got[0])
+	}
+}
+
+// A handful of surviving roots is not a working trust store either. The
+// verdict and the repair now use one threshold, so a bundle cannot call a
+// store fine that the agent itself considers broken.
+func TestAFewSurvivingRootsStillCountAsMissing(t *testing.T) {
+	dir := t.TempDir()
+	thin := filepath.Join(dir, "thin.crt")
+	writeFile(t, thin, publicRoots(t, 2))
+
+	got := trustStoreSnapshotPaths([]string{thin}, nil)
+	if got[0].UsableRootCount != 2 {
+		t.Fatalf("want the two roots counted: %+v", got[0])
+	}
+	if !got[0].PublicRootsMissing {
+		t.Errorf("two roots is not a trust store, and the repair agrees: %+v", got[0])
 	}
 }
 
 func TestTrustStoreSnapshotMarksAnAbsentBundle(t *testing.T) {
-	got := trustStoreSnapshotPaths([]string{filepath.Join(t.TempDir(), "nope.crt")}, []byte(fakeRoot))
+	got := trustStoreSnapshotPaths([]string{filepath.Join(t.TempDir(), "nope.crt")}, nil)
 	if got[0].Exists || got[0].Err != "" {
 		t.Errorf("absent bundle should read as not existing without an error: %+v", got[0])
 	}
@@ -66,8 +158,9 @@ func TestReadRootCAPEMReturnsNilWithoutACA(t *testing.T) {
 		t.Errorf("want nil for a dir without a CA, got %d bytes", len(b))
 	}
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, rootCAFile), fakeRoot)
-	if b := ReadRootCAPEM(dir); string(b) != fakeRoot {
+	root := realRoot(t, "str")
+	writeFile(t, filepath.Join(dir, rootCAFile), root)
+	if b := ReadRootCAPEM(dir); string(b) != root {
 		t.Errorf("root CA not read back verbatim: %q", string(b))
 	}
 }

--- a/internal/webui/assets/index.html
+++ b/internal/webui/assets/index.html
@@ -849,7 +849,11 @@ function volSend(v) {
   grpVol.sentAt = Date.now();
   (zone.members || []).forEach(function(m){
     if (!m.ip) return;
-    var base = (typeof grpVol.base[m.ip] === 'number') ? grpVol.base[m.ip] : +v;
+    // Fall back to the ANCHOR, not to the slider's current value. A member
+    // that reported -1 (standby, waking, busy) has no baseline, and using the
+    // live value there added the whole drag on top of itself and sent that one
+    // speaker toward 100 while the others moved by the delta.
+    var base = (typeof grpVol.base[m.ip] === 'number') ? grpVol.base[m.ip] : grpVol.at;
     var want = Math.max(0, Math.min(100, Math.round(base + delta)));
     grpVol.want[m.ip] = want;
     api('/api/box/zone/volume', 'POST', { ip: m.ip, value: want });

--- a/internal/webui/assets/index.html
+++ b/internal/webui/assets/index.html
@@ -807,7 +807,25 @@ function scrollSafeSlider(el, send, label) {
 // baseline also survives the ends: members that run into 0 or 100 would
 // otherwise lose their spacing for good, whereas from a baseline, returning the
 // slider to where it was restores exactly the levels the user dialled in.
-var grpVol = { base: {}, at: null };
+var grpVol = { base: {}, at: null, want: {}, sentAt: 0 };
+
+// grpVolSettling reports whether our own writes are still on their way to the
+// speakers. A refresh landing inside this window carries levels from BEFORE
+// those writes, so anything it says about the group is out of date.
+var GRP_VOL_SETTLE_MS = 1500;
+function grpVolSettling() { return Date.now() - grpVol.sentAt < GRP_VOL_SETTLE_MS; }
+
+// grpVolChangedElsewhere reports whether a member sits at a level we did not
+// ask for, which is the only reason to throw the captured balance away. A
+// member we never wrote to does not count: it has no requested value to
+// disagree with.
+function grpVolChangedElsewhere() {
+  return (zone.members || []).some(function(m){
+    if (!m.ip || typeof m.volume !== 'number' || m.volume < 0) return false;
+    var want = grpVol.want[m.ip];
+    return typeof want === 'number' && Math.abs(m.volume - want) > 1;
+  });
+}
 
 function captureGroupBaseline(anchor) {
   grpVol.base = {};
@@ -822,10 +840,12 @@ function volSend(v) {
   if (volScope === 'one' || !zone.grouped) { api('/api/box/volume', 'PUT', { value: +v }); return; }
   if (grpVol.at === null) captureGroupBaseline(+v);
   var delta = +v - grpVol.at;
+  grpVol.sentAt = Date.now();
   (zone.members || []).forEach(function(m){
     if (!m.ip) return;
     var base = (typeof grpVol.base[m.ip] === 'number') ? grpVol.base[m.ip] : +v;
     var want = Math.max(0, Math.min(100, Math.round(base + delta)));
+    grpVol.want[m.ip] = want;
     api('/api/box/zone/volume', 'POST', { ip: m.ip, value: want });
   });
 }
@@ -1936,9 +1956,21 @@ async function loadZone() {
   // A member changed on its own (or from another phone) makes the captured
   // balance stale: re-anchor so the next group move offsets from what is
   // actually set, the way setMemberVolume does on the desktop.
-  if (grpVol.at !== null && memberDragging === null) grpVol.at = null;
+  //
+  // Only for a change we did not make. This used to re-anchor on EVERY
+  // refresh, which meant a poll landing mid-drag re-anchored from levels our
+  // own writes had already moved. Each following drag event then measured its
+  // offset from a moved baseline and gave away most of the travel: dragging to
+  // 53 across five speakers arrived at 39 (live 2026-08-15). While our writes
+  // are still settling, this refresh knows less than we do.
+  if (grpVol.at !== null && memberDragging === null && !grpVolSettling() && grpVolChangedElsewhere()) {
+    grpVol.at = null;
+    grpVol.want = {};
+  }
   var shown = (typeof z.loudest === 'number' && z.loudest >= 0) ? z.loudest : z.average;
-  if (volScope !== 'one' && typeof shown === 'number' && shown >= 0) {
+  // Same reason: pulling the thumb back to a pre-write level mid-gesture is
+  // what the finger feels as the slider fighting back.
+  if (volScope !== 'one' && typeof shown === 'number' && shown >= 0 && !grpVolSettling()) {
     var el = document.getElementById('vol');
     if (el) { el.value = shown; document.getElementById('volval').textContent = shown; volLast = shown; }
   }

--- a/internal/webui/assets/index.html
+++ b/internal/webui/assets/index.html
@@ -1269,13 +1269,42 @@ async function loadPresets() {
 // "Starting..." status) so the user sees the press land, then confirms via the
 // existing 5s status poll. No extra box request beyond the play + one refresh,
 // so it adds no polling load on the speaker.
+// pendingStart holds the tapped key highlighted until the speaker confirms it
+// or until it is clear the stream never came up.
+//
+// The highlight follows what the SPEAKER reports, and a speaker reports the
+// PREVIOUS station until the new stream actually starts. The first status poll
+// therefore took the frame straight back off the key the user had just
+// pressed, a second after pressing it, and put it back several seconds later
+// when the audio arrived. What the user saw was the press being rejected.
+//
+// Twenty seconds is deliberately generous: an https station that has to be
+// resolved, connected and buffered takes a few seconds on this hardware, and
+// nothing is lost by waiting longer before calling it a failure. If the
+// speaker never gets there, the frame comes off AND the reason is said out
+// loud, which is the case that was silent before.
+var pendingStart = { slot: 0, until: 0 };
+var PENDING_START_MS = 20000;
+
+function clearPendingStart() { pendingStart = { slot: 0, until: 0 }; }
+
 async function playSlot(n, tile, name) {
   document.querySelectorAll('.preset.active').forEach(function(e){ e.classList.remove('active'); });
   if (tile) tile.classList.add('active');
   setNow((name ? T.starting + ' ' + name : T.starting), T.pleaseWait);
+  pendingStart = { slot: n, until: Date.now() + PENDING_START_MS };
   const r = await api('/api/play/' + n, 'POST');
-  if (r) { setTimeout(refreshStatus, 1200); setTimeout(refreshStatus, 3000); }
-  else { setNow(T.cantStart, T.tapAgain); if (tile) tile.classList.remove('active'); }
+  if (r) {
+    // Poll across the whole window rather than twice at the start: the point
+    // is to notice the moment the stream arrives, whenever that is.
+    [1200, 3000, 6000, 10000, 15000, PENDING_START_MS + 1000].forEach(function(ms){
+      setTimeout(refreshStatus, ms);
+    });
+  } else {
+    clearPendingStart();
+    setNow(T.cantStart, T.tapAgain);
+    if (tile) tile.classList.remove('active');
+  }
 }
 
 // currentSong returns the live ICY title of the running stream, or ''.
@@ -1342,6 +1371,16 @@ function markPlaying(loc) {
   var grid = document.getElementById('presets');
   if (!grid) return;
   var n = playingSlot(loc, lastPresetList);
+  if (pendingStart.slot) {
+    if (n === pendingStart.slot) {
+      clearPendingStart(); // the speaker got there
+    } else if (Date.now() < pendingStart.until) {
+      n = pendingStart.slot; // still on its way, keep the press visible
+    } else {
+      clearPendingStart();
+      setNow(T.cantStart, T.tapAgain); // it never started, and now it says so
+    }
+  }
   var tiles = grid.querySelectorAll('.preset');
   for (var i = 0; i < tiles.length; i++) {
     if (i + 1 === n) tiles[i].classList.add('active');

--- a/internal/webui/assets/index.html
+++ b/internal/webui/assets/index.html
@@ -126,6 +126,11 @@ button.btn.armed { border-color:var(--accent); color:var(--accent); font-weight:
 .joinbtn { border-color:var(--accent); color:var(--accent); }
 .leavebtn { width:38px; font-size:20px; color:var(--muted); margin-left:auto; }
 .joinbtn[disabled], .leavebtn[disabled] { opacity:.55; }
+/* Inside the group card the button carries the speaker's name, so it needs to
+   size to its text instead of the 46px square used next to a peer row. */
+.joinbtn-named { width:auto; padding:0 12px; font-size:14px; height:38px; }
+#groupAdd { gap:8px; flex-wrap:wrap; margin-top:10px; }
+#groupAdd:empty { display:none; }
 button.btn:active { background:var(--press); }
 @media (hover:hover) { button.btn:hover, a.btn:hover { background:var(--hover); } .preset:hover { background:var(--hover); } }
 .volrock .volstep { flex-shrink:0; padding:6px 12px; -webkit-touch-callout:none; -webkit-user-select:none; user-select:none; }
@@ -453,6 +458,7 @@ html.a11y-contrast .tabbar button[aria-selected="true"] { outline:2px solid var(
 <div class="sum" id="groupSum"></div>
 <div class="msg" id="groupNote" hidden></div>
 <div id="members"></div>
+<div class="row" id="groupAdd"></div>
 <button class="btn" id="btnUngroup" style="width:100%;margin-top:12px"><span id="lblUngroup">Dissolve group</span></button>
 </div>
 
@@ -1564,6 +1570,9 @@ async function loadPeers() {
   // step; until then this 404s and the section stays hidden.
   const list = await api('/api/peers');
   peersList = list || [];
+  // The group card offers the joinable ones too, so it has to follow a peer
+  // appearing or going away.
+  try { renderGroupAdd(); } catch (e) {}
   renderDevMenu();
   // A home with one speaker gets three tabs, not four. A tab that can only ever
   // say "there is nothing here" is worse than no tab: it invites a tap, answers
@@ -1839,6 +1848,37 @@ function applyScopeUI() {
   });
 })();
 
+// renderGroupAdd offers the speakers that could still join, inside the group
+// card itself.
+//
+// Adding one was only possible from the "other speakers" card further down the
+// page, which is where you go to CONTROL another speaker. Somebody looking at
+// their group and wanting a third room in it had no reason to scroll past it,
+// so the group looked closed. Each member row already carries a minus to drop
+// it; this is the other half of that pair.
+//
+// It reuses joinPeer and canJoinPeer, so the rules about stereo pairs and
+// followers hold here without being restated.
+function renderGroupAdd() {
+  var box = document.getElementById('groupAdd');
+  if (!box) return;
+  var joinable = (peersList || []).filter(canJoinPeer);
+  var want = joinable.map(function(p){ return p.ip; }).join(',');
+  if (box.getAttribute('data-ips') === want) return;
+  box.setAttribute('data-ips', want);
+  box.innerHTML = '';
+  joinable.forEach(function(p){
+    var b = document.createElement('button');
+    b.type = 'button';
+    b.className = 'btn joinbtn joinbtn-named';
+    b.textContent = '+ ' + (p.name || p.ip || '');
+    b.title = T.joinTitle || 'Play together';
+    b.setAttribute('aria-label', fmt(T.joinAria || 'Add {{name}} to the group', { name: p.name || p.ip || '' }));
+    b.addEventListener('click', function(){ joinPeer(p, b); });
+    box.appendChild(b);
+  });
+}
+
 // renderMembers builds the rows once and afterwards only writes values into
 // them. Rebuilding the DOM on every poll tears a slider out from under a
 // finger mid-drag, which on the phones this project serves is the difference
@@ -1941,6 +1981,7 @@ async function loadZone() {
   var lblUn = document.getElementById('lblUngroup');
   if (lblUn) lblUn.textContent = zone.stereo ? T.unpair : T.ungroup;
   renderMembers();
+  renderGroupAdd();
   // Dissolving is a DELETE against the MASTER, and a follower cannot reach a
   // sibling from this page. Rather than offering a button that would fail,
   // a follower is told where the group can be taken apart.

--- a/internal/webui/livegroupview_test.go
+++ b/internal/webui/livegroupview_test.go
@@ -160,3 +160,47 @@ func TestAFollowerWithoutTheLeadersAddressReportsNothing(t *testing.T) {
 		t.Error("no address for the leader means no group can be reported")
 	}
 }
+
+// The desktop app reads /api/box/zone, which returned the speaker's own view.
+// On a follower that is a group of one, so the app showed a different set of
+// speakers depending on which one it happened to ask.
+func TestTheZoneReadReportsTheWholeGroupFromAFollower(t *testing.T) {
+	withSpeakers(t,
+		map[string]boxapi.Zone{
+			livingHost: {Master: leaderID, SenderIP: leaderIP, Members: []boxapi.ZoneMember{{DeviceID: livingID, IP: "192.168.178.44"}}},
+			leaderIP:   {Master: leaderID, Members: []boxapi.ZoneMember{{DeviceID: bathID, IP: "192.168.178.48"}, {DeviceID: livingID, IP: "192.168.178.44"}}},
+		},
+		map[string]string{livingHost: livingID, leaderIP: leaderID})
+
+	s := quietServer(livingHost)
+	own := boxapi.Zone{Master: leaderID, SenderIP: leaderIP, Members: []boxapi.ZoneMember{{DeviceID: livingID, IP: "192.168.178.44"}}}
+	members, ok := s.leaderZone(context.Background(), own)
+	if !ok {
+		t.Fatal("a follower must be able to report the whole group")
+	}
+	if len(members) != 2 {
+		t.Fatalf("want both members of the group, got %d: %+v", len(members), members)
+	}
+}
+
+// The leader's own answer is already complete and must not be replaced by a
+// call to itself.
+func TestTheLeaderKeepsItsOwnMemberList(t *testing.T) {
+	withSpeakers(t,
+		map[string]boxapi.Zone{livingHost: {Master: leaderID, SenderIP: leaderIP}},
+		map[string]string{livingHost: leaderID})
+
+	own := boxapi.Zone{Master: leaderID, SenderIP: leaderIP,
+		Members: []boxapi.ZoneMember{{DeviceID: bathID, IP: "192.168.178.48"}}}
+	if _, ok := quietServer(livingHost).leaderZone(context.Background(), own); ok {
+		t.Error("the leader already has the full list, it must not ask anybody")
+	}
+}
+
+// A standalone speaker has no leader to ask, and must not be turned into one.
+func TestAStandaloneZoneReadIsLeftAlone(t *testing.T) {
+	withSpeakers(t, map[string]boxapi.Zone{livingHost: {}}, map[string]string{livingHost: livingID})
+	if _, ok := quietServer(livingHost).leaderZone(context.Background(), boxapi.Zone{}); ok {
+		t.Error("no master means nothing to fetch")
+	}
+}

--- a/internal/webui/livegroupview_test.go
+++ b/internal/webui/livegroupview_test.go
@@ -1,0 +1,162 @@
+package webui
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/JRpersonal/streborn/internal/boxapi"
+)
+
+// withSpeakers answers the two firmware reads liveGroupView makes from a map,
+// so a case reads as "this is what each speaker says" rather than as HTTP
+// plumbing. boxapi pins port 8090, which a test cannot serve anyway.
+func withSpeakers(t *testing.T, zones map[string]boxapi.Zone, ids map[string]string) {
+	t.Helper()
+	prevZone, prevID := fetchZone, fetchDeviceID
+	fetchZone = func(_ context.Context, host string) (boxapi.Zone, error) {
+		z, ok := zones[host]
+		if !ok {
+			return boxapi.Zone{}, errors.New("speaker not answering")
+		}
+		return z, nil
+	}
+	fetchDeviceID = func(_ context.Context, host string) string { return ids[host] }
+	t.Cleanup(func() { fetchZone, fetchDeviceID = prevZone, prevID })
+}
+
+func quietServer(host string) *Server {
+	return &Server{logger: slog.New(slog.NewTextHandler(io.Discard, nil)), boxHost: host}
+}
+
+const (
+	leaderID   = "08DF1F0C9870"
+	livingID   = "000C8A96488D"
+	bathID     = "EC24B8B790CC"
+	leaderIP   = "192.168.178.79"
+	livingHost = "127.0.0.1"
+)
+
+// The field case, five speakers in one group led by the Portable: the leader
+// reported the group, one speaker holding a stale document claimed to LEAD it,
+// and the others said they were not grouped at all while playing the group's
+// music. A follower has to report the group it is actually in.
+func TestAFollowerReportsTheGroupItIsActuallyIn(t *testing.T) {
+	withSpeakers(t,
+		map[string]boxapi.Zone{
+			// What a follower's own firmware answers: the real master, itself
+			// as the only member, and the master's address to reach it at.
+			livingHost: {Master: leaderID, SenderIP: leaderIP, Members: []boxapi.ZoneMember{{DeviceID: livingID, IP: "192.168.178.44"}}},
+			leaderIP:   {Master: leaderID, Members: []boxapi.ZoneMember{{DeviceID: bathID, IP: "192.168.178.48"}, {DeviceID: livingID, IP: "192.168.178.44"}}},
+		},
+		map[string]string{livingHost: livingID, leaderIP: leaderID})
+
+	s := quietServer(livingHost)
+	members, isFollower := s.liveGroupView(context.Background())
+	if !isFollower {
+		t.Fatal("a speaker whose firmware names another master must report as a follower")
+	}
+	if len(members) != 3 {
+		t.Fatalf("want the leader plus its two followers, got %d: %+v", len(members), members)
+	}
+	if !members[0].IsMaster || members[0].DeviceID != leaderID {
+		t.Errorf("the leader must come first and be marked as such: %+v", members[0])
+	}
+	var selfSeen bool
+	for _, m := range members {
+		if m.DeviceID == livingID {
+			selfSeen = true
+			if !m.IsSelf {
+				t.Errorf("this speaker's own entry must be marked isSelf: %+v", m)
+			}
+			if m.IP != livingHost {
+				t.Errorf("own entry should be addressed over the local host, got %q", m.IP)
+			}
+		}
+		if m.IsMaster && m.DeviceID != leaderID {
+			t.Errorf("only the real leader may be marked master: %+v", m)
+		}
+	}
+	if !selfSeen {
+		t.Error("the group must include this speaker, it is playing the group's music")
+	}
+}
+
+// senderIsMaster reads "true" on a follower on these chassis, which is what
+// made a follower claim leadership. The deviceIDs decide instead, and that has
+// to hold in the other direction too.
+func TestTheLeaderIsDecidedByDeviceIDNotBySenderIsMaster(t *testing.T) {
+	withSpeakers(t,
+		map[string]boxapi.Zone{
+			livingHost: {Master: leaderID, Members: []boxapi.ZoneMember{{DeviceID: bathID, IP: "192.168.178.48"}}},
+		},
+		map[string]string{livingHost: leaderID}) // this speaker IS the leader
+
+	if _, isFollower := quietServer(livingHost).liveGroupView(context.Background()); isFollower {
+		t.Error("a speaker whose own deviceID is the master must not be demoted to a follower")
+	}
+}
+
+// A speaker in no group at all must not be turned into a follower of nobody.
+func TestAStandaloneSpeakerIsNotAFollower(t *testing.T) {
+	withSpeakers(t,
+		map[string]boxapi.Zone{livingHost: {}},
+		map[string]string{livingHost: livingID})
+
+	if _, isFollower := quietServer(livingHost).liveGroupView(context.Background()); isFollower {
+		t.Error("an empty zone is not a group")
+	}
+}
+
+// A speaker that cannot say who it is must not guess. Comparing against an
+// empty deviceID would make every grouped speaker look like a follower.
+func TestASpeakerThatCannotIdentifyItselfStaysWithTheStoredDocument(t *testing.T) {
+	withSpeakers(t,
+		map[string]boxapi.Zone{livingHost: {Master: leaderID, SenderIP: leaderIP}},
+		map[string]string{livingHost: ""})
+
+	if _, isFollower := quietServer(livingHost).liveGroupView(context.Background()); isFollower {
+		t.Error("without its own deviceID the speaker cannot tell, so it must not claim to follow")
+	}
+}
+
+// The leader not answering must not cost the follower its group: it still
+// knows that it follows, and whom.
+func TestAnUnreachableLeaderStillLeavesAGroup(t *testing.T) {
+	withSpeakers(t,
+		map[string]boxapi.Zone{
+			livingHost: {Master: leaderID, SenderIP: leaderIP, Members: []boxapi.ZoneMember{{DeviceID: livingID, IP: "192.168.178.44"}}},
+			// the leader is absent from the map, so it does not answer
+		},
+		map[string]string{livingHost: livingID})
+
+	members, isFollower := quietServer(livingHost).liveGroupView(context.Background())
+	if !isFollower {
+		t.Fatal("an unreachable leader is not evidence the group is gone")
+	}
+	if len(members) != 2 {
+		t.Fatalf("want the leader and this speaker, got %d: %+v", len(members), members)
+	}
+	if !strings.EqualFold(members[0].DeviceID, leaderID) || !members[0].IsMaster {
+		t.Errorf("the leader must still be named: %+v", members[0])
+	}
+	if !members[1].IsSelf {
+		t.Errorf("this speaker must be in its own group: %+v", members[1])
+	}
+}
+
+// Without the leader's address there is nothing to ask and nothing to show,
+// and inventing a group from a deviceID alone would give the page rows it
+// cannot read a volume from.
+func TestAFollowerWithoutTheLeadersAddressReportsNothing(t *testing.T) {
+	withSpeakers(t,
+		map[string]boxapi.Zone{livingHost: {Master: leaderID}},
+		map[string]string{livingHost: livingID})
+
+	if _, isFollower := quietServer(livingHost).liveGroupView(context.Background()); isFollower {
+		t.Error("no address for the leader means no group can be reported")
+	}
+}

--- a/internal/webui/livegroupview_test.go
+++ b/internal/webui/livegroupview_test.go
@@ -204,3 +204,44 @@ func TestAStandaloneZoneReadIsLeftAlone(t *testing.T) {
 		t.Error("no master means nothing to fetch")
 	}
 }
+
+// The regression the audit caught the same day it was introduced: the read was
+// moved onto the firmware and the write was left on the stored document, so a
+// follower drew a full group card whose every press came back 409. Whatever
+// the page is allowed to SHOW, it has to be allowed to SET.
+func TestWhatTheGroupViewShowsIsWhatCanBeSet(t *testing.T) {
+	withSpeakers(t,
+		map[string]boxapi.Zone{
+			livingHost: {Master: leaderID, SenderIP: leaderIP, Members: []boxapi.ZoneMember{{DeviceID: livingID, IP: "192.168.178.44"}}},
+			leaderIP:   {Master: leaderID, Members: []boxapi.ZoneMember{{DeviceID: bathID, IP: "192.168.178.48"}, {DeviceID: livingID, IP: "192.168.178.44"}}},
+		},
+		map[string]string{livingHost: livingID, leaderIP: leaderID})
+
+	// A follower has no stored document at all, which is the whole point.
+	s := quietServer(livingHost)
+	members, grouped, stereo := s.groupView(context.Background())
+	if !grouped {
+		t.Fatal("a follower must be reported as grouped, it is playing the group's music")
+	}
+	if stereo {
+		t.Error("a multiroom zone is not a stereo pair")
+	}
+	if len(members) != 3 {
+		t.Fatalf("want the leader and both followers, got %d: %+v", len(members), members)
+	}
+	// Every row the page draws must be addressable by the write path.
+	for _, m := range members {
+		if m.IP == "" {
+			t.Errorf("a member with no address can be shown but never set: %+v", m)
+		}
+	}
+}
+
+// A speaker in no group answers the same way to both, so the page draws
+// nothing and the write path refuses.
+func TestAStandaloneSpeakerIsNotGroupedForEitherPath(t *testing.T) {
+	withSpeakers(t, map[string]boxapi.Zone{livingHost: {}}, map[string]string{livingHost: livingID})
+	if _, grouped, _ := quietServer(livingHost).groupView(context.Background()); grouped {
+		t.Error("no group means no group, for the reader and the writer alike")
+	}
+}

--- a/internal/webui/sleeptimer.go
+++ b/internal/webui/sleeptimer.go
@@ -187,7 +187,13 @@ func (s *Server) fireSleep(gen uint64) {
 	if !group {
 		return
 	}
-	members, grouped, _ := s.groupMembers()
+	// The same resolver the volume control uses. Reading membership from the
+	// stored document here meant the "switch the whole group off" box was
+	// OFFERED from the live view and ACTED ON from the document, so on a
+	// follower it switched off one speaker.
+	sctx, scancel := context.WithTimeout(context.Background(), 3*time.Second)
+	members, grouped, _ := s.groupView(sctx)
+	scancel()
 	if !grouped {
 		return
 	}

--- a/internal/webui/sleeptimer_test.go
+++ b/internal/webui/sleeptimer_test.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	"github.com/JRpersonal/streborn/internal/zones"
+
+	"github.com/JRpersonal/streborn/internal/boxapi"
 )
 
 // fakeZoneStore gives the server a persisted group with the given member IPs.
@@ -242,6 +244,13 @@ func TestSleepGroupSwitchesEveryMemberOff(t *testing.T) {
 	f.install(t)
 	s := newSleepServer()
 	s.zones = fakeZoneStore(t, "192.0.2.20", "192.0.2.30")
+	// The group resolver asks the firmware whether the stored group is still
+	// live, so the speaker has to answer. Without this the test waits on a
+	// real connection to an unroutable address.
+	withSpeakers(t,
+		map[string]boxapi.Zone{"192.0.2.10": {Master: "DEV-SELF", Members: []boxapi.ZoneMember{
+			{DeviceID: "DEV-192.0.2.20", IP: "192.0.2.20"}, {DeviceID: "DEV-192.0.2.30", IP: "192.0.2.30"}}}},
+		map[string]string{"192.0.2.10": "DEV-SELF"})
 
 	s.armSleep(10*time.Millisecond, true)
 	if !waitFor(func() bool { return len(f.offList()) == 3 }) {
@@ -263,6 +272,13 @@ func TestSleepGroupCarriesOnPastAnUnreachableMember(t *testing.T) {
 	f.install(t)
 	s := newSleepServer()
 	s.zones = fakeZoneStore(t, "192.0.2.20", "192.0.2.30")
+	// The group resolver asks the firmware whether the stored group is still
+	// live, so the speaker has to answer. Without this the test waits on a
+	// real connection to an unroutable address.
+	withSpeakers(t,
+		map[string]boxapi.Zone{"192.0.2.10": {Master: "DEV-SELF", Members: []boxapi.ZoneMember{
+			{DeviceID: "DEV-192.0.2.20", IP: "192.0.2.20"}, {DeviceID: "DEV-192.0.2.30", IP: "192.0.2.30"}}}},
+		map[string]string{"192.0.2.10": "DEV-SELF"})
 
 	s.armSleep(10*time.Millisecond, true)
 	if !waitFor(func() bool { return len(f.offList()) == 2 }) {

--- a/internal/webui/zones_stereo.go
+++ b/internal/webui/zones_stereo.go
@@ -70,6 +70,16 @@ func (s *Server) handleZoneGet(w http.ResponseWriter, r *http.Request) {
 	// every caller assumed until now anyway.
 	// Embedded, so the zone fields keep their exact previous JSON shape
 	// (omitempty and all) and only gain a sibling.
+	// A FOLLOWER's own /getZone lists only itself, so a caller asking one
+	// speaker saw a group of one while the group had five members. The
+	// desktop app reads this endpoint, which is why it showed some speakers
+	// and not others depending on which one it happened to ask (live
+	// 2026-08-15). The leader has the full list, and a follower carries its
+	// address, so it is fetched and reported here. The speaker's OWN master
+	// and sender fields are kept, so nothing that relies on them changes.
+	if full, ok := s.leaderZone(ctx, z); ok {
+		z.Members = full
+	}
 	out := struct {
 		boxapi.Zone
 		Stereo *boxapi.Group `json:"stereo,omitempty"`
@@ -1477,4 +1487,32 @@ func zoneFormBudget(slaves int) time.Duration {
 		return ceiling
 	}
 	return d
+}
+
+// leaderZone returns the full member list of the group described by z, when z
+// is a FOLLOWER's view of it.
+//
+// A follower's /getZone names the master and carries its address in
+// senderIPAddress, but lists only the follower itself as a member. Anything
+// reading that alone sees a one-speaker group, which is what made the desktop
+// app show a different set of speakers depending on which one it asked.
+//
+// Returns false when this speaker leads the group, when it is in none, or when
+// the leader cannot be reached: in all three the caller keeps the speaker's own
+// answer, which is either already right or the best that is available.
+func (s *Server) leaderZone(ctx context.Context, z boxapi.Zone) ([]boxapi.ZoneMember, bool) {
+	master := strings.TrimSpace(z.Master)
+	senderIP := strings.TrimSpace(z.SenderIP)
+	if master == "" || senderIP == "" {
+		return nil, false
+	}
+	ownID := fetchDeviceID(ctx, s.boxHost)
+	if ownID == "" || strings.EqualFold(ownID, master) {
+		return nil, false // we lead it, or cannot tell who we are
+	}
+	lz, err := fetchZone(ctx, senderIP)
+	if err != nil || len(lz.Members) == 0 {
+		return nil, false
+	}
+	return lz.Members, true
 }

--- a/internal/webui/zonevolume.go
+++ b/internal/webui/zonevolume.go
@@ -316,11 +316,11 @@ var (
 // the same question on one fleet (live 2026-08-15, five speakers in one group
 // led by the Portable):
 //
-//   the leader          reported the group correctly
-//   a speaker holding a stale document from an earlier session claimed to
-//                       LEAD a group somebody else leads, listing itself as
-//                       master while playing as a follower
-//   the other three     reported "not grouped" while playing the group's music
+//	the leader          reported the group correctly
+//	a speaker holding a stale document from an earlier session claimed to
+//	                    LEAD a group somebody else leads, listing itself as
+//	                    master while playing as a follower
+//	the other three     reported "not grouped" while playing the group's music
 //
 // The firmware knows better on every one of them: a follower's own /getZone
 // carries the real master's deviceID and, in senderIPAddress, the address to

--- a/internal/webui/zonevolume.go
+++ b/internal/webui/zonevolume.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/JRpersonal/streborn/internal/boxapi"
 	"github.com/JRpersonal/streborn/internal/zones"
+	"strings"
 )
 
 // zoneMemberVolume is one speaker of the group as the phone page sees it.
@@ -158,6 +159,17 @@ func (s *Server) storedGroupIsLive() bool {
 
 func (s *Server) zoneVolumeGet(w http.ResponseWriter, r *http.Request) {
 	members, grouped, stereo := s.groupMembers()
+	// The firmware outranks the stored document. A speaker that follows
+	// somebody else reports THAT group, whether or not it has a document of
+	// its own, and a stale document claiming leadership is overruled.
+	if !stereo {
+		lctx, lcancel := context.WithTimeout(r.Context(), 3*time.Second)
+		live, isFollower := s.liveGroupView(lctx)
+		lcancel()
+		if isFollower {
+			members, grouped = live, true
+		}
+	}
 	// A stereo pair is NOT a zone. It is a firmware group created with
 	// /addGroup, and /getZone answers <zone /> for a perfectly healthy pair, so
 	// the liveness check below must never be applied to one: doing so reported
@@ -278,4 +290,95 @@ func (s *Server) zoneVolumeSet(w http.ResponseWriter, r *http.Request) {
 		"ok": len(failed) == 0, "value": req.Value,
 		"changed": len(targets) - len(failed), "failed": failed,
 	})
+}
+
+// The two firmware reads liveGroupView makes, behind seams. boxapi pins port
+// 8090, which a test cannot serve, and the same swap is what the other box
+// tests in this package use.
+var (
+	fetchZone = func(ctx context.Context, host string) (boxapi.Zone, error) {
+		return boxapi.New(host).GetZone(ctx)
+	}
+	fetchDeviceID = func(ctx context.Context, host string) string {
+		info, err := boxapi.New(host).GetInfo(ctx)
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSpace(info.DeviceID)
+	}
+)
+
+// liveGroupView reports the group this speaker is actually in, as seen by the
+// speaker that leads it, or false when this speaker is not following anybody.
+//
+// Why it exists. groupMembers reads the STORED zone document, which only the
+// speaker that FORMED the group has. That produced three different answers to
+// the same question on one fleet (live 2026-08-15, five speakers in one group
+// led by the Portable):
+//
+//   the leader          reported the group correctly
+//   a speaker holding a stale document from an earlier session claimed to
+//                       LEAD a group somebody else leads, listing itself as
+//                       master while playing as a follower
+//   the other three     reported "not grouped" while playing the group's music
+//
+// The firmware knows better on every one of them: a follower's own /getZone
+// carries the real master's deviceID and, in senderIPAddress, the address to
+// reach it at. So the leader is asked for the member list and every speaker
+// answers with the same group.
+//
+// senderIsMaster is deliberately not consulted. It reads "true" on a follower
+// on these chassis, which is exactly the trap that made a follower look like a
+// leader in the first place; the deviceIDs are unambiguous.
+func (s *Server) liveGroupView(ctx context.Context) ([]zoneMemberVolume, bool) {
+	if s.boxHost == "" {
+		return nil, false
+	}
+	live, err := fetchZone(ctx, s.boxHost)
+	if err != nil || strings.TrimSpace(live.Master) == "" {
+		return nil, false
+	}
+	ownID := fetchDeviceID(ctx, s.boxHost)
+	if ownID == "" || strings.EqualFold(ownID, strings.TrimSpace(live.Master)) {
+		// We lead it, or the speaker cannot say who it is. Either way the
+		// stored document is the better source and the caller keeps it.
+		return nil, false
+	}
+	masterIP := strings.TrimSpace(live.SenderIP)
+	if masterIP == "" {
+		return nil, false
+	}
+	mz, err := fetchZone(ctx, masterIP)
+	if err != nil {
+		// The leader is not answering. Report what is certain: this speaker
+		// follows, and who it follows. A short list beats "not grouped" while
+		// the group's music is playing.
+		return []zoneMemberVolume{
+			{Name: s.peerName(zones.Member{IP: masterIP}), IP: masterIP, DeviceID: live.Master, IsMaster: true, Volume: -1},
+			{Name: s.groupSelfName(zones.Zone{}), IP: s.boxHost, DeviceID: ownID, IsSelf: true, Volume: -1},
+		}, true
+	}
+	// The leader lists its followers, not itself, so it is added first.
+	out := []zoneMemberVolume{{
+		Name: s.peerName(zones.Member{IP: masterIP}), IP: masterIP, DeviceID: live.Master,
+		IsMaster: true, Volume: -1,
+	}}
+	for _, m := range mz.Members {
+		if strings.TrimSpace(m.IP) == "" {
+			continue
+		}
+		self := ownID != "" && strings.EqualFold(strings.TrimSpace(m.DeviceID), ownID)
+		ip := m.IP
+		name := s.peerName(zones.Member{IP: m.IP})
+		if self {
+			// Talk to ourselves over the loopback the rest of this file uses,
+			// and use the name this speaker calls itself.
+			ip = s.boxHost
+			name = s.groupSelfName(zones.Zone{})
+		}
+		out = append(out, zoneMemberVolume{
+			Name: name, IP: ip, DeviceID: m.DeviceID, Role: m.Role, IsSelf: self, Volume: -1,
+		})
+	}
+	return out, true
 }

--- a/internal/webui/zonevolume.go
+++ b/internal/webui/zonevolume.go
@@ -146,7 +146,7 @@ func (s *Server) storedGroupIsLive() bool {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	live, err := boxapi.New(s.boxHost).GetZone(ctx)
+	live, err := fetchZone(ctx, s.boxHost)
 	if err != nil {
 		return true // unreachable right now is not evidence the group is gone
 	}
@@ -158,26 +158,10 @@ func (s *Server) storedGroupIsLive() bool {
 }
 
 func (s *Server) zoneVolumeGet(w http.ResponseWriter, r *http.Request) {
-	members, grouped, stereo := s.groupMembers()
-	// The firmware outranks the stored document. A speaker that follows
-	// somebody else reports THAT group, whether or not it has a document of
-	// its own, and a stale document claiming leadership is overruled.
-	if !stereo {
-		lctx, lcancel := context.WithTimeout(r.Context(), 3*time.Second)
-		live, isFollower := s.liveGroupView(lctx)
-		lcancel()
-		if isFollower {
-			members, grouped = live, true
-		}
-	}
-	// A stereo pair is NOT a zone. It is a firmware group created with
-	// /addGroup, and /getZone answers <zone /> for a perfectly healthy pair, so
-	// the liveness check below must never be applied to one: doing so reported
-	// a working pair as standalone seconds after it was created (caught live on
-	// two SoundTouch 10s, 2026-08-09).
-	if grouped && !stereo && !s.storedGroupIsLive() {
-		grouped = false
-	}
+	gctx, gcancel := context.WithTimeout(r.Context(), 3*time.Second)
+	members, grouped, stereo := s.groupView(gctx)
+	gcancel()
+	_ = stereo // groupView already applied the stereo exception
 	if !grouped {
 		writeJSON(w, http.StatusOK, map[string]any{"grouped": false})
 		return
@@ -229,6 +213,33 @@ func (s *Server) zoneVolumeGet(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// groupView is the ONE answer to "which speakers is this one grouped with".
+//
+// It has to be one, because a reader and a writer that disagree produce a
+// control that draws itself and then refuses every press. That is exactly what
+// happened when the read was moved onto the firmware and the write was left on
+// the stored document: on a follower the phone drew a full group card with
+// live levels, and every volume it sent came back 409 "not in a group",
+// including the follower's own (caught by the audit the same day, before
+// anybody reported it).
+//
+// Order: a stereo pair is the firmware's own concept and the stored document
+// describes it, so it wins. Otherwise the firmware outranks the document,
+// because only the speaker that FORMED the group has one.
+func (s *Server) groupView(ctx context.Context) ([]zoneMemberVolume, bool, bool) {
+	members, grouped, stereo := s.groupMembers()
+	if stereo {
+		return members, grouped, true
+	}
+	if live, isFollower := s.liveGroupView(ctx); isFollower {
+		return live, true, false
+	}
+	if grouped && !s.storedGroupIsLive() {
+		return nil, false, false
+	}
+	return members, grouped, false
+}
+
 func (s *Server) zoneVolumeSet(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		IP    string `json:"ip"`
@@ -242,7 +253,9 @@ func (s *Server) zoneVolumeSet(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "value must be 0..100", http.StatusBadRequest)
 		return
 	}
-	members, grouped, _ := s.groupMembers()
+	vctx, vcancel := context.WithTimeout(r.Context(), 3*time.Second)
+	members, grouped, _ := s.groupView(vctx)
+	vcancel()
 	if !grouped {
 		http.Error(w, "this speaker is not in a group", http.StatusConflict)
 		return

--- a/internal/webui/zonevolume_live_test.go
+++ b/internal/webui/zonevolume_live_test.go
@@ -1,7 +1,11 @@
 package webui
 
 import (
+	"context"
+	"github.com/JRpersonal/streborn/internal/boxapi"
+	"github.com/JRpersonal/streborn/internal/zones"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -51,12 +55,30 @@ func contains(hay, needle string) bool { return strings.Contains(hay, needle) }
 //
 //	19:44:48  stereo: paired id=str-grp-... members=2
 //	19:44:54  zone: the stored group is not on the speaker any more
+//
+// Asserted through the resolver rather than by grepping the source: the check
+// has moved once already, and a test that reads the code cannot tell a
+// refactor from a regression.
 func TestStereoPairIsNotJudgedByGetZone(t *testing.T) {
-	src, err := readSourceFile("zonevolume.go")
+	dir := t.TempDir()
+	st, err := zones.Load(filepath.Join(dir, "zones.json"))
 	if err != nil {
-		t.Fatalf("read source: %v", err)
+		t.Fatalf("zone store: %v", err)
 	}
-	if !contains(src, "grouped && !stereo && !s.storedGroupIsLive()") {
-		t.Error("the zone liveness check still applies to stereo pairs, which /getZone never reports")
+	if err := st.Set(zones.Zone{Master: "DEV-SELF", MasterIP: "192.0.2.10", Stereo: true,
+		Slaves: []zones.Member{{DeviceID: "DEV-RIGHT", IP: "192.0.2.20", Role: "right"}}}); err != nil {
+		t.Fatalf("store the pair: %v", err)
+	}
+	// What a healthy pair's firmware answers: nothing at all about a zone.
+	withSpeakers(t, map[string]boxapi.Zone{"192.0.2.10": {}}, map[string]string{"192.0.2.10": "DEV-SELF"})
+
+	s := quietServer("192.0.2.10")
+	s.zones = st
+	members, grouped, stereo := s.groupView(context.Background())
+	if !grouped || !stereo {
+		t.Fatalf("a healthy stereo pair read as grouped=%v stereo=%v, and an empty /getZone must not decide that", grouped, stereo)
+	}
+	if len(members) != 2 {
+		t.Errorf("want both halves of the pair, got %d: %+v", len(members), members)
 	}
 }


### PR DESCRIPTION
Four fixes, two of them found live on my own five speakers this afternoon.

## The agent crashed and took a whole group's music with it

At 16:51:03 all five speakers stopped at once. The panic trace was on the box:

```
panic: runtime error: invalid memory address or nil pointer dereference
spotify.(*closeNotifyWriter).Write  serve.go:367
spotify.(*Manager).forward          ogg.go:91
```

The Ogg pages are written by the engine goroutine, not by the HTTP handler, and `net/http` recycles the response writer the moment the handler returns. A box detaching mid-track left the engine writing into a freed buffer. The connection is now handed back under a lock that waits for a write in flight. The regression test fails without the fix and passes with it, checked both ways.

## The group volume slider gave away most of its travel

Dragging to 53 across five speakers arrived at 39. Every refresh threw the captured balance away, so a poll landing mid-drag re-anchored from levels our own writes had already moved. The balance is now only re-captured for a change somebody else made.

## Certificates: what I got wrong, and what replaces it

Three releases went after an ST20 whose trust store was assumed to have lost its public roots. Comparing its bundle against eight other boxes and pulling the live chains shows something else:

| host | chains to | on that speaker |
|---|---|---|
| `st01.sslstream.dlf.de` | Amazon Root CA 1 | played |
| `f131.rndfnk.com` | DigiCert Global Root G2 | refused |
| `apresolve.spotify.com` | DigiCert Global Root G2 | refused |

Same box, same minute. It is missing one authority, not its trust. All fifteen `x509` lines in that bundle are the same root, across two separate processes.

Two things follow.

**The header count was measuring the wrong thing.** `RootCount` counted occurrences of `-----BEGIN CERTIFICATE-----`, which cannot distinguish a working store from certificate-shaped text. `usable_root_count` now reports what `crypto/x509` parses, and the diagnostic and the repair share one threshold instead of disagreeing about the same file.

**A refused station now names the authority that signed it.** `x509: certificate signed by unknown authority` reads identically whether one authority is missing, the whole store is broken, or something on the owner's network substitutes certificates. The issuer name on the failure line separates all three in one line of the next bundle.

## What I removed again

An earlier commit on this branch made the agent union both trust store files and pointed the Spotify engine at the healthiest one. The premise was wrong: `crypto/x509` stops at the first certificate *file*, but it also reads both certificate *directories* and unions everything, so the second store was never unreachable. The `SSL_CERT_FILE` hand-off was worse than redundant, because that variable suppresses those directories and would have narrowed what the engine trusts. Reverted before it reached anyone.

Refs #600