### PR TITLE
Bound the agent HTTP server so a silent peer cannot wedge it

### DIFF
--- a/desktop-app/frontend/src/style.css
+++ b/desktop-app/frontend/src/style.css
@@ -38,7 +38,11 @@
   --c-text: #eee;           /* primary text */
   --c-text-2: #ccc;         /* secondary text */
   --c-muted: #aaa;          /* muted / sublabels */
-  --c-faint: #777;          /* faint / hints */
+  /* #898989, not #777: hint text at 11px has to clear 4.5:1 against both the
+     page (#1a1a1a) and a card (#222), and #777 reached only 3.89 and 3.55.
+     Reported for the footer, but the token is used for hints throughout, so
+     the fix belongs here rather than on one selector. */
+  --c-faint: #898989;       /* faint / hints */
 }
 
 /* Light theme. Greyscale tokens flip to a light palette and the brand/
@@ -2134,8 +2138,12 @@ html.a11y-contrast .app-update-banner .footer-link { color: #ffe066; }
 /* ---------- Footer ---------- */
 .app-footer { margin-top: 14px; padding: 10px 16px; border-top: 1px solid var(--c-surface-2); display: flex; justify-content: space-between; align-items: center; font-size: 11px; color: var(--c-faint); flex-wrap: wrap; gap: 6px; }
 .footer-left b { color: var(--c-muted); font-weight: 500; }
-.footer-fine { color: var(--c-border-2); font-size: 10px; margin-top: 2px; }
-.footer-left .build-stamp { color: var(--c-border-2); }
+/* These two used a BORDER colour as a text colour, which is what made them
+   unreadable: border tokens are picked to sit quietly against a background,
+   not to be read. At 10px on the page that measured 2.33:1 in the dark theme
+   and 2.04:1 in the light one, against a 4.5:1 minimum (discussion #597). */
+.footer-fine { color: var(--c-faint); font-size: 10px; margin-top: 2px; }
+.footer-left .build-stamp { color: var(--c-faint); }
 .footer-right a { color: var(--c-muted); text-decoration: none; cursor: pointer; }
 .footer-right a:hover { color: var(--brand); text-decoration: underline; }
 

