### PR TITLE
fix(multiroom): adding a speaker to a playing group no longer interrupts the music

### DIFF
--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -43,6 +43,13 @@ type Server struct {
 	// after reboot/standby (#70). nil when not wired; zone write endpoints
 	// then still drive the box but do not persist.
 	zones *zones.Store
+	// zoneFormSerial serializes zone form/dissolve drives so two member
+	// changes never interleave against the firmware; zoneFormSeq stamps each
+	// arriving form request so a request that waited behind a newer one can
+	// stand down and let the newest full member list win (rapid successive
+	// taps then cost one drive, not N).
+	zoneFormSerial sync.Mutex
+	zoneFormSeq    atomic.Uint64
 	// memberIDs remembers, per member IP, the SoundTouch deviceID that
 	// speaker's own firmware reported. Zone forming corrects the caller's
 	// deviceID from a live /info read, because a two-chip chassis announces

--- a/internal/webui/zones_incremental_test.go
+++ b/internal/webui/zones_incremental_test.go
@@ -1,0 +1,121 @@
+package webui
+
+import (
+	"testing"
+
+	"github.com/JRpersonal/streborn/internal/boxapi"
+)
+
+// Adding a speaker to a playing group used to run a full /setZone re-form per
+// tap, each one restarting the master's stream (three audible gaps in 20 s,
+// live 2026-08-21). zoneDiff is the split that lets an existing zone take new
+// members incrementally instead.
+
+func TestZoneDiffAddOnly(t *testing.T) {
+	live := boxapi.Zone{Master: "MASTER", Members: []boxapi.ZoneMember{
+		{DeviceID: "AAA", IP: "192.0.2.11"},
+	}}
+	want := []boxapi.ZoneMember{
+		{DeviceID: "AAA", IP: "192.0.2.11"},
+		{DeviceID: "BBB", IP: "192.0.2.12"},
+	}
+	toAdd, toRemove := zoneDiff(live, want)
+	if len(toAdd) != 1 || toAdd[0].DeviceID != "BBB" {
+		t.Fatalf("toAdd = %+v, want only BBB", toAdd)
+	}
+	if len(toRemove) != 0 {
+		t.Fatalf("toRemove = %+v, want none", toRemove)
+	}
+}
+
+func TestZoneDiffRemoveOnly(t *testing.T) {
+	live := boxapi.Zone{Master: "MASTER", Members: []boxapi.ZoneMember{
+		{DeviceID: "AAA", IP: "192.0.2.11"},
+		{DeviceID: "BBB", IP: "192.0.2.12"},
+	}}
+	want := []boxapi.ZoneMember{{DeviceID: "AAA", IP: "192.0.2.11"}}
+	toAdd, toRemove := zoneDiff(live, want)
+	if len(toAdd) != 0 {
+		t.Fatalf("toAdd = %+v, want none", toAdd)
+	}
+	if len(toRemove) != 1 || toRemove[0].DeviceID != "BBB" {
+		t.Fatalf("toRemove = %+v, want only BBB", toRemove)
+	}
+}
+
+func TestZoneDiffMixed(t *testing.T) {
+	live := boxapi.Zone{Master: "MASTER", Members: []boxapi.ZoneMember{
+		{DeviceID: "OLD", IP: "192.0.2.11"},
+	}}
+	want := []boxapi.ZoneMember{{DeviceID: "NEW", IP: "192.0.2.12"}}
+	toAdd, toRemove := zoneDiff(live, want)
+	if len(toAdd) != 1 || toAdd[0].DeviceID != "NEW" || len(toRemove) != 1 || toRemove[0].DeviceID != "OLD" {
+		t.Fatalf("toAdd=%+v toRemove=%+v, want NEW added and OLD removed", toAdd, toRemove)
+	}
+}
+
+// A two-chip chassis (Portable, ST20 BCO) is listed by the firmware under its
+// SCM deviceID while discovery hands the caller its wlan0 MAC. The IP is the
+// stable key: a live member requested again under the other MAC must be
+// neither re-added nor removed.
+func TestZoneDiffMatchesOnIPWhenDeviceIDsDiffer(t *testing.T) {
+	live := boxapi.Zone{Master: "MASTER", Members: []boxapi.ZoneMember{
+		{DeviceID: "SCMMAC", IP: "192.0.2.11"},
+	}}
+	want := []boxapi.ZoneMember{{DeviceID: "WLANMAC", IP: "192.0.2.11"}}
+	toAdd, toRemove := zoneDiff(live, want)
+	if len(toAdd) != 0 || len(toRemove) != 0 {
+		t.Fatalf("toAdd=%+v toRemove=%+v, want the aliased member recognized as unchanged", toAdd, toRemove)
+	}
+}
+
+// A firmware member row can miss the ipaddress attribute; the deviceID match
+// must then hold the member in the zone.
+func TestZoneDiffFallsBackToDeviceIDWithoutIP(t *testing.T) {
+	live := boxapi.Zone{Master: "MASTER", Members: []boxapi.ZoneMember{
+		{DeviceID: "AAA", IP: ""},
+	}}
+	want := []boxapi.ZoneMember{{DeviceID: "aaa", IP: "192.0.2.11"}}
+	toAdd, toRemove := zoneDiff(live, want)
+	if len(toAdd) != 0 || len(toRemove) != 0 {
+		t.Fatalf("toAdd=%+v toRemove=%+v, want case-insensitive deviceID match to hold", toAdd, toRemove)
+	}
+}
+
+func TestZoneDiffEmptyLiveZoneAddsEverything(t *testing.T) {
+	want := []boxapi.ZoneMember{
+		{DeviceID: "AAA", IP: "192.0.2.11"},
+		{DeviceID: "BBB", IP: "192.0.2.12"},
+	}
+	toAdd, toRemove := zoneDiff(boxapi.Zone{}, want)
+	if len(toAdd) != 2 || len(toRemove) != 0 {
+		t.Fatalf("toAdd=%+v toRemove=%+v, want all added, none removed", toAdd, toRemove)
+	}
+}
+
+// The stream-survival gate: after a group change the master that is still
+// audibly playing must NOT get the re-push (that push IS the audible gap on
+// incremental joins); an idle box falls through to the push, the historical
+// safe behavior for the fresh-zone 1036 case.
+func TestResumeAfterZoneFormSkipsWhenStreamSurvived(t *testing.T) {
+	s, rec := newPlayTestServer(t)
+	s.playStateFn = func() (bool, bool) { return false, true } // playing
+	s.resumeAfterZoneForm(lastPlayInfo{boxURL: "http://192.0.2.1:8888/stream/1", title: "x"})
+	if rec.count() != 0 {
+		t.Fatalf("stream survived but the resume pushed anyway: %v", rec.list())
+	}
+}
+
+func TestResumeAfterZoneFormPushesWhenBoxWentSilent(t *testing.T) {
+	s, rec := newPlayTestServer(t)
+	s.playStateFn = func() (bool, bool) { return false, false } // idle
+	lp := lastPlayInfo{boxURL: "http://192.0.2.1:8888/stream/1", title: "x"}
+	s.lastPlayMu.Lock()
+	cp := lp
+	s.lastPlay = &cp // the capture in handleZoneForm is a copy of lastPlay
+	s.lastPlayMu.Unlock()
+	s.resumeAfterZoneForm(lp)
+	if !rec.has("SetAVTransportURI") {
+		t.Fatalf("box went silent but no re-push was sent: %v", rec.list())
+	}
+}

--- a/internal/webui/zones_stereo.go
+++ b/internal/webui/zones_stereo.go
@@ -318,6 +318,37 @@ func (s *Server) handleZoneForm(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Coalesce rapid successive form requests (adding speakers one tap after
+	// another): every caller sends the FULL member list it wants, so the
+	// newest request carries the newest intent and older ones can stand down.
+	// Each arrival takes a sequence number; after a short settle it waits its
+	// turn on the serial lock, and a request that is no longer the newest
+	// answers with the live zone instead of driving a stale list. Without
+	// this, N quick taps ran N full drives back to back (live 2026-08-21,
+	// three drives in 20 s, each one restarting the master's stream).
+	mySeq := s.zoneFormSeq.Add(1)
+	select {
+	case <-time.After(zoneCoalesceSettle):
+	case <-ctx.Done():
+		http.Error(w, "canceled", http.StatusRequestTimeout)
+		return
+	}
+	s.zoneFormSerial.Lock()
+	defer s.zoneFormSerial.Unlock()
+	if latest := s.zoneFormSeq.Load(); latest != mySeq {
+		liveNow, lerr := c.GetZone(ctx)
+		s.logger.Info("zone: form request superseded by a newer member list, standing down", "seq", mySeq, "latest", latest)
+		if lerr != nil {
+			writeJSON(w, http.StatusOK, map[string]any{"ok": true, "mode": "native", "superseded": true})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"ok": true, "mode": "native", "superseded": true,
+			"master": liveNow.Master, "senderIP": liveNow.SenderIP, "members": liveNow.Members,
+		})
+		return
+	}
+
 	// Ask the leader ONE cheap question before touching anything. On 2026-08-18
 	// a fleet bundle showed the leader's BoseApp (:8090) frozen for minutes
 	// BEFORE the user added a third speaker: the form then burned ~30 s in
@@ -437,46 +468,54 @@ func (s *Server) handleZoneForm(w http.ResponseWriter, r *http.Request) {
 			"wakeErr", err, "master", master.DeviceID)
 	}
 
-	// Remove members the user dropped from the group. /setZone only ADDS the
-	// listed slaves, it never removes one, so re-forming with a smaller list -
-	// exactly how the app removes a member (uncheck + apply) - leaves the dropped
-	// box in the firmware zone: it "briefly leaves then comes back" (Albrecht,
-	// 7-box fleet, 2026-07-14). Read the live zone and RemoveZoneSlave anyone no
-	// longer wanted. Match on IP, the chassis-stable key: a two-chip box (Portable,
-	// ST20 BCO) announces its wlan0 MAC over discovery, which is NOT the SCM
-	// deviceID the firmware lists for it, so a deviceID-only match would wrongly
-	// keep the dropped box. Best-effort, before the add below.
-	if live, gerr := c.GetZone(ctx); gerr == nil && live.Master != "" && len(live.Members) > 0 {
-		wantIP := make(map[string]bool, len(slaves))
-		wantDev := make(map[string]bool, len(slaves))
-		for _, sl := range slaves {
-			if sl.IP != "" {
-				wantIP[sl.IP] = true
-			}
-			if sl.DeviceID != "" {
-				wantDev[strings.ToLower(sl.DeviceID)] = true
-			}
-		}
-		var toRemove []boxapi.ZoneMember
-		for _, m := range live.Members {
-			keep := (m.IP != "" && wantIP[m.IP]) || (m.DeviceID != "" && wantDev[strings.ToLower(m.DeviceID)])
-			if !keep {
-				toRemove = append(toRemove, boxapi.ZoneMember{DeviceID: m.DeviceID, IP: m.IP})
-			}
-		}
-		if len(toRemove) > 0 {
-			s.logger.Info("zone: dropping members no longer in the group before re-forming", "count", len(toRemove), "master", master.DeviceID)
-			if err := c.RemoveZoneSlave(ctx, master, toRemove); err != nil {
-				s.logger.Warn("zone: reconcile removeZoneSlave failed", "err", err)
-			}
+	// Read the live zone ONCE: it carries both the members the user dropped
+	// (which /setZone alone never removes - "briefly leaves then comes back",
+	// Albrecht, 7-box fleet, 2026-07-14) and the decision between the
+	// incremental join path and a full re-form. Matching is IP-or-deviceID,
+	// with IP as the chassis-stable key: a two-chip box (Portable, ST20 BCO)
+	// announces its wlan0 MAC over discovery, which is NOT the SCM deviceID
+	// the firmware lists for it, so a deviceID-only match would wrongly treat
+	// a live member as new (or keep a dropped one).
+	live, liveErr := c.GetZone(ctx)
+	zoneExists := liveErr == nil && live.Master != "" && len(live.Members) > 0 &&
+		strings.EqualFold(strings.TrimSpace(live.Master), strings.TrimSpace(master.DeviceID))
+	toAdd, toRemove := zoneDiff(live, slaves)
+	if liveErr == nil && live.Master != "" && len(live.Members) > 0 && len(toRemove) > 0 {
+		s.logger.Info("zone: dropping members no longer in the group", "count", len(toRemove), "master", master.DeviceID)
+		if err := c.RemoveZoneSlave(ctx, master, toRemove); err != nil {
+			s.logger.Warn("zone: removeZoneSlave failed", "err", err)
 		}
 	}
 
-	if err := c.SetZone(ctx, master, slaves); err != nil {
-		s.logger.Warn("zone: setZone failed", "err", err, "master", master.DeviceID)
-		s.restorePreviousZone(ctx, c, master, prevDoc, hadPrevDoc, prevLive)
-		http.Error(w, "setZone: "+err.Error(), http.StatusBadGateway)
-		return
+	// When this master already leads a live zone, join new members with
+	// /addZoneSlave instead of re-forming the whole zone: the firmware keeps
+	// the master's source running through an incremental join (the original
+	// Bose app added members this way, without interrupting the music), while
+	// a full /setZone re-form ended in the stream restart below on every tap.
+	// Any error falls back to the proven full re-form, so the worst case is
+	// exactly the old behavior.
+	usedIncremental := false
+	if zoneExists {
+		switch {
+		case len(toAdd) == 0:
+			s.logger.Info("zone: requested group already live, nothing to drive", "master", master.DeviceID, "members", len(live.Members)-len(toRemove))
+			usedIncremental = true
+		default:
+			if err := c.AddZoneSlave(ctx, master, toAdd); err != nil {
+				s.logger.Warn("zone: addZoneSlave failed, falling back to a full setZone", "err", err, "adding", len(toAdd))
+			} else {
+				s.logger.Info("zone: added members to the live group without re-forming", "adding", len(toAdd), "master", master.DeviceID)
+				usedIncremental = true
+			}
+		}
+	}
+	if !usedIncremental {
+		if err := c.SetZone(ctx, master, slaves); err != nil {
+			s.logger.Warn("zone: setZone failed", "err", err, "master", master.DeviceID)
+			s.restorePreviousZone(ctx, c, master, prevDoc, hadPrevDoc, prevLive)
+			http.Error(w, "setZone: "+err.Error(), http.StatusBadGateway)
+			return
+		}
 	}
 	z2, err := c.GetZone(ctx)
 	if err != nil {
@@ -491,6 +530,39 @@ func (s *Server) handleZoneForm(w http.ResponseWriter, r *http.Request) {
 	// own /getZone (verifyFollowersJoined), polled with a short retry because a
 	// slave's self-report lags forming by ~100ms to several seconds. The master's
 	// read-back is kept only as supplementary diagnostics (masterMissing).
+	fetchFollower := func(fctx context.Context, ip string) (boxapi.Zone, error) {
+		return boxapi.New(ip).GetZone(fctx)
+	}
+	// On the incremental path only the members that were actually ADDED need
+	// the follower poll: the pre-existing ones are in the live zone already,
+	// and polling them again burned the form budget for nothing (the very
+	// bug the twelve-speaker fleet hit on 2026-08-09).
+	verifyTargets := slaves
+	if usedIncremental {
+		verifyTargets = toAdd
+	}
+	missing, unverifiable := []string{}, []string{}
+	if len(verifyTargets) > 0 {
+		missing, unverifiable = verifyFollowersJoined(ctx, s.logger, z2.Master, verifyTargets, fetchFollower)
+	}
+	// Incremental join where NOT ONE added member confirmed: distrust
+	// /addZoneSlave on this firmware and run the proven full re-form once.
+	if usedIncremental && len(toAdd) > 0 && len(missing) == len(toAdd) {
+		s.logger.Warn("zone: no added member confirmed the incremental join, re-forming the whole zone once", "adding", len(toAdd))
+		if err := c.SetZone(ctx, master, slaves); err != nil {
+			s.logger.Warn("zone: fallback setZone failed", "err", err, "master", master.DeviceID)
+			s.restorePreviousZone(ctx, c, master, prevDoc, hadPrevDoc, prevLive)
+			http.Error(w, "setZone: "+err.Error(), http.StatusBadGateway)
+			return
+		}
+		usedIncremental = false
+		if z2, err = c.GetZone(ctx); err != nil {
+			s.logger.Warn("zone: formed but getZone read-back failed", "err", err)
+			writeJSON(w, http.StatusOK, map[string]any{"ok": true, "mode": "native"})
+			return
+		}
+		missing, unverifiable = verifyFollowersJoined(ctx, s.logger, z2.Master, slaves, fetchFollower)
+	}
 	masterLive := make(map[string]bool, len(z2.Members))
 	for _, m := range z2.Members {
 		masterLive[strings.ToLower(m.DeviceID)] = true
@@ -501,9 +573,8 @@ func (s *Server) handleZoneForm(w http.ResponseWriter, r *http.Request) {
 			masterMissing = append(masterMissing, sl.DeviceID)
 		}
 	}
-	missing, unverifiable := verifyFollowersJoined(ctx, s.logger, z2.Master, slaves, func(fctx context.Context, ip string) (boxapi.Zone, error) {
-		return boxapi.New(ip).GetZone(fctx)
-	})
+	// Pre-existing members of an incremental join count as verified: only the
+	// added ones were polled, so "missing" can only name those.
 	verified := len(slaves) - len(missing)
 	// Regression guard (#70 / Albrecht 0.8.x): if the master's own read-back shows
 	// no members and no master after SetZone, the firmware never actually formed a
@@ -545,6 +616,17 @@ func (s *Server) resumeAfterZoneForm(lp lastPlayInfo) {
 	time.Sleep(1500 * time.Millisecond)
 	if s.userStoppedRecently() {
 		s.logger.Info("zone: not restarting playback after forming, user stopped meanwhile")
+		return
+	}
+	// The re-push exists for the fresh-zone case, where /setZone tears the
+	// master's UPnP session down (1036 wrong-state) and the room goes silent.
+	// An incremental join, and often an additive re-form over a live zone,
+	// leaves the stream running - restarting it then IS the audible gap the
+	// user reports. So ask the box: still playing after the settle means the
+	// stream survived and the push would only interrupt it. An unreadable or
+	// idle box falls through to the push, the historical safe behavior.
+	if standby, busy := s.boxPlayState(); busy && !standby {
+		s.logger.Info("zone: stream survived the group change, not restarting playback")
 		return
 	}
 	s.boxCmdMu.Lock()
@@ -1410,6 +1492,11 @@ func (s *Server) reconcileZoneOnce() {
 
 // handleZoneDissolve tears down the zone this box leads and stops re-forming it.
 func (s *Server) handleZoneDissolve(w http.ResponseWriter, r *http.Request) {
+	// Same serial lock as handleZoneForm: a dissolve arriving between two
+	// member changes executes in arrival order and never interleaves with a
+	// drive against the firmware.
+	s.zoneFormSerial.Lock()
+	defer s.zoneFormSerial.Unlock()
 	c := boxapi.New(s.boxHost)
 	ctx, cancel := context.WithTimeout(r.Context(), 8*time.Second)
 	defer cancel()
@@ -1709,6 +1796,50 @@ func (s *Server) handleMargeGroupDoc(w http.ResponseWriter, r *http.Request) {
 // app's own 45 s call timeout, because an agent that answers after the app has
 // given up is worse than one that fails: the app would report failure for a
 // group the firmware went on to build.
+// zoneCoalesceSettle is how long a form request waits before checking whether
+// a newer one arrived: rapid successive taps (adding speakers one after
+// another) then merge into the newest request's full list instead of running
+// one drive per tap.
+const zoneCoalesceSettle = 700 * time.Millisecond
+
+// zoneDiff splits the requested member list against the live firmware zone:
+// toAdd are requested members not yet in the zone, toRemove are live members
+// no longer requested. Matching is IP-or-deviceID; IP is the chassis-stable
+// key (a two-chip box announces its wlan0 MAC over discovery, which is not
+// the SCM deviceID the firmware lists). With no live zone every requested
+// member is toAdd and nothing is toRemove.
+func zoneDiff(live boxapi.Zone, want []boxapi.ZoneMember) (toAdd, toRemove []boxapi.ZoneMember) {
+	wantIP := make(map[string]bool, len(want))
+	wantDev := make(map[string]bool, len(want))
+	for _, m := range want {
+		if m.IP != "" {
+			wantIP[m.IP] = true
+		}
+		if m.DeviceID != "" {
+			wantDev[strings.ToLower(m.DeviceID)] = true
+		}
+	}
+	liveIP := make(map[string]bool, len(live.Members))
+	liveDev := make(map[string]bool, len(live.Members))
+	for _, m := range live.Members {
+		if m.IP != "" {
+			liveIP[m.IP] = true
+		}
+		if m.DeviceID != "" {
+			liveDev[strings.ToLower(m.DeviceID)] = true
+		}
+		if !((m.IP != "" && wantIP[m.IP]) || (m.DeviceID != "" && wantDev[strings.ToLower(m.DeviceID)])) {
+			toRemove = append(toRemove, boxapi.ZoneMember{DeviceID: m.DeviceID, IP: m.IP})
+		}
+	}
+	for _, m := range want {
+		if !((m.IP != "" && liveIP[m.IP]) || (m.DeviceID != "" && liveDev[strings.ToLower(m.DeviceID)])) {
+			toAdd = append(toAdd, m)
+		}
+	}
+	return toAdd, toRemove
+}
+
 func zoneFormBudget(slaves int) time.Duration {
 	const (
 		base    = 10 * time.Second

--- a/internal/webui/zones_stereo.go
+++ b/internal/webui/zones_stereo.go
@@ -555,7 +555,6 @@ func (s *Server) handleZoneForm(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "setZone: "+err.Error(), http.StatusBadGateway)
 			return
 		}
-		usedIncremental = false
 		if z2, err = c.GetZone(ctx); err != nil {
 			s.logger.Warn("zone: formed but getZone read-back failed", "err", err)
 			writeJSON(w, http.StatusOK, map[string]any{"ok": true, "mode": "native"})
@@ -1828,12 +1827,12 @@ func zoneDiff(live boxapi.Zone, want []boxapi.ZoneMember) (toAdd, toRemove []box
 		if m.DeviceID != "" {
 			liveDev[strings.ToLower(m.DeviceID)] = true
 		}
-		if !((m.IP != "" && wantIP[m.IP]) || (m.DeviceID != "" && wantDev[strings.ToLower(m.DeviceID)])) {
+		if (m.IP == "" || !wantIP[m.IP]) && (m.DeviceID == "" || !wantDev[strings.ToLower(m.DeviceID)]) {
 			toRemove = append(toRemove, boxapi.ZoneMember{DeviceID: m.DeviceID, IP: m.IP})
 		}
 	}
 	for _, m := range want {
-		if !((m.IP != "" && liveIP[m.IP]) || (m.DeviceID != "" && liveDev[strings.ToLower(m.DeviceID)])) {
+		if (m.IP == "" || !liveIP[m.IP]) && (m.DeviceID == "" || !liveDev[strings.ToLower(m.DeviceID)]) {
 			toAdd = append(toAdd, m)
 		}
 	}


### PR DESCRIPTION
Adding speakers to a playing group one after another ran a full /setZone re-form per tap, each followed by an unconditional master stream restart: one audible stop/start per member (live logs 2026-08-21 12:20, three restarts in 20 s). The original Bose firmware added members incrementally without interrupting playback.

Design came out of a three-way analysis (agent zone code path, Bose zone API semantics incl. the official Webservices API PDF and the thlucas1 reference, and both UI callers). All changes are agent-side; desktop app and phone webui keep their existing API and behavior.

1. **Incremental joins.** When this master already leads a live zone, new members join via `/addZoneSlave` (removals via `/removeZoneSlave`), which keeps the master's source running. Full `/setZone` remains for initial creation, master change, and as an automatic fallback when the incremental call errors or no added member confirms the join. Only ADDED members are polled for confirmation, so pre-existing members no longer burn the form budget (the 2026-08-09 twelve-speaker misreport).

2. **Conditional stream restart.** The post-form re-push now asks the box first: a master still playing after the settle kept its stream through the group change, and the push would be the only audible gap. Idle or unreadable falls through to the push (the proven fresh-zone 1036 recovery, unchanged).

3. **Coalescing.** Rapid successive form requests merge: each takes a sequence number, waits a short settle, and stands down when a newer full member list arrived. Form and dissolve are serialized against each other.

Unit tests cover the diff logic (incl. the two-chip wlan0/SCM MAC alias), the survival gate in both directions, and the existing suite stays green. Live-fleet verification on the office speakers follows in-session.

Refs #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)