### PR TITLE
A stale warning, and the home screen guide

### DIFF
--- a/desktop-app/frontend/src/state.cache.test.js
+++ b/desktop-app/frontend/src/state.cache.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+// The suite runs in node, which has no localStorage. A tiny stand-in is enough:
+// the cache only ever does getItem, setItem and clear.
+const store = new Map();
+globalThis.localStorage = {
+  getItem: (k) => (store.has(k) ? store.get(k) : null),
+  setItem: (k, v) => store.set(k, String(v)),
+  removeItem: (k) => store.delete(k),
+  clear: () => store.clear(),
+};
+
+import { loadCachedBoxes, saveCachedBoxes } from './state.js';
+
+// Reported by a user whose speaker had refused every station days earlier: the
+// warning was still on screen after the fault was fixed, after the speaker was
+// restarted, and after the app was restarted. His speaker reported healthy; the
+// state lived in this cache on his PC, which is why restarting the speaker
+// could never clear it.
+describe('the speaker cache', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('does not carry a speaker condition across a restart', () => {
+    localStorage.setItem('cachedBoxes', JSON.stringify([{
+      host: '192.168.178.44', deviceID: 'DEV#1', friendlyName: 'Wohnzimmer',
+      model: 'SoundTouch 30', storm1036: true, recallRefusal: true,
+      boxHealth: 'wedged', conflictingMod: 'AfterTouch',
+    }]));
+    const [box] = loadCachedBoxes();
+    expect(box.friendlyName).toBe('Wohnzimmer');
+    expect(box.model).toBe('SoundTouch 30');
+    expect(box.storm1036).toBeUndefined();
+    expect(box.recallRefusal).toBeUndefined();
+    expect(box.boxHealth).toBeUndefined();
+    expect(box.conflictingMod).toBeUndefined();
+  });
+
+  it('does not write a condition into the cache either', () => {
+    saveCachedBoxes([{ host: '192.168.178.44', friendlyName: 'Wohnzimmer', storm1036: true }]);
+    const stored = JSON.parse(localStorage.getItem('cachedBoxes'));
+    expect(stored[0].friendlyName).toBe('Wohnzimmer');
+    expect(stored[0].storm1036).toBeUndefined();
+  });
+
+  it('still keeps what the list is for', () => {
+    saveCachedBoxes([{ host: '192.168.178.44', deviceID: 'DEV#1', friendlyName: 'Küche', model: 'SoundTouch 10', port: 8888 }]);
+    const [box] = loadCachedBoxes();
+    expect(box).toMatchObject({ host: '192.168.178.44', deviceID: 'DEV#1', friendlyName: 'Küche', model: 'SoundTouch 10', port: 8888 });
+  });
+
+  it('still drops the USB gadget address', () => {
+    saveCachedBoxes([{ host: '203.0.113.1', friendlyName: 'gadget' }]);
+    expect(loadCachedBoxes()).toHaveLength(0);
+  });
+});

