### PR TITLE
fix(app): engine-push stall watchdog checks progress rate; honest end-state row

### DIFF
--- a/desktop-app/frontend/src/i18n/bundles/ar.json
+++ b/desktop-app/frontend/src/i18n/bundles/ar.json
@@ -29,6 +29,7 @@
   "updateAll.phase.spotifyUnreachable": "مكبر الصوت لا يستجيب الآن، انتظار",
   "updateAll.phase.done": "تم",
   "updateAll.phase.deferred": "تم التحديث، Spotify لاحقًا",
+  "updateAll.phase.engineMissing": "تم التحديث، لكن Spotify لم يصل. أعد تشغيل التحديث فحسب.",
   "updateAll.phase.timeout": "يستغرق وقتاً أطول من المتوقع. إذا أطفأ الجهاز نفسه، أعد تشغيله وعادةً ما يكتمل التحديث.",
   "updateAll.phase.failed": "فشل",
   "locale.label": "العربية",

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -29,6 +29,7 @@
   "updateAll.phase.spotifyUnreachable": "Lautsprecher antwortet gerade nicht, warte",
   "updateAll.phase.done": "Fertig",
   "updateAll.phase.deferred": "Aktualisiert, Spotify folgt",
+  "updateAll.phase.engineMissing": "Aktualisiert, aber Spotify ist nicht angekommen. Starte das Update einfach noch einmal.",
   "updateAll.phase.timeout": "Dauert länger als erwartet. Falls sich die Anlage abgeschaltet hat, schalte sie wieder ein, dann läuft das Update meist durch.",
   "updateAll.phase.failed": "Fehlgeschlagen",
   "locale.label": "Deutsch",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -29,6 +29,7 @@
   "updateAll.phase.spotifyUnreachable": "Speaker is not answering right now, waiting",
   "updateAll.phase.done": "Done",
   "updateAll.phase.deferred": "Updated, Spotify follows",
+  "updateAll.phase.engineMissing": "Updated, but Spotify did not arrive. Run the update again to retry.",
   "updateAll.phase.timeout": "Taking longer than expected. If the speaker switched itself off, switch it on again and the update usually finishes.",
   "updateAll.phase.failed": "Failed",
   "locale.label": "English",

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -29,6 +29,7 @@
   "updateAll.phase.spotifyUnreachable": "El altavoz no responde ahora mismo, esperando",
   "updateAll.phase.done": "Listo",
   "updateAll.phase.deferred": "Actualizado, Spotify a continuación",
+  "updateAll.phase.engineMissing": "Actualizado, pero Spotify no llegó. Vuelve a iniciar la actualización.",
   "updateAll.phase.timeout": "Está tardando más de lo esperado. Si el equipo se apagó solo, vuelve a encenderlo y la actualización suele completarse.",
   "updateAll.phase.failed": "Error",
   "locale.label": "Español",

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -29,6 +29,7 @@
   "updateAll.phase.spotifyUnreachable": "L’enceinte ne répond pas pour l’instant, patience",
   "updateAll.phase.done": "Terminé",
   "updateAll.phase.deferred": "Mise à jour faite, Spotify suit",
+  "updateAll.phase.engineMissing": "Mis à jour, mais Spotify n'est pas arrivé. Relance simplement la mise à jour.",
   "updateAll.phase.timeout": "Plus long que prévu. Si l'appareil s'est éteint, rallumez-le et la mise à jour se termine généralement.",
   "updateAll.phase.failed": "Échec",
   "locale.label": "Français",

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -29,6 +29,7 @@
   "updateAll.phase.spotifyUnreachable": "スピーカーが応答しません。待機中",
   "updateAll.phase.done": "完了",
   "updateAll.phase.deferred": "更新済み、Spotify は後で",
+  "updateAll.phase.engineMissing": "更新されましたが、Spotifyが届きませんでした。もう一度アップデートを実行してください。",
   "updateAll.phase.timeout": "予想より時間がかかっています。本体の電源が切れた場合は、もう一度電源を入れると通常は更新が完了します。",
   "updateAll.phase.failed": "失敗",
   "locale.label": "日本語",

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -29,6 +29,7 @@
   "updateAll.phase.spotifyUnreachable": "Kolonėlė dabar neatsako, laukiama",
   "updateAll.phase.done": "Atlikta",
   "updateAll.phase.deferred": "Atnaujinta, Spotify netrukus",
