### PR TITLE
Feedback sweep 2026-08-18: group/stereo failures, preset preservation, OTA loop

### DIFF
--- a/cmd/agent/foreignpresets.go
+++ b/cmd/agent/foreignpresets.go
@@ -1,0 +1,187 @@
+package main
+
+// Foreign preset preservation.
+//
+// The box treats marge's /preset/list answer as the cloud's source of truth
+// and REPLACES its own preset list with it on every re-onboarding. STR's
+// answer used to contain only the STR store, so any slot the user still had
+// from the Bose days - a Deezer Flow, a TuneIn station, a STORED_MUSIC album -
+// silently fell out of the box's own list the next time the box re-read its
+// cloud presets (field case 2026-08-17: the user edited STR slot 2, the box
+// re-onboarded, and its Deezer slot 3 was gone, while the DEEZER source
+// itself survived via the reflect-sources Path A).
+//
+// This store remembers the box's own presets that STR did NOT write, persisted
+// on NAND, so marge can keep serving them alongside the STR slots and the
+// firmware never sees a cloud answer that starves them out. Fed from the box's
+// gabbo presetsUpdated frames (live) and from the boot-time :8090/presets seed
+// read, i.e. from what the BOX says it has - not from the pre-takeover
+// snapshot, which the app-side restore action already covers.
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"sync"
+
+	"github.com/JRpersonal/streborn/internal/marge"
+	"github.com/JRpersonal/streborn/internal/webui"
+)
+
+// foreignPreset is one box-owned preset slot STR did not write.
+type foreignPreset struct {
+	Slot          int    `json:"slot"`
+	Source        string `json:"source"`
+	Type          string `json:"type"`
+	Location      string `json:"location"`
+	SourceAccount string `json:"sourceAccount"`
+	Name          string `json:"name"`
+}
+
+// foreignPresetStore persists the foreign slots across reboots. All values are
+// stored UNESCAPED (plain text); escaping happens once, at serve time.
+type foreignPresetStore struct {
+	mu      sync.Mutex
+	path    string
+	logger  *slog.Logger
+	entries map[int]foreignPreset
+}
+
+func newForeignPresetStore(path string, logger *slog.Logger) *foreignPresetStore {
+	s := &foreignPresetStore{path: path, logger: logger, entries: map[int]foreignPreset{}}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return s
+	}
+	var list []foreignPreset
+	if err := json.Unmarshal(data, &list); err != nil {
+		logger.Warn("foreign presets: persisted file unreadable, starting empty", "err", err)
+		return s
+	}
+	for _, e := range list {
+		if e.Slot >= 1 && e.Slot <= 6 {
+			s.entries[e.Slot] = e
+		}
+	}
+	if len(s.entries) > 0 {
+		logger.Info("foreign presets: loaded persisted box-owned slots", "count", len(s.entries))
+	}
+	return s
+}
+
+// isForeignBoxPreset reports whether a box preset was NOT written by STR: it
+// carries a location that is neither STR's UPnP stream proxy nor a native
+// orion radio form. isOwnBoxPresetLocation alone is not enough here: the box
+// reports STR's own native slots with the RELATIVE "/station?data=" location
+// (the baseUrl-relative form), which that strict predicate does not match, and
+// preserving those would let a deleted STR preset resurrect itself as a
+// "foreign" one. Old-cloud orion radio presets are excluded with them - they
+// are the same station-descriptor shape, and the STR store, not this
+// preservation, is the authority on radio slots. An empty location cannot be
+// re-served and is skipped.
+func isForeignBoxPreset(location string) bool {
+	return location != "" && !isOwnBoxPresetLocation(location) && !isNativeRadioLocation(location)
+}
+
+// NoteBoxList ingests a FULL box preset report (gabbo presetsUpdated frame or
+// the boot seed read) and replaces the foreign set with what the report says.
+//
+// An EMPTY report while entries are held is deliberately ignored: the known
+// firmware wipe (the box dropping its whole list around a re-login) reports
+// exactly that, and honouring it would erase the memory this store exists to
+// keep. A foreign slot therefore only disappears when a NON-empty report no
+// longer carries it - e.g. the user overwrote the slot with an STR preset.
+func (s *foreignPresetStore) NoteBoxList(bps []webui.BoxPreset) {
+	fresh := map[int]foreignPreset{}
+	for _, p := range bps {
+		loc := xmlEntityUnescape(p.Location)
+		if p.Slot < 1 || p.Slot > 6 || !isForeignBoxPreset(loc) {
+			continue
+		}
+		fresh[p.Slot] = foreignPreset{
+			Slot:          p.Slot,
+			Source:        xmlEntityUnescape(p.Source),
+			Type:          xmlEntityUnescape(p.Type),
+			Location:      loc,
+			SourceAccount: xmlEntityUnescape(p.SourceAccount),
+			Name:          xmlEntityUnescape(p.Name),
+		}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(bps) == 0 && len(s.entries) > 0 {
+		return
+	}
+	if reflect.DeepEqual(fresh, s.entries) {
+		return // no change, no NAND write (presetsUpdated arrives in bursts)
+	}
+	s.entries = fresh
+	s.persistLocked()
+}
+
+func (s *foreignPresetStore) persistLocked() {
+	list := make([]foreignPreset, 0, len(s.entries))
+	for _, e := range s.entries {
+		list = append(list, e)
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].Slot < list[j].Slot })
+	data, err := json.MarshalIndent(list, "", "  ")
+	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		s.logger.Warn("foreign presets: persist failed", "err", err)
+		return
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		s.logger.Warn("foreign presets: persist failed", "err", err)
+		return
+	}
+	if err := os.Rename(tmp, s.path); err != nil {
+		s.logger.Warn("foreign presets: persist failed", "err", err)
+		return
+	}
+	s.logger.Info("foreign presets: preserving box-owned slots in the marge preset answer", "count", len(list))
+}
+
+// MargePresets returns the foreign slots as marge presets, escaped for the
+// text/template (see the marge.Preset escaping contract), skipping any slot in
+// taken (the STR store owns those). Sorted by slot for a stable answer.
+func (s *foreignPresetStore) MargePresets(taken map[int]bool) []marge.Preset {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]marge.Preset, 0, len(s.entries))
+	for slot, e := range s.entries {
+		if taken[slot] {
+			continue
+		}
+		out = append(out, marge.Preset{
+			ID:            e.Slot,
+			Source:        margeXMLEscape(e.Source),
+			Type:          margeXMLEscape(e.Type),
+			Location:      margeXMLEscape(e.Location),
+			SourceAccount: margeXMLEscape(e.SourceAccount),
+			ItemName:      margeXMLEscape(e.Name),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// DebugState is the /api/debug/state section: which box-owned slots STR is
+// currently preserving, so a bundle answers "did STR know about the Deezer
+// preset when the box dropped it" without SSH.
+func (s *foreignPresetStore) DebugState() any {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	list := make([]foreignPreset, 0, len(s.entries))
+	for _, e := range s.entries {
+		list = append(list, e)
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].Slot < list[j].Slot })
+	return map[string]any{"count": len(list), "slots": list}
+}

--- a/cmd/agent/foreignpresets_test.go
+++ b/cmd/agent/foreignpresets_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/JRpersonal/streborn/internal/webui"
+)
+
+func testForeignStore(t *testing.T) *foreignPresetStore {
+	t.Helper()
+	return newForeignPresetStore(filepath.Join(t.TempDir(), "foreign-presets.json"), slog.Default())
+}
+
+// The classifier must keep everything STR writes OUT of the preservation:
+// the strict UPnP proxy form, the relative native form the box echoes back,
+// and the absolute orion form - and keep real foreign presets IN.
+func TestIsForeignBoxPreset(t *testing.T) {
+	cases := []struct {
+		loc     string
+		foreign bool
+	}{
+		{"http://127.0.0.1:8888/stream/3", false},
+		{"http://127.0.0.1:8888/spotify/stream-2.ogg", false},
+		{"/station?data=eyJuYW1lIjoi", false},
+		{"/core02/svc-bmx-adapter-orion/prod/orion/station?data=abc", false},
+		{"https://content.api.bose.io/core02/svc-bmx-adapter-orion/prod/orion/station?data=abc", false},
+		{"https://api.deezer.com/user/me/flow", true},
+		{"/v1/playback/station/s10464", true},
+		{"0$1$13$75$1429$1430", true},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isForeignBoxPreset(c.loc); got != c.foreign {
+			t.Errorf("isForeignBoxPreset(%q) = %v, want %v", c.loc, got, c.foreign)
+		}
+	}
+}
+
+// A full box report replaces the foreign set: STR-written slots are ignored,
+// foreign ones are kept, and a later NON-empty report without a slot drops it
+// (the user overwrote it), while an EMPTY report - the firmware wipe shape -
+// must not erase anything.
+func TestForeignStoreNoteBoxList(t *testing.T) {
+	s := testForeignStore(t)
+	s.NoteBoxList([]webui.BoxPreset{
+		{Slot: 1, Source: "LOCAL_INTERNET_RADIO", Type: "stationurl", Location: "/station?data=x", Name: "France Inter"},
+		{Slot: 3, Source: "DEEZER", Type: "tracklistRadio", Location: "https://api.deezer.com/user/me/flow", SourceAccount: "user@example.com", Name: "Flux"},
+		{Slot: 4, Source: "UPNP", Type: "audio", Location: "http://127.0.0.1:8888/stream/4", Name: "Europe 2"},
+	})
+	if got := s.MargePresets(nil); len(got) != 1 || got[0].ID != 3 || got[0].Source != "DEEZER" {
+		t.Fatalf("expected exactly the Deezer slot preserved, got %+v", got)
+	}
+
+	// Empty report (firmware wipe): nothing may be erased.
+	s.NoteBoxList(nil)
+	if got := s.MargePresets(nil); len(got) != 1 {
+		t.Fatalf("empty report erased the preservation, got %+v", got)
+	}
+
+	// Non-empty report without slot 3: the user overwrote it, so it goes.
+	s.NoteBoxList([]webui.BoxPreset{
+		{Slot: 3, Source: "UPNP", Type: "audio", Location: "http://127.0.0.1:8888/stream/3", Name: "Now STR"},
+	})
+	if got := s.MargePresets(nil); len(got) != 0 {
+		t.Fatalf("overwritten slot survived, got %+v", got)
+	}
+}
+
+// The store persists across restarts (that is its whole point: the wipe this
+// guards against happens at the first re-onboarding after an agent start).
+func TestForeignStorePersistence(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "foreign-presets.json")
+	s := newForeignPresetStore(path, slog.Default())
+	s.NoteBoxList([]webui.BoxPreset{
+		{Slot: 5, Source: "STORED_MUSIC", Location: "0$1$13$75", SourceAccount: "aa/0", Name: "Random Access Memories"},
+	})
+	s2 := newForeignPresetStore(path, slog.Default())
+	got := s2.MargePresets(nil)
+	if len(got) != 1 || got[0].ID != 5 || got[0].Source != "STORED_MUSIC" {
+		t.Fatalf("persisted store did not reload, got %+v", got)
+	}
+}
+
+// Serve-time rules: STR-store slots win (taken map), and values are escaped
+// for the verbatim text/template (a name with '&' must not break the box's
+// preset parse).
+func TestForeignStoreMargePresets(t *testing.T) {
+	s := testForeignStore(t)
+	s.NoteBoxList([]webui.BoxPreset{
+		{Slot: 2, Source: "DEEZER", Location: "https://api.deezer.com/x?a=1&b=2", Name: "Pop & Rock"},
+		{Slot: 6, Source: "TUNEIN", Location: "/v1/playback/station/s1", Name: "Radio"},
+	})
+	got := s.MargePresets(map[int]bool{6: true})
+	if len(got) != 1 || got[0].ID != 2 {
+		t.Fatalf("taken slot not skipped, got %+v", got)
+	}
+	if got[0].ItemName != "Pop &amp; Rock" || got[0].Location != "https://api.deezer.com/x?a=1&amp;b=2" {
+		t.Fatalf("values not escaped for the marge template: %+v", got[0])
+	}
+}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -343,6 +343,12 @@ func run() error {
 		hostsMgr = hosts.New(*hostsPath, logger)
 	}
 
