### PR TITLE
fix(speaker): the previous radio song no longer sits under a NAS track

### DIFF
--- a/internal/streamproxy/icy.go
+++ b/internal/streamproxy/icy.go
@@ -60,6 +60,23 @@ func (s *Server) clearTitleForNewURL(url string) {
 	s.titleMu.Unlock()
 }
 
+// clearTitleOnEnd drops the title when the proxy stops carrying url. Without
+// it CurrentTitle kept reporting the LAST stream's song forever, and a client
+// that cannot tell radio-via-proxy from other playback showed it under
+// whatever came next: the phone remote's source gate cured the line inputs,
+// but a NAS track plays over the same UPnP source as proxied radio, so the
+// old radio song sat under it (SA-5, #274, still with v0.9.52). Guarded by
+// URL so a handler that outlived a station switch cannot wipe the successor's
+// title; curTitleURL stays, so a plain reconnect refills on the next metadata
+// block instead of blanking through the flap.
+func (s *Server) clearTitleOnEnd(url string) {
+	s.titleMu.Lock()
+	if url == s.curTitleURL {
+		s.curTitle = ""
+	}
+	s.titleMu.Unlock()
+}
+
 // icyConn wraps a net.Conn so a legacy SHOUTcast "ICY 200 OK" response line is
 // rewritten to "HTTP/1.0 200 OK" on the first read, letting Go's net/http parse
 // the response instead of rejecting it. All bytes after the status line (headers,

--- a/internal/streamproxy/streamproxy.go
+++ b/internal/streamproxy/streamproxy.go
@@ -253,6 +253,7 @@ func (s *Server) handleRaw(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.logger.Info("stream proxy raw start", "url", url)
+	defer s.clearTitleOnEnd(url)
 	start := time.Now()
 	s.resetAudioGap()
 	headersSent := false
@@ -350,6 +351,8 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+
+	defer s.clearTitleOnEnd(p.StreamURL)
 
 	// We do exactly one GET to the CDN and copy bytes to Bose. When the CDN
 	// returns EOF (token expiry), we reconnect internally and keep streaming —

--- a/internal/streamproxy/title_end_test.go
+++ b/internal/streamproxy/title_end_test.go
@@ -1,0 +1,56 @@
+package streamproxy
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+)
+
+// The proxy's CurrentTitle must go empty once the proxy stops carrying the
+// stream. It used to report the LAST stream's song forever, and a client that
+// cannot tell radio-via-proxy from other playback showed it under whatever
+// came next: a NAS track plays over the same UPnP source as proxied radio, so
+// the old radio song sat under it (SA-5, #274, still with v0.9.52).
+
+func newTitleServer() *Server {
+	return &Server{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+}
+
+func TestClearTitleOnEndDropsTheServedStreamsTitle(t *testing.T) {
+	s := newTitleServer()
+	s.setTitle("http://radio/a", "The Beatles - Help!")
+	s.clearTitleOnEnd("http://radio/a")
+	if got := s.CurrentTitle(); got != "" {
+		t.Fatalf("title after the stream ended = %q, want empty", got)
+	}
+}
+
+func TestClearTitleOnEndLeavesASuccessorAlone(t *testing.T) {
+	s := newTitleServer()
+	s.setTitle("http://radio/a", "Old Song")
+	// The box switched stations: the new handler already owns the title.
+	s.clearTitleForNewURL("http://radio/b")
+	s.setTitle("http://radio/b", "New Song")
+	// The OLD handler returns late; it must not wipe the successor.
+	s.clearTitleOnEnd("http://radio/a")
+	if got := s.CurrentTitle(); got != "New Song" {
+		t.Fatalf("title = %q, want the successor's %q", got, "New Song")
+	}
+}
+
+func TestReconnectSameURLRefillsAfterEndClear(t *testing.T) {
+	s := newTitleServer()
+	s.setTitle("http://radio/a", "Song One")
+	s.clearTitleOnEnd("http://radio/a")
+	// Box re-fetches the same stream (flap): the URL is unchanged, so the
+	// pre-metadata window shows nothing rather than a stale song, and the
+	// next metadata block refills.
+	s.clearTitleForNewURL("http://radio/a")
+	if got := s.CurrentTitle(); got != "" {
+		t.Fatalf("title in the pre-metadata window = %q, want empty", got)
+	}
+	s.setTitle("http://radio/a", "Song Two")
+	if got := s.CurrentTitle(); got != "Song Two" {
+		t.Fatalf("title after refill = %q, want %q", got, "Song Two")
+	}
+}


### PR DESCRIPTION
The stream proxy kept reporting the last carried stream's ICY title forever; the remote's source gate (#274 first round) cured AUX/Bluetooth but not NAS tracks, which play over the same UPnP source as proxied radio. The proxy now clears its title when it stops serving the stream (URL-guarded against late handlers, reconnects refill on the next metadata block). Unit tests for the three lifecycle cases.

Refs #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)