### PR TITLE
fix(presets): a station name with quotes no longer leaves the preset key empty

### DIFF
--- a/desktop-app/update_app.go
+++ b/desktop-app/update_app.go
@@ -451,7 +451,10 @@ func (a *App) ApplyUpdate(downloadedPath string) error {
 		// nicety: it is what makes the swap safe to ship, since every refusal
 		// (running from the DMG, an unwritable folder, a signature that does not
 		// verify) lands the user exactly where they were before.
-		if err := a.applyDarwin(downloadedPath); err != nil {
+		// The non-darwin stub of applyDarwin always errors, which makes this
+		// comparison "always true" to a linter running on Linux; on macOS
+		// builds it is a real branch.
+		if err := a.applyDarwin(downloadedPath); err != nil { //nolint:staticcheck // SA4023: false positive from the cross-platform stub
 			a.logger.Info("macOS in-place update not possible, falling back to the assisted install", "reason", err)
 			return a.RevealUpdateFile(downloadedPath)
 		}

--- a/internal/boxcli/boxcli.go
+++ b/internal/boxcli/boxcli.go
@@ -246,6 +246,21 @@ func PresetKey(ctx context.Context, host string, slot int, mode string) error {
 	return err
 }
 
+// tapLabel makes a preset name safe as a quoted TAP CLI argument. The
+// tokeniser splits on the label's OWN quotes, so a station name like
+// `CFSM 107.5 "2Day FM"` turns the command into too many arguments and the
+// box stores nothing while the socket reports success (#654). Newlines end
+// the command line early, same effect. A label that cleans down to nothing
+// gets the fallback, because an empty `""` is collapsed by the tokeniser
+// and shifts every following argument.
+func tapLabel(name, fallback string) string {
+	name = strings.NewReplacer("\"", "", "\n", " ", "\r", " ").Replace(name)
+	if name = strings.TrimSpace(name); name == "" {
+		return fallback
+	}
+	return name
+}
+
 // AddPreset stores a preset on the box so the hardware keys can trigger
 // a `nowSelectionUpdated` event with the ContentItem. We set all presets
 // as a UPNP source because that is what the box is most likely to accept
@@ -258,7 +273,7 @@ func AddPreset(ctx context.Context, host string, slot int, name, streamURL strin
 	// LABEL must be in quotes, otherwise the box splits it at the space.
 	// LOCATION should have no quotes.
 	cmd := fmt.Sprintf(`ws AddPreset UPNP audio %s "%s" UPnPUserName %d`,
-		streamURL, name, slot)
+		streamURL, tapLabel(name, fmt.Sprintf("Preset %d", slot)), slot)
 	_, err := Send(ctx, host, cmd)
 	return err
 }
@@ -276,7 +291,7 @@ func AddPresetRaw(ctx context.Context, host string, slot int, source, typ, locat
 	typ = clean(typ)
 	location = clean(location)
 	account = clean(account)
-	name = clean(name)
+	name = tapLabel(name, fmt.Sprintf("Preset %d", slot))
 	if source == "" || location == "" || slot < 1 || slot > 6 {
 		return fmt.Errorf("AddPresetRaw: source, location and slot 1..6 required")
 	}
@@ -338,7 +353,7 @@ func AddPresetNative(ctx context.Context, host string, slot int, name, location 
 	// (2026-08-02): "none" occupies the argument and the firmware stores
 	// sourceAccount="" from it, which is exactly the shape that plays.
 	cmd := fmt.Sprintf(`ws AddPreset LOCAL_INTERNET_RADIO stationurl %s "%s" none %d`,
-		location, name, slot)
+		location, tapLabel(name, fmt.Sprintf("Preset %d", slot)), slot)
 	out, err := Send(ctx, host, cmd)
 	if err != nil {
 		return err

--- a/internal/boxcli/boxcli_test.go
+++ b/internal/boxcli/boxcli_test.go
@@ -138,3 +138,24 @@ func TestWakeAndWaitTogglesWhenAsleep(t *testing.T) {
 		t.Fatalf("WakeAndWait sent %d `sys power` toggle(s) to an asleep box; want >=1", n)
 	}
 }
+
+// TestTapLabel covers the names that broke TAP tokenisation in the field:
+// quotes inside a station name shifted the argument boundaries so the box
+// stored nothing while reporting success (#654, `CFSM 107.5 "2Day FM"`).
+func TestTapLabel(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{`CFSM 107.5 "2Day FM" Cranbrook, BC`, `CFSM 107.5 2Day FM Cranbrook, BC`},
+		{"Line\nBreak\rName", "Line Break Name"},
+		{"  plain name  ", "plain name"},
+		{`"`, "Preset 3"},
+		{"", "Preset 3"},
+		{"   ", "Preset 3"},
+	}
+	for _, c := range cases {
+		if got := tapLabel(c.in, "Preset 3"); got != c.want {
+			t.Errorf("tapLabel(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
A double quote inside a station name (reported in #654 with `CFSM 107.5 "2Day FM" Cranbrook, BC`) split the TAP `ws AddPreset` command at the name's own quotes. The box stored nothing while the socket reported success, the native-preset latch tripped after three sweeps (`slots [3] stayed empty after a native write`), and the UPnP restore of the same slot failed on the same tokenisation, so the hardware key stayed truly empty ("Preset 3 is Open").

`AddPresetRaw` already sanitised its inputs for exactly this reason; `AddPreset` and `AddPresetNative` did not. This adds a shared `tapLabel` helper (strip quotes, fold newlines, trim) used by all three, with a `Preset N` fallback when a name cleans down to nothing, because an empty `""` argument is collapsed by the TAP tokeniser and shifts every following argument.

The latch is in-memory per run, so the agent restart that comes with the speaker update clears it and the next reconcile writes the slot natively.

Refs #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)