### PR TITLE
fix(spotify): a track that fails to load no longer silences the whole group

### DIFF
--- a/internal/spotify/engine.go
+++ b/internal/spotify/engine.go
@@ -455,6 +455,12 @@ func (m *Manager) runOnce(ctx context.Context) error {
 			m.logger.Info("spotify: track boundary (BOS)",
 				"track", trackNum+1, "prevTrackKB", trackBody/1024,
 				"prevMaxGran", maxGran, "forwardedKB", forwarded/1024)
+			// A fresh logical stream means the engine is demonstrably
+			// delivering audio: that is the recovery signal the delayed
+			// auto-advance checks before skipping (see handleEnginePlaybackEnd).
+			m.mu.Lock()
+			m.lastEngineActiveAt = time.Now()
+			m.mu.Unlock()
 			trackNum++
 			granOffset += maxGran // finished track extends the continuous timeline
 			hdr = append([]byte(nil), page...)

--- a/internal/spotify/engine.go
+++ b/internal/spotify/engine.go
@@ -652,6 +652,18 @@ func (m *Manager) noteLibrespotLine(line string) {
 		m.mu.Unlock()
 		m.logger.Warn("spotify: the engine could not resolve what to play after this playlist, so playback is about to stop", "line", line)
 	}
+	// The engine could not LOAD the next track (a transient Spotify-side
+	// failure mid-playlist, distinct from the context running out above). It
+	// stops afterwards, and that stop must not arm the deliberate-stop latch:
+	// live 2026-08-21 a group of six speakers fell silent after six songs
+	// because "failed advancing to next track" was read as the listener
+	// stopping playback in the Spotify app.
+	if strings.Contains(lc, "failed advancing to next track") || strings.Contains(lc, "failed loading current track") {
+		m.mu.Lock()
+		m.lastTrackLoadFailAt = time.Now()
+		m.mu.Unlock()
+		m.logger.Warn("spotify: the engine failed loading the next track, so playback is about to stop mid-playlist", "line", line)
+	}
 	// Spotify refused the audio key for a track. One is unremarkable: a single
 	// track can be unavailable in a region. A run of them is the account being
 	// refused wholesale, and that is what a listener experiences as a playlist

--- a/internal/spotify/manager.go
+++ b/internal/spotify/manager.go
@@ -147,6 +147,17 @@ type Manager struct {
 	// account whose every track fails (PlayPlay cohort) cannot skip-storm.
 	lastTrackLoadFailAt time.Time
 	lastAutoAdvanceAt   time.Time
+	// lastEngineActiveAt is the last moment the engine demonstrably played:
+	// a playing/active event or a fresh Ogg track boundary. The delayed
+	// auto-advance below compares it against the stop moment, because the
+	// engine frequently RECOVERS from a "failed advancing" on its own a few
+	// seconds later (live 2026-08-21 13:33, three times in one playlist);
+	// advancing then skips the very track the engine just loaded, heard as
+	// "the next song plays two seconds and jumps to the one after".
+	lastEngineActiveAt time.Time
+	// selfRecoveryWait overrides how long the auto-advance waits for that
+	// self-recovery; 0 means the production default. Injected by tests.
+	selfRecoveryWait time.Duration
 
 	// zeroconfLabel is the bare mDNS label the engine advertises as its SRV
 	// target, empty until the agent's own responder is answering for it.

--- a/internal/spotify/manager.go
+++ b/internal/spotify/manager.go
@@ -138,6 +138,15 @@ type Manager struct {
 	// ended, on every speaker of the group at once (live 2026-08-15 16:56 and
 	// 2026-08-16 16:58, both times reported as something else).
 	lastCtxResolveFailAt time.Time
+	// lastTrackLoadFailAt is when go-librespot last failed to LOAD a track
+	// ("failed advancing to next track" / "failed loading current track"), a
+	// transient Spotify-side failure mid-playlist. The stop that follows must
+	// not arm the deliberate-stop latch (live 2026-08-21: a six-speaker group
+	// fell silent after six songs), and one bounded auto-advance tries the
+	// NEXT track instead. lastAutoAdvanceAt rate-limits that advance so an
+	// account whose every track fails (PlayPlay cohort) cannot skip-storm.
+	lastTrackLoadFailAt time.Time
+	lastAutoAdvanceAt   time.Time
 
 	// zeroconfLabel is the bare mDNS label the engine advertises as its SRV
 	// target, empty until the agent's own responder is answering for it.

--- a/internal/spotify/pendingrepoint_test.go
+++ b/internal/spotify/pendingrepoint_test.go
@@ -118,3 +118,40 @@ func TestAPlaylistRunningOutIsNotAUserStop(t *testing.T) {
 		t.Errorf("a pause with no resolve failure must latch, got %d", latched.Load())
 	}
 }
+
+// The sibling false signal, caught live 2026-08-21: the engine failed to LOAD
+// the next track mid-playlist ("failed advancing to next track"), stopped, and
+// STR read that stop as the listener stopping playback in the Spotify app. A
+// six-speaker group fell silent after six songs with no recovery.
+func TestATrackLoadFailureIsNotAUserStop(t *testing.T) {
+	var latched atomic.Int32
+	m := &Manager{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	m.connectPauseFn = func(string) { latched.Add(1) }
+
+	m.lastTrackLoadFailAt = time.Now()
+	m.handleEnginePlaybackEnd("stopped")
+	if latched.Load() != 0 {
+		t.Error("a stop right after a track-load failure must not arm the deliberate-stop latch")
+	}
+	if m.lastAutoAdvanceAt.IsZero() {
+		t.Error("the load-fail stop must attempt one auto-advance (stamp missing)")
+	}
+
+	// A second load-fail stop inside the rate window must not advance again.
+	prev := m.lastAutoAdvanceAt
+	m.lastTrackLoadFailAt = time.Now()
+	m.handleEnginePlaybackEnd("stopped")
+	if !m.lastAutoAdvanceAt.Equal(prev) {
+		t.Error("auto-advance must be rate-limited to one per window")
+	}
+	if latched.Load() != 0 {
+		t.Error("the rate-limited second stop must still not latch")
+	}
+
+	// A stop long after the failure IS the listener, and must still latch.
+	m.lastTrackLoadFailAt = time.Now().Add(-time.Hour)
+	m.handleEnginePlaybackEnd("stopped")
+	if latched.Load() != 1 {
+		t.Errorf("a genuine stop must still latch, got %d", latched.Load())
+	}
+}

--- a/internal/spotify/pendingrepoint_test.go
+++ b/internal/spotify/pendingrepoint_test.go
@@ -155,3 +155,48 @@ func TestATrackLoadFailureIsNotAUserStop(t *testing.T) {
 		t.Errorf("a genuine stop must still latch, got %d", latched.Load())
 	}
 }
+
+// The engine frequently recovers from a load failure on its own a few seconds
+// later. An immediate auto-advance then skips the very track it just loaded:
+// two seconds of the next song, then the one after (live 2026-08-21, three
+// times in one playlist). The advance must wait and stand down on recovery.
+func TestAutoAdvanceStandsDownWhenTheEngineRecovers(t *testing.T) {
+	m, calls, cleanup := mockLibrespot(t)
+	defer cleanup()
+	m.selfRecoveryWait = 50 * time.Millisecond
+
+	m.lastTrackLoadFailAt = time.Now()
+	m.handleEnginePlaybackEnd("stopped")
+	// The engine loads the next track by itself before the wait ends. The
+	// small sleep keeps the two stamps in distinct clock ticks (Windows'
+	// timer granularity); in production the recovery arrives seconds later.
+	time.Sleep(20 * time.Millisecond)
+	m.handleEnginePlaybackStart()
+
+	time.Sleep(250 * time.Millisecond)
+	for _, p := range pathsOf(*calls) {
+		if p == "/player/next" {
+			t.Fatal("the engine recovered on its own, the auto-advance must not skip")
+		}
+	}
+}
+
+func TestAutoAdvanceFiresWhenTheEngineStaysDown(t *testing.T) {
+	m, calls, cleanup := mockLibrespot(t)
+	defer cleanup()
+	m.selfRecoveryWait = 50 * time.Millisecond
+
+	m.lastTrackLoadFailAt = time.Now()
+	m.handleEnginePlaybackEnd("stopped")
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, p := range pathsOf(*calls) {
+			if p == "/player/next" {
+				return // advanced, as it must
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("engine stayed down but the auto-advance never skipped")
+}

--- a/internal/spotify/volume.go
+++ b/internal/spotify/volume.go
@@ -162,7 +162,7 @@ func (m *Manager) handleEnginePlaybackEnd(evType string) {
 		wait := m.selfRecoveryWait
 		m.mu.Unlock()
 		if wait == 0 {
-			wait = 7 * time.Second
+			wait = 15 * time.Second
 		}
 		m.logger.Warn("spotify: playback stopped because a track failed to load, NOT because anybody stopped it",
 			"event", evType, "sinceLoadFailMs", time.Since(loadFailedAt).Milliseconds(), "autoAdvance", canAutoAdvance)
@@ -170,15 +170,30 @@ func (m *Manager) handleEnginePlaybackEnd(evType string) {
 			// The engine frequently recovers from a load failure on its own a
 			// few seconds later; an immediate /player/next then skips the very
 			// track it just loaded (2 s of the next song, then the one after,
-			// live 2026-08-21). So wait first, and advance only when the
-			// engine demonstrably did NOT come back on its own.
+			// live 2026-08-21). POLL for that recovery through the whole
+			// window instead of one look after a fixed sleep: live 14:16:51
+			// the recovery landed 150 ms AFTER the single 7 s check and the
+			// advance skipped the freshly recovered track anyway. A genuinely
+			// dead engine stays dead; waiting the full window adds nothing to
+			// a silence that is already there.
 			stoppedAt := time.Now()
 			go func() {
-				time.Sleep(wait)
-				m.mu.Lock()
-				recovered := m.lastEngineActiveAt.After(stoppedAt)
-				m.mu.Unlock()
-				if recovered {
+				recovered := func() bool {
+					m.mu.Lock()
+					defer m.mu.Unlock()
+					return m.lastEngineActiveAt.After(stoppedAt)
+				}
+				deadline := time.Now().Add(wait)
+				for time.Now().Before(deadline) {
+					if recovered() {
+						m.logger.Info("spotify: engine recovered the next track on its own, no auto-advance needed")
+						return
+					}
+					time.Sleep(500 * time.Millisecond)
+				}
+				// Last look immediately before the skip, so a recovery that
+				// beat the POST by a hair still wins.
+				if recovered() {
 					m.logger.Info("spotify: engine recovered the next track on its own, no auto-advance needed")
 					return
 				}

--- a/internal/spotify/volume.go
+++ b/internal/spotify/volume.go
@@ -159,11 +159,29 @@ func (m *Manager) handleEnginePlaybackEnd(evType string) {
 		if canAutoAdvance {
 			m.lastAutoAdvanceAt = time.Now()
 		}
+		wait := m.selfRecoveryWait
 		m.mu.Unlock()
+		if wait == 0 {
+			wait = 7 * time.Second
+		}
 		m.logger.Warn("spotify: playback stopped because a track failed to load, NOT because anybody stopped it",
 			"event", evType, "sinceLoadFailMs", time.Since(loadFailedAt).Milliseconds(), "autoAdvance", canAutoAdvance)
 		if canAutoAdvance && m.client != nil {
+			// The engine frequently recovers from a load failure on its own a
+			// few seconds later; an immediate /player/next then skips the very
+			// track it just loaded (2 s of the next song, then the one after,
+			// live 2026-08-21). So wait first, and advance only when the
+			// engine demonstrably did NOT come back on its own.
+			stoppedAt := time.Now()
 			go func() {
+				time.Sleep(wait)
+				m.mu.Lock()
+				recovered := m.lastEngineActiveAt.After(stoppedAt)
+				m.mu.Unlock()
+				if recovered {
+					m.logger.Info("spotify: engine recovered the next track on its own, no auto-advance needed")
+					return
+				}
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
 				if err := m.Next(ctx); err != nil {
@@ -191,6 +209,7 @@ func (m *Manager) handleEnginePlaybackEnd(evType string) {
 func (m *Manager) handleEnginePlaybackStart() {
 	m.mu.Lock()
 	fn := m.connectPlayFn
+	m.lastEngineActiveAt = time.Now()
 	m.mu.Unlock()
 	if fn != nil {
 		fn()

--- a/internal/spotify/volume.go
+++ b/internal/spotify/volume.go
@@ -137,6 +137,7 @@ func (m *Manager) handleEnginePlaybackEnd(evType string) {
 	m.mu.Lock()
 	fn := m.connectPauseFn
 	ctxFailedAt := m.lastCtxResolveFailAt
+	loadFailedAt := m.lastTrackLoadFailAt
 	m.mu.Unlock()
 	// A stop that follows the engine failing to resolve the continuation of a
 	// playlist is the playlist running out, not the listener stopping it.
@@ -145,6 +146,33 @@ func (m *Manager) handleEnginePlaybackEnd(evType string) {
 	if !ctxFailedAt.IsZero() && time.Since(ctxFailedAt) < 15*time.Second {
 		m.logger.Warn("spotify: playback stopped because the playlist ran out and the engine could not resolve what follows, NOT because anybody stopped it",
 			"event", evType, "sinceResolveFailMs", time.Since(ctxFailedAt).Milliseconds())
+		return
+	}
+	// A stop after a transient track-LOAD failure is the same false signal
+	// mid-playlist (live 2026-08-21: six-speaker group silent after six
+	// songs). Do not arm the latch; instead try the NEXT track once, bounded
+	// to one advance per two minutes so an account whose every load fails
+	// cannot skip-storm through the playlist.
+	if !loadFailedAt.IsZero() && time.Since(loadFailedAt) < 15*time.Second {
+		m.mu.Lock()
+		canAutoAdvance := m.lastAutoAdvanceAt.IsZero() || time.Since(m.lastAutoAdvanceAt) > 2*time.Minute
+		if canAutoAdvance {
+			m.lastAutoAdvanceAt = time.Now()
+		}
+		m.mu.Unlock()
+		m.logger.Warn("spotify: playback stopped because a track failed to load, NOT because anybody stopped it",
+			"event", evType, "sinceLoadFailMs", time.Since(loadFailedAt).Milliseconds(), "autoAdvance", canAutoAdvance)
+		if canAutoAdvance && m.client != nil {
+			go func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				if err := m.Next(ctx); err != nil {
+					m.logger.Warn("spotify: auto-advance past the unloadable track failed", "err", err)
+				} else {
+					m.logger.Info("spotify: auto-advanced past the unloadable track, playback continues")
+				}
+			}()
+		}
 		return
 	}
 	if fn == nil {


### PR DESCRIPTION
Live case 2026-08-21, Jens' office group: six speakers fell silent after six songs. The log shows go-librespot throwing `failed advancing to next track: failed loading current track` (a transient Spotify-side load failure), then stopping; STR classified that stop as "Spotify app ended playback" and armed the deliberate-stop latch, which parks every recovery path. The box drained its buffer for five minutes and the whole group went to INVALID_SOURCE.

This is the sibling of the already-fenced "failed resolving station" case (2026-08-15/16), with a different error line the fence did not cover.

The fix remembers the load failure, keeps the stop that follows it out of the deliberate-stop latch, and issues one bounded auto-advance to the next track (at most one per two minutes, so an account whose every load fails, e.g. the PlayPlay cohort, cannot skip-storm through a playlist). Regression test mirrors the existing playlist-ran-out test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)