--- a/desktop-app/frontend/src/state.js
+++ b/desktop-app/frontend/src/state.js
@@ -151,18 +151,44 @@ function isRoutableHost(h) {
 // before the pickReachableIP filter existed; without filtering here
 // the bad entry survives every relaunch and breaks the volume slider
 // and preset playback until the next successful discovery overwrite.
+// A speaker's momentary CONDITION is not part of its identity and must not
+// survive in the cache. Reported by a user whose speaker had refused every
+// station days earlier: the warning was still on screen after the fault was
+// fixed, after the speaker was restarted, and after the app was restarted,
+// because it was being read back out of this cache on every launch. His
+// speaker reported boxHealth ok and no refusal at all; the state lived on his
+// PC, which is why restarting the speaker could never help.
+//
+// The cache exists so the speaker list appears instantly instead of after four
+// seconds of mDNS. Names, addresses and models are worth keeping for that.
+// Anything that says how a speaker is doing RIGHT NOW is not, and discovery
+// fills it in a moment later anyway.
+const TRANSIENT_BOX_FIELDS = ['storm1036', 'storm1036SinceSec', 'recallRefusal',
+  'recallRefusalSinceSec', 'boxHealth', 'conflictingMod', 'updateAvailable',
+  'noWifi', 'wedged'];
+
+function withoutTransientState(b) {
+  const out = { ...b };
+  for (const k of TRANSIENT_BOX_FIELDS) delete out[k];
+  return out;
+}
+
 export function loadCachedBoxes() {
   try {
     const raw = localStorage.getItem('cachedBoxes');
     if (!raw) return [];
     const arr = JSON.parse(raw);
     if (!Array.isArray(arr)) return [];
-    return arr.filter(b => b && isRoutableHost(b.host));
+    return arr.filter(b => b && isRoutableHost(b.host)).map(withoutTransientState);
   } catch { return []; }
 }
 export function saveCachedBoxes(list) {
   try {
-    const clean = (list || []).filter(b => b && isRoutableHost(b.host));
+    // Stripped on the way in as well, so a cache written by this version
+    // cannot carry a condition forward even if the reader ever changes.
+    const clean = (list || [])
+      .filter(b => b && isRoutableHost(b.host))
+      .map(withoutTransientState);
     localStorage.setItem('cachedBoxes', JSON.stringify(clean));
   } catch {}
 }

--- a/desktop-app/frontend/src/style.css
+++ b/desktop-app/frontend/src/style.css
@@ -2230,12 +2230,28 @@ html.a11y-contrast .app-update-banner .footer-link { color: #ffe066; }
 /* Home-screen sketches. Deliberately small and flat: they exist to show that
    the icon lands among ordinary apps, not to imitate a phone. */
 .phone-shots { display: flex; gap: 12px; flex-wrap: wrap; }
-.phone-shot { margin: 0; width: 160px; display: flex; flex-direction: column; gap: 6px; }
+.phone-shot { margin: 10px 0 0; width: 132px; display: flex; flex-direction: column; gap: 6px; }
 .phone-shot figcaption { font-size: 11px; color: var(--c-muted); line-height: 1.35; }
+/* The sketch should read as a phone at a glance, not as a coloured box: a tall
+   portrait shape, a dark bezel around a rounded screen, and the one detail
+   each platform is known by, a notch on the iPhone and a punch hole on the
+   Android. Everything here is drawn in CSS, so it costs no image and follows
+   the theme. */
 .hs {
-  border-radius: 16px; padding: 10px 9px 9px; min-height: 150px;
+  position: relative;
+  aspect-ratio: 9 / 17;
+  border-radius: 20px; padding: 16px 10px 10px; min-height: 190px;
   display: flex; flex-direction: column; gap: 10px;
-  border: 1px solid rgba(255, 255, 255, .12);
+  border: 3px solid #0d0d0f;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, .16), 0 4px 10px rgba(0, 0, 0, .35);
+}
+/* The notch, and the punch hole for the other one. */
+.hs::before {
+  content: ""; position: absolute; top: 3px; left: 50%; transform: translateX(-50%);
+  width: 42%; height: 9px; background: #0d0d0f; border-radius: 0 0 8px 8px;
+}
+.hs-and::before {
+  width: 7px; height: 7px; top: 5px; border-radius: 50%;
 }
 .hs-ios { background: linear-gradient(165deg, #5b6b8c, #2d3550 62%, #1d2236); }
 .hs-and { background: linear-gradient(165deg, #3f5a4b, #233528 60%, #18241b); }

--- a/desktop-app/frontend/src/views/settings.js
+++ b/desktop-app/frontend/src/views/settings.js
@@ -1182,6 +1182,18 @@ function renderBoxSettings(s, box) {
       const data = await PhoneQR(url);
       const img = $('phoneQrImg');
       if (img && data) img.src = data;
+      // Tapping the code opens the instructions underneath. People point a
+      // phone at it first and look for the next step second, and the summary
+      // line was the only way in.
+      if (img) {
+        img.style.cursor = 'pointer';
+        img.onclick = () => {
+          const how = $('phoneHowto');
+          if (!how) return;
+          how.open = true;
+          how.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        };
+      }
     } catch (e) { try { console.warn('phone QR failed', e); } catch {} }
     // The home-screen sketches show the icon the phone will actually end up
     // with: the agent serves it at /icon.png, the same file the manifest points
@@ -2646,6 +2658,17 @@ function phoneHomeScreenBlock() {
               ${step('settingsView.phoneIos4')}
             </ol>
             <p class="phone-path-note">${t('settingsView.phoneIosNote')}</p>
+            <figure class="phone-shot">
+              <div class="hs hs-ios">
+                <div class="hs-time">9:41</div>
+                <div class="hs-grid">
+                ${dummy('')}${dummy('')}${dummy('')}
+                  <span class="hs-app hs-ring"><img class="hs-ico hs-real" data-role="phoneShotIcon" alt="" /><span class="hs-name">ST Reborn</span></span>
+                </div>
+                <div class="hs-dock">${dummy('')}${dummy('')}${dummy('')}${dummy('')}</div>
+              </div>
+              <figcaption>${escapeHtml(t('settingsView.phoneShotIos'))}</figcaption>
+            </figure>
           </div>
           <div class="phone-path phone-path-and">
             <div class="phone-path-head">
@@ -2659,32 +2682,19 @@ function phoneHomeScreenBlock() {
               ${step('settingsView.phoneAndroid4')}
             </ol>
             <p class="phone-path-note">${t('settingsView.phoneAndroidNote')}</p>
-          </div>
-        </div>
-        <div class="phone-shots">
-          <figure class="phone-shot">
-            <div class="hs hs-ios">
-              <div class="hs-time">9:41</div>
-              <div class="hs-grid">
-                ${dummy('')}${dummy('')}${dummy('')}
-                <span class="hs-app hs-ring"><img class="hs-ico hs-real" data-role="phoneShotIcon" alt="" /><span class="hs-name">ST Reborn</span></span>
-              </div>
-              <div class="hs-dock">${dummy('')}${dummy('')}${dummy('')}${dummy('')}</div>
-            </div>
-            <figcaption>${escapeHtml(t('settingsView.phoneShotIos'))}</figcaption>
-          </figure>
-          <figure class="phone-shot">
-            <div class="hs hs-and">
-              <div class="hs-time">9:41</div>
-              <div class="hs-grid">
+            <figure class="phone-shot">
+              <div class="hs hs-and">
+                <div class="hs-time">9:41</div>
+                <div class="hs-grid">
                 ${dummy('rnd')}${dummy('rnd')}
-                <span class="hs-app hs-ring rnd"><img class="hs-ico rnd hs-real" data-role="phoneShotIcon" alt="" /><span class="hs-name">ST Reborn</span></span>
+                  <span class="hs-app hs-ring rnd"><img class="hs-ico rnd hs-real" data-role="phoneShotIcon" alt="" /><span class="hs-name">ST Reborn</span></span>
                 ${dummy('rnd')}
+                </div>
+                <div class="hs-pill"></div>
               </div>
-              <div class="hs-pill"></div>
-            </div>
-            <figcaption>${escapeHtml(t('settingsView.phoneShotAndroid'))}</figcaption>
-          </figure>
+              <figcaption>${escapeHtml(t('settingsView.phoneShotAndroid'))}</figcaption>
+            </figure>
+          </div>
         </div>
       </div>
     </details>`;


### PR DESCRIPTION
Three things, all from the same evening of feedback.

**The stale warning.** A user's speaker had refused every station days earlier; the fault is fixed and his speaker plays, but the banner stayed. Restarting the speaker did not clear it, which is the tell: his diagnostic shows the speaker healthy with no refusal at all. The state was in the app's speaker cache, which kept every field including how a speaker is doing right now, and rebuilt the banner from it on every launch. Conditions are now stripped from the cache; names, addresses and models stay.

**The guide.** Each sketch now sits under its own platform instead of both at the bottom, and they read as a phone rather than a coloured box.

**The QR code** opens the guide when tapped.