### PR TITLE
fix(wifi): a Wi-Fi move survives the next reboot

### DIFF
--- a/internal/webui/wlan.go
+++ b/internal/webui/wlan.go
@@ -28,10 +28,13 @@ import (
 //     reboots to apply them through the proven boot-time provisioning path.
 //
 // In ALL cases the SSID/PASS are written to the canonical NAND wlan-creds that
-// the boot path replays, so the change survives a reboot. The previous version
-// only wrote a runtime wpa file at the wrong path and never updated wlan-creds,
-// so a reboot reverted it AND on BCO boxes it poked a non-existent
-// wpa_supplicant and silently did nothing while reporting success.
+// the boot path replays, AND the one-shot apply marker is dropped so the next
+// boot actively programs the new network once (the firmware's own profile
+// store still holds the old one and wins the boot association otherwise,
+// #461). The previous version only wrote a runtime wpa file at the wrong path
+// and never updated wlan-creds, so a reboot reverted it AND on BCO boxes it
+// poked a non-existent wpa_supplicant and silently did nothing while
+// reporting success.
 //
 // The switch runs in the background and the response returns immediately: the
 // box leaves the current network as it switches, so the client must rediscover
@@ -246,6 +249,16 @@ func (s *Server) applyWLANChange(iface, mech, ssid, password string, hidden bool
 			s.logger.Info("WLAN: live switch confirmed", "ssid", ssid, "iface", iface)
 			_ = os.Remove(wlanCredsPath + ".bak")
 			_ = os.Remove(wpaBackupPath)
+			// Drop the apply marker even though the LIVE switch succeeded: the
+			// firmware keeps its own network profile store and re-associates to
+			// the OLD network at boot, where run.sh's hands-off replay sees a
+			// working network and deliberately stays out. Without the marker the
+			// speaker therefore woke up back on the old Wi-Fi after every reboot
+			// (#461; field bundles 2026-08-20, "FB40 kommt immer wieder"). With
+			// it, the next boot actively programs the new SSID once, which also
+			// rewrites the firmware's own profile, and the marker is consumed on
+			// read so this cannot loop.
+			touchWLANApplyMarker()
 		case wpaCannotApply:
 			// The conf could not be written live (read-only /etc and the
 			// bind-mount overlay both failed). The new creds are already on NAND,


### PR DESCRIPTION
The #461 mechanism, pinned today by a user's before/after diagnostic pair: the runtime switch works live (log: "live switch confirmed") and persists the new creds to NAND, but the boot path then runs as a hands-off REPLAY. The firmware re-associates to the old network out of its own profile store within the 90s grace, run.sh sees a working network and deliberately stays out (v0.9.7 hands-off rule), and the speaker wakes up on the old Wi-Fi after every reboot. The user's workaround observation matches exactly: the move only sticks when the old network is out of range, because then no lease appears and the rescue pushes the new creds.

Fix: the live-confirmed switch now drops the same one-shot `.wlan-apply-pending` marker the reboot-to-apply paths already use (#184 machinery, shipped and field-proven). The next boot runs the active provisioning pipeline once with the new creds, which also rewrites the firmware's own profile store, so every later boot associates to the new network natively. The marker is deleted on read, so no loop is possible; the creds were proven correct by the live association.

Agent-side only, reaches speakers via the normal OTA.

Refs #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)