+  "updateAll.phase.engineMissing": "Atnaujinta, bet „Spotify“ neatkeliavo. Tiesiog paleisk atnaujinimą dar kartą.",
   "updateAll.phase.timeout": "Trunka ilgiau nei tikėtasi. Jei įrenginys išsijungė, įjunkite jį vėl, tada atnaujinimas paprastai užbaigiamas.",
   "updateAll.phase.failed": "Nepavyko",
   "locale.label": "Lietuvių",

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -29,6 +29,7 @@
   "updateAll.phase.spotifyUnreachable": "Skaļrunis pašlaik neatbild, gaida",
   "updateAll.phase.done": "Pabeigts",
   "updateAll.phase.deferred": "Atjaunināts, Spotify sekos",
+  "updateAll.phase.engineMissing": "Atjaunināts, bet Spotify nepienāca. Vienkārši palaid atjauninājumu vēlreiz.",
   "updateAll.phase.timeout": "Aizņem ilgāk nekā gaidīts. Ja ierīce izslēdzās pati, ieslēdziet to atkal, un atjauninājums parasti pabeidzas.",
   "updateAll.phase.failed": "Neizdevās",
   "locale.label": "Latviešu",

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -29,6 +29,7 @@
   "updateAll.phase.spotifyUnreachable": "Luidspreker antwoordt nu niet, wachten",
   "updateAll.phase.done": "Klaar",
   "updateAll.phase.deferred": "Bijgewerkt, Spotify volgt",
+  "updateAll.phase.engineMissing": "Bijgewerkt, maar Spotify is niet aangekomen. Start de update gewoon opnieuw.",
   "updateAll.phase.timeout": "Duurt langer dan verwacht. Als het toestel zichzelf heeft uitgeschakeld, zet het weer aan, dan wordt de update meestal voltooid.",
   "updateAll.phase.failed": "Mislukt",
   "locale.label": "Nederlands",

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -29,6 +29,7 @@
   "updateAll.phase.spotifyUnreachable": "Głośnik teraz nie odpowiada, czekam",
   "updateAll.phase.done": "Gotowe",
   "updateAll.phase.deferred": "Zaktualizowano, Spotify wkrótce",
+  "updateAll.phase.engineMissing": "Zaktualizowano, ale Spotify nie dotarł. Po prostu uruchom aktualizację ponownie.",
   "updateAll.phase.timeout": "Trwa dłużej niż zwykle. Jeśli urządzenie samo się wyłączyło, włącz je ponownie, wtedy aktualizacja zwykle się kończy.",
   "updateAll.phase.failed": "Niepowodzenie",
   "locale.label": "Polski",

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -29,6 +29,7 @@
   "updateAll.phase.spotifyUnreachable": "Hoparlör şu anda yanıt vermiyor, bekleniyor",
   "updateAll.phase.done": "Tamam",
   "updateAll.phase.deferred": "Güncellendi, Spotify birazdan",
+  "updateAll.phase.engineMissing": "Güncellendi ama Spotify gelmedi. Güncellemeyi yeniden başlatman yeterli.",
   "updateAll.phase.timeout": "Beklenenden uzun sürüyor. Cihaz kendini kapattıysa tekrar açın, güncelleme genelde o zaman tamamlanır.",
   "updateAll.phase.failed": "Başarısız",
   "locale.label": "Türkçe",

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -29,6 +29,7 @@
   "updateAll.phase.spotifyUnreachable": "Колонка зараз не відповідає, чекаю",
   "updateAll.phase.done": "Готово",
   "updateAll.phase.deferred": "Оновлено, Spotify далі",
