### PR TITLE
feat(app): minute-cadence background speaker refresh, honest nand-full install error, badge contrast

### DIFF
--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -344,6 +344,7 @@ import {
   loadWifiProfiles,
   refreshDrives,
   initSetupView,
+  installRunActive,
 } from './views/setup.js';
 // Inject the main.js-local helpers the views reuse so they behave exactly as
 // before without reimplementing them. All hoisted function declarations, safe
@@ -1762,6 +1763,25 @@ async function discoverBoxes() {
     if (rb) rb.classList.remove('spinning');
   }
 }
+
+// Periodic background refresh (2026-08-20): the app used to learn a speaker's
+// new agent version only when the user pressed Refresh, so an app left open
+// all day kept showing "needs update" for speakers that were long done. Every
+// minute, re-probe the KNOWN speakers directly (no mDNS sweep, the same quick
+// path the Refresh button uses first) and re-evaluate the update banner.
+// Skipped while an OTA or an install runs so the probe never lands on a
+// speaker mid-flash, and skipped while no speaker is known (the recovery
+// burst owns the empty case).
+setInterval(async () => {
+  if (state.otaInProgress || installRunActive() || !state.boxes.length) return;
+  try {
+    const quick = await RefreshKnownBoxes();
+    if (quick && quick.length) {
+      applyBoxList(quick);
+      checkBoxUpdate();
+    }
+  } catch { /* transient network trouble: the next tick retries */ }
+}, 60000);
 
 // applyBoxList folds a freshly probed box list into state + the UI. Shared by
 // the known-first quick refresh and the full discovery so both render

