### PR TITLE
The window is centred again

### DIFF
--- a/desktop-app/frontend/src/style.css
+++ b/desktop-app/frontend/src/style.css
@@ -283,7 +283,12 @@ body {
    of leaving the same pixels to hold larger words. */
 @media (min-width: 62em) {
   .donate-side { display: flex; }
-  .layout { padding-left: 11.5rem; }
+  /* BOTH sides, not just the left. Reserving only the rail side pushed the
+     centred column half a rail to the right, and the window stopped looking
+     centred, which is how this was reported. Reserving the same width on
+     both keeps the column optically in the middle of the window AND clear of
+     the rail, which is what the two fixes were each trying to do alone. */
+  .layout { padding-left: 11.5rem; padding-right: 11.5rem; }
 }
 
 /* Share modal: one tile per platform. Each tile opens the browser share on this


### PR DESCRIPTION
Reported right after the donate rail overlap fix. That fix reserved the rail's width on the left only, so the centred column sat about ninety pixels right of the window's middle.

Reserving the same width on both sides keeps it centred and still clear of the rail. Cost: at the smallest allowed window the column is 632px instead of 720px.