+  "updateAll.phase.engineMissing": "Оновлено, але Spotify не надійшов. Просто запусти оновлення ще раз.",
   "updateAll.phase.timeout": "Триває довше, ніж очікувалося. Якщо пристрій вимкнувся сам, увімкніть його знову, і оновлення зазвичай завершується.",
   "updateAll.phase.failed": "Помилка",
   "locale.label": "Українська",

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -4151,7 +4151,7 @@ async function updateAllBoxes() {
         } catch { /* still settling: trust the delivery */ }
         outcome = stillMissing ? 'partial' : 'done';
         if (stillMissing) {
-          setRow(b.host, { phaseText: t('updateAll.phase.deferred'), pct: 100, barClass: 'ua-defer' });
+          setRow(b.host, { phaseText: t('updateAll.phase.engineMissing'), pct: 100, barClass: 'ua-defer' });
         } else {
           setRow(b.host, { phaseText: t('updateAll.phase.engineDone'), pct: 100, barClass: 'ua-done' });
           try { ClearUpdateIntent(b.host, b.port); } catch {}
@@ -4219,7 +4219,7 @@ async function updateAllBoxes() {
       if (outcome !== 'failed' && (b.model || '').includes('300')) {
         setRow(b.host, { phaseText: t('update.st300PowerCycle'), pct: 100, barClass: 'ua-defer' });
       } else if (outcome === 'done') setRow(b.host, { phaseText: t('updateAll.phase.done'), pct: 100, barClass: 'ua-done' });
-      else if (outcome === 'partial') setRow(b.host, { phaseText: t('updateAll.phase.deferred'), pct: 100, barClass: 'ua-defer' });
+      else if (outcome === 'partial') setRow(b.host, { phaseText: t('updateAll.phase.engineMissing'), pct: 100, barClass: 'ua-defer' });
       else setRow(b.host, { phaseText: t('updateAll.phase.timeout'), barClass: 'ua-defer' });
     } catch (e) {
       outcome = 'failed';

--- a/desktop-app/ota.go
+++ b/desktop-app/ota.go
@@ -23,6 +23,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/JRpersonal/streborn/sticksetup"
@@ -1090,11 +1091,14 @@ func (a *App) streamPostBinary(host string, port int, path string, bin []byte) (
 	// percentage and live throughput (the box reads the body as we send it),
 	// instead of a blind "uploading" spinner that looks frozen on a slow link.
 	prog := newTransferProgress(a, "box:update:progress", total, host)
-	beat := make(chan struct{}, 1)
 	uploadDone := make(chan struct{})
 	finished := false
+	// transferred feeds the stall watchdog below with the cumulative byte
+	// count the HTTP transport has consumed.
+	var transferred atomic.Int64
 	body := &countingReader{r: bytes.NewReader(bin), onProgress: func(n int64) {
 		prog.report(n)
+		transferred.Store(n)
 		if n >= total {
 			// Body fully streamed. Stop the upload-stall watchdog so the box's
 			// NAND-write + reply window (bounded by ResponseHeaderTimeout) is not
@@ -1104,11 +1108,6 @@ func (a *App) streamPostBinary(host string, port int, path string, bin []byte) (
 				finished = true
 				close(uploadDone)
 			}
-			return
-		}
-		select {
-		case beat <- struct{}{}:
-		default:
 		}
 	}}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
@@ -1118,29 +1117,33 @@ func (a *App) streamPostBinary(host string, port int, path string, bin []byte) (
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.ContentLength = total
 
-	// Upload-stall watchdog: cancel only if no bytes move for 60 s while the body
-	// is still being sent. Exits cleanly once the upload completes or the context
-	// is done, so it never trips during the post-upload NAND write.
+	// Upload-stall watchdog. Two shapes of a dead transfer, both paid for:
+	// total silence, and the TRICKLE - a Wi-Fi black hole where the OS keeps
+	// retransmitting a few bytes at a time, so a beat-reset watchdog is fed
+	// forever while nothing real moves (field 2026-08-19: an engine push sat
+	// 15 minutes at 12.6 of 16.5 MB until macOS's own TCP give-up surfaced as
+	// a broken pipe; the speaker had aborted 12 minutes earlier). The check is
+	// therefore a progress RATE: every 30 s the transferred count must have
+	// grown by a real amount, or the transfer is dead and waiting helps nobody.
 	go func() {
-		t := time.NewTimer(60 * time.Second)
+		const window = 30 * time.Second
+		const minProgress = 64 * 1024 // bytes per window; any live link beats this
+		t := time.NewTicker(window)
 		defer t.Stop()
+		last := int64(0)
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-uploadDone:
 				return
-			case <-beat:
-				if !t.Stop() {
-					select {
-					case <-t.C:
-					default:
-					}
-				}
-				t.Reset(60 * time.Second)
 			case <-t.C:
-				cancel()
-				return
+				cur := transferred.Load()
+				if cur-last < minProgress {
+					cancel()
+					return
+				}
+				last = cur
 			}
 		}
 	}()


### PR DESCRIPTION
From shorty310's #597 bundle and deqw's #645:

- The upload stall watchdog reset on ANY byte, so a Wi-Fi black hole with TCP retransmission trickle fed it forever: one hung engine push consumed the whole 10-minute retry window (15 min until macOS's own TCP give-up), no retry ever ran, and the speaker stayed engine-less behind a perpetual "Updated, Spotify follows". The watchdog now requires 64 KB of progress per 30 s window.
- Because the dialog's close button is (deliberately) disabled while a write is in flight, the endless hang also trapped the user in the dialog (#645); with the watchdog the busy state ends within a minute.
- The batch update's terminal partial row now says "Updated, but Spotify did not arrive. Run the update again to retry." instead of the misleading "Spotify follows" (nothing follows on its own since #506), in all twelve languages.

Tests: frontend 116/116, desktop-app Go suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)