### PR TITLE
refactor: top 5 payoff-per-effort cleanups from the 2026-08-20 review

### DIFF
--- a/cmd/agent/boxprobe.go
+++ b/cmd/agent/boxprobe.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"regexp"
 	"strings"
 	"time"
 
@@ -28,6 +27,43 @@ func firstAttr(doc, name string) string {
 		return rest[:j]
 	}
 	return ""
+}
+
+// firstElem extracts the first simple element's text (e.g. <itemName>X</itemName>)
+// from a now_playing document. Empty if absent.
+func firstElem(doc, name string) string {
+	key := "<" + name + ">"
+	i := strings.Index(doc, key)
+	if i < 0 {
+		return ""
+	}
+	rest := doc[i+len(key):]
+	if j := strings.IndexByte(rest, '<'); j >= 0 {
+		return rest[:j]
+	}
+	return ""
+}
+
+// probeClient is shared by every now_playing probe. Some of them sit on
+// 10-second reconcile cadences, so the client (and its connection pool) is
+// allocated once instead of per call.
+var probeClient = &http.Client{Timeout: 4 * time.Second}
+
+// fetchNowPlaying reads the box's :8090/now_playing document once. Every
+// probe below is a pure verdict over this document, so each stays testable
+// against canned XML without hardware or a fixed :8090 listener. ok is false
+// on any transport error, which every verdict maps to its zero value.
+func fetchNowPlaying(boxHost string) (doc string, ok bool) {
+	if boxHost == "" {
+		boxHost = "127.0.0.1"
+	}
+	resp, err := probeClient.Get("http://" + boxHost + ":8090/now_playing")
+	if err != nil {
+		return "", false
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+	return string(b), true
 }
 
 // boxInSetupOOB reports whether BoseApp's /setup says the box is still
@@ -58,21 +94,11 @@ func lastN(s string, n int) string {
 // boxNowPlayingSource returns the source attribute of the box's now_playing
 // (e.g. "SETUP", "STANDBY", "UPNP", "INVALID_SOURCE"), or "" on any error.
 func boxNowPlayingSource(boxHost string) string {
-	if boxHost == "" {
-		boxHost = "127.0.0.1"
-	}
-	cl := &http.Client{Timeout: 4 * time.Second}
-	resp, err := cl.Get("http://" + boxHost + ":8090/now_playing")
-	if err != nil {
+	doc, ok := fetchNowPlaying(boxHost)
+	if !ok {
 		return ""
 	}
-	defer resp.Body.Close()
-	b, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
-	m := regexp.MustCompile(`source="([^"]*)"`).FindSubmatch(b)
-	if len(m) == 2 {
-		return string(m[1])
-	}
-	return ""
+	return firstAttr(doc, "source")
 }
 
 // leaveSetupSourceWatcher clears a stuck out-of-box SETUP source so the box can
@@ -140,18 +166,14 @@ func leaveSetupSourceWatcher(ctx context.Context, boxHost string, logger *slog.L
 // source), so the memory guard never reboots mid-playback. Best-effort: any
 // error or a non-play state counts as not playing.
 func boxIsPlaying(boxHost string) bool {
-	if boxHost == "" {
-		boxHost = "127.0.0.1"
-	}
-	cl := &http.Client{Timeout: 4 * time.Second}
-	resp, err := cl.Get("http://" + boxHost + ":8090/now_playing")
-	if err != nil {
-		return false
-	}
-	defer resp.Body.Close()
-	b, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
-	s := string(b)
-	return strings.Contains(s, "PLAY_STATE") || strings.Contains(s, "BUFFERING_STATE")
+	doc, ok := fetchNowPlaying(boxHost)
+	return ok && nowPlayingIsPlaying(doc)
+}
+
+// nowPlayingIsPlaying is boxIsPlaying's verdict over an already-fetched
+// now_playing document: a play or buffering state on any source.
+func nowPlayingIsPlaying(doc string) bool {
+	return strings.Contains(doc, "PLAY_STATE") || strings.Contains(doc, "BUFFERING_STATE")
 }
 
 // boxNowPlayingSummary returns compact now_playing evidence for the recall
@@ -162,27 +184,17 @@ func boxIsPlaying(boxHost string) bool {
 // #469/Wave 2026-07-25), and whether a verify success was the box's stale
 // same-slot ContentItem rather than a real fetch (#419 Finding 1).
 func boxNowPlayingSummary(boxHost string) (source, itemName, playStatus string) {
-	if boxHost == "" {
-		boxHost = "127.0.0.1"
-	}
-	cl := &http.Client{Timeout: 4 * time.Second}
-	resp, err := cl.Get("http://" + boxHost + ":8090/now_playing")
-	if err != nil {
+	doc, ok := fetchNowPlaying(boxHost)
+	if !ok {
 		return "", "", ""
 	}
-	defer resp.Body.Close()
-	b, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
-	s := string(b)
-	if m := regexp.MustCompile(`source="([^"]*)"`).FindStringSubmatch(s); len(m) == 2 {
-		source = m[1]
-	}
-	if m := regexp.MustCompile(`<itemName>([^<]*)</itemName>`).FindStringSubmatch(s); len(m) == 2 {
-		itemName = m[1]
-	}
-	if m := regexp.MustCompile(`<playStatus>([^<]*)</playStatus>`).FindStringSubmatch(s); len(m) == 2 {
-		playStatus = m[1]
-	}
-	return source, itemName, playStatus
+	return nowPlayingSummary(doc)
+}
+
+// nowPlayingSummary is boxNowPlayingSummary's verdict over an already-fetched
+// now_playing document.
+func nowPlayingSummary(doc string) (source, itemName, playStatus string) {
+	return firstAttr(doc, "source"), firstElem(doc, "itemName"), firstElem(doc, "playStatus")
 }
 
 // nudgeStuckSource is the sys-power-nudge decision: the box still reports
@@ -207,17 +219,8 @@ func nudgeStuckSource(attempt int, nudged bool, source string) bool {
 // location at all falls back to the plain play-state verdict, so a model that
 // simply does not report a location does not end up in an endless re-push loop.
 func boxPlayingURL(boxHost, wantURL string) bool {
-	if boxHost == "" {
-		boxHost = "127.0.0.1"
-	}
-	cl := &http.Client{Timeout: 4 * time.Second}
-	resp, err := cl.Get("http://" + boxHost + ":8090/now_playing")
-	if err != nil {
-		return false
-	}
-	defer resp.Body.Close()
-	b, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
-	return nowPlayingIsURL(string(b), wantURL)
+	doc, ok := fetchNowPlaying(boxHost)
+	return ok && nowPlayingIsURL(doc, wantURL)
 }
 
 // nowPlayingIsURL is boxPlayingURL's verdict over an already-fetched
@@ -259,21 +262,14 @@ func streamPath(u string) string {
 // playing Spotify, and re-pointing on that flap re-attaches the box and
 // restarts the track. The now_playing location tells the two apart.
 func boxPlayingSpotify(boxHost string) bool {
-	if boxHost == "" {
-		boxHost = "127.0.0.1"
-	}
-	cl := &http.Client{Timeout: 4 * time.Second}
-	resp, err := cl.Get("http://" + boxHost + ":8090/now_playing")
-	if err != nil {
-		return false
-	}
-	defer resp.Body.Close()
-	b, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
-	s := string(b)
-	if !strings.Contains(s, "spotify/stream") {
-		return false
-	}
-	return strings.Contains(s, "PLAY_STATE") || strings.Contains(s, "BUFFERING_STATE")
+	doc, ok := fetchNowPlaying(boxHost)
+	return ok && nowPlayingIsSpotify(doc)
+}
+
+// nowPlayingIsSpotify is boxPlayingSpotify's verdict over an already-fetched
+// now_playing document: STR's Spotify stream in a play or buffering state.
+func nowPlayingIsSpotify(doc string) bool {
+	return strings.Contains(doc, "spotify/stream") && nowPlayingIsPlaying(doc)
 }
 
 // boxReallyPlayingSpotify is the strict form of boxPlayingSpotify: the box is on
@@ -282,16 +278,13 @@ func boxPlayingSpotify(boxHost string) bool {
 // a box that has genuinely started playing after a transient 1036 wrong-state flap
 // on a preset->preset switch.
 func boxReallyPlayingSpotify(boxHost string) bool {
-	if boxHost == "" {
-		boxHost = "127.0.0.1"
-	}
-	cl := &http.Client{Timeout: 4 * time.Second}
-	resp, err := cl.Get("http://" + boxHost + ":8090/now_playing")
-	if err != nil {
-		return false
-	}
-	defer resp.Body.Close()
-	b, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
-	s := string(b)
-	return strings.Contains(s, "spotify/stream") && strings.Contains(s, "PLAY_STATE")
+	doc, ok := fetchNowPlaying(boxHost)
+	return ok && nowPlayingReallySpotify(doc)
+}
+
+// nowPlayingReallySpotify is boxReallyPlayingSpotify's verdict over an
+// already-fetched now_playing document: the Spotify stream in PLAY_STATE
+// proper, not merely BUFFERING.
+func nowPlayingReallySpotify(doc string) bool {
+	return strings.Contains(doc, "spotify/stream") && strings.Contains(doc, "PLAY_STATE")
 }

--- a/cmd/agent/boxprobe_verdict_test.go
+++ b/cmd/agent/boxprobe_verdict_test.go
@@ -1,0 +1,51 @@
+package main
+
+import "testing"
+
+// A trimmed but shape-faithful now_playing document as the firmware emits it.
+const sampleNowPlaying = `<?xml version="1.0" encoding="UTF-8" ?>
+<nowPlaying deviceID="device-id-here" source="LOCAL_INTERNET_RADIO" sourceAccount="">
+  <ContentItem source="LOCAL_INTERNET_RADIO" location="/station?data=abc" sourceAccount="" isPresetable="true">
+    <itemName>Radio Paradise</itemName>
+  </ContentItem>
+  <playStatus>PLAY_STATE</playStatus>
+</nowPlaying>`
+
+const sampleStandby = `<nowPlaying deviceID="device-id-here" source="STANDBY">
+  <playStatus>STOP_STATE</playStatus>
+</nowPlaying>`
+
+const sampleSpotifyBuffering = `<nowPlaying source="UPNP">
+  <ContentItem source="UPNP" location="http://127.0.0.1:8888/spotify/stream"></ContentItem>
+  <playStatus>BUFFERING_STATE</playStatus>
+</nowPlaying>`
+
+func TestNowPlayingVerdicts(t *testing.T) {
+	if got := firstAttr(sampleNowPlaying, "source"); got != "LOCAL_INTERNET_RADIO" {
+		t.Errorf("firstAttr source = %q", got)
+	}
+	src, item, status := nowPlayingSummary(sampleNowPlaying)
+	if src != "LOCAL_INTERNET_RADIO" || item != "Radio Paradise" || status != "PLAY_STATE" {
+		t.Errorf("nowPlayingSummary = %q, %q, %q", src, item, status)
+	}
+	if !nowPlayingIsPlaying(sampleNowPlaying) {
+		t.Error("nowPlayingIsPlaying(sample) = false")
+	}
+	if nowPlayingIsPlaying(sampleStandby) {
+		t.Error("nowPlayingIsPlaying(standby) = true")
+	}
+	if src, item, status := nowPlayingSummary(sampleStandby); src != "STANDBY" || item != "" || status != "STOP_STATE" {
+		t.Errorf("nowPlayingSummary(standby) = %q, %q, %q", src, item, status)
+	}
+	if !nowPlayingIsSpotify(sampleSpotifyBuffering) {
+		t.Error("nowPlayingIsSpotify(buffering) = false")
+	}
+	// The strict form refuses BUFFERING: re-pointing a box that is merely
+	// buffering restarts the track.
+	if nowPlayingReallySpotify(sampleSpotifyBuffering) {
+		t.Error("nowPlayingReallySpotify(buffering) = true")
+	}
+	if nowPlayingIsSpotify(sampleNowPlaying) {
+		t.Error("nowPlayingIsSpotify(radio) = true")
+	}
+}

--- a/desktop-app/boxssh.go
+++ b/desktop-app/boxssh.go
@@ -302,34 +302,9 @@ func runSSHWithFlagsStdin(flags []string, host, cmd string, in io.Reader, timeou
 	// bytes have been consumed for `timeout`.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	beat := make(chan struct{}, 1)
-	in = &countingReader{r: in, onProgress: func(int64) {
-		select {
-		case beat <- struct{}{}:
-		default:
-		}
-	}}
-	go func() {
-		t := time.NewTimer(timeout)
-		defer t.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-beat:
-				if !t.Stop() {
-					select {
-					case <-t.C:
-					default:
-					}
-				}
-				t.Reset(timeout)
-			case <-t.C:
-				cancel()
-				return
-			}
-		}
-	}()
+	var beat <-chan struct{}
+	in, beat = beatingReader(in)
+	go watchStall(ctx, cancel, beat, timeout)
 	args := append(append([]string{}, flags...), "root@"+host, cmd)
 	c := exec.CommandContext(ctx, "ssh", args...)
 	hideCmdWindow(c)
@@ -717,33 +692,19 @@ func runNativeSession(sess *ssh.Session, cmd string, stdin io.Reader, timeout ti
 		// data (ssh flow control), so a beat tracks real upload throughput; a real
 		// freeze stops the beats and trips the timer. A short command (stdin == nil)
 		// keeps the total timeout below.
-		beat := make(chan struct{}, 1)
-		sess.Stdin = &countingReader{r: stdin, onProgress: func(int64) {
-			select {
-			case beat <- struct{}{}:
-			default:
-			}
-		}}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		src, beat := beatingReader(stdin)
+		sess.Stdin = src
 		go func() { out, e := sess.CombinedOutput(cmd); ch <- res{out, e} }()
-		t := time.NewTimer(timeout)
-		defer t.Stop()
-		for {
-			select {
-			case r := <-ch:
-				return string(r.out), r.err
-			case <-beat:
-				if !t.Stop() {
-					select {
-					case <-t.C:
-					default:
-					}
-				}
-				t.Reset(timeout)
-			case <-t.C:
-				_ = sess.Signal(ssh.SIGKILL)
-				_ = sess.Close()
-				return "", fmt.Errorf("ssh native upload stalled (no progress for %s)", timeout)
-			}
+		go watchStall(ctx, cancel, beat, timeout)
+		select {
+		case r := <-ch:
+			return string(r.out), r.err
+		case <-ctx.Done():
+			_ = sess.Signal(ssh.SIGKILL)
+			_ = sess.Close()
+			return "", fmt.Errorf("ssh native upload stalled (no progress for %s)", timeout)
 		}
 	}
 	go func() { out, e := sess.CombinedOutput(cmd); ch <- res{out, e} }()

--- a/desktop-app/frontend/src/api.js
+++ b/desktop-app/frontend/src/api.js
@@ -199,3 +199,40 @@ export function boxURL(box, path) {
   if (!box) return '';
   return `http://${box.host}:${box.port}${path}`;
 }
+
+// boxFetch is a self-healing fetch for the agent's plain-HTTP endpoints
+// (region, radio search/tags/languages, stick status, WLAN). Unlike the Go
+// bindings it cannot reuse boxDo, so it replicates the same resilience in
+// JS: a hard timeout, so a flaky port can never hang the UI forever (the
+// "region keeps loading" bug on BCO boxes), plus a :8888 <-> :17008
+// failover for BCO speakers where only one of the two answers. The first
+// reachable port is remembered on the box so later calls go straight to it.
+export async function boxFetch(box, path, opts = {}, timeoutMs = 8000) {
+  if (!box) throw new Error('no box');
+  const ports = [...new Set([box.port, 17008, 8888].filter(Boolean))];
+  let lastErr;
+  for (const p of ports) {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      const r = await fetch(`http://${box.host}:${p}${path}`, { ...opts, signal: ctrl.signal });
+      clearTimeout(timer);
+      if (p !== box.port) box.port = p; // remember the reachable port
+      return r;
+    } catch (e) {
+      clearTimeout(timer);
+      lastErr = e;
+    }
+  }
+  throw lastErr || new Error('box unreachable');
+}
+
+// readBoxBalance reads a speaker's stereo balance, or null when the speaker
+// does not report one or cannot be asked right now.
+export async function readBoxBalance(box) {
+  try {
+    const r = await boxFetch(box, '/api/box/balance');
+    const b = await r.json();
+    return (b && b.available) ? (Number(b.actual) || 0) : null;
+  } catch { return null; /* asleep or unreachable: show nothing rather than an error */ }
+}

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -113,6 +113,8 @@ import {
   DissolveZone,
   WakeBox,
   EventsOn,
+  boxFetch,
+  readBoxBalance,
 } from './api.js';
 
 // Global frontend crash capture, registered as early as possible.
@@ -202,6 +204,7 @@ import {
   activeSlotFromLocation,
   orionStationPayload,
   clearNoticeDismissal,
+  balanceLabel,
 } from './utils.js';
 
 // Group membership (who follows master X) and the shared zoneLive poll live
@@ -356,7 +359,7 @@ function openSpeakerSettings(box) {
   switchView('settings');
 }
 
-initMultiroomView({ boxNeedsUpdate, discoverBoxes, selectBox, boxFetch, switchView, openSpeakerSettings });
+initMultiroomView({ boxNeedsUpdate, discoverBoxes, selectBox, switchView, openSpeakerSettings });
 initSpotifyView({
   switchView,
   // Live STR speaker list for the "sync Spotify login to all speakers" action.
@@ -364,9 +367,9 @@ initSpotifyView({
     .filter(b => b && b.kind !== 'stock' && b.deviceID && b.host)
     .map(b => ({ host: b.host, port: b.port, name: getBoxLabel(b) })),
 });
-initSettingsView({ switchView, updateFilterIndicators, discoverBoxes, renderBoxSelect, boxFetch, localizeLanguageName, doBoxUpdate, updateAllBoxes, boxNeedsUpdate, loadPresets, getRoomNames, speakerPicked: speakerPickedInTab });
+initSettingsView({ switchView, updateFilterIndicators, discoverBoxes, renderBoxSelect, localizeLanguageName, doBoxUpdate, updateAllBoxes, boxNeedsUpdate, loadPresets, getRoomNames, speakerPicked: speakerPickedInTab });
 initLibraryView({ showSlotPicker, formatDuration, effectivePlayTarget, speakerPicked: speakerPickedInTab });
-initSetupView({ switchView, discoverBoxes, doBoxUpdate, getRoomNames, boxFetch, celebrateProvision: inviteWorldMapAfterProvision, speakerPicked: speakerPickedInTab });
+initSetupView({ switchView, discoverBoxes, doBoxUpdate, getRoomNames, celebrateProvision: inviteWorldMapAfterProvision, speakerPicked: speakerPickedInTab });
 initPodcastsView();
 
 // __nextLogoFallback walks a preset logo <img>'s data-fallbacks list (a
@@ -2619,32 +2622,7 @@ async function updateSourceButtonVisibility() {
   }
 }
 
-// boxFetch is a self-healing fetch for the agent's plain-HTTP endpoints
-// (region, radio search/tags/languages, stick status). Unlike the Go
-// bindings it cannot reuse boxDo, so it replicates the same resilience in
-// JS: a hard timeout, so a flaky port can never hang the UI forever (the
-// "region keeps loading" bug on BCO boxes), plus a :8888 <-> :17008
-// failover for BCO speakers where only one of the two answers. The first
-// reachable port is remembered on the box so later calls go straight to it.
-async function boxFetch(box, path, opts = {}, timeoutMs = 8000) {
-  if (!box) throw new Error('no box');
-  const ports = [...new Set([box.port, 17008, 8888].filter(Boolean))];
-  let lastErr;
-  for (const p of ports) {
-    const ctrl = new AbortController();
-    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
-    try {
-      const r = await fetch(`http://${box.host}:${p}${path}`, { ...opts, signal: ctrl.signal });
-      clearTimeout(timer);
-      if (p !== box.port) box.port = p; // remember the reachable port
-      return r;
-    } catch (e) {
-      clearTimeout(timer);
-      lastErr = e;
-    }
-  }
-  throw lastErr || new Error('box unreachable');
-}
+// boxFetch lives in api.js next to boxURL, imported above.
 
 let regionLoaded = false;
 async function loadStickRegion() {
@@ -6117,17 +6095,9 @@ async function refreshBalance() {
   if (!selected || selected.kind === 'stock') { el.classList.add('hidden'); return; }
   const box = balanceSourceBox(selected, stereoPairOf(state.zoneLive || {}), state.boxes) || selected;
   if (box.kind === 'stock') { el.classList.add('hidden'); return; }
-  let b = null;
-  try {
-    const r = await boxFetch(box, '/api/box/balance');
-    b = await r.json();
-  } catch { /* asleep or unreachable: show nothing rather than an error */ }
-  if (!b || !b.available) { el.classList.add('hidden'); return; }
-  const v = Number(b.actual) || 0;
-  el.textContent = v === 0
-    ? t('controls.balanceCentre')
-    : (v < 0 ? t('controls.balanceLeft', { n: Math.abs(v) })
-             : t('controls.balanceRight', { n: v }));
+  const v = await readBoxBalance(box);
+  if (v === null) { el.classList.add('hidden'); return; }
+  el.textContent = balanceLabel(v);
   el.title = t('controls.balanceTitle');
   el.classList.remove('hidden');
 }

--- a/desktop-app/frontend/src/utils.js
+++ b/desktop-app/frontend/src/utils.js
@@ -430,3 +430,12 @@ export function orionStationPayload(loc) {
     return null;
   }
 }
+
+// balanceLabel renders a stereo-balance reading (-7..+7, 0 = centred) as the
+// localized label the three balance displays share.
+export function balanceLabel(v) {
+  return v === 0
+    ? t('controls.balanceCentre')
+    : (v < 0 ? t('controls.balanceLeft', { n: Math.abs(v) })
+             : t('controls.balanceRight', { n: v }));
+}

--- a/desktop-app/frontend/src/views/multiroom.js
+++ b/desktop-app/frontend/src/views/multiroom.js
@@ -6,9 +6,9 @@
 // discoverBoxes) via initMultiroomView, so it never imports back into main.js.
 
 import { state } from '../state.js';
-import { $, escapeHtml, escapeAttr, getBoxLabel, showToast } from '../utils.js';
+import { $, escapeHtml, escapeAttr, getBoxLabel, showToast, balanceLabel } from '../utils.js';
 import { t } from '../i18n/index.js';
-import { FormZone, DissolveZone, DissolveStereoPair, WakeBox, BrowserOpenURL } from '../api.js';
+import { FormZone, DissolveZone, DissolveStereoPair, WakeBox, BrowserOpenURL, readBoxBalance } from '../api.js';
 // Group membership + the shared zoneLive poll live in groups.js: ONE
 // implementation for this tab, the music-tab frames and the group chips.
 import { masterOf as zoneMasterOf, fetchZoneLive, groupMembersOf, stereoPairOf, pairMemberBoxes, stereoUndoTargets } from '../groups.js';
@@ -580,17 +580,8 @@ async function fillPairBalance(pair, boxes) {
     .find(b => b && String(b.deviceID || '').toUpperCase() === String(pair.master || '').toUpperCase());
   const src = master || pairMemberBoxes(pair, boxes).map(x => x.box).find(Boolean);
   if (!src || src.kind === 'stock') return;
-  let b = null;
-  try {
-    const r = await deps.boxFetch(src, '/api/box/balance');
-    b = await r.json();
-  } catch { /* asleep or unreachable: show nothing rather than an error */ }
-  if (!b || !b.available) return;
-  const v = Number(b.actual) || 0;
-  const reading = v === 0
-    ? t('controls.balanceCentre')
-    : (v < 0 ? t('controls.balanceLeft', { n: Math.abs(v) })
-             : t('controls.balanceRight', { n: v }));
-  el.textContent = reading + '. ' + t('controls.balanceTitle');
+  const v = await readBoxBalance(src);
+  if (v === null) return;
+  el.textContent = balanceLabel(v) + '. ' + t('controls.balanceTitle');
   el.hidden = false;
 }

--- a/desktop-app/frontend/src/views/settings.js
+++ b/desktop-app/frontend/src/views/settings.js
@@ -3,7 +3,7 @@
 // Extracted from the main.js monolith, same pattern as views/recent.js and
 // views/multiroom.js: the module pulls shared things (state, utils, i18n, api,
 // localization) from their own modules and receives the few main.js-local
-// helpers it needs (switchView, discoverBoxes, boxFetch, ...) via
+// helpers it needs (switchView, discoverBoxes, ...) via
 // initSettingsView, so it never imports back into main.js (which would create a
 // cycle). New views should follow this pattern so main.js stops growing.
 //
@@ -24,6 +24,7 @@ import {
   showToast,
   compareVerBuild,
   getBoxLabel,
+  balanceLabel,
 } from '../utils.js';
 import { t, tLookup, getLocale } from '../i18n/index.js';
 import { COUNTRIES, optFlag } from '../localization.js';
@@ -74,6 +75,8 @@ import {
   ListBoxMediaServers,
   EnableBoxMediaServer,
   DisableBoxMediaServer,
+  boxFetch,
+  readBoxBalance,
 } from '../api.js';
 
 // isMacOS is re-derived locally (the same pure check main.js uses) so the WLAN
@@ -93,7 +96,6 @@ let deps = {
   updateFilterIndicators: () => {},
   discoverBoxes: async () => {},
   renderBoxSelect: () => {},
-  boxFetch: async () => ({ ok: false }),
   localizeLanguageName: (n) => n,
   doBoxUpdate: async () => {},
   loadPresets: async () => {},
@@ -1314,7 +1316,7 @@ function renderBoxSettings(s, box) {
     let sshOpen = false;
     let sshPersistent = false;
     try {
-      const r = await deps.boxFetch(box, '/api/stick/status');
+      const r = await boxFetch(box, '/api/stick/status');
       const ct = r.headers.get('content-type') || '';
       if (r.ok && ct.includes('json')) {
         const data = await r.json();
@@ -1350,7 +1352,7 @@ function renderBoxSettings(s, box) {
         }
       } else {
         // Fallback: debug/state listing for older agents.
-        const rd = await deps.boxFetch(box, '/api/debug/state');
+        const rd = await boxFetch(box, '/api/debug/state');
         if (rd.ok && (rd.headers.get('content-type') || '').includes('json')) {
           const d = await rd.json();
           const listing = d.stick_listing;
@@ -2301,7 +2303,7 @@ function renderBoxSettings(s, box) {
         ? `${optFlag(cc)}${escapeHtml(c.name)} (${escapeHtml(cc)})`
         : escapeHtml(cc || t('common.unknown'));
     };
-    deps.boxFetch(box, '/api/region').then(r => r.ok ? r.json() : null).then(data => {
+    boxFetch(box, '/api/region').then(r => r.ok ? r.json() : null).then(data => {
       if (data && data.country) {
         regSel.value = data.country;
         updateCurrentDisplay(data.country);
@@ -2312,7 +2314,7 @@ function renderBoxSettings(s, box) {
     $('appRegionSave').onclick = async () => {
       const cc = regSel.value;
       try {
-        const r = await deps.boxFetch(box, '/api/region', {
+        const r = await boxFetch(box, '/api/region', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ country: cc }),
@@ -2464,7 +2466,7 @@ function wireWlanSwitch(box) {
       t('settingsView.wlanConfirmBody', { ssid: escapeHtml(ssid) })
     );
     if (!ok) return;
-    const putWlan = (force) => deps.boxFetch(box, '/api/box/wlan', {
+    const putWlan = (force) => boxFetch(box, '/api/box/wlan', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ ssid, password: pass, hidden, force: hidden || force }),
@@ -2875,21 +2877,9 @@ export async function refreshBoxBalanceRow(box, pair, boxes) {
   if (!row || !el) return;
   const src = balanceSourceBox(box, pair, boxes) || box;
   if (!src || src.kind === 'stock') { row.hidden = true; return; }
-  let b = null;
-  try {
-    // deps.boxFetch, like every other call in this file. Without the prefix
-    // this threw on every run, the catch below swallowed it, and the balance
-    // row of a stereo pair was therefore never shown. Found by the linter on
-    // its first run, 2026-08-16.
-    const r = await deps.boxFetch(src, '/api/box/balance');
-    b = await r.json();
-  } catch { /* asleep or unreachable: show nothing rather than an error */ }
-  if (!b || !b.available) { row.hidden = true; return; }
-  const v = Number(b.actual) || 0;
-  el.textContent = v === 0
-    ? t('controls.balanceCentre')
-    : (v < 0 ? t('controls.balanceLeft', { n: Math.abs(v) })
-             : t('controls.balanceRight', { n: v }));
+  const v = await readBoxBalance(src);
+  if (v === null) { row.hidden = true; return; }
+  el.textContent = balanceLabel(v);
   el.title = t('controls.balanceTitle');
   row.hidden = false;
 }

--- a/desktop-app/frontend/src/views/setup.js
+++ b/desktop-app/frontend/src/views/setup.js
@@ -72,6 +72,7 @@ import {
   EventsOn,
   BrowserOpenURL,
   PhoneQR,
+  boxFetch,
 } from '../api.js';
 
 // Official Bose SoundTouch app store listings (verified live 2026-07-09). The
@@ -165,10 +166,6 @@ let deps = {
   // box is successfully provisioned with STR (the most reliable "alive again"
   // moment). Wired in main.js; no-op default so the view never depends on it.
   celebrateProvision: () => {},
-  // boxFetch(box, path, opts): self-healing fetch to the installed agent's HTTP
-  // API. Used to PUT /api/box/wlan right after a network install so a
-  // cable-installed speaker joins Wi-Fi. Wired in main.js.
-  boxFetch: async () => ({ ok: false }),
   // speakerPicked(box): focus this speaker across the tabs (it sets
   // state.settingsBox and state.currentBox), so leaving Setup for another tab
   // lands on the speaker the user just pointed at. It was already being called
@@ -2205,7 +2202,7 @@ async function verifyInstalledState(box, onState) {
           // "WLAN switch refused ... visible=[]"), silently breaking the
           // Wi-Fi save; on a first install the cable stays in anyway, so the
           // strand-protection the preflight exists for does not apply.
-          const wr = await deps.boxFetch(agentBox, '/api/box/wlan', {
+          const wr = await boxFetch(agentBox, '/api/box/wlan', {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ ssid: wifiForBox.ssid, password: wifiForBox.pass, hidden: !!wifiForBox.hidden, force: true }),
@@ -2254,7 +2251,7 @@ async function verifyInstalledState(box, onState) {
     // the steps below; the per-step retries give more chances.
     const readyDeadline = Date.now() + 90 * 1000;
     while (Date.now() < readyDeadline) {
-      try { const r = await deps.boxFetch(agentBox, '/api/status', {}); if (r && r.ok) break; } catch {}
+      try { const r = await boxFetch(agentBox, '/api/status', {}); if (r && r.ok) break; } catch {}
       await sleep(3000);
     }
     waitingAgent = false;

--- a/desktop-app/progress.go
+++ b/desktop-app/progress.go
@@ -97,6 +97,18 @@ func (c *countingReader) Read(p []byte) (int, error) {
 	return n, err
 }
 
+// beatingReader wraps r so every chunk read sends a non-blocking heartbeat,
+// the producer shape watchStall consumes.
+func beatingReader(r io.Reader) (io.Reader, <-chan struct{}) {
+	beat := make(chan struct{}, 1)
+	return &countingReader{r: r, onProgress: func(int64) {
+		select {
+		case beat <- struct{}{}:
+		default:
+		}
+	}}, beat
+}
+
 // watchStall cancels via cancel() when no heartbeat arrives on beat within idle,
 // turning a frozen transfer (connection alive but no bytes) into a prompt error
 // the caller can retry, instead of waiting out a long overall deadline. Returns

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -195,6 +195,34 @@ func (a *Announcer) register() error {
 	return nil
 }
 
+// shutdownServersLocked stops both mDNS servers and reports whether any was
+// running. Caller must hold a.mu.
+func (a *Announcer) shutdownServersLocked() bool {
+	stopped := false
+	if a.server != nil {
+		a.server.Shutdown()
+		a.server = nil
+		stopped = true
+	}
+	if a.legacyServer != nil {
+		a.legacyServer.Shutdown()
+		a.legacyServer = nil
+		stopped = true
+	}
+	return stopped
+}
+
+// reannounceLocked logs the trigger, tears both servers down, and registers
+// again with the (already mutated) config. Caller must hold a.mu.
+func (a *Announcer) reannounceLocked(reason, oldV, newV string) error {
+	a.logger.Warn("mDNS phase: re-announce trigger",
+		slog.String("reason", reason),
+		slog.String("old", oldV),
+		slog.String("new", newV))
+	a.shutdownServersLocked()
+	return a.register()
+}
+
 // UpdateFriendlyName updates the display name in the TXT record and
 // re-announces both service types. No-op if the name has not changed.
 func (a *Announcer) UpdateFriendlyName(name string) error {
@@ -206,20 +234,9 @@ func (a *Announcer) UpdateFriendlyName(name string) error {
 	if name == a.cfg.FriendlyName {
 		return nil
 	}
-	a.logger.Warn("mDNS phase: re-announce trigger",
-		slog.String("reason", "friendlyName change"),
-		slog.String("old", a.cfg.FriendlyName),
-		slog.String("new", name))
+	old := a.cfg.FriendlyName
 	a.cfg.FriendlyName = name
-	if a.server != nil {
-		a.server.Shutdown()
-		a.server = nil
-	}
-	if a.legacyServer != nil {
-		a.legacyServer.Shutdown()
-		a.legacyServer = nil
-	}
-	return a.register()
+	return a.reannounceLocked("friendlyName change", old, name)
 }
 
 // UpdateModel updates the model field in the TXT record and re-announces
@@ -238,20 +255,9 @@ func (a *Announcer) UpdateModel(model string) error {
 	if model == a.cfg.Model {
 		return nil
 	}
-	a.logger.Warn("mDNS phase: re-announce trigger",
-		slog.String("reason", "model change"),
-		slog.String("old", a.cfg.Model),
-		slog.String("new", model))
+	old := a.cfg.Model
 	a.cfg.Model = model
-	if a.server != nil {
-		a.server.Shutdown()
-		a.server = nil
-	}
-	if a.legacyServer != nil {
-		a.legacyServer.Shutdown()
-		a.legacyServer = nil
-	}
-	return a.register()
+	return a.reannounceLocked("model change", old, model)
 }
 
 // Snapshot returns the friendlyName and model currently held in the TXT
@@ -276,18 +282,7 @@ func (a *Announcer) Close() {
 	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	stopped := false
-	if a.server != nil {
-		a.server.Shutdown()
-		a.server = nil
-		stopped = true
-	}
-	if a.legacyServer != nil {
-		a.legacyServer.Shutdown()
-		a.legacyServer = nil
-		stopped = true
-	}
-	if stopped {
+	if a.shutdownServersLocked() {
 		a.logger.Warn("mDNS phase: announce stopped")
 	}
 }

--- a/internal/webui/boxsettings_http.go
+++ b/internal/webui/boxsettings_http.go
@@ -382,24 +382,11 @@ func (s *Server) handleBoxSource(w http.ResponseWriter, r *http.Request) {
 	}
 	client := &http.Client{Timeout: 6 * time.Second}
 
-	// Special case STANDBY: no ContentItem source at Bose. /key POWER
-	// only triggers the LED animation, /standby is the real endpoint —
-	// and Bose expects **GET**, not POST (POST returns 400).
+	// Special case STANDBY: no ContentItem source at Bose, boxStandby is the
+	// real power-off.
 	if src == "STANDBY" {
-		// An app-initiated standby is a deliberate stop: arm the latch BEFORE
-		// the call so the UPNP->STANDBY flip it causes is not classified as a
-		// spontaneous firmware drop and auto-resumed (#419).
-		s.NoteUserStop()
-		u := fmt.Sprintf("http://%s:8090/standby", s.boxHost)
-		resp, err := client.Get(u)
-		if err != nil {
-			http.Error(w, "box unreachable: "+err.Error(), http.StatusBadGateway)
-			return
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode >= 400 {
-			respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-			http.Error(w, "box error: "+string(respBody), http.StatusBadGateway)
+		if msg := s.boxStandby(); msg != "" {
+			http.Error(w, msg, http.StatusBadGateway)
 			return
 		}
 		writeJSON(w, http.StatusOK, map[string]string{"source": "STANDBY"})
@@ -467,21 +454,8 @@ func (s *Server) handleBoxPower(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !req.On {
-		// Power off: Bose /standby expects GET (POST returns 400). Same call the
-		// Standby input uses; the real power-off, unlike Stop/Pause. Arm the
-		// deliberate-stop latch BEFORE the call so the UPNP->STANDBY flip it
-		// causes is not classified as a spontaneous firmware drop (#419).
-		s.NoteUserStop()
-		client := &http.Client{Timeout: 6 * time.Second}
-		resp, err := client.Get(fmt.Sprintf("http://%s:8090/standby", s.boxHost))
-		if err != nil {
-			http.Error(w, "box unreachable: "+err.Error(), http.StatusBadGateway)
-			return
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode >= 400 {
-			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-			http.Error(w, "box error: "+string(body), http.StatusBadGateway)
+		if msg := s.boxStandby(); msg != "" {
+			http.Error(w, msg, http.StatusBadGateway)
 			return
 		}
 		writeJSON(w, http.StatusOK, map[string]bool{"on": false})
@@ -615,13 +589,10 @@ func (s *Server) handleBoxAirplayOpt(w http.ResponseWriter, r *http.Request) {
 			// Attribute absent (older file): add it to the root element.
 			out = strings.Replace(out, "<AirplayConfiguration ", `<AirplayConfiguration BCOResetTimerEnabled="`+val+`" `, 1)
 		}
-		tmp := path + ".str-new"
-		if err := os.WriteFile(tmp, []byte(out), 0o644); err != nil {
-			http.Error(w, "write: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-		if err := os.Rename(tmp, path); err != nil {
-			http.Error(w, "rename: "+err.Error(), http.StatusInternalServerError)
+		// writeFileAtomic, never writeFlagFile: a trailing newline must not be
+		// appended to the XML BoseApp parses at boot.
+		if err := writeFileAtomic(path, []byte(out)); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		_ = exec.Command("sync").Run()
@@ -661,21 +632,12 @@ func (s *Server) handleResumeOnPowerOn(w http.ResponseWriter, r *http.Request) {
 		if path == "" {
 			path = defaultResumeOnPowerOnPath
 		}
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			http.Error(w, "mkdir: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
 		val := "1"
 		if !body.Enabled {
 			val = "0"
 		}
-		tmp := path + ".str-new"
-		if err := os.WriteFile(tmp, []byte(val+"\n"), 0o644); err != nil {
-			http.Error(w, "write: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-		if err := os.Rename(tmp, path); err != nil {
-			http.Error(w, "rename: "+err.Error(), http.StatusInternalServerError)
+		if err := persistFlagFile(path, val); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		_ = exec.Command("sync").Run()
@@ -709,23 +671,19 @@ func (s *Server) handleDisplayTrack(w http.ResponseWriter, r *http.Request) {
 		if path == "" {
 			path = defaultDisplayTrackPath
 		}
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			http.Error(w, "mkdir: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
 		val := "0"
 		if body.Enabled {
 			val = "1"
 		}
-		if err := writeFlagFile(path, val); err != nil {
-			http.Error(w, "write: "+err.Error(), http.StatusInternalServerError)
+		if err := persistFlagFile(path, val); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		// Persist the display mode too, when a valid one is supplied.
 		mode := strings.ToLower(strings.TrimSpace(body.Mode))
 		if mode == "title" || mode == "artist" || mode == "both" {
 			if err := writeFlagFile(modePathFor(path), mode); err != nil {
-				http.Error(w, "write mode: "+err.Error(), http.StatusInternalServerError)
+				http.Error(w, "mode: "+err.Error(), http.StatusInternalServerError)
 				return
 			}
 		}
@@ -745,13 +703,57 @@ func (s *Server) handleDisplayTrack(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// boxStandby puts the box into Bose standby, the real power-off. /key POWER
+// only triggers the LED animation, /standby is the real endpoint, and Bose
+// expects **GET**, not POST (POST returns 400). Unlike Stop/Pause, which only
+// halt the transport, this actually switches the speaker off.
+//
+// An app-initiated standby is a deliberate stop: the latch is armed BEFORE
+// the call so the UPNP->STANDBY flip it causes is not classified as a
+// spontaneous firmware drop and auto-resumed (#419).
+//
+// Returns "" on success, else the message for the handler's 502.
+func (s *Server) boxStandby() string {
+	s.NoteUserStop()
+	client := &http.Client{Timeout: 6 * time.Second}
+	resp, err := client.Get(fmt.Sprintf("http://%s:8090/standby", s.boxHost))
+	if err != nil {
+		return "box unreachable: " + err.Error()
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return "box error: " + string(respBody)
+	}
+	return ""
+}
+
+// writeFileAtomic writes data to path via a temp file and rename, so a crash
+// mid-write never leaves a torn file. Callers on NAND follow up with one sync.
+func writeFileAtomic(path string, data []byte) error {
+	tmp := path + ".str-new"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}
+
 // writeFlagFile atomically writes a one-line value to a NAND flag file.
 func writeFlagFile(path, val string) error {
-	tmp := path + ".str-new"
-	if err := os.WriteFile(tmp, []byte(val+"\n"), 0o644); err != nil {
-		return err
+	return writeFileAtomic(path, []byte(val+"\n"))
+}
+
+// persistFlagFile is writeFlagFile plus creating the directory, for handlers
+// that may run before the flag's directory exists. The caller keeps the single
+// trailing sync (a handler writing two flag files syncs ONCE, after both).
+func persistFlagFile(path, val string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir: %w", err)
 	}
-	return os.Rename(tmp, path)
+	return writeFlagFile(path, val)
 }
 
 // contentItemForSource builds the /select ContentItem for a source the user


### PR DESCRIPTION
The five highest-ranked proposals from today's verified refactoring review, one commit each, all behaviour-preserving:

1. **frontend: boxFetch moves to api.js, balance read deduped.** Kills the deps.-prefix injection that already shipped one silent-throw bug (2026-08-16) and the triplicated /api/box/balance block whose settings copy had drifted.
2. **agent: one now_playing fetch + pure verdict functions in boxprobe.go.** Six hand-rolled fetches and per-call regex compilation on 10s poll paths collapse into one shared fetch and testable verdicts; new unit test covers them against canned XML.
3. **discovery: shared shutdown-and-re-register.** UpdateFriendlyName/UpdateModel were line-for-line twins; Close carried a third copy.
4. **app: one stall watchdog.** boxssh.go carried the watchStall timer loop twice inline; both now use the shared helper via a new beatingReader.
5. **webui: box standby + NAND flag-file writes deduped.** The #419 latch-ordering and GET-not-POST rationale now exists once (boxStandby); writeFileAtomic/persistFlagFile replace three slightly different tmp+rename copies, with the airplay-opt XML explicitly kept newline-free.

Go builds, vet, and the full test suites for cmd/agent, discovery, internal/webui, and desktop-app pass; the frontend builds clean with eslint at 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)