+	// Box-owned presets STR did not write (Deezer, TuneIn, STORED_MUSIC, ...),
+	// preserved so the marge preset answer below cannot starve them out of the
+	// box's own list (see foreignpresets.go).
+	foreignPresets := newForeignPresetStore("/mnt/nv/streborn/foreign-presets.json",
+		logger.With("comp", "foreignpresets"))
+
 	// Initialize subsystems
 	margeSrv := marge.New(logger.With("comp", "marge"),
 		marge.WithDeviceID(deviceID),
@@ -363,7 +369,9 @@ func run() error {
 		marge.WithPresetSource(func() []marge.Preset {
 			all := store.All()
 			out := make([]marge.Preset, 0, len(all))
+			taken := make(map[int]bool, len(all))
 			for _, p := range all {
+				taken[p.Slot] = true
 				out = append(out, marge.Preset{
 					ID:            p.Slot,
 					Source:        "UPNP",
@@ -374,7 +382,10 @@ func run() error {
 					ContainerArt:  margeXMLEscape(firstArtURL(p.Art)),
 				})
 			}
-			return out
+			// The box's OWN presets STR did not write ride along, or the
+			// firmware drops them on its next cloud re-read (a Deezer slot 3
+			// vanished exactly that way, 2026-08-17).
+			return append(out, foreignPresets.MargePresets(taken)...)
 		}))
 	// A configured account makes every legacy account/config probe answer
 	// "signed in": some firmwares poll marge account endpoints that fell into
@@ -863,6 +874,7 @@ func run() error {
 				})
 			}
 			webuiSrv.NoteBoxPresets(out)
+			foreignPresets.NoteBoxList(out)
 		},
 		// Let a hardware press of a queue preset (a saved DLNA folder) start the
 		// webui play-queue instead of the single-track recall.
