### PR TITLE
A diagnostic says which common certificate authorities a speaker has

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -497,6 +497,11 @@ func run() error {
 		return map[string]any{
 			"stores": tlsgen.TrustStoreSnapshot(root),
 			"repair": tlsgen.LastTrustRepair(),
+			// Which common authorities this speaker actually has. A count of
+			// certificates says nothing about WHICH ones, and a speaker can
+			// hold 157 of them and still be missing the two that most internet
+			// radio depends on.
+			"wellKnownRoots": tlsgen.WellKnownRoots(),
 		}
 	})
 	bmxSrv := bmx.New(logger.With("comp", "bmx"))

--- a/internal/tlsgen/truststatus.go
+++ b/internal/tlsgen/truststatus.go
@@ -141,3 +141,67 @@ func trustStoreSnapshotPaths(paths []string, rootCAPEM []byte) []TrustStoreStatu
 	}
 	return out
 }
+
+// WellKnownRoot names one widely used certificate authority and whether this
+// speaker has it.
+//
+// "certificate signed by unknown authority" names the authority the STATION
+// presented; it cannot say whether the speaker has it. On an ST20 whose store
+// held 157 usable certificates, two of the most common roots in the world were
+// nevertheless absent, and there was no way to see that from a bundle. These
+// few names are the ones behind most internet radio and the streaming
+// services, so their presence answers "is this speaker's set simply too old?"
+// in one line.
+type WellKnownRoot struct {
+	Name    string `json:"name"`
+	Present bool   `json:"present"`
+}
+
+// wellKnownRootCNs are matched against a certificate's Subject CommonName.
+var wellKnownRootCNs = []string{
+	"DigiCert Global Root G2",
+	"DigiCert Global Root CA",
+	"ISRG Root X1",
+	"Amazon Root CA 1",
+	"Baltimore CyberTrust Root",
+	"GlobalSign Root CA",
+	"USERTrust RSA Certification Authority",
+	"Go Daddy Root Certificate Authority - G2",
+}
+
+// WellKnownRoots reports which of the common authorities this speaker's trust
+// stores carry, across ALL of them: crypto/x509 reads one store file and then
+// unions both certificate directories, so a root present in any of them counts.
+func WellKnownRoots() []WellKnownRoot {
+	return wellKnownRootsIn(DefaultTrustStorePaths)
+}
+
+func wellKnownRootsIn(paths []string) []WellKnownRoot {
+	have := map[string]bool{}
+	for _, p := range paths {
+		body, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		for rest := body; len(rest) > 0; {
+			var block *pem.Block
+			block, rest = pem.Decode(rest)
+			if block == nil {
+				break
+			}
+			if block.Type != "CERTIFICATE" {
+				continue
+			}
+			c, err := x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				continue
+			}
+			have[strings.TrimSpace(c.Subject.CommonName)] = true
+		}
+	}
+	out := make([]WellKnownRoot, 0, len(wellKnownRootCNs))
+	for _, cn := range wellKnownRootCNs {
+		out = append(out, WellKnownRoot{Name: cn, Present: have[cn]})
+	}
+	return out
+}

--- a/internal/tlsgen/truststatus_test.go
+++ b/internal/tlsgen/truststatus_test.go
@@ -46,6 +46,13 @@ func mustRoot(cn string) string {
 	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
 }
 
+// namedRoot mints a self-signed certificate with a chosen common name, so a
+// test can place a specific authority in a specific store.
+func namedRoot(t *testing.T, cn string) string {
+	t.Helper()
+	return mustRoot(cn)
+}
+
 // publicRoots returns enough real roots to clear minPlausiblePublicRoots, so
 // a test store looks like a firmware bundle rather than like a repair that
 // only put our own root back.
@@ -162,5 +169,33 @@ func TestReadRootCAPEMReturnsNilWithoutACA(t *testing.T) {
 	writeFile(t, filepath.Join(dir, rootCAFile), root)
 	if b := ReadRootCAPEM(dir); string(b) != root {
 		t.Errorf("root CA not read back verbatim: %q", string(b))
+	}
+}
+
+// A count of certificates says nothing about WHICH ones. An ST20 held 157
+// usable roots and was still missing the two that most internet radio chains
+// to, and no bundle could show that.
+func TestWellKnownRootsAreReportedAcrossAllStores(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "ca-certificates.crt")
+	second := filepath.Join(dir, "ca-bundle.crt")
+	// Split them across the two files on purpose: crypto/x509 reads one store
+	// file and then unions both certificate directories, so a root in either
+	// one counts.
+	writeFile(t, first, namedRoot(t, "ISRG Root X1"))
+	writeFile(t, second, namedRoot(t, "Amazon Root CA 1"))
+
+	got := map[string]bool{}
+	for _, r := range wellKnownRootsIn([]string{first, second}) {
+		got[r.Name] = r.Present
+	}
+	if !got["ISRG Root X1"] {
+		t.Error("a root in the first store must be reported as present")
+	}
+	if !got["Amazon Root CA 1"] {
+		t.Error("a root in the second store must be reported as present too")
+	}
+	if got["DigiCert Global Root G2"] {
+		t.Error("a root that is in neither store must be reported as absent, that is the whole point")
 	}
 }


### PR DESCRIPTION
A count of certificates says nothing about WHICH ones.

An ST20 held 157 usable roots and was still refusing stations, and no bundle could show why: the failure text names the authority the STATION presented, never whether the speaker has it. `tls_trust.wellKnownRoots` now names eight common authorities and reports presence across all trust stores, since `crypto/x509` reads one store file and unions both certificate directories.

Read on a healthy sm2 speaker, all eight present. On the scm ST20 in the field, DigiCert Global Root G2 and ISRG Root X1 are refused, so its next diagnostic will name them.

This is measurement only. The fix for the missing roots is a separate decision.

Refs #600