--- a/desktop-app/frontend/src/style.css
+++ b/desktop-app/frontend/src/style.css
@@ -1722,8 +1722,11 @@ html.a11y-light .preset.error .name { color: #991b1b; }
 .setup-target-card.selected .stc-radio::after { content: ''; position: absolute; inset: 2px; border-radius: 50%; background: var(--brand, #58a); }
 .stc-label { font-size: 14px; color: var(--c-text); }
 .stc-badge { font-size: 10px; background: var(--c-surface-3); color: var(--c-text); border: 1px solid var(--c-border); padding: 2px 6px; border-radius: 10px; white-space: nowrap; }
-.stc-badge.badge-warn { background: #d97706; }
-.stc-badge.badge-ok { background: #2a7f3f; }
+/* Fixed text colours, independent of the theme's --c-text: the orange chip
+   needs DARK text (white/#eee measures ~2.9:1 on it), the green chip needs
+   WHITE text (dark theme text passes, the light theme's near-black is 3.3:1). */
+.stc-badge.badge-warn { background: #d97706; color: #1c1917; }
+.stc-badge.badge-ok { background: #2a7f3f; color: #fff; }
 .stc-sublabel { font-size: 11px; color: var(--c-muted); margin-top: 3px; }
 .setup-target-empty { padding: 8px 4px; }
 .setup-target-factory-help { background: var(--c-bg); border: 1px dashed var(--c-border); border-radius: 4px; padding: 8px 10px; margin-top: 6px; }
@@ -1800,7 +1803,7 @@ code { background: var(--c-bg); padding: 1px 4px; border-radius: 3px; font-size:
 .drive-path { font-size: 14px; color: var(--c-text); }
 .drive-meta { font-size: 11px; color: var(--c-muted); }
 .badge { font-size: 10px; background: #58a; color: #fff; padding: 2px 6px; border-radius: 10px; margin-left: 6px; vertical-align: middle; }
-.badge-warn { background: #d97706; }
+.badge-warn { background: #d97706; color: #1c1917; }
 /* Hard-demote notice on the Wi-Fi-only (no-stick) onboarding panel. */
 .setup-ap-push-warn { margin: 6px 0 8px; padding: 8px 10px; background: #2f1f0f; border-left: 3px solid #d97706; border-radius: 4px; color: #fbbf24; font-size: 12px; }
 .security-warn { margin-top: 10px; padding: 10px 12px; background: linear-gradient(135deg, #2f1f0f 0%, #3a2a1a 100%); border-left: 3px solid #d97706; border-radius: 4px; }

--- a/desktop-app/frontend/src/views/setup.js
+++ b/desktop-app/frontend/src/views/setup.js
@@ -730,6 +730,10 @@ function updateSetupGoButtonLabel() {
 // true while startNetworkInstall runs, disabling the button.
 let networkInstallRunning = false;
 
+// installRunActive tells main.js's periodic background refresh whether an
+// install is running, so the refresh never probes a speaker mid-install.
+export function installRunActive() { return networkInstallRunning; }
+
 // renderPrimaryAction paints the OTA-first primary action above the (collapsed)
 // USB-stick wizard. For a reachable stock box it shows the network-install hero
 // whose button installs STR over the network with no stick; for a box that
@@ -1644,6 +1648,11 @@ const INSTALL_HELP_STEPS = {
   // Usually a large stick force-formatted to FAT32 with a block size the
   // speaker can't read (the 64 GB case), or a faulty stick.
   'stick-io-error': ['reformatApp', 'usbPicky', 'smallerStick', 'differentStick', 'logs'],
+  // The speaker's internal storage is full (ENOSPC during the NAND copy): the
+  // stick is fine and reformatting would not help, so no stick advice here.
+  // The result message names the cause; the report's '# nv usage' section
+  // lists what occupies the space.
+  'nand-full': ['logs'],
   // USB power dropout, not a faulty stick: the speaker's port could not keep the
   // stick powered under read load (dmesg VBUS_ERROR / error -110), so it
   // disconnected mid-install. The same stick installs fine on ST10/ST20, so the

--- a/desktop-app/install_str.go
+++ b/desktop-app/install_str.go
@@ -393,6 +393,12 @@ func (a *App) InstallSTROnBox(host, model string) (InstallResult, error) {
 		switch {
 		case strings.Contains(err.Error(), "timeout"):
 			res.Code = "install-timeout"
+		// Before the I/O-error case on purpose: install.sh's own failure text
+		// guesses "(stick I/O error?)" even when the copy died on ENOSPC, so an
+		// out-of-space box was blamed on the stick (live case 2026-08-20: 4.7 MB
+		// free of 31.6 MB on a stock ST10, stick perfectly readable).
+		case strings.Contains(lowOut, "no space left on device"):
+			res.Code = "nand-full"
 		case strings.Contains(lowOut, "input/output error"), strings.Contains(lowOut, "i/o error"):
 			// Media-level read failure of install.sh. Distinguish the two causes:
 			// a USB power/enumeration dropout (the ST30's port cannot keep VBUS up
@@ -410,6 +416,9 @@ func (a *App) InstallSTROnBox(host, model string) (InstallResult, error) {
 		hint := classifySSHError(out, err)
 		if res.Code == "stick-usb-power" {
 			hint = usbPowerHint
+		}
+		if res.Code == "nand-full" {
+			hint = "the speaker's internal storage is full, so STR does not fit (the stick is fine). Something besides the Bose firmware already occupies it, often an earlier third-party SoundTouch tool. The diagnostic in this report lists the largest folders under '# nv usage'."
 		}
 		res.Message = "install.sh execution failed: " + hint
 		// The rich diagnostics must also reach str.log, not only res.Log:
@@ -1224,6 +1233,11 @@ func boxInstallDiag(host string) string {
 		"echo '# block devices'; ls -la /dev/sd* /dev/mmcblk* 2>&1",
 		"echo '# mounts'; mount 2>&1",
 		"echo '# df'; df -h 2>&1",
+		// The largest NAND entries, so a "No space left on device" report names
+		// WHAT occupies /mnt/nv (a stock box with a full NAND usually carries a
+		// third-party mod or leftovers no listing ever showed; live case
+		// 2026-08-20: 25 of 31 MB used on a box with no STR and no way to tell).
+		"echo '# nv usage (largest last)'; du -a /mnt/nv 2>/dev/null | sort -n | tail -25",
 		"echo '# stick contents'; ls -la /media/sda1 /mnt/usb /run/media/* 2>&1 | head -40",
 		// install.sh head + line-ending/exec evidence: exit 126 is usually a
 		// CRLF script the box's BusyBox refuses, a non-executable/no-exec mount,


### PR DESCRIPTION
Three changes from today's field feedback:

- **Background speaker refresh**: every minute the app re-probes known speakers over the quick no-mDNS path and re-evaluates the update banner, so an app left open notices finished speaker updates without a manual Refresh. Pauses during OTA and install runs.
- **nand-full install classification**: "No space left on device" during the NAND copy was classified as stick-io-error (install.sh's own text guesses "stick I/O error?"), sending users to re-format perfectly good sticks. New code nand-full with an honest message, no stick advice, and the install diagnostics now capture the largest /mnt/nv entries so the report names what occupies the space. From a mail report today: stock ST10 with 4.7 MB free of 31.6 MB, cause invisible in the report.
- **Badge contrast**: the "first install" / ok chips carry fixed text colours that clear 4.5:1 in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)