@@ -888,6 +900,11 @@ func run() error {
 	// is recorded: the next report about a remote in the wrong language arrives
 	// with the evidence attached.
 	webui.RegisterDebugSection("phone_languages", func() any { return webuiSrv.PhoneLanguages() })
+	// The :8090 outage record (the 2026-08-18 ST20 zone-leader freeze was only
+	// provable by hand-counting stale-status WARNs) and the box-owned preset
+	// slots STR preserves in the marge answer (the Deezer slot-3 loss class).
+	webui.RegisterDebugSection("boseapp_health", func() any { return webuiSrv.BoseAppHealth() })
+	webui.RegisterDebugSection("foreign_presets", foreignPresets.DebugState)
 	// When the user starts playback from the Spotify app (selecting this device)
 	// while the box is on another source, point the box at the Spotify stream so
 	// it actually plays instead of staying on the current source (#14).
@@ -988,7 +1005,14 @@ func run() error {
 	// preset list - before the recovery had its one chance to snapshot it.
 	seedFirstRead := make(chan struct{})
 	go seedBoxPresetsAndRecoverStore(store, recentStore, *boxHost,
-		func(bps []webui.BoxPreset) { webuiSrv.NoteBoxPresets(bps) },
+		func(bps []webui.BoxPreset) {
+			webuiSrv.NoteBoxPresets(bps)
+			// Seed the foreign-preset preservation from the same first read, so
+			// the very first re-onboarding after agent start already serves the
+			// box-owned slots (the wipe this guards against happens exactly
+			// there; NoteBoxList unescapes the regex-captured values).
+			foreignPresets.NoteBoxList(bps)
+		},
 		logger.With("comp", "presetrecovery"),
 		func() { close(seedFirstRead) })
 

--- a/desktop-app/app_zone.go
+++ b/desktop-app/app_zone.go
@@ -37,7 +37,14 @@ type ZoneSpec struct {
 // (GET /api/box/zone) -> {master, senderIP, members[]}. Self-heals across
 // :8888/:17008 like the other box calls.
 func (a *App) GetZoneState(host string, port int) (map[string]any, error) {
-	resp, err := a.boxDo(host, port, http.MethodGet, "/api/box/zone", "", "")
+	// 10 s, not the shared 6 s: agents up to v0.9.49 chained the firmware's
+	// /getGroup — which HANGS on scm/BCO chassis — into this read, so their
+	// answer arrives after ~6.0-6.1 s and the shared client always gave up a
+	// hair first. Net effect: no non-ST10 speaker ever delivered a live zone
+	// to the app and the group screens ran on optimistic data alone (the
+	// two-screens-disagree family, 2026-08-18). Newer agents answer in ~2 s
+	// worst case; the headroom keeps the poll working against older ones.
+	resp, err := a.boxDoTimeout(host, port, http.MethodGet, "/api/box/zone", "", "", 10*time.Second)
 	if err != nil {
 		return nil, err
 	}
@@ -139,9 +146,13 @@ func (a *App) FormZone(masterHost string, masterPort int, spec ZoneSpec) (result
 	// failure (e.g. the firmware refusing /addGroup) left no trace at all. The
 	// error returned to the frontend already carries the agent's "addGroup: ..."
 	// / "setZone: ..." text, so this records the real firmware reason.
+	slaveIDs := make([]string, 0, len(spec.Slaves))
+	for _, m := range spec.Slaves {
+		slaveIDs = append(slaveIDs, m.DeviceID+"@"+m.IP)
+	}
 	a.logger.Info("FormZone: forming (stereo=alpha, zone=beta)", "masterHost", masterHost,
 		"master", spec.Master.DeviceID, "masterIP", spec.Master.IP, "slaves", len(spec.Slaves),
-		"stereo", spec.Stereo, "mode", spec.Mode)
+		"slaveList", strings.Join(slaveIDs, ","), "stereo", spec.Stereo, "mode", spec.Mode)
 	defer func() {
 		if err != nil {
 			a.logger.Warn("FormZone: failed", "stereo", spec.Stereo, "master", spec.Master.DeviceID, "err", err)

--- a/desktop-app/frontend/src/i18n/bundles/ar.json
+++ b/desktop-app/frontend/src/i18n/bundles/ar.json
@@ -719,6 +719,8 @@
   "settingsView.webhookTestOk": "أُرسل طلب الاختبار (HTTP {{status}}).",
   "settingsView.webhookTestFailed": "فشل الاختبار: {{err}}",
   "settingsView.wlanHeading": "Wi-Fi",
+  "settingsView.netHeading": "الشبكة",
+  "settingsView.wlanWired": "متصل عبر كابل الشبكة",
   "settingsView.wlanSsid": "SSID",
   "settingsView.wlanIp": "عنوان IP",
   "settingsView.wlanSignal": "الإشارة",

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -783,6 +783,8 @@
   "settingsView.webhookTestOk": "Test-Anfrage gesendet (HTTP {{status}}).",
   "settingsView.webhookTestFailed": "Test fehlgeschlagen: {{err}}",
   "settingsView.wlanHeading": "WLAN",
+  "settingsView.netHeading": "Netzwerk",
+  "settingsView.wlanWired": "Über Netzwerkkabel verbunden",
   "settingsView.wlanSsid": "SSID",
   "settingsView.wlanIp": "IP-Adresse",
   "settingsView.wlanSignal": "Signal",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -783,6 +783,8 @@
   "settingsView.webhookTestOk": "Test request sent (HTTP {{status}}).",
   "settingsView.webhookTestFailed": "Test failed: {{err}}",
   "settingsView.wlanHeading": "Wi-Fi",
+  "settingsView.netHeading": "Network",
+  "settingsView.wlanWired": "Connected via network cable",
   "settingsView.wlanSsid": "SSID",
   "settingsView.wlanIp": "IP address",
   "settingsView.wlanSignal": "Signal",

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -719,6 +719,8 @@
   "settingsView.webhookTestOk": "Petición de prueba enviada (HTTP {{status}}).",
   "settingsView.webhookTestFailed": "Prueba fallida: {{err}}",
   "settingsView.wlanHeading": "Wi-Fi",
+  "settingsView.netHeading": "Red",
+  "settingsView.wlanWired": "Conectado por cable de red",
   "settingsView.wlanSsid": "SSID",
   "settingsView.wlanIp": "Dirección IP",
   "settingsView.wlanSignal": "Señal",

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -719,6 +719,8 @@
   "settingsView.webhookTestOk": "Requête de test envoyée (HTTP {{status}}).",
   "settingsView.webhookTestFailed": "Échec du test : {{err}}",
   "settingsView.wlanHeading": "Wi-Fi",
+  "settingsView.netHeading": "Réseau",
+  "settingsView.wlanWired": "Connecté par câble réseau",
   "settingsView.wlanSsid": "SSID",
   "settingsView.wlanIp": "Adresse IP",
   "settingsView.wlanSignal": "Signal",

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -719,6 +719,8 @@
   "settingsView.webhookTestOk": "テストリクエストを送信しました（HTTP {{status}}）。",
   "settingsView.webhookTestFailed": "テストに失敗しました: {{err}}",
   "settingsView.wlanHeading": "Wi-Fi",
+  "settingsView.netHeading": "ネットワーク",
+  "settingsView.wlanWired": "ネットワークケーブルで接続中",
   "settingsView.wlanSsid": "SSID",
   "settingsView.wlanIp": "IPアドレス",
   "settingsView.wlanSignal": "信号",

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -719,6 +719,8 @@
   "settingsView.webhookTestOk": "Bandomoji užklausa išsiųsta (HTTP {{status}}).",
   "settingsView.webhookTestFailed": "Bandymas nepavyko: {{err}}",
   "settingsView.wlanHeading": "Wi-Fi",
+  "settingsView.netHeading": "Tinklas",
+  "settingsView.wlanWired": "Prijungta tinklo kabeliu",
   "settingsView.wlanSsid": "SSID",
   "settingsView.wlanIp": "IP adresas",
   "settingsView.wlanSignal": "Signalas",

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -719,6 +719,8 @@
   "settingsView.webhookTestOk": "Pārbaudes pieprasījums nosūtīts (HTTP {{status}}).",
   "settingsView.webhookTestFailed": "Pārbaude neizdevās: {{err}}",
   "settingsView.wlanHeading": "Wi-Fi",
+  "settingsView.netHeading": "Tīkls",
+  "settingsView.wlanWired": "Savienots ar tīkla kabeli",
   "settingsView.wlanSsid": "SSID",
   "settingsView.wlanIp": "IP adrese",
   "settingsView.wlanSignal": "Signāls",

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -719,6 +719,8 @@
   "settingsView.webhookTestOk": "Testaanvraag verstuurd (HTTP {{status}}).",
   "settingsView.webhookTestFailed": "Test mislukt: {{err}}",
   "settingsView.wlanHeading": "Wifi",
+  "settingsView.netHeading": "Netwerk",
+  "settingsView.wlanWired": "Verbonden via netwerkkabel",
   "settingsView.wlanSsid": "SSID",
   "settingsView.wlanIp": "IP-adres",
   "settingsView.wlanSignal": "Signaal",

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -719,6 +719,8 @@
   "settingsView.webhookTestOk": "Wysłano żądanie testowe (HTTP {{status}}).",
   "settingsView.webhookTestFailed": "Test nie powiódł się: {{err}}",
   "settingsView.wlanHeading": "Wi-Fi",
+  "settingsView.netHeading": "Sieć",
+  "settingsView.wlanWired": "Połączono kablem sieciowym",
   "settingsView.wlanSsid": "SSID",
   "settingsView.wlanIp": "Adres IP",
   "settingsView.wlanSignal": "Sygnał",

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -719,6 +719,8 @@
   "settingsView.webhookTestOk": "Test isteği gönderildi (HTTP {{status}}).",
   "settingsView.webhookTestFailed": "Test başarısız oldu: {{err}}",
   "settingsView.wlanHeading": "Wi-Fi",
+  "settingsView.netHeading": "Ağ",
+  "settingsView.wlanWired": "Ağ kablosuyla bağlı",
   "settingsView.wlanSsid": "SSID",
   "settingsView.wlanIp": "IP adresi",
   "settingsView.wlanSignal": "Sinyal",

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -719,6 +719,8 @@
   "settingsView.webhookTestOk": "Тестовий запит надіслано (HTTP {{status}}).",
   "settingsView.webhookTestFailed": "Помилка перевірки: {{err}}",
   "settingsView.wlanHeading": "Wi-Fi",
+  "settingsView.netHeading": "Мережа",
+  "settingsView.wlanWired": "Підключено мережевим кабелем",
   "settingsView.wlanSsid": "SSID",
   "settingsView.wlanIp": "IP-адреса",
   "settingsView.wlanSignal": "Сигнал",

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -5871,7 +5871,14 @@ function scheduleLiveTitle() {
     if (state.currentBox !== box) { liveTitleActive = false; return; }   // speaker changed
     const loc = state.nowLocation || '';
     if (loc === '') { liveTitleActive = false; return; }                 // playback stopped
-    const isRadio = /\/stream\//.test(loc) && !/\/spotify\/stream/.test(loc);
+    // Slot-based, not a raw /stream/ match: a NATIVE radio preset carries the
+    // ORION "/station?data=<base64>" descriptor, which the raw regex never
+    // matched, so on native playback this loop spun without ever fetching a
+    // title and the Play tab showed no artist/track at all (#597).
+    // activeSlotFromLocation decodes the descriptor (the #555 fix) and also
+    // correctly yields null for a native station pointing straight at a CDN,
+    // where the proxy has no title to offer.
+    const isRadio = !/\/spotify\//.test(loc) && activeSlotFromLocation(loc) !== null;
     if (isRadio) {
       let title = '';
       try { title = (await StreamTitle(box.host, box.port)) || ''; } catch {}
@@ -6016,7 +6023,10 @@ function renderNowPlayingBar() {
       ? `${state.nowSpotifyArtist} - ${state.nowSpotifyTrack}`
       : state.nowSpotifyTrack;
     displayName = name ? `${t('status.playlistLabel')}: "${name}" · ${song}` : song;
-  } else if (/\/stream\//.test(loc) && !/\/spotify\/stream/.test(loc) && state.nowTitle) {
+  } else if (!/\/spotify\//.test(loc) && activeSlotFromLocation(loc) !== null && state.nowTitle) {
+    // Slot-based like the title poller above: the raw /stream/ regex missed
+    // NATIVE radio locations (ORION descriptor), so the status line dropped
+    // the artist/track exactly when the box played natively (#597).
     displayName = name ? `${t('status.stationLabel')}: "${name}" · ${state.nowTitle}` : state.nowTitle;
   }
   // Match the source case-insensitively: the firmware is not consistent about

--- a/desktop-app/frontend/src/views/library.js
+++ b/desktop-app/frontend/src/views/library.js
@@ -98,6 +98,33 @@ export function rememberServerUDN(udn) {
   }
 }
 
+// The folder the user last had open, alongside the server it belongs to
+// (#642): reopening the library lands where they left off instead of at the
+// server root. One path, not one per server: the request was "continue where
+// I was", and a map of stale paths for servers no longer around is exactly
+// the kind of leftover the server memory above deliberately avoids.
+const LIB_PATH_KEY = 'str.library.lastPath';
+
+function rememberPath() {
+  try {
+    localStorage.setItem(LIB_PATH_KEY, JSON.stringify({
+      udn: libState.currentUDN,
+      stack: (libState.stack || []).map(s => ({ id: s.id, title: s.title })),
+    }));
+  } catch { /* same trade-off as rememberServerUDN */ }
+}
+
+function rememberedPathFor(udn) {
+  try {
+    const p = JSON.parse(localStorage.getItem(LIB_PATH_KEY) || 'null');
+    if (p && p.udn === udn && Array.isArray(p.stack) && p.stack.length > 1 &&
+        p.stack.every(s => s && typeof s.id === 'string')) {
+      return p.stack;
+    }
+  } catch { /* corrupt entry: fall back to the root */ }
+  return null;
+}
+
 export async function openLibrary() {
   renderLibrary();
   if (libState.servers.length === 0) {
@@ -128,7 +155,8 @@ async function loadMediaServers() {
       : libState.servers.find(s => s.udn === preferred);
     if (auto) {
       libState.currentUDN = auto.udn;
-      libState.stack = [{ id: '0', title: auto.friendlyName || '' }];
+      libState.stack = rememberedPathFor(auto.udn) ||
+        [{ id: '0', title: auto.friendlyName || '' }];
       await libraryBrowseCurrent();
       return;
     }
@@ -228,7 +256,8 @@ async function libraryPickServer(udn) {
   if (!srv) return;
   libState.currentUDN = udn;
   rememberServerUDN(udn);
-  libState.stack = [{ id: '0', title: srv.friendlyName || '' }];
+  libState.stack = rememberedPathFor(udn) ||
+    [{ id: '0', title: srv.friendlyName || '' }];
   await libraryBrowseCurrent();
 }
 
@@ -272,6 +301,15 @@ async function libraryBrowseCurrent() {
       }
     }
   } catch (e) {
+    // A remembered folder can stop existing: DLNA object ids are not
+    // guaranteed stable across a server restart. Fall back to the server
+    // root once instead of showing an error for a folder the user never
+    // asked for this session (#642).
+    if (libState.stack.length > 1 && top !== libState.stack[0]) {
+      libState.stack = libState.stack.slice(0, 1);
+      await libraryBrowseCurrent();
+      return;
+    }
     showError(`BrowseLibrary: ${e}`);
   } finally {
     if (token === libState.browseToken) {
@@ -279,6 +317,7 @@ async function libraryBrowseCurrent() {
       libState.loadingMore = false;
       libState.page = acc.returned ? acc : (libState.page || null);
       renderLibrary();
+      if (!libState.loading && acc.returned >= 0 && libState.currentUDN) rememberPath();
     }
   }
 }

--- a/desktop-app/frontend/src/views/multiroom.js
+++ b/desktop-app/frontend/src/views/multiroom.js
@@ -77,8 +77,13 @@ export function renderMultiroom(fetchLive) {
     // the first one discovered meant the star, and with it the dissolve, sat on
     // whichever speaker happened to be first in the list while another one led
     // the group, so the page described a group nobody was in.
+    // liveZoneMaster returns the box OBJECT; zoneMaster holds a deviceID
+    // string everywhere else (card badges compare, doFormZone looks it up).
+    // Assigning the object (v0.9.48) made every comparison false: no card
+    // ever showed MAIN and forming silently no-oped on fleets with a live
+    // zone answer.
     const live = liveZoneMaster(strBoxes);
-    state.zoneMaster = live || (strBoxes.length ? strBoxes[0].deviceID : '');
+    state.zoneMaster = (live && live.deviceID) || (strBoxes.length ? strBoxes[0].deviceID : '');
   }
   const anyOutdated = strBoxes.some(b => deps.boxNeedsUpdate(b));
 

--- a/desktop-app/frontend/src/views/settings.js
+++ b/desktop-app/frontend/src/views/settings.js
@@ -474,6 +474,7 @@ function groupSettingsSections() {
     [t('settingsView.bassHeading')]: 'basics',
     [t('settingsView.clockHeading')]: 'sound',
     [t('settingsView.wlanHeading')]: 'network',
+    [t('settingsView.netHeading')]: 'network',
     [t('settingsView.langHeading')]: 'basics',
     [t('settingsView.regionHeading')]: 'network',
     [t('settingsView.sourcesHeading')]: 'info',
@@ -750,6 +751,14 @@ function renderBoxSettings(s, box) {
   const wifi = (net.interfaces || []).find(i =>
     (i.type === 'WIFI_INTERFACE' && i.state === 'NETWORK_WIFI_CONNECTED') ||
     (i.state === 'NETWORK_ETHERNET_CONNECTED' && i.ipAddress));
+  // A connected ETHERNET_INTERFACE is ambiguous: on BCO chassis it IS the
+  // Wi-Fi coprocessor, but on a box that also lists a real WIFI_INTERFACE
+  // (SA-5, sm2 ST20/ST30 on a cable) it is a genuine wired link, and calling
+  // that "Wi-Fi connected" with the wired IP was wrong (#641). The presence
+  // of a separate WIFI_INTERFACE in the box's own list is the discriminator:
+  // BCO boxes have none at all.
+  const hasRealWifiIface = (net.interfaces || []).some(i => i.type === 'WIFI_INTERFACE');
+  const isWired = !!(wifi && wifi.type !== 'WIFI_INTERFACE' && hasRealWifiIface);
   const signalLabel = {
     'EXCELLENT_SIGNAL': t('signal.excellent'),
     'GOOD_SIGNAL': t('signal.good'),
@@ -760,7 +769,7 @@ function renderBoxSettings(s, box) {
   // BCO boxes (scm ST20, Portable) expose Wi-Fi as an ethernet coprocessor
   // and report no signal class. Show an honest note instead of a bare "-"
   // so it does not read like a missing/failed reading (issue #90).
-  const isCoprocessorWifi = wifi && wifi.type !== 'WIFI_INTERFACE';
+  const isCoprocessorWifi = wifi && wifi.type !== 'WIFI_INTERFACE' && !hasRealWifiIface;
   const signalText = signalLabel[wifi && wifi.signal] || (wifi && wifi.signal) ||
     (isCoprocessorWifi ? t('signal.notReported') : '-');
   const uid = uidSuffixFor(box);
@@ -813,13 +822,16 @@ function renderBoxSettings(s, box) {
     </div>
 
     <div class="settings-section">
-      <h3>${escapeHtml(t('settingsView.wlanHeading'))}</h3>
-      ${wifi ? `
+      <h3>${escapeHtml(t(isWired ? 'settingsView.netHeading' : 'settingsView.wlanHeading'))}</h3>
+      ${wifi ? (isWired ? `
+        <div class="kv-row"><span class="kv-key">${escapeHtml(t('settingsView.wlanIp'))}</span><span class="kv-val">${escapeHtml(wifi.ipAddress || '-')}</span></div>
+        <div class="muted small">${escapeHtml(t('settingsView.wlanWired'))}</div>
+      ` : `
         <div class="kv-row"><span class="kv-key">${escapeHtml(t('settingsView.wlanSsid'))}</span><span class="kv-val">${escapeHtml(wifi.ssid || '-')}</span></div>
         <div class="kv-row"><span class="kv-key">${escapeHtml(t('settingsView.wlanIp'))}</span><span class="kv-val">${escapeHtml(wifi.ipAddress || '-')}</span></div>
         <div class="kv-row"><span class="kv-key">${escapeHtml(t('settingsView.wlanSignal'))}</span><span class="kv-val">${escapeHtml(signalText)}</span></div>
         ${wifi.frequencyKHz ? `<div class="kv-row"><span class="kv-key">${escapeHtml(t('settingsView.wlanFrequency'))}</span><span class="kv-val">${(wifi.frequencyKHz/1000).toFixed(0)} MHz</span></div>` : ''}
-      ` : `<div class="muted small">${escapeHtml(t('settingsView.wlanNotConnected'))}</div>`}
+      `) : `<div class="muted small">${escapeHtml(t('settingsView.wlanNotConnected'))}</div>`}
       <small class="muted small" style="display:block;margin-top:8px">${escapeHtml(t('settingsView.wlanSwitchHint'))}</small>
       <button class="btn" id="wlanSwitchToggle" style="margin-top:8px">${escapeHtml(t('settingsView.wlanSwitchToggle'))}</button>
       <div id="wlanSwitchForm" class="hidden" style="margin-top:8px">

--- a/desktop-app/logexport.go
+++ b/desktop-app/logexport.go
@@ -499,7 +499,10 @@ func captureBoxSnapshot(host string) boxSnapshot {
 		s.BoxSnapshot = httpGetText(base+"/api/box/snapshot", 16*1024)
 		// Live multiroom zone, best-effort (empty on stock boxes, agents
 		// without the zone API, or a zone read the box firmware rejects).
-		s.STRZone = httpGetText(base+"/api/box/zone", 4096)
+		// 10 s, not the 4 s default: agents up to v0.9.49 answer this after
+		// ~6 s on scm/BCO chassis (the firmware /getGroup hang), which is why
+		// no group bundle from those fleets ever carried strZoneJson.
+		s.STRZone = httpGetTextTimeout(base+"/api/box/zone", 4096, 10*time.Second)
 		raw := httpGetText(base+"/api/agent/version", 1024)
 		if raw != "" {
 			_ = json.Unmarshal([]byte(raw), &s.STRAgentVer)

--- a/desktop-app/ota.go
+++ b/desktop-app/ota.go
@@ -533,6 +533,19 @@ func (a *App) stageSidecarBeforeReboot(host string, port int) {
 		a.recordOTA(host, "sidecar: box on a pre-sidecar agent, cannot stage over HTTP pre-reboot; will deliver after the box is on the new agent")
 		return
 	}
+	// Version gate (field 2026-08-18, an ST20 stuck on v0.9.14 in an endless
+	// update loop): agents before v0.9.26 collect an upload via growth-doubling
+	// io.ReadAll, so the ~16 MB engine body peaks near 33 MB of RAM and the
+	// watchdog reboots the SPEAKER mid-push — every retry then led with the
+	// engine push and killed the box before the agent update could even start.
+	// Those agents must never be fed the engine pre-reboot; the post-reboot
+	// delivery to the NEW agent (which streams to disk) is the path that works.
+	if bv := strings.TrimSpace(ver["version"]); bv != "" && versionLess(bv, "v0.9.26") {
+		a.recordOTA(host, "sidecar: box agent "+bv+" predates the streamed upload path (v0.9.26) and dies under a 16 MB push; deferring the engine to the post-reboot delivery")
+		a.logger.Info("stageSidecarBeforeReboot: agent too old for a pre-reboot engine push, deferring to post-OTA delivery",
+			"host", host, "agent", bv)
+		return
+	}
 	// Space gate (#ST30 Daniel). Staging the ~10 MB sidecar pre-reboot lands it
 	// on disk BEFORE the agent .new (~12 MB) is written, so on a tight box (e.g. a
 	// SoundTouch 30, ~31 MB NAND) the two second copies cannot coexist and the

--- a/desktop-app/ota.go
+++ b/desktop-app/ota.go
@@ -246,6 +246,33 @@ func (a *App) UpdateBoxAgent(host string, port int) (err error) {
 	a.notePostOTA(host)
 	a.refreshStick(host)
 
+	// Pre-v0.9.26 agents cannot SURVIVE the HTTP push: they collect an upload
+	// via growth-doubling ReadAll, so the ~13.6 MB agent body peaks near 27 MB
+	// of RAM and the box's watchdog reboots the SPEAKER mid-receive or
+	// mid-apply. Field case 2026-08-18: an ST20 on v0.9.14 looped forever -
+	// upload, crash, reboot, still old, app correctly re-offers, repeat. For
+	// those agents the update goes over SSH instead: ask the OLD agent to open
+	// sshd via its tiny /api/agent/enable-ssh POST (present since long before
+	// v0.9.14; costs no memory), then stream the binary to NAND over SSH with
+	// the old agent's dying upload path never involved. The sshd marker lives
+	// in tmpfs, so SSH closes itself again on the post-swap reboot. Any
+	// failure here falls through to the normal HTTP path, which is exactly
+	// today's behaviour - this detour can only improve things.
+	if ver, verr := a.BoxAgentVersion(host, port); verr == nil {
+		if bv := strings.TrimSpace(ver["version"]); bv != "" && versionLess(bv, "v0.9.26") {
+			a.recordOTA(host, "agent "+bv+" predates the streamed upload path (v0.9.26): updating over SSH, the old agent dies receiving large HTTP bodies")
+			a.logger.Info("update agent: old agent, using SSH instead of the HTTP push", "host", host, "agent", bv)
+			a.enableAgentSSH(host, port)
+			if sshErr := a.updateAgentViaSSH(host, bin); sshErr == nil {
+				a.logger.Info("update agent: SSH-OTA for old agent succeeded", "host", host, "bytes", len(bin))
+				return nil
+			} else {
+				a.recordOTA(host, "old-agent SSH update failed, falling back to the HTTP path: "+sshErr.Error())
+				a.logger.Warn("update agent: SSH-OTA for old agent failed, falling back to HTTP", "host", host, "err", sshErr)
+			}
+		}
+	}
+
 	// Deliver the go-librespot Spotify sidecar BEFORE the agent binary push, and
 	// copy everything onto the box so it reboots exactly once with all files
 	// already in place — no post-reboot re-install (better UX). The agent binary
@@ -1150,6 +1177,26 @@ func (a *App) streamPostBinary(host string, port int, path string, bin []byte) (
 // it from the new file. Each step's failure is reported with concrete
 // context so the desktop's error toast tells the user what to look at
 // instead of "ssh: exit 1".
+// enableAgentSSH asks the running agent to start the box's sshd via its
+// /api/agent/enable-ssh endpoint (LAN-gated agent-side; the marker it writes
+// lives in tmpfs, so sshd stays closed again after the next reboot). Used
+// before an SSH-OTA against a pre-v0.9.26 agent whose HTTP upload path cannot
+// be trusted with large bodies. Best-effort: updateAgentViaSSH retries its
+// handshake and has its own :17000 escalation, so a failure here costs
+// nothing.
+func (a *App) enableAgentSSH(host string, port int) {
+	resp, err := a.boxDo(host, port, http.MethodPost, "/api/agent/enable-ssh", "", "")
+	if err != nil {
+		a.logger.Info("enable-ssh: agent endpoint not reachable", "host", host, "err", err)
+		return
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	a.logger.Info("enable-ssh: requested from agent", "host", host, "status", resp.StatusCode, "resp", strings.TrimSpace(string(body)))
+	// Give sshd a moment to bind before the handshake probes start.
+	time.Sleep(2 * time.Second)
+}
+
 func (a *App) updateAgentViaSSH(host string, bin []byte) error {
 	// 4 spaced attempts (sshHandshake): the OTA path runs when the box is
 	// busiest, exactly where the one-shot 8 s attempt used to flake (#114).

--- a/internal/boxapi/boxapi.go
+++ b/internal/boxapi/boxapi.go
@@ -25,11 +25,33 @@ type Client struct {
 }
 
 // New creates a client with defaults.
+//
+// The client deliberately carries NO http.Client Timeout: that field caps the
+// whole request regardless of any context deadline, which silently defeated
+// every deliberately longer budget a caller passed (the stereo /addGroup
+// patience of 20 s died at exactly 6 s in every field bundle, 2026-08-18 —
+// the firmware spends ~20 s on a pairing op before it answers). The deadline
+// comes from the caller's context instead; callCtx supplies the old 6 s
+// default for callers that set none, so nothing can hang forever.
 func New(host string) *Client {
 	return &Client{
 		Host: host,
-		HTTP: &http.Client{Timeout: 6 * time.Second},
+		HTTP: &http.Client{},
 	}
+}
+
+// defaultCallTimeout bounds a boxapi call whose caller passed a context
+// without a deadline. See New for why the bound lives here and not on the
+// http.Client.
+const defaultCallTimeout = 6 * time.Second
+
+// callCtx returns ctx unchanged when it already carries a deadline, and a
+// defaultCallTimeout-bounded child otherwise.
+func callCtx(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, defaultCallTimeout)
 }
 
 // ---------- Data model ----------
@@ -605,6 +627,8 @@ func (c *Client) Key(ctx context.Context, key string) error {
 // and stays where it is. The caller still has to check first, because on some
 // chassis a request into a sleeping box is what wakes it.
 func (c *Client) Standby(ctx context.Context) error {
+	ctx, cancel := callCtx(ctx)
+	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url("/standby"), nil)
 	if err != nil {
 		return err
@@ -672,6 +696,8 @@ func (c *Client) url(path string) string {
 // (the box would otherwise leave its current network and fail to join the new
 // one, forcing a Bose-app re-pair).
 func (c *Client) SiteSurvey(ctx context.Context) ([]string, error) {
+	ctx, cancel := callCtx(ctx)
+	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url("/performWirelessSiteSurvey"), strings.NewReader(`<PerformWirelessSiteSurvey timeout="5"/>`))
 	if err != nil {
 		return nil, err
@@ -707,6 +733,8 @@ func (c *Client) SiteSurvey(ctx context.Context) ([]string, error) {
 }
 
 func (c *Client) getXML(ctx context.Context, path string, dst any) error {
+	ctx, cancel := callCtx(ctx)
+	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url(path), nil)
 	if err != nil {
 		return err
@@ -754,6 +782,8 @@ func ensureUTF8(b []byte) []byte {
 }
 
 func (c *Client) postXML(ctx context.Context, path, body string) error {
+	ctx, cancel := callCtx(ctx)
+	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(path), strings.NewReader(body))
 	if err != nil {
 		return err
@@ -775,6 +805,8 @@ func (c *Client) postXML(ctx context.Context, path, body string) error {
 // postXML otherwise: a >=400 status carries the box's own error text, which is
 // where the firmware puts its "field not found" parse complaints.
 func (c *Client) postXMLInto(ctx context.Context, path, body string, dst any) error {
+	ctx, cancel := callCtx(ctx)
+	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(path), strings.NewReader(body))
 	if err != nil {
 		return err

--- a/internal/boxcli/boxcli.go
+++ b/internal/boxcli/boxcli.go
@@ -156,10 +156,26 @@ func WakeAndWaitAbort(ctx context.Context, host string, maxWait time.Duration, l
 			return nil
 		}
 		if err != nil {
-			logPhase("wake phase: pre-check read failed", "attempt", i, "err", err.Error())
-		} else {
-			logPhase("wake phase: STANDBY, sending sys power", "attempt", i, "source", state)
+			// The box's power state is UNKNOWN, and `sys power` is a TOGGLE:
+			// sent blind it switches a PLAYING box off. Measured live 2026-08-18
+			// (ST20 leading a playing 2-box zone whose BoseApp :8090 froze): the
+			// pre-check read timed out, the blind toggle went out anyway, and 66ms
+			// later the master dropped UPNP -> STANDBY and the zone dissolved. So
+			// a failed read never earns a toggle; keep asking until the deadline
+			// and report the unreadable state instead.
+			logPhase("wake phase: state read failed, withholding the power toggle (unknown state)", "attempt", i, "err", err.Error())
+			if time.Now().After(deadline) {
+				return fmt.Errorf("box power state unreadable, power toggle withheld: %w", err)
+			}
+			select {
+			case <-ctx.Done():
+				logPhase("wake phase: ctx cancelled (state unknown)", "attempt", i, "err", ctx.Err().Error())
+				return ctx.Err()
+			case <-time.After(700 * time.Millisecond):
+			}
+			continue
 		}
+		logPhase("wake phase: STANDBY, sending sys power", "attempt", i, "source", state)
 		if abort != nil && abort() {
 			logPhase("wake phase: abort signalled (caller stood down), not toggling", "attempt", i)
 			return nil

--- a/internal/boxcli/boxcli_test.go
+++ b/internal/boxcli/boxcli_test.go
@@ -23,6 +23,7 @@ type fakeBox struct {
 	cliLn    net.Listener
 	selfWoke atomic.Bool  // the box left standby on its own (user button press)
 	powerCmd atomic.Int32 // number of `sys power` commands received
+	frozen   atomic.Bool  // BoseApp wedge: :8090 accepts TCP but never answers
 }
 
 func (b *fakeBox) awake() bool { return b.selfWoke.Load() || b.powerCmd.Load() > 0 }
@@ -41,7 +42,11 @@ func startFakeBox(t *testing.T) *fakeBox {
 	b := &fakeBox{httpLn: httpLn, cliLn: cliLn}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/now_playing", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/now_playing", func(w http.ResponseWriter, r *http.Request) {
+		if b.frozen.Load() {
+			<-r.Context().Done() // hold the reply until the client gives up
+			return
+		}
 		src := "STANDBY"
 		if b.awake() {
 			src = "UPNP"
@@ -94,6 +99,26 @@ func TestWakeAndWaitDoesNotToggleSelfWake(t *testing.T) {
 	}
 	if n := b.powerCmd.Load(); n != 0 {
 		t.Fatalf("WakeAndWait sent %d `sys power` toggle(s) to a self-waking box; want 0 (toggling cancels the user's wake)", n)
+	}
+}
+
+// TestWakeAndWaitWithholdsToggleOnUnknownState pins the 2026-08-18 field
+// failure: an ST20 led a PLAYING 2-box zone, its BoseApp :8090 froze (accepts
+// TCP, never answers), and the wake helper — unable to read the state — sent
+// the `sys power` toggle anyway, switching the playing master OFF and
+// dissolving the group. A state that cannot be read must never be toggled:
+// WakeAndWait has to return an error without a single `sys power` going out.
+func TestWakeAndWaitWithholdsToggleOnUnknownState(t *testing.T) {
+	b := startFakeBox(t)
+	b.frozen.Store(true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := WakeAndWait(ctx, "127.0.0.1", 4*time.Second, nil); err == nil {
+		t.Fatalf("WakeAndWait reported success against a frozen :8090; want an unreadable-state error")
+	}
+	if n := b.powerCmd.Load(); n != 0 {
+		t.Fatalf("WakeAndWait sent %d `sys power` toggle(s) while the box state was unreadable; want 0 (a blind toggle switches a playing box off)", n)
 	}
 }
 

--- a/internal/streamproxy/streamproxy.go
+++ b/internal/streamproxy/streamproxy.go
@@ -606,6 +606,12 @@ func (s *Server) streamOneDepth(ctx context.Context, w http.ResponseWriter, r *h
 		brSettle = 4 * time.Second
 		brWindow = 6 * time.Second
 	)
+	// upstreamStallAfter is how long the copy loop tolerates Read() returning
+	// nothing before the stall watchdog closes the upstream connection. Five
+	// seconds is several buffers' worth at any real bitrate, so it never fires
+	// on a healthy stream, and it is short enough that the internal reconnect
+	// lands before the box gives up on its own connection.
+	const upstreamStallAfter = 5 * time.Second
 	streamStart := time.Now()
 	var winBytes int64
 	var winStart time.Time
@@ -630,17 +636,85 @@ func (s *Server) streamOneDepth(ctx context.Context, w http.ResponseWriter, r *h
 	connStart := time.Now()
 	var connBytes int64
 	gotData := false
+	// Rolling short-window byte count: the number that decides between "the
+	// box bailed at full data rate" and "the upstream starved the box" is the
+	// delivery rate AT the drop moment, and until #510 no end-of-stream line
+	// carried it. Coarse on purpose (one window, no ring): recentBytes counts
+	// the CURRENT window, recentStart says how old it is.
+	var recentBytes int64
+	recentStart := time.Now()
+	// Stall watchdog (#510): a silent upstream stall (no FIN, no RST, no
+	// bytes) blocked this loop in Read() forever, because streams are endless
+	// by design and the body has no read deadline. The box then starved on an
+	// open, byte-less connection: measured live 2026-08-18, an ST20 sat in
+	// BUFFERING_STATE for minutes on exactly such a connection. The watchdog
+	// closes the upstream body after upstreamStallAfter without a completed
+	// read; the Read unblocks with an error, the normal reconnect path takes
+	// over, and the box's own connection stays open throughout.
+	lastReadNano := new(int64)
+	*lastReadNano = time.Now().UnixNano()
+	var lastReadMu sync.Mutex
+	touchRead := func() {
+		lastReadMu.Lock()
+		*lastReadNano = time.Now().UnixNano()
+		lastReadMu.Unlock()
+	}
+	sinceRead := func() time.Duration {
+		lastReadMu.Lock()
+		defer lastReadMu.Unlock()
+		return time.Duration(time.Now().UnixNano() - *lastReadNano)
+	}
+	watchdogDone := make(chan struct{})
+	defer close(watchdogDone)
+	go func() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-watchdogDone:
+				return
+			case <-ticker.C:
+				if sinceRead() >= upstreamStallAfter {
+					s.logger.Warn("stream proxy upstream stalled (no bytes), closing the upstream connection to force a reconnect",
+						"url", url, "stalledSec", int(sinceRead().Seconds()),
+						"connectedSec", int(time.Since(connStart).Seconds()), "bytes", connBytes)
+					_ = resp.Body.Close()
+					return
+				}
+			}
+		}
+	}()
+	// connSummary is the end-of-connection forensic line for the paths that
+	// used to discard the telemetry (the box closing, ctx cancel): duration,
+	// total bytes, average rate, and the recent-window delivery.
+	connSummary := func(why string) {
+		secs := time.Since(connStart).Seconds()
+		kbps := 0
+		if secs > 0 {
+			kbps = int(float64(connBytes) * 8 / 1000 / secs)
+		}
+		s.logger.Info("stream proxy conn summary", "why", why, "url", url,
+			"connectedSec", int(secs), "bytes", connBytes, "avgKbps", kbps,
+			"recentBytes", recentBytes, "recentWindowSec", int(time.Since(recentStart).Seconds()))
+	}
 	for {
 		n, readErr := src.Read(buf)
 		if n > 0 {
+			touchRead()
 			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
 				// Bose closed the connection
+				connSummary("bose closed")
 				return false, nil
 			}
 			if flusher != nil {
 				flusher.Flush()
 			}
 			connBytes += int64(n)
+			recentBytes += int64(n)
+			if time.Since(recentStart) >= 10*time.Second {
+				recentBytes = 0
+				recentStart = time.Now()
+			}
 			gotData = true
 			s.markByteDelivery() // records "last byte to box" wall clock across reconnects
 			if !measured && time.Since(streamStart) >= brSettle {
@@ -665,6 +739,7 @@ func (s *Server) streamOneDepth(ctx context.Context, w http.ResponseWriter, r *h
 		if readErr != nil {
 			// Bose has closed — NO retry, otherwise an endless loop
 			if errors.Is(readErr, context.Canceled) || ctx.Err() != nil {
+				connSummary("ctx canceled")
 				return false, nil
 			}
 			if readErr == io.EOF {

--- a/internal/streamproxy/streamproxy_test.go
+++ b/internal/streamproxy/streamproxy_test.go
@@ -141,3 +141,43 @@ func TestSlotPulledSinceLiveness(t *testing.T) {
 		t.Fatal("a sustained finished session must count as playback")
 	}
 }
+
+// TestUpstreamStallForcesReconnect pins the #510 stall watchdog: an upstream
+// that goes silent WITHOUT closing (no FIN, no RST) used to block the copy
+// loop in Read() forever, starving the box on an open, byte-less connection
+// (live 2026-08-18: an ST20 in BUFFERING_STATE for minutes). The watchdog has
+// to close the upstream after a few silent seconds so the normal reconnect
+// path takes over while the box's own connection stays open.
+func TestUpstreamStallForcesReconnect(t *testing.T) {
+	stallRelease := make(chan struct{})
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "audio/mpeg")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(make([]byte, 4096))
+		w.(http.Flusher).Flush()
+		<-stallRelease // stall: connection stays open, no further bytes
+	}))
+	defer func() { close(stallRelease); up.Close() }()
+
+	s := New(presets.New(), silentLogger())
+	// The production client refuses loopback dials (SSRF guard); the watchdog
+	// under test sits below the client, so a plain client keeps the test local.
+	s.client = &http.Client{}
+
+	req := httptest.NewRequest(http.MethodGet, "/raw", nil)
+	rw := httptest.NewRecorder()
+	start := time.Now()
+	boseAlive, err := s.streamOne(req.Context(), rw, req, up.URL, true)
+	if elapsed := time.Since(start); elapsed > 15*time.Second {
+		t.Fatalf("stall took %s to detect; the watchdog should fire after ~5s", elapsed)
+	}
+	if !boseAlive {
+		t.Fatalf("streamOne reported the box gone; a stalled UPSTREAM must ask for a reconnect instead")
+	}
+	if err == nil {
+		t.Fatalf("expected the stall-closed read error, got nil")
+	}
+	if rw.Body.Len() == 0 {
+		t.Fatalf("the bytes before the stall never reached the client")
+	}
+}

--- a/internal/webui/assets/index.html
+++ b/internal/webui/assets/index.html
@@ -2018,7 +2018,15 @@ function applyScopeUI() {
   var bG = document.getElementById('scopeGroup'), bP = document.getElementById('scopePair'), bO = document.getElementById('scopeOne');
   if (!row || !bG || !bP || !bO) return;
   row.hidden = !zone.grouped;
-  if (!zone.grouped) { volScope = 'one'; volScopeChosen = false; return; }
+  if (!zone.grouped) {
+    volScope = 'one'; volScopeChosen = false;
+    // The hint is a SIBLING of the scope row, so hiding the row does not take
+    // it along: after a dissolve the "N speakers playing together" line stayed
+    // on the Play tab until the page was reopened (#640).
+    var goneHint = document.getElementById('volScopeHint');
+    if (goneHint) goneHint.hidden = true;
+    return;
+  }
   // Group and pair are the same membership seen two ways, so only one of the
   // two ever appears. Offering both would invite the question "what is the
   // difference", which has no answer.

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -452,6 +452,20 @@ type Server struct {
 	// ignored/pruned. Guarded by boxPresetsMu.
 	deletedBoxSlots map[int]time.Time
 
+	// The stereo /getGroup hang tracker (see handleZoneGet): consecutive
+	// timeouts and the pause window they earn. Guarded by groupReadMu.
+	groupReadMu        sync.Mutex
+	groupReadFails     int
+	groupReadSkipUntil time.Time
+
+	// BoseApp (:8090) outage episodes, fed by the /api/status fetch path. The
+	// 2026-08-18 ST20 freeze was only provable by counting statusStaleWarned
+	// transitions by hand; this records the episodes so a bundle answers "how
+	// long and how often was the firmware webserver dead" directly. Guarded by
+	// statusMu. boseappDownSince is zero while :8090 answers.
+	boseappDownSince time.Time
+	boseappOutages   []boseappOutage
+
 	// queue is the agent-side DLNA library play queue (#202 follow-up). It
 	// auto-advances on track end so a NAS/FRITZ!Box folder plays through like the
 	// original SoundTouch box-side queue, even with the desktop app closed. A

--- a/internal/webui/status_index.go
+++ b/internal/webui/status_index.go
@@ -151,6 +151,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	// every /api/status poll forever.
 	cl := &http.Client{Timeout: 5 * time.Second}
 	resp, err := cl.Get(fmt.Sprintf("http://%s:8090/now_playing", s.boxHost))
+	s.noteBoseAppFetch(err == nil)
 	if err != nil {
 		// Fall back to the last cached body on a box error so a brief BoseApp
 		// hiccup does not blank the now-playing display. The body must stay
@@ -202,6 +203,61 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
 	w.WriteHeader(resp.StatusCode)
 	_, _ = w.Write(body)
+}
+
+// boseappOutage is one closed episode of the firmware webserver (:8090) not
+// answering, as observed by the /api/status fetch path.
+type boseappOutage struct {
+	Start   string `json:"start"`
+	End     string `json:"end"`
+	Seconds int    `json:"seconds"`
+}
+
+// boseappOutageKeep bounds the episode ring; the freeze family produces a
+// handful of long episodes, not thousands, so a short ring is plenty.
+const boseappOutageKeep = 10
+
+// noteBoseAppFetch feeds the :8090 outage tracker with one fetch verdict.
+func (s *Server) noteBoseAppFetch(ok bool) {
+	now := time.Now()
+	s.statusMu.Lock()
+	defer s.statusMu.Unlock()
+	if ok {
+		if !s.boseappDownSince.IsZero() {
+			s.boseappOutages = append(s.boseappOutages, boseappOutage{
+				Start:   s.boseappDownSince.Format(time.RFC3339),
+				End:     now.Format(time.RFC3339),
+				Seconds: int(now.Sub(s.boseappDownSince).Seconds()),
+			})
+			if len(s.boseappOutages) > boseappOutageKeep {
+				s.boseappOutages = s.boseappOutages[len(s.boseappOutages)-boseappOutageKeep:]
+			}
+			s.boseappDownSince = time.Time{}
+		}
+		return
+	}
+	if s.boseappDownSince.IsZero() {
+		s.boseappDownSince = now
+	}
+}
+
+// BoseAppHealth is the /api/debug/state section with the :8090 outage record:
+// whether the firmware webserver is answering right now, for how long it has
+// been dead if not, and the recent closed outage episodes. Observation is
+// demand-driven (the app's status poll), so gaps with no polling show no data
+// rather than false uptime.
+func (s *Server) BoseAppHealth() any {
+	s.statusMu.Lock()
+	defer s.statusMu.Unlock()
+	out := map[string]any{
+		"currentlyDown": !s.boseappDownSince.IsZero(),
+		"episodes":      append([]boseappOutage(nil), s.boseappOutages...),
+	}
+	if !s.boseappDownSince.IsZero() {
+		out["downSince"] = s.boseappDownSince.Format(time.RFC3339)
+		out["downForSec"] = int(time.Since(s.boseappDownSince).Seconds())
+	}
+	return out
 }
 
 // ---- Helpers ----

--- a/internal/webui/zones_stereo.go
+++ b/internal/webui/zones_stereo.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net"
@@ -84,11 +85,54 @@ func (s *Server) handleZoneGet(w http.ResponseWriter, r *http.Request) {
 		boxapi.Zone
 		Stereo *boxapi.Group `json:"stereo,omitempty"`
 	}{Zone: z}
-	if g, gerr := c.GetGroup(ctx); gerr == nil && (g.ID != "" || len(g.Members) > 0) {
-		g := g
-		out.Stereo = &g
+	// The pair read gets its own SHORT budget, never the zone's. The firmware's
+	// /getGroup HANGS on scm/BCO chassis — no refusal, just silence (12 s and
+	// counting on an awake scm ST30, 2026-08-18, while its /getZone answered in
+	// 28 ms). Chained on the zone ctx it ate the whole 6 s budget, the desktop
+	// app's 6 s client always gave up first, and so no non-ST10 speaker EVER
+	// delivered a live zone to the app: both group screens then ran on
+	// optimistic data alone (Bernard's two-screens-disagree family). After a
+	// few consecutive hangs the read is paused for a while — the answer cannot
+	// change while the firmware refuses to give one.
+	if s.groupReadAllowed() {
+		gctx, gcancel := context.WithTimeout(r.Context(), 1500*time.Millisecond)
+		g, gerr := c.GetGroup(gctx)
+		gcancel()
+		s.noteGroupReadResult(gerr)
+		if gerr == nil && (g.ID != "" || len(g.Members) > 0) {
+			out.Stereo = &g
+		}
 	}
 	writeJSON(w, http.StatusOK, out)
+}
+
+// groupReadAllowed reports whether the stereo /getGroup read should be tried,
+// i.e. it is not currently paused after consecutive firmware hangs.
+func (s *Server) groupReadAllowed() bool {
+	s.groupReadMu.Lock()
+	defer s.groupReadMu.Unlock()
+	return time.Now().After(s.groupReadSkipUntil)
+}
+
+// noteGroupReadResult tracks consecutive /getGroup timeouts and pauses the
+// read once the firmware has proven it will not answer. The pause is short
+// (5 min): a deep-standby speaker hangs this endpoint too and must get its
+// pair read back soon after waking.
+func (s *Server) noteGroupReadResult(err error) {
+	s.groupReadMu.Lock()
+	defer s.groupReadMu.Unlock()
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		s.groupReadFails = 0
+		return
+	}
+	s.groupReadFails++
+	if s.groupReadFails < 3 {
+		return
+	}
+	s.groupReadSkipUntil = time.Now().Add(5 * time.Minute)
+	s.groupReadFails = 0
+	s.logger.Info("zone: the firmware's /getGroup keeps hanging (known on scm/BCO chassis), pausing the stereo-pair read",
+		"pauseMin", 5)
 }
 
 // handleBoxBalance reports the left/right balance of a stereo pair.
@@ -171,8 +215,15 @@ func (s *Server) handleZoneForm(w http.ResponseWriter, r *http.Request) {
 	for _, m := range req.Slaves {
 		slaves = append(slaves, boxapi.ZoneMember{DeviceID: m.DeviceID, IP: m.IP})
 	}
+	// Log WHO, not just how many: the 2026-08-18 third-speaker bundle could
+	// not say which box was being added, because every log line carried only
+	// slaves=2.
+	slaveIDs := make([]string, 0, len(slaves))
+	for _, m := range slaves {
+		slaveIDs = append(slaveIDs, m.DeviceID+"@"+m.IP)
+	}
 	s.logger.Info("zone: forming (beta)", "mode", mode, "master", master.DeviceID, "masterIP", master.IP,
-		"slaves", len(slaves), "stereo", req.Stereo, "name", req.Name)
+		"slaves", len(slaves), "slaveList", strings.Join(slaveIDs, ","), "stereo", req.Stereo, "name", req.Name)
 
 	ctx, cancel := context.WithTimeout(r.Context(), zoneFormBudget(len(slaves)))
 	defer cancel()
@@ -267,6 +318,24 @@ func (s *Server) handleZoneForm(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Ask the leader ONE cheap question before touching anything. On 2026-08-18
+	// a fleet bundle showed the leader's BoseApp (:8090) frozen for minutes
+	// BEFORE the user added a third speaker: the form then burned ~30 s in
+	// timing-out pre-reads and the playing 2-box group was lost along the way.
+	// A leader whose :8090 does not answer cannot take a /setZone anyway, so
+	// fail fast here, with the stored document and the live group untouched.
+	// Mirror mode is exempt: it streams to each member directly and does not
+	// need the leader's :8090. (A reboot of the leading speaker clears this
+	// firmware freeze; the wedge is documented in status_index.go.)
+	if mode != "mirror" {
+		if perr := s.speakerStaysSilent(ctx, c); perr != nil {
+			s.logger.Warn("zone: the speaker leading the group is not answering, not starting the group change",
+				"probeErr", perr, "master", master.DeviceID)
+			http.Error(w, "the speaker leading the group is not answering: "+perr.Error(), http.StatusBadGateway)
+			return
+		}
+	}
+
 	// What the user already had, read BEFORE anything is changed. Adding a
 	// speaker to a group that is playing must not be able to end with no group
 	// at all, and on 2026-08-16 it did: a working pair, a third speaker added,
@@ -278,7 +347,24 @@ func (s *Server) handleZoneForm(w http.ResponseWriter, r *http.Request) {
 	if s.zones != nil {
 		prevDoc, hadPrevDoc = s.zones.Get()
 	}
-	prevLive, _ := c.GetZone(ctx)
+	prevLive, prevLiveErr := c.GetZone(ctx)
+	if prevLiveErr != nil {
+		// A swallowed error here left the restore blind on 2026-08-18: the
+		// leader's :8090 died between the probe above and this read, prevLive
+		// came back empty, and restorePreviousZone concluded "there was no live
+		// group to lose". Fall back to the stored document, which describes the
+		// group the user last asked for, so the restore still knows what to put
+		// back once the leader answers again.
+		s.logger.Warn("zone: could not read the live group before changing it, falling back to the stored document for the restore",
+			"err", prevLiveErr)
+		if hadPrevDoc && !prevDoc.Stereo && len(prevDoc.Slaves) > 0 &&
+			strings.EqualFold(strings.TrimSpace(prevDoc.Master), strings.TrimSpace(master.DeviceID)) {
+			prevLive.Master = prevDoc.Master
+			for _, m := range prevDoc.Slaves {
+				prevLive.Members = append(prevLive.Members, boxapi.ZoneMember{DeviceID: m.DeviceID, IP: m.IP})
+			}
+		}
+	}
 
 	// Persist first so a transient drive error still leaves the group on record
 	// for the reconcile loop to retry. Only the master persists.
@@ -816,7 +902,15 @@ func (s *Server) formStereoPair(w http.ResponseWriter, ctx context.Context, c *b
 	// the handler deadline killed it mid-call. The firmware went on to form the
 	// pair 4 s later and the speakers announced it, but the user had already
 	// been told the pairing failed.
-	actx, acancel := context.WithTimeout(context.WithoutCancel(ctx), 20*time.Second)
+	// 30 s, not 20: the firmware runs a pairing op for a fixed ~20 s before it
+	// answers /addGroup at all (measured on a failing pair, eight identical
+	// attempts, 2026-08-18 — every groupUpdated arrived exactly ~20 s after the
+	// POST). Until the boxapi client cap was removed this budget silently died
+	// at 6 s anyway ("Client.Timeout exceeded while awaiting headers" in every
+	// bundle), so no field run has ever actually waited for the firmware's own
+	// verdict; 30 s finally collects it, including the error XML that names the
+	// reject reason on a refusing box.
+	actx, acancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 	defer acancel()
 	ctx = actx
 	if err := c.AddGroup(ctx, name, master.DeviceID, members); err != nil {
@@ -842,10 +936,20 @@ func (s *Server) formStereoPair(w http.ResponseWriter, ctx context.Context, c *b
 			// two SoundTouch 10s, 2026-08-04). Reporting failure for a pair that
 			// exists is worse than the timeout itself, because the user's next
 			// move is to pair again, which the firmware then rejects with
-			// GROUP_ALREADY_EXISTS.
-			cctx, ccancel := context.WithTimeout(context.WithoutCancel(ctx), 6*time.Second)
-			g, gerr := c.GetGroup(cctx)
-			ccancel()
+			// GROUP_ALREADY_EXISTS. One immediate read is not enough: the
+			// firmware's pairing op takes ~20 s, so a read 40 ms after a lost
+			// reply always saw "no group" — poll for a while instead.
+			var g boxapi.Group
+			gerr := errors.New("not read")
+			for vDeadline := time.Now().Add(12 * time.Second); ; {
+				cctx, ccancel := context.WithTimeout(context.WithoutCancel(ctx), 6*time.Second)
+				g, gerr = c.GetGroup(cctx)
+				ccancel()
+				if (gerr == nil && len(g.Members) == 2) || time.Now().After(vDeadline) {
+					break
+				}
+				time.Sleep(2 * time.Second)
+			}
 			if gerr == nil && len(g.Members) == 2 {
 				s.logger.Warn("stereo: addGroup reported an error but the speaker formed the pair anyway, treating it as paired",
 					"err", err, "id", g.ID)

--- a/usb-stick/run.sh
+++ b/usb-stick/run.sh
@@ -234,25 +234,32 @@ wifi_failover_seed() {
         if wget -qO- -T 2 "http://127.0.0.1:8090/info" >/dev/null 2>&1; then break; fi
         sleep 3; _fs_w=$((_fs_w + 3))
     done
-    # Positive evidence gate: any sign of an existing profile -> hands off.
+    # Positive evidence gate, in two halves. Any sign of an existing profile in
+    # ANY store bails: NetManager's DB, the BCO AirplayConfiguration.xml (a
+    # Wi-Fi-provisioned taigan/BCO box keeps its ONLY profile there while TAP
+    # still answers an empty <WiFiProfiles />, so skipping this check would
+    # have re-programmed a live association), and the TAP runtime view. Then
+    # the box must ADDITIONALLY say wifiProfileCount="0" itself - an explicit
+    # zero, not silence - before anything is written. Unreadable = hands off.
     _profile_xml="/mnt/nv/BoseApp-Persistence/1/NetworkProfiles.xml"
     if [ -s "$_profile_xml" ] && grep -q "<profile " "$_profile_xml" 2>/dev/null; then
         return 0
     fi
-    _fs_empty=""; _fs_src=""
+    _airplay_xml="/mnt/nv/BoseApp-Persistence/1/AirplayConfiguration.xml"
+    if [ -s "$_airplay_xml" ] && grep -q 'PersistentWifiProfile' "$_airplay_xml" 2>/dev/null \
+        && grep -q 'ssid="[^"]' "$_airplay_xml" 2>/dev/null; then
+        return 0
+    fi
     _fs_tap=$(printf 'network wifi profiles info\n' | nc -w 3 127.0.0.1 17000 2>/dev/null | tr '\n' ' ')
     case "$_fs_tap" in
         *"<profile "*|*"<profile>"*) return 0 ;;
-        *WiFiProfiles*) _fs_empty=1; _fs_src="tap" ;;
     esac
-    if [ -z "$_fs_empty" ]; then
-        _fs_ni=$(wget -qO- -T 3 "http://127.0.0.1:8090/networkInfo" 2>/dev/null | head -c 400)
-        case "$_fs_ni" in
-            *'wifiProfileCount="0"'*) _fs_empty=1; _fs_src="http" ;;
-            *'wifiProfileCount="'*) return 0 ;;
-        esac
-    fi
-    [ -n "$_fs_empty" ] || return 0
+    _fs_ni=$(wget -qO- -T 3 "http://127.0.0.1:8090/networkInfo" 2>/dev/null | head -c 400)
+    _fs_src="http"
+    case "$_fs_ni" in
+        *'wifiProfileCount="0"'*) ;;
+        *) return 0 ;;
+    esac
     setup_log "wifi failover seed: box online with NO stored Wi-Fi profile (src=$_fs_src) - seeding '$_fs_ssid' so a later cable pull can fail over (non-destructive)"
     if [ -z "$_fs_taigan" ]; then
         _fs_es=$(printf '%s' "$_fs_ssid" | sed -e 's/\&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&apos;/g")

--- a/usb-stick/run.sh
+++ b/usb-stick/run.sh
@@ -201,6 +201,75 @@ goform_wlan_push() {
     return 1
 }
 
+# wifi_failover_seed SSID PASS IS_TAIGAN
+# Non-destructive Wi-Fi failover seed for a box that is ONLINE without any
+# stored Wi-Fi profile - the LAN-cable-only box (live case 2026-08-18, scm
+# ST20: set up over ethernet, TAP `network wifi profiles info` answered an
+# empty <WiFiProfiles />, and pulling the cable left the box with nothing to
+# fall back to, blinking orange). The hands-off replay boot used to end
+# without ever giving such a box its Wi-Fi, even though NAND wlan-creds hold
+# the user's network; the M0a-prelease failover seed (same two steps, live
+# verified on the scm ST30 2026-07-09) only fires on app-apply or fresh-stick
+# boots, never on the everyday replay boot.
+#
+# Strictly gated on POSITIVE evidence that the box holds no Wi-Fi profile at
+# all: an empty profile store is simultaneously the proof that the current
+# lease is the cable (a box associated to Wi-Fi cannot have zero profiles) and
+# the proof that there is nothing to disturb. Silence from every probe means
+# hands off (the v0.9.7 rule stays intact for every provisioned box). The two
+# writes are the proven non-destructive pair: /addWirelessProfile (NetManager
+# DB entry; skipped on taigan where it silently fails) + goform_wlan_push
+# (programs the SMSC/JukeBlox coprocessor; no-ops where no :80 handler
+# answers). No teardown, no reboot, the working ethernet is untouched; the box
+# merely gains a network to fail over to when the cable goes. Post-state is
+# logged so the next diagnostic bundle proves whether the seed LANDED on this
+# chassis. Defined at top level (sibling-subshell scope trap).
+wifi_failover_seed() {
+    _fs_ssid="$1"; _fs_pass="$2"; _fs_taigan="$3"
+    [ -n "$_fs_ssid" ] || return 0
+    # Wait (bounded) for BoseApp :8090 - the hands-off branch can run before
+    # the Bose HTTP stack finishes coming up, same race M0a-refresh had.
+    _fs_w=0
+    while [ "$_fs_w" -lt 45 ]; do
+        if wget -qO- -T 2 "http://127.0.0.1:8090/info" >/dev/null 2>&1; then break; fi
+        sleep 3; _fs_w=$((_fs_w + 3))
+    done
+    # Positive evidence gate: any sign of an existing profile -> hands off.
+    _profile_xml="/mnt/nv/BoseApp-Persistence/1/NetworkProfiles.xml"
+    if [ -s "$_profile_xml" ] && grep -q "<profile " "$_profile_xml" 2>/dev/null; then
+        return 0
+    fi
+    _fs_empty=""; _fs_src=""
+    _fs_tap=$(printf 'network wifi profiles info\n' | nc -w 3 127.0.0.1 17000 2>/dev/null | tr '\n' ' ')
+    case "$_fs_tap" in
+        *"<profile "*|*"<profile>"*) return 0 ;;
+        *WiFiProfiles*) _fs_empty=1; _fs_src="tap" ;;
+    esac
+    if [ -z "$_fs_empty" ]; then
+        _fs_ni=$(wget -qO- -T 3 "http://127.0.0.1:8090/networkInfo" 2>/dev/null | head -c 400)
+        case "$_fs_ni" in
+            *'wifiProfileCount="0"'*) _fs_empty=1; _fs_src="http" ;;
+            *'wifiProfileCount="'*) return 0 ;;
+        esac
+    fi
+    [ -n "$_fs_empty" ] || return 0
+    setup_log "wifi failover seed: box online with NO stored Wi-Fi profile (src=$_fs_src) - seeding '$_fs_ssid' so a later cable pull can fail over (non-destructive)"
+    if [ -z "$_fs_taigan" ]; then
+        _fs_es=$(printf '%s' "$_fs_ssid" | sed -e 's/\&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&apos;/g")
+        _fs_ep=$(printf '%s' "$_fs_pass" | sed -e 's/\&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&apos;/g")
+        _fs_resp=$(wget -qO- -T 6 --header="Content-Type: text/xml" \
+            --post-data="<AddWirelessProfile timeout=\"5\"><profile ssid=\"$_fs_es\" password=\"$_fs_ep\" securityType=\"wpa_or_wpa2\" /></AddWirelessProfile>" \
+            "http://127.0.0.1:8090/addWirelessProfile" 2>&1)
+        setup_log "wifi failover seed: /addWirelessProfile rc=$? response='$(echo "$_fs_resp" | head -c 200)'"
+    fi
+    goform_wlan_push "$_fs_ssid" "$_fs_pass"
+    # Outcome evidence for the next bundle: did the profile land?
+    sleep 5
+    _fs_after=$(printf 'network wifi profiles info\n' | nc -w 3 127.0.0.1 17000 2>/dev/null | tr '\n' ' ' | head -c 200)
+    _fs_ni2=$(wget -qO- -T 3 "http://127.0.0.1:8090/networkInfo" 2>/dev/null | head -c 400 | sed -n 's/.*\(wifiProfileCount="[0-9]*"\).*/\1/p')
+    setup_log "wifi failover seed: post-state tap='$_fs_after' networkInfo=${_fs_ni2:-unreadable}"
+}
+
 # Earliest breadcrumb: prove run.sh actually started and stamp the box
 # fingerprint (kernel + Bose variant/firmware) up front, BEFORE the ~170 lines
 # of provisioning logic that could abort. A genuinely failed ST10 boot left a
@@ -1799,6 +1868,12 @@ if [ -n "$SSID" ] && [ -n "$PASS" ]; then
         *replay*)
             if wait_for_sta_lease 90; then
                 setup_log "hands-off: box came online by itself ($(current_sta_lease 2>/dev/null)) - no boot-time Wi-Fi provisioning (v0.9.7)"
+                # LAN-cable-only exception: a box that is online WITHOUT any
+                # stored Wi-Fi profile gets the known network seeded as a
+                # failover, non-destructively (see wifi_failover_seed). A
+                # provisioned box is untouched - the seed's first probe
+                # bails on any sign of an existing profile.
+                ( wifi_failover_seed "$SSID" "$PASS" "$IS_TAIGAN" ) &
             else
                 setup_log "hands-off: no lease after 90s - starting the pure-rescue goform watchdog (non-destructive re-push only, no profile writes)"
                 (


### PR DESCRIPTION
Root-caused from today's nine diagnostic bundles (five reporters). All five mechanisms were pinned from field evidence before fixing:

## Agent

- **Blind power toggle** (`boxcli`): the wake helper sent the `sys power` TOGGLE even when the state read failed. A fleet bundle caught it switching a playing zone master OFF 66 ms after its BoseApp froze. An unreadable state now never earns a toggle; regression test with a frozen `:8090` included.
- **boxapi client cap** (`boxapi`): the flat 6 s `http.Client.Timeout` silently overrode every longer context budget — the stereo `/addGroup` 20 s patience died at exactly 6 s in every bundle ever collected, hiding the firmware's real verdict (it decides after a fixed ~20 s). Deadlines now come from the context; a 6 s default applies only when the caller sets none.
- **Group change against a frozen leader** (`zones_stereo`): probe the leader before touching anything (fail fast with the previous group intact), stop swallowing the pre-change live-group read error (restore falls back to the stored document), poll the post-addGroup verify instead of reading 40 ms after a lost reply, log WHICH speakers a form adds, and record `:8090` outage episodes in a new `boseapp_health` debug section.
- **Foreign preset preservation** (`cmd/agent`): the box replaces its preset list with marge's cloud answer on every re-onboarding; STR's answer only contained STR slots, so Deezer/TuneIn/STORED_MUSIC buttons fell out (live case: Deezer slot 3 vanished after the user edited slot 2). The agent now persists the box-owned slots it did not write and serves them alongside its own, with a `foreign_presets` debug section. Unit tests cover classification, wipe protection, persistence and template escaping.

## App

- **Zone view on scm/BCO chassis**: firmware `/getGroup` hangs there, agents answered the zone read after ~6.0–6.1 s, and the app's 6 s client always lost the race — no non-ST10 speaker ever delivered a live zone (the "two screens disagree / Multiroom tab wipes the group display" family). Agent now isolates `/getGroup` on a 1.5 s sub-budget with a hang latch; app zone poll and bundle zone snapshot get 10 s so older agents land too; plus a v0.9.48 frontend type bug that made the MAIN badge impossible.
- **OTA endless loop on ancient agents**: pre-v0.9.26 agents OOM-die under the 16 MB engine push (growth-doubling ReadAll), and every update retry led with exactly that push. The pre-reboot engine staging is now version-gated; those boxes get the engine post-reboot via the new agent's streaming path.

Tests: full `go test ./...` green in both modules; ARM cross-build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-ups (same branch, after review of the drafts)

- **feat(agent): Wi-Fi failover seed for cable-only boxes** — a box online via ethernet with provably NO stored Wi-Fi profile (all three stores empty AND the box itself reports `wifiProfileCount="0"`) gets the known network seeded non-destructively at boot (NetManager DB + goform coprocessor push, no teardown, no reboot). Bernhard's LAN-only scm ST20 case. Tightened for BCO: a provisioned taigan keeps its only profile in AirplayConfiguration.xml while TAP answers empty — that store now counts as provisioned, so a live association can never be re-programmed.
- **feat(app): old-agent OTA over SSH** — pre-v0.9.26 agents now update via `/api/agent/enable-ssh` + the existing SSH streaming path instead of the HTTP push they cannot survive; falls through to the old behaviour on any failure. Ends the v0.9.14 endless loop without requiring the USB stick.