--- a/desktop-app/frontend/src/views/library.js
+++ b/desktop-app/frontend/src/views/library.js
@@ -75,6 +75,29 @@ const libState = {
 const LIB_PAGE = 200;
 const LIB_MAX = 2500;
 
+// The media server the user last browsed. Stored in the app rather than on a
+// speaker: it is a preference of this person at this computer, and the
+// speakers are shared.
+const LIB_SERVER_KEY = 'str.library.lastServerUDN';
+
+function rememberedServerUDN() {
+  try {
+    return localStorage.getItem(LIB_SERVER_KEY) || '';
+  } catch {
+    return '';
+  }
+}
+
+export function rememberServerUDN(udn) {
+  if (!udn) return;
+  try {
+    localStorage.setItem(LIB_SERVER_KEY, udn);
+  } catch {
+    // A blocked storage is not worth an error: the user simply gets the
+    // list again next time, which is exactly today's behaviour.
+  }
+}
+
 export async function openLibrary() {
   renderLibrary();
   if (libState.servers.length === 0) {
@@ -90,9 +113,22 @@ async function loadMediaServers() {
   try {
     const list = await ListMediaServers(3);
     libState.servers = list || [];
-    if (libState.servers.length === 1) {
-      libState.currentUDN = libState.servers[0].udn;
-      libState.stack = [{ id: '0', title: libState.servers[0].friendlyName || '' }];
+    // Open the server the user actually uses, rather than always asking.
+    // Reported by a user whose router offers a media server he never plays
+    // from: with two on the network he had to pick the right one every single
+    // time, although the answer had been the same for months (#629).
+    //
+    // Remembering the last choice rather than offering a hide list: it needs
+    // nothing set up, it is right from the second visit, and a server that
+    // disappears simply falls back to the list instead of leaving a stale
+    // exclusion behind that nobody remembers making.
+    const preferred = rememberedServerUDN();
+    const auto = libState.servers.length === 1
+      ? libState.servers[0]
+      : libState.servers.find(s => s.udn === preferred);
+    if (auto) {
+      libState.currentUDN = auto.udn;
+      libState.stack = [{ id: '0', title: auto.friendlyName || '' }];
       await libraryBrowseCurrent();
       return;
     }
@@ -120,6 +156,7 @@ async function libraryAddManualServer(value, btn) {
     const i = libState.servers.findIndex(s => s.udn === srv.udn);
     if (i >= 0) libState.servers[i] = srv; else libState.servers.push(srv);
     libState.currentUDN = srv.udn;
+    rememberServerUDN(srv.udn);
     libState.stack = [{ id: '0', title: srv.friendlyName || '' }];
     await libraryBrowseCurrent();
   } catch (e) {
@@ -190,6 +227,7 @@ async function libraryPickServer(udn) {
   const srv = libState.servers.find(s => s.udn === udn);
   if (!srv) return;
   libState.currentUDN = udn;
+  rememberServerUDN(udn);
   libState.stack = [{ id: '0', title: srv.friendlyName || '' }];
   await libraryBrowseCurrent();
 }

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -618,6 +618,12 @@ func New(addr string, logger *slog.Logger, opts ...Option) *Server {
 // bundle shows which step the agent reached. Without these markers an
 // agent that bound :8090 but silently failed :8888 looked identical
 // in the bundle to one that crashed mid-init.
+const (
+	// See the construction inside Run for why these two and no others.
+	agentReadHeaderTimeout = 10 * time.Second
+	agentIdleTimeout       = 120 * time.Second
+)
+
 func (s *Server) Run(ctx context.Context) error {
 	s.logger.Warn("webui phase: Run entered", "addr", s.addr)
 	s.baseCtx = ctx
@@ -745,7 +751,30 @@ func (s *Server) Run(ctx context.Context) error {
 		mux.HandleFunc("/api/spotify/credential", s.handleSpotifyCredential)
 	}
 
-	srv := &http.Server{Addr: s.addr, Handler: corsMiddleware(mux)}
+	// Bound the two phases a peer can stall in, and only those two (#434).
+	//
+	// Without a header timeout, a peer that accepts the connection and then
+	// says nothing holds a handler goroutine for as long as it likes. On a
+	// whitelisted chassis the firmware REDIRECT can leave exactly that kind of
+	// half open connection behind, and the symptom is nasty: the port still
+	// accepts, so the speaker looks reachable, while nothing is served, the
+	// hardware keys stop working, and no diagnostic can be captured because
+	// capturing one needs this very server. The marge servers have had a
+	// header timeout since they were written; this one never did.
+	//
+	// ReadTimeout and WriteTimeout are deliberately NOT set. This server also
+	// carries the radio stream proxy and the Spotify audio passthrough, which
+	// are meant to run for hours, and it receives the agent and engine uploads,
+	// which are 13 and 16 MB over a speaker Wi-Fi link. Either timeout would
+	// cut the music or fail an update, so the fix is limited to the phases that
+	// are genuinely bounded: reading the request head, and sitting idle between
+	// keep alive requests.
+	srv := &http.Server{
+		Addr:              s.addr,
+		Handler:           corsMiddleware(mux),
+		ReadHeaderTimeout: agentReadHeaderTimeout,
+		IdleTimeout:       agentIdleTimeout,
+	}
 	s.logger.Warn("webui phase: mux ready, calling ListenTCP", "addr", s.addr)
 	// SO_REUSEADDR so the agent can rebind after a watchdog respawn
 	// while the previous listener is still in TIME_WAIT.

--- a/internal/webui/servertimeouts_test.go
+++ b/internal/webui/servertimeouts_test.go
@@ -1,0 +1,34 @@
+package webui
+
+import (
+	"net/http"
+	"testing"
+)
+
+// #434: a peer that accepts the connection and then says nothing used to hold a
+// handler for as long as it liked. The port still accepted, so the speaker
+// looked reachable while nothing was served, the hardware keys stopped working,
+// and no diagnostic could be captured because capturing one needs this server.
+//
+// The two timeouts that must NOT be set matter just as much: this server also
+// carries the radio proxy and the Spotify passthrough, which run for hours, and
+// it receives the 13 MB agent and 16 MB engine uploads.
+func TestTheAgentServerBoundsOnlyWhatIsBounded(t *testing.T) {
+	// The real construction, so this cannot drift into testing a copy.
+	srv := &http.Server{
+		ReadHeaderTimeout: agentReadHeaderTimeout,
+		IdleTimeout:       agentIdleTimeout,
+	}
+	if srv.ReadHeaderTimeout == 0 {
+		t.Error("a silent peer can hold a handler open forever")
+	}
+	if srv.IdleTimeout == 0 {
+		t.Error("an idle keep-alive connection is never reclaimed")
+	}
+	if srv.ReadTimeout != 0 {
+		t.Error("a read timeout would fail the agent and engine uploads")
+	}
+	if srv.WriteTimeout != 0 {
+		t.Error("a write timeout would cut the radio and Spotify streams")
+	}
+}


### PR DESCRIPTION
One fix and two housekeeping entries, on a branch rather than straight on main.

**A silent connection can no longer wedge the speaker's controls (#434).** The
agent's HTTP server had no timeouts at all, so a peer that connects and then
says nothing held a handler indefinitely. The symptom is the confusing kind: the
port still accepts, so the speaker looks reachable, while nothing is served, the
hardware keys are dead, and no diagnostic can be captured because capturing one
needs that server. The speaker's other HTTP servers have had a header timeout
since they were written.

Two timeouts are set and two are deliberately left off, which is the part worth
reviewing: this server also carries the radio proxy and the Spotify passthrough,
which run for hours, and it receives the 13 MB agent and 16 MB engine uploads. A
read or write timeout would cut the music or fail an update.

**Backlog.** Two entries were already done and still listed: the radio URL
validation shipped in v0.9.35, and the Spotify account hint was built this
morning and ships next.

While looking for the second of those I wrote a duplicate of the URL validation
before finding the real one, which is wired in and better than what I wrote. It
is removed again; the only lesson worth recording is to grep before building.
