### PR TITLE
fix(radio): the live-title display push no longer stutters the stream in a loop

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -722,6 +722,7 @@ func run() error {
 		webui.WithSpotifyImportCred(spotifyMgr.ImportCredential),
 		webui.WithSpotifySetRecalling(spotifyMgr.SetRecalling),
 		webui.WithSpotifySuppressActivate(spotifyMgr.SuppressActivate),
+		webui.WithSpotifyExpectReattach(spotifyMgr.ExpectReattach),
 		webui.WithSpotifyInfo(spotifyMgr.ServeInfo),
 		webui.WithSpotifyReload(spotifyMgr.ReloadBinary),
 		webui.WithSpotifyStop(spotifyMgr.StopEngine),

--- a/internal/spotify/manager.go
+++ b/internal/spotify/manager.go
@@ -97,7 +97,11 @@ type Manager struct {
 	configVol    int       // initial_volume currently written to config.yml
 	sink         io.Writer // current HTTP consumer, nil when none
 	lastAttachAt time.Time // when the box last attached to the Ogg stream (re-attach storm detection)
-	cmd          *exec.Cmd
+	// expectReattachUntil marks the next re-attach as deliberately caused by
+	// STR's own re-push (one-shot, see ExpectReattach), keeping it out of the
+	// storm accounting.
+	expectReattachUntil time.Time
+	cmd                 *exec.Cmd
 	// runCancel restarts the current go-librespot process when called: it
 	// cancels the per-process context so the supervise loop relaunches it.
 	// Used to re-apply a changed device_name (go-librespot reads its name only

--- a/internal/spotify/recall.go
+++ b/internal/spotify/recall.go
@@ -467,6 +467,19 @@ func (m *Manager) SuppressActivate(d time.Duration) {
 	m.mu.Unlock()
 }
 
+// ExpectReattach marks the NEXT box re-attach inside window as deliberate,
+// caused by STR's own re-push, so ServeOgg's storm damping does not count it.
+// The soft-skip re-push legitimately re-attaches as often as every 8 s, well
+// inside the 20 s storm window; counting those grew the activate backoff and
+// held the auto-repoint off for up to a minute after two ordinary skips.
+// One-shot: a genuine INVALID_SOURCE storm re-attaches repeatedly and only
+// the announced one is excused.
+func (m *Manager) ExpectReattach(window time.Duration) {
+	m.mu.Lock()
+	m.expectReattachUntil = time.Now().Add(window)
+	m.mu.Unlock()
+}
+
 // recalling reports whether a recall is currently in progress.
 func (m *Manager) recalling() bool {
 	m.mu.Lock()

--- a/internal/spotify/serve.go
+++ b/internal/spotify/serve.go
@@ -253,6 +253,12 @@ func (m *Manager) ServeOgg(w http.ResponseWriter, r *http.Request) {
 		sinceLast = time.Since(m.lastAttachAt)
 	}
 	m.lastAttachAt = time.Now()
+	// A re-attach STR's own re-push announced (ExpectReattach) is deliberate:
+	// consume the one-shot mark and keep it out of the storm accounting.
+	deliberate := time.Now().Before(m.expectReattachUntil)
+	if deliberate {
+		m.expectReattachUntil = time.Time{}
+	}
 	m.mu.Unlock()
 	// Single-connection invariant: tear down the previous box connection now.
 	// A box stuck in INVALID_SOURCE re-fetches the stream repeatedly; if the old
@@ -270,7 +276,7 @@ func (m *Manager) ServeOgg(w http.ResponseWriter, r *http.Request) {
 	// re-pointing so it stops shoving the box back into the same failing state.
 	// A rapid re-attach grows the backoff (capped); a healthy, spaced-out attach
 	// resets it so normal playlist switches stay responsive.
-	if reattach && sinceLast > 0 && sinceLast < spotifyStormWindow {
+	if reattach && !deliberate && sinceLast > 0 && sinceLast < spotifyStormWindow {
 		m.mu.Lock()
 		if m.activateBackoff < spotifyActivateBackoffBase {
 			m.activateBackoff = spotifyActivateBackoffBase

--- a/internal/streamproxy/icy.go
+++ b/internal/streamproxy/icy.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // SetOnTitle registers a callback invoked when the live ICY StreamTitle of
@@ -60,6 +61,28 @@ func (s *Server) clearTitleForNewURL(url string) {
 	s.titleMu.Unlock()
 }
 
+// titleEndGrace is how long after a handler ends the title survives while a
+// successor handler of the SAME stream may still take over. An immediate wipe
+// fed a self-sustaining stutter loop with the on-display track push enabled
+// (v0.9.53, #119): the push re-issues the URI, the box drops and re-fetches
+// the same stream, the OLD handler's wipe then emptied the title, and the
+// next (unchanged) metadata block counted as a change and re-fired the push,
+// re-buffering the box once per throttle window. A takeover bumps the url's
+// generation and cancels the pending wipe; a stream that truly ended has no
+// successor and goes blank after the grace, so #274 stays fixed.
+const titleEndGrace = 5 * time.Second
+
+// noteStreamStart marks a handler taking (over) url; called at every proxy
+// handler start so a pending end-of-stream title wipe knows it is stale.
+func (s *Server) noteStreamStart(url string) {
+	s.titleMu.Lock()
+	if s.titleGens == nil {
+		s.titleGens = make(map[string]uint64)
+	}
+	s.titleGens[url]++
+	s.titleMu.Unlock()
+}
+
 // clearTitleOnEnd drops the title when the proxy stops carrying url. Without
 // it CurrentTitle kept reporting the LAST stream's song forever, and a client
 // that cannot tell radio-via-proxy from other playback showed it under
@@ -67,14 +90,27 @@ func (s *Server) clearTitleForNewURL(url string) {
 // but a NAS track plays over the same UPnP source as proxied radio, so the
 // old radio song sat under it (SA-5, #274, still with v0.9.52). Guarded by
 // URL so a handler that outlived a station switch cannot wipe the successor's
-// title; curTitleURL stays, so a plain reconnect refills on the next metadata
-// block instead of blanking through the flap.
+// title, and DELAYED by titleEndGrace so a box re-fetch of the same stream
+// (display push, brief flap) keeps the title instead of re-firing it.
 func (s *Server) clearTitleOnEnd(url string) {
 	s.titleMu.Lock()
+	gen := s.titleGens[url]
+	s.titleMu.Unlock()
+	time.AfterFunc(titleEndGrace, func() { s.wipeTitleIfUnclaimed(url, gen) })
+}
+
+// wipeTitleIfUnclaimed is clearTitleOnEnd's delayed half: it wipes only when
+// no successor handler for url has started since the snapshot was taken.
+func (s *Server) wipeTitleIfUnclaimed(url string, gen uint64) {
+	s.titleMu.Lock()
+	defer s.titleMu.Unlock()
+	if s.titleGens[url] != gen {
+		return
+	}
+	delete(s.titleGens, url)
 	if url == s.curTitleURL {
 		s.curTitle = ""
 	}
-	s.titleMu.Unlock()
 }
 
 // icyConn wraps a net.Conn so a legacy SHOUTcast "ICY 200 OK" response line is

--- a/internal/streamproxy/streamproxy.go
+++ b/internal/streamproxy/streamproxy.go
@@ -123,6 +123,10 @@ type Server struct {
 	titleMu     sync.Mutex
 	curTitle    string
 	curTitleURL string
+	// titleGens counts handler starts per stream URL so a handler that ends
+	// can tell whether a successor already took the same stream over (see
+	// clearTitleOnEnd; the wipe is delayed and cancelled by a takeover).
+	titleGens map[string]uint64
 	// onTitle, if set, is called whenever the live StreamTitle changes to a
 	// non-empty value. Used to push the radio track text to the box display.
 	onTitle func(title string)
@@ -253,6 +257,7 @@ func (s *Server) handleRaw(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.logger.Info("stream proxy raw start", "url", url)
+	s.noteStreamStart(url)
 	defer s.clearTitleOnEnd(url)
 	start := time.Now()
 	s.resetAudioGap()
@@ -352,6 +357,7 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.noteStreamStart(p.StreamURL)
 	defer s.clearTitleOnEnd(p.StreamURL)
 
 	// We do exactly one GET to the CDN and copy bytes to Bose. When the CDN
@@ -615,6 +621,16 @@ func (s *Server) streamOneDepth(ctx context.Context, w http.ResponseWriter, r *h
 	// on a healthy stream, and it is short enough that the internal reconnect
 	// lands before the box gives up on its own connection.
 	const upstreamStallAfter = 5 * time.Second
+	// Below the watchdog threshold, a short upstream starve (Wi-Fi hiccup,
+	// CDN pause) is audible as a brief stutter but used to leave no log line
+	// at all, so a diagnostic bundle could not confirm or time a reported
+	// "stream stockt kurzzeitig" (#119, 2026-08-21). Log each recovered gap
+	// over audioGapLogAfter, capped per connection so a flapping link cannot
+	// spam the NAND log.
+	const (
+		audioGapLogAfter = 2 * time.Second
+		audioGapLogMax   = 10
+	)
 	streamStart := time.Now()
 	var winBytes int64
 	var winStart time.Time
@@ -646,6 +662,7 @@ func (s *Server) streamOneDepth(ctx context.Context, w http.ResponseWriter, r *h
 	// the CURRENT window, recentStart says how old it is.
 	var recentBytes int64
 	recentStart := time.Now()
+	gapLogged := 0
 	// Stall watchdog (#510): a silent upstream stall (no FIN, no RST, no
 	// bytes) blocked this loop in Read() forever, because streams are endless
 	// by design and the body has no read deadline. The box then starved on an
@@ -703,6 +720,12 @@ func (s *Server) streamOneDepth(ctx context.Context, w http.ResponseWriter, r *h
 	for {
 		n, readErr := src.Read(buf)
 		if n > 0 {
+			if gap := sinceRead(); gap >= audioGapLogAfter && gapLogged < audioGapLogMax {
+				gapLogged++
+				s.logger.Warn("stream proxy audio delivery gap (recovered)", "url", url,
+					"gapMs", gap.Milliseconds(), "connectedSec", int(time.Since(connStart).Seconds()),
+					"bytes", connBytes, "gapNr", gapLogged)
+			}
 			touchRead()
 			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
 				// Bose closed the connection

--- a/internal/streamproxy/title_end_test.go
+++ b/internal/streamproxy/title_end_test.go
@@ -11,15 +11,29 @@ import (
 // cannot tell radio-via-proxy from other playback showed it under whatever
 // came next: a NAS track plays over the same UPnP source as proxied radio, so
 // the old radio song sat under it (SA-5, #274, still with v0.9.52).
+//
+// The wipe is DELAYED and takeover-aware since the v0.9.53 stutter loop
+// (#119): tests exercise wipeTitleIfUnclaimed, the synchronous half behind
+// clearTitleOnEnd's grace timer.
 
 func newTitleServer() *Server {
 	return &Server{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
 }
 
+// genOf snapshots what clearTitleOnEnd would capture for url at handler end.
+func genOf(s *Server, url string) uint64 {
+	s.titleMu.Lock()
+	defer s.titleMu.Unlock()
+	return s.titleGens[url]
+}
+
 func TestClearTitleOnEndDropsTheServedStreamsTitle(t *testing.T) {
 	s := newTitleServer()
+	s.noteStreamStart("http://radio/a")
 	s.setTitle("http://radio/a", "The Beatles - Help!")
-	s.clearTitleOnEnd("http://radio/a")
+	// The handler ends and nothing takes the stream over: the delayed wipe
+	// must land.
+	s.wipeTitleIfUnclaimed("http://radio/a", genOf(s, "http://radio/a"))
 	if got := s.CurrentTitle(); got != "" {
 		t.Fatalf("title after the stream ended = %q, want empty", got)
 	}
@@ -27,24 +41,57 @@ func TestClearTitleOnEndDropsTheServedStreamsTitle(t *testing.T) {
 
 func TestClearTitleOnEndLeavesASuccessorAlone(t *testing.T) {
 	s := newTitleServer()
+	s.noteStreamStart("http://radio/a")
 	s.setTitle("http://radio/a", "Old Song")
+	gen := genOf(s, "http://radio/a")
 	// The box switched stations: the new handler already owns the title.
+	s.noteStreamStart("http://radio/b")
 	s.clearTitleForNewURL("http://radio/b")
 	s.setTitle("http://radio/b", "New Song")
-	// The OLD handler returns late; it must not wipe the successor.
-	s.clearTitleOnEnd("http://radio/a")
+	// The OLD handler's delayed wipe fires; it must not touch the successor.
+	s.wipeTitleIfUnclaimed("http://radio/a", gen)
 	if got := s.CurrentTitle(); got != "New Song" {
 		t.Fatalf("title = %q, want the successor's %q", got, "New Song")
 	}
 }
 
+// The v0.9.53 stutter loop (#119): with the on-display track push enabled the
+// box re-fetches the SAME stream after every push. The old handler's wipe must
+// be cancelled by the successor's takeover, so the unchanged title does NOT
+// count as a change and cannot re-fire the push (which would re-buffer the box
+// and start the cycle again).
+func TestSameURLTakeoverCancelsTheWipeAndDoesNotRefire(t *testing.T) {
+	s := newTitleServer()
+	fired := 0
+	s.onTitle = func(string) { fired++ }
+	s.noteStreamStart("http://radio/a")
+	s.setTitle("http://radio/a", "Song A")
+	if fired != 1 {
+		t.Fatalf("first title fired %d times, want 1", fired)
+	}
+	gen := genOf(s, "http://radio/a")
+	// Box drops and re-fetches the same stream: successor starts, old ends.
+	s.noteStreamStart("http://radio/a")
+	s.wipeTitleIfUnclaimed("http://radio/a", gen) // stale wipe must be a no-op
+	if got := s.CurrentTitle(); got != "Song A" {
+		t.Fatalf("title after takeover = %q, want it kept", got)
+	}
+	// The successor's first metadata block carries the same song.
+	s.setTitle("http://radio/a", "Song A")
+	if fired != 1 {
+		t.Fatalf("unchanged title re-fired the push (%d times), the stutter loop is back", fired)
+	}
+}
+
 func TestReconnectSameURLRefillsAfterEndClear(t *testing.T) {
 	s := newTitleServer()
+	s.noteStreamStart("http://radio/a")
 	s.setTitle("http://radio/a", "Song One")
-	s.clearTitleOnEnd("http://radio/a")
-	// Box re-fetches the same stream (flap): the URL is unchanged, so the
-	// pre-metadata window shows nothing rather than a stale song, and the
-	// next metadata block refills.
+	// The stream truly ended (no successor), the wipe landed.
+	s.wipeTitleIfUnclaimed("http://radio/a", genOf(s, "http://radio/a"))
+	// Much later the box fetches the same stream again: the pre-metadata
+	// window shows nothing rather than a stale song, then metadata refills.
+	s.noteStreamStart("http://radio/a")
 	s.clearTitleForNewURL("http://radio/a")
 	if got := s.CurrentTitle(); got != "" {
 		t.Fatalf("title in the pre-metadata window = %q, want empty", got)

--- a/internal/webui/options.go
+++ b/internal/webui/options.go
@@ -378,6 +378,13 @@ func WithSpotifySetRecalling(setRecalling func()) Option {
 	return func(s *Server) { s.spotifySetRecalling = setRecalling }
 }
 
+// WithSpotifyExpectReattach registers the hook that marks the next box
+// re-attach to the Ogg stream as deliberate (STR's own re-push), so the
+// engine's re-attach storm damping does not count it.
+func WithSpotifyExpectReattach(expect func(time.Duration)) Option {
+	return func(s *Server) { s.spotifyExpectReattach = expect }
+}
+
 // WithSpotifySuppressActivate registers the hook that holds go-librespot's
 // auto-repoint off for a window, so the hardware-skip recovery's clean slot
 // recall is not raced by the #14 auto-attach.

--- a/internal/webui/queueplay.go
+++ b/internal/webui/queueplay.go
@@ -955,6 +955,18 @@ func (s *Server) repushSpotifyStream(why string, requireSlot int) {
 	}
 	s.boxCmdMu.Lock()
 	defer s.boxCmdMu.Unlock()
+	// This push makes the box drop and re-fetch the Ogg stream; announce the
+	// re-attach so the engine's storm damping does not count STR's own work.
+	if s.spotifyExpectReattach != nil {
+		s.spotifyExpectReattach(15 * time.Second)
+	}
+	// Re-arm the auto-repoint hold HERE, at the moment of the push: the arm
+	// at the start of the soft-skip flow can expire during the up-to-12 s
+	// track-boundary wait, leaving the detach gap this push causes uncovered
+	// (SuppressActivate only ever extends, so the early arm stays harmless).
+	if s.spotifySuppressActivate != nil {
+		s.spotifySuppressActivate(12 * time.Second)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
 	defer cancel()
 	var err error

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -193,6 +193,9 @@ type Server struct {
 	// the competing #14 auto-attach cannot race the clean slot recall while the box
 	// is tearing its UPnP source down. nil when Spotify is not configured.
 	spotifySuppressActivate func(time.Duration)
+	// spotifyExpectReattach marks the next Ogg re-attach as deliberate (an
+	// STR re-push), keeping it out of the engine's storm damping.
+	spotifyExpectReattach func(time.Duration)
 	// spotifyInfo answers GET /spotify/info with the live Spotify state
 	// (ready, measured bitrate, device name) the UI reads to show the real
 	// stream bitrate on a Spotify preset tile. nil when not configured.


### PR DESCRIPTION
Found while chasing the "stream stutters briefly on v0.9.53" report (discussion #119, ST30 bundle).

**The loop.** v0.9.53's end-of-stream title wipe (`clearTitleOnEnd`, from the #274 fix) armed a self-sustaining cycle whenever "show the running track on the speaker display" is enabled: the title push re-issues the URI, the box drops and re-fetches the same stream, the OLD handler's deferred wipe empties the live title, and the next (unchanged) metadata block counts as a change and re-fires the push. One audible re-buffer gap per 12 s throttle window, indefinitely.

**The fix.** The wipe is delayed by a 5 s grace and cancelled when a successor handler takes the same stream over (per-URL generation counter). An unchanged title can no longer re-fire the push; a stream that truly ends still blanks, so #274 stays fixed. Regression test included.

**Also in this PR:**
- Short recovered delivery gaps (>= 2 s, capped per connection) now leave a WARN in the agent log; a brief stutter used to be invisible in a diagnostic bundle.
- The soft-skip re-push (every 8 s at most) no longer counts toward the Spotify re-attach storm damping (20 s window): two ordinary skips 9 s apart grew the backoff and held the auto-repoint off for up to a minute. The re-push announces itself via a one-shot `ExpectReattach`.
- The auto-repoint hold is re-armed at the moment of the delayed skip push; the early arm could expire during the up-to-12 s track-boundary wait.

**Live verification** on the Portable (taigan) with display-track enabled and an ICY radio stream: exactly one re-fetch per real title change, the title survives the reconnect, no re-fire in the following minute. `go build ./...`, `go vet`, and the streamproxy/spotify/webui test suites are green.

Refs #119, #274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)