### PR TITLE
fix(spotify): pressing a playing preset again reaches the next track in seconds

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -721,6 +721,12 @@ func run() error {
 		webui.WithSpotifyExportCred(spotifyMgr.ExportCredential),
 		webui.WithSpotifyImportCred(spotifyMgr.ImportCredential),
 		webui.WithSpotifySetRecalling(spotifyMgr.SetRecalling),
+		// Recall boundary cut: armed with SetRecalling so a preset re-press
+		// never feeds the box the old track's audio during the load preamble;
+		// the stale-KB probe lets the recall re-push stand down when the cut
+		// kept the box clean.
+		webui.WithSpotifyArmRecallCut(spotifyMgr.ArmRecallCut),
+		webui.WithSpotifyBoundaryStaleKB(spotifyMgr.LastBoundaryStaleKB),
 		webui.WithSpotifySuppressActivate(spotifyMgr.SuppressActivate),
 		webui.WithSpotifyExpectReattach(spotifyMgr.ExpectReattach),
 		webui.WithSpotifyInfo(spotifyMgr.ServeInfo),
@@ -817,6 +823,10 @@ func run() error {
 		// Record hardware-preset recalls so the wake-resume + auto-re-push know
 		// what to bring back. Returns the recall generation for supersession.
 		noteLastPlay: webuiSrv.NoteLastPlay,
+		// Conditional post-recall re-push (shared with the app path): drop the
+		// box's buffer only when stale pre-boundary audio reached it despite
+		// the armed recall cut.
+		repushAfterRecall: webuiSrv.ReattachAfterSpotifyRecall,
 		// Supersession: a hardware verify stands down as soon as a newer play
 		// (hardware or app) bumps the shared recall generation, mirroring the
 		// soft path's verifyRecall guard ("pressed 2, got 1").

--- a/cmd/agent/wshandler.go
+++ b/cmd/agent/wshandler.go
@@ -101,6 +101,12 @@ type presetWsHandler struct {
 	// noteRecentPreset records a hardware-preset press into the recently-played
 	// ring (#135). Wired to webui.NoteRecentPreset. nil-safe.
 	noteRecentPreset func(presets.Preset)
+	// repushAfterRecall re-pushes the slot's Spotify stream once a hardware
+	// recall's track boundary lands, and only when stale pre-boundary audio
+	// reached the box's attachment despite the armed cut (the app path runs
+	// the identical gate). Blocking; called in a goroutine. Wired to
+	// webui.ReattachAfterSpotifyRecall. nil-safe.
+	repushAfterRecall func(gen uint64, started time.Time, slot int, armedAt time.Time)
 	// onPowerWake is invoked when the box leaves standby on a power press: a
 	// powerStateUpdated on firmware that sends it, or the DO_NOT_RESUME selection
 	// restore on firmware that does not (Portable/taigan). Resumes the last
@@ -1043,8 +1049,13 @@ func (h *presetWsHandler) playSpotifyPreset(ctx context.Context, seq uint64, pre
 
 	// Mark a recall BEFORE the box attaches (PlayURLMime below / the box's own
 	// self-activation) so ServeOgg does not resume the old mid-position track;
-	// Play drives the new shuffled track from its start.
+	// Play drives the new shuffled track from its start. Arm the boundary cut
+	// in the same breath: the fresh attachment must never be fed the OLD
+	// track's audio while the new context loads (the 20+s same-preset
+	// re-press, live Portable 2026-08-21).
 	h.spotify.SetRecalling()
+	h.spotify.ArmRecallCut()
+	armedAt := time.Now()
 	playCtx, cancel := context.WithTimeout(ctx, 25*time.Second)
 	defer cancel()
 	// Show the preset on the box display IMMEDIATELY: point the box at this
@@ -1084,6 +1095,12 @@ func (h *presetWsHandler) playSpotifyPreset(ctx context.Context, seq uint64, pre
 	// (shuffle off, in-order); a shuffle preset starts on a fresh random track.
 	if err := h.spotify.PlayAccount(playCtx, p.URI, p.Account, spotify.PlayOptions{Shuffle: p.Shuffle}); err != nil {
 		h.logger.Warn("spotify play (initial) failed, will verify+retry", "slot", slot, "err", err)
+	} else if h.repushAfterRecall != nil {
+		// The context loaded: mirror the app path's conditional post-boundary
+		// re-push, which drops the box's buffer only when stale pre-boundary
+		// audio reached it despite the armed cut. gen lives in the same
+		// generation space as the webui's recalls (NoteLastPlay).
+		go h.repushAfterRecall(gen, pressAt, slot, armedAt)
 	}
 	// Verify+retry in the background: the first press after a cold boot races
 	// go-librespot's auth, so the box gets no audio and the user had to press

--- a/internal/spotify/accounts.go
+++ b/internal/spotify/accounts.go
@@ -293,11 +293,18 @@ func (m *Manager) captureLoop(ctx context.Context) {
 // public playlists still work). Otherwise it swaps the credential and restarts
 // go-librespot, waiting until it re-auths as the target.
 func (m *Manager) SwitchAccount(ctx context.Context, username string) (bool, error) {
+	return m.switchAccountFrom(ctx, m.currentUsername(ctx), username)
+}
+
+// switchAccountFrom is SwitchAccount with the active account already probed
+// (cur, "" when unknown/down). The recall preamble passes its single /status
+// result in, so a warm same-account recall spends no extra round trip here.
+func (m *Manager) switchAccountFrom(ctx context.Context, cur, username string) (bool, error) {
 	username = strings.TrimSpace(username)
 	if username == "" {
 		return false, nil
 	}
-	if cur := m.currentUsername(ctx); cur == username {
+	if cur == username {
 		return false, nil // already this account: no switch, no restart
 	}
 	data, err := os.ReadFile(filepath.Join(m.credStore, sanitizeUser(username)+".json"))

--- a/internal/spotify/manager.go
+++ b/internal/spotify/manager.go
@@ -228,10 +228,16 @@ type Manager struct {
 	// dropped instead of flushed (NoteSkip / skipCutArmed).
 	skipCutUntil     time.Time
 	lastSkipBoundary time.Time
-	sinkBytes        int64
-	sinkPages        int64
-	sinkFirstAudioAt time.Time
-	sinkLastPageAt   time.Time
+	// lastBoundaryStaleBytes snapshots, at the moment a cut boundary was
+	// stamped, how much non-header audio the current attachment had already
+	// been fed. ~0 means the cut kept the box's buffer clean, so the recall
+	// re-push can stand down instead of flapping the stream for nothing
+	// (LastBoundaryStaleKB).
+	lastBoundaryStaleBytes int64
+	sinkBytes              int64
+	sinkPages              int64
+	sinkFirstAudioAt       time.Time
+	sinkLastPageAt         time.Time
 	// lastContext is the Spotify context (playlist/album) URI go-librespot last
 	// announced via will_play. When it changes (the app switched to another
 	// playlist) the box is re-pointed at the stream so it drops its buffer and

--- a/internal/spotify/manager.go
+++ b/internal/spotify/manager.go
@@ -97,6 +97,7 @@ type Manager struct {
 	configVol    int       // initial_volume currently written to config.yml
 	sink         io.Writer // current HTTP consumer, nil when none
 	lastAttachAt time.Time // when the box last attached to the Ogg stream (re-attach storm detection)
+	lastDetachAt time.Time // when the box last detached; the warm-recall gate's "streaming until a moment ago"
 	// expectReattachUntil marks the next re-attach as deliberately caused by
 	// STR's own re-push (one-shot, see ExpectReattach), keeping it out of the
 	// storm accounting.

--- a/internal/spotify/ogg.go
+++ b/internal/spotify/ogg.go
@@ -260,6 +260,22 @@ func (m *Manager) NoteSkip() {
 	m.mu.Unlock()
 }
 
+// ArmRecallCut arms the boundary cut for a preset recall, so the box never
+// re-buffers the OLD track's audio while the new context loads. The window is
+// 30s, longer than NoteSkip's 15s: the recall preamble may include an account
+// restart (~8s) plus the play POST before the new context's BOS can arrive.
+// Extends only, never shrinks, so a re-arm mid-recall cannot cut the window
+// short. Every recall path that arms this and then aborts before /player/play
+// MUST disarm (clearSkipCut): an armed cut with no BOS coming drops live audio
+// until the window expires.
+func (m *Manager) ArmRecallCut() {
+	m.mu.Lock()
+	if t := time.Now().Add(30 * time.Second); t.After(m.skipCutUntil) {
+		m.skipCutUntil = t
+	}
+	m.mu.Unlock()
+}
+
 // skipCutArmed reports whether an armed user skip is awaiting its track
 // boundary; clearSkipCut disarms it the moment that boundary arrives, so the
 // new track's pages are never mistaken for stale ones.
@@ -284,6 +300,11 @@ func (m *Manager) clearSkipCut() {
 func (m *Manager) noteSkipBoundary() {
 	m.mu.Lock()
 	m.lastSkipBoundary = time.Now()
+	// Snapshot how much non-header audio this attachment received before the
+	// boundary (the per-attach counters reset in ServeOgg). The header
+	// subtraction is conservative: it can only under-count the stale audio,
+	// which errs toward NOT tearing the box's buffer down.
+	m.lastBoundaryStaleBytes = max(0, m.sinkBytes-int64(len(m.headerPages)))
 	m.mu.Unlock()
 }
 
@@ -293,4 +314,14 @@ func (m *Manager) LastSkipBoundary() time.Time {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.lastSkipBoundary
+}
+
+// LastBoundaryStaleKB reports the stale (pre-boundary) KB the current sink was
+// fed before the last cut boundary landed. It gates the recall re-push: ~0
+// means the armed cut kept the box's buffer clean, so no re-push (and no
+// audible stream flap) is needed.
+func (m *Manager) LastBoundaryStaleKB() int64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastBoundaryStaleBytes / 1024
 }

--- a/internal/spotify/recall.go
+++ b/internal/spotify/recall.go
@@ -70,6 +70,22 @@ func (m *Manager) Play(ctx context.Context, uri string, opts PlayOptions) error 
 	// Mark a recall in progress so ServeOgg does not resume the OLD (mid) track
 	// when the box attaches; this path drives the chosen track from its start.
 	m.SetRecalling()
+	// Warm same-context fast path: the requested context is ALREADY loaded and
+	// audibly streaming to a sink, so the paused-load/pause/wait staging below
+	// buys nothing and costs ~7-9s (the "pressing the playing preset again
+	// takes 20+s" report, live Portable 2026-08-21). A stalled stream
+	// (attached but silent) deliberately falls through to the cold reload.
+	m.mu.Lock()
+	same := m.lastContext != "" && normalizeContextURI(m.lastContext) == uri
+	m.mu.Unlock()
+	if same && m.Streaming() && !m.StreamStalled() {
+		return m.replayWarm(ctx, uri, opts)
+	}
+	// Arm the boundary cut for the cold path too: the box re-attaches within a
+	// second of the press and would otherwise re-buffer the OLD track's audio
+	// for the whole load preamble. Idempotent re-arm (the recall entry points
+	// already armed before their PlayURLMime).
+	m.ArmRecallCut()
 	// Point the resume tracker at the context we are loading right now and drop
 	// the previous track. The will_play event that normally sets lastContext can
 	// lag or be missed, so without this a metadata/status event arriving after
@@ -99,6 +115,9 @@ func (m *Manager) Play(ctx context.Context, uri string, opts PlayOptions) error 
 	playAt := time.Now()
 	playBody, _ := json.Marshal(playReq)
 	if err := m.apiPostC(ctx, m.playClient, "/player/play", string(playBody)); err != nil {
+		// The play never happened, so no track boundary (BOS) is coming: an
+		// armed cut would now drop whatever IS still playing for up to 30s.
+		m.clearSkipCut()
 		// The API 500 is bare; the reason (e.g. Spotify's audio-key denial on
 		// a non-Premium account, #311) only appears on go-librespot's stderr.
 		// Attach it so the app's error message explains itself.
@@ -169,6 +188,40 @@ func (m *Manager) Play(ctx context.Context, uri string, opts PlayOptions) error 
 	m.logger.Info("spotify: recall play", "uri", uri, "shuffle", opts.Shuffle, "resumeTrack", resumeURI != "")
 	// Debounce the will_play context change this recall triggers (this path
 	// already drives the box separately, so no extra re-point needed).
+	m.mu.Lock()
+	m.lastActivate = time.Now()
+	m.mu.Unlock()
+	return nil
+}
+
+// replayWarm handles a recall of the context that is already loaded and
+// streaming, without the paused reload staging. Shuffle preset: reseed
+// (off->on, the fresh-order guarantee, live Portable 2026-08-19) plus one
+// /player/next; the caller-armed recall cut then turns the resulting BOS into
+// drop + re-anchor + boundary stamp, so the next track is audible in seconds.
+// Resume preset: there is nothing to reload; clear the cut (no BOS is coming,
+// an armed cut would drop the live audio) and just ensure shuffle is off and
+// playback runs. Deliberate semantics change: re-pressing an already-playing
+// resume preset no longer restarts the current track from 0:00.
+func (m *Manager) replayWarm(ctx context.Context, uri string, opts PlayOptions) error {
+	// Same bookkeeping as the cold path: retarget the resume tracker and drop
+	// the stale track so a late metadata event cannot corrupt the resume store.
+	m.mu.Lock()
+	m.lastContext = uri
+	m.curTrackURI = ""
+	m.mu.Unlock()
+	if opts.Shuffle {
+		_ = m.apiPost(ctx, "/player/shuffle_context", `{"shuffle_context":false}`)
+		_ = m.apiPost(ctx, "/player/shuffle_context", `{"shuffle_context":true}`)
+		_ = m.apiPost(ctx, "/player/next", "")
+	} else {
+		m.clearSkipCut()
+		_ = m.apiPost(ctx, "/player/shuffle_context", `{"shuffle_context":false}`)
+	}
+	// No-op while playing; recovers an engine another controller paused.
+	_ = m.apiPost(ctx, "/player/resume", "")
+	m.logger.Info("spotify: warm same-context recall (fast path)", "uri", uri, "shuffle", opts.Shuffle)
+	// Debounce the will_play repoint exactly like the cold path does.
 	m.mu.Lock()
 	m.lastActivate = time.Now()
 	m.mu.Unlock()
@@ -375,13 +428,19 @@ func (m *Manager) CanRecall(ctx context.Context) bool {
 // used by both the hardware-button and the desktop/API paths, so both honour
 // the preset's shuffle flag and the per-context resume point identically.
 func (m *Manager) PlayAccount(ctx context.Context, uri, account string, opts PlayOptions) error {
+	// ONE /status probe for the whole preamble. The diagnostic log line, the
+	// account switch and the session gate each probed on their own, which on a
+	// slow engine turned the recall preamble into three serial 5s-timeout
+	// windows before /player/play was even sent (part of the 20+s same-preset
+	// re-press, live Portable 2026-08-21).
+	cur := m.currentUsername(ctx)
 	// Diagnostic: log the live session state at the recall boundary so a bundle
 	// disambiguates "never logged in" vs "dead session" vs "playing fine" without
 	// guesswork (every Spotify-recall investigation hit this blind spot).
 	m.logger.Info("spotify: recall start", "uri", uri, "wantAccount", account,
-		"sessionUser", m.currentUsername(ctx), "loggedIn", m.LoggedIn())
+		"sessionUser", cur, "loggedIn", m.LoggedIn())
 	if account != "" {
-		if _, err := m.SwitchAccount(ctx, account); err != nil {
+		if _, err := m.switchAccountFrom(ctx, cur, account); err != nil {
 			m.logger.Warn("spotify: account switch failed, playing with current account", "account", account, "err", err)
 		}
 	}
@@ -393,10 +452,25 @@ func (m *Manager) PlayAccount(ctx context.Context, uri, account string, opts Pla
 	// for the cold/dropped case; a box that is genuinely not logged in (or whose
 	// credential a takeover invalidated) yields ErrNoSpotifySession so the caller
 	// shows the tap-once hint instead of silently playing nothing.
-	if !m.ensureSession(ctx) {
+	if !m.ensureSessionWith(ctx, cur) {
+		// The recall aborts before /player/play, so no track boundary (BOS) is
+		// coming: disarm the recall cut the entry point armed, or it would drop
+		// whatever is still playing for up to 30s.
+		m.clearSkipCut()
 		return ErrNoSpotifySession
 	}
 	return m.Play(ctx, uri, opts)
+}
+
+// ensureSessionWith is ensureSession fed with an already-probed username, so
+// the common warm recall (live session, no account restart) needs no extra
+// /status round trip. Any restart since the probe (a cross-account switch)
+// invalidates it, and the full ensureSession then re-verifies the session.
+func (m *Manager) ensureSessionWith(ctx context.Context, cur string) bool {
+	if cur != "" && !m.recallRestartedRecently() {
+		return true
+	}
+	return m.ensureSession(ctx)
 }
 
 // noteResume records the current track as the resume point for the current

--- a/internal/spotify/recall.go
+++ b/internal/spotify/recall.go
@@ -88,7 +88,21 @@ func (m *Manager) Play(ctx context.Context, uri string, opts PlayOptions) error 
 	recentlyDetached := !m.lastDetachAt.IsZero() && time.Since(m.lastDetachAt) < 15*time.Second
 	m.mu.Unlock()
 	if same && ((m.Streaming() && !m.StreamStalled()) || recentlyDetached) {
-		return m.replayWarm(ctx, uri, opts)
+		// One cheap proof that the engine still HOLDS the context before
+		// taking the shortcut. Spotify can pull the session out from under
+		// the engine ("playback was transferred to <unknown>"), which leaves
+		// it logged in with an EMPTY queue: shuffle/next/resume then do
+		// nothing at all, the box sits on a byte-less stream for 30 s and
+		// dies with 3101 AUDIO_ERROR_BAD_URL. Live 2026-08-21, three presses
+		// in a row, every one of them silent. Without a loaded track the
+		// cold path below is the only thing that can rebuild the queue.
+		sctx, scancel := context.WithTimeout(ctx, 3*time.Second)
+		_, _, _, hasTrack := m.liveNowPlaying(sctx)
+		scancel()
+		if hasTrack {
+			return m.replayWarm(ctx, uri, opts)
+		}
+		m.logger.Info("spotify: the engine holds no track (session transferred away?), taking the full recall instead of the fast path")
 	}
 	// Arm the boundary cut for the cold path too: the box re-attaches within a
 	// second of the press and would otherwise re-buffer the OLD track's audio

--- a/internal/spotify/recall.go
+++ b/internal/spotify/recall.go
@@ -77,8 +77,17 @@ func (m *Manager) Play(ctx context.Context, uri string, opts PlayOptions) error 
 	// (attached but silent) deliberately falls through to the cold reload.
 	m.mu.Lock()
 	same := m.lastContext != "" && normalizeContextURI(m.lastContext) == uri
+	// The webui recall re-pushes the URI to the box BEFORE this call, which
+	// makes the box drop and re-fetch the Ogg stream: at this instant the
+	// sink is usually nil even though music played until a second ago. A
+	// DETACH moments ago therefore counts as warm too - that tear-down was
+	// the recall's own doing, the engine kept playing through it. (Two live
+	// rounds proved the lessons: the sink-only gate never fired, and a
+	// lastAttachAt window did not either, because a stable sink attaches
+	// once and then plays for minutes.)
+	recentlyDetached := !m.lastDetachAt.IsZero() && time.Since(m.lastDetachAt) < 15*time.Second
 	m.mu.Unlock()
-	if same && m.Streaming() && !m.StreamStalled() {
+	if same && ((m.Streaming() && !m.StreamStalled()) || recentlyDetached) {
 		return m.replayWarm(ctx, uri, opts)
 	}
 	// Arm the boundary cut for the cold path too: the box re-attaches within a

--- a/internal/spotify/recall_warm_test.go
+++ b/internal/spotify/recall_warm_test.go
@@ -208,10 +208,13 @@ func TestPlayAccountAbortDisarmsCut(t *testing.T) {
 	}
 }
 
-// TestPlayAccountWarmSingleStatusProbe: the warm recall preamble must cost
-// exactly ONE /status round trip (the old shape probed three times, each a
-// potential 5s timeout on a slow engine).
-func TestPlayAccountWarmSingleStatusProbe(t *testing.T) {
+// TestPlayAccountWarmStatusProbeBudget: the warm recall preamble must stay
+// cheap. The old shape probed /status three times, each a potential 5s
+// timeout on a slow engine. Two are legitimate now: the session check, and
+// the proof that the engine still HOLDS a track before the fast path is
+// taken (a transferred-away session leaves it logged in with an empty queue,
+// where the fast path produces silence).
+func TestPlayAccountWarmStatusProbeBudget(t *testing.T) {
 	var (
 		mu          sync.Mutex
 		statusCount int
@@ -237,8 +240,51 @@ func TestPlayAccountWarmSingleStatusProbe(t *testing.T) {
 	}
 	mu.Lock()
 	defer mu.Unlock()
-	if statusCount != 1 {
-		t.Errorf("warm PlayAccount made %d /status probes, want exactly 1", statusCount)
+	if statusCount != 2 {
+		t.Errorf("warm PlayAccount made %d /status probes, want exactly 2 (session + queue proof)", statusCount)
+	}
+}
+
+// A warm re-press must NOT take the fast path when the engine holds no track:
+// Spotify can transfer the session away mid-session, leaving the engine
+// logged in with an empty queue where shuffle/next/resume do nothing and the
+// box sits on a byte-less stream until it dies with 3101 (live 2026-08-21,
+// three silent presses in a row).
+func TestWarmRecallFallsBackWhenTheEngineHoldsNoTrack(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		paths []string
+	)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+		if r.URL.Path == "/status" {
+			// Logged in, but no track: the transferred-away shape.
+			_, _ = w.Write([]byte(`{"username":"u"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+	m := New("", filepath.Join(t.TempDir(), "cfg"), "", nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	m.apiAddr = strings.TrimPrefix(ts.URL, "http://")
+	const ctxURI = "spotify:playlist:abc"
+	makeWarm(m, ctxURI)
+
+	if err := m.Play(context.Background(), ctxURI, PlayOptions{Shuffle: true}); err != nil {
+		t.Fatalf("Play: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	sawPlay := false
+	for _, p := range paths {
+		if p == "/player/play" {
+			sawPlay = true
+		}
+	}
+	if !sawPlay {
+		t.Errorf("an engine without a track must get the full recall (a /player/play), got %v", paths)
 	}
 }
 

--- a/internal/spotify/recall_warm_test.go
+++ b/internal/spotify/recall_warm_test.go
@@ -1,0 +1,294 @@
+// Tests for the warm same-context recall fast path and the recall boundary
+// cut (the 20+s same-preset re-press, live Portable 2026-08-21). The
+// mockLibrespot harness has no sink, so Streaming() is false there and every
+// pre-existing test keeps exercising the cold path untouched; the warm tests
+// inject a fake sink + first-audio stamp to make the stream count as flowing.
+
+package spotify
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// makeWarm makes m look like a box is attached and audibly streaming the
+// given context: exactly the state a same-preset re-press finds.
+func makeWarm(m *Manager, ctxURI string) {
+	m.mu.Lock()
+	m.lastContext = ctxURI
+	m.sink = io.Discard
+	m.sinkAttachedAt = time.Now()
+	m.sinkFirstAudioAt = time.Now()
+	m.mu.Unlock()
+}
+
+// TestPlayWarmShuffleFastPath: re-pressing the playing shuffle preset must
+// skip the paused-reload staging entirely (no /player/play) and instead
+// reseed the shuffle order (off->on), skip once, and ensure playback - with
+// the recall cut left armed so the /player/next BOS is cut, not flushed.
+func TestPlayWarmShuffleFastPath(t *testing.T) {
+	m, calls, cleanup := mockLibrespot(t)
+	defer cleanup()
+	const ctxURI = "spotify:playlist:abc"
+	makeWarm(m, ctxURI)
+	m.ArmRecallCut() // the recall entry point arms before its PlayURLMime
+
+	if err := m.Play(context.Background(), ctxURI, PlayOptions{Shuffle: true}); err != nil {
+		t.Fatalf("Play: %v", err)
+	}
+
+	want := []string{"/player/shuffle_context", "/player/shuffle_context", "/player/next", "/player/resume"}
+	got := pathsOf(*calls)
+	if len(got) != len(want) {
+		t.Fatalf("warm shuffle calls = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("warm shuffle calls = %v, want %v", got, want)
+		}
+	}
+	if !strings.Contains((*calls)[0].body, `"shuffle_context":false`) ||
+		!strings.Contains((*calls)[1].body, `"shuffle_context":true`) {
+		t.Errorf("warm shuffle must reseed off-then-on, got %q then %q", (*calls)[0].body, (*calls)[1].body)
+	}
+	if !m.skipCutArmed() {
+		t.Error("the recall cut must stay armed so the /player/next BOS drops the old tail")
+	}
+}
+
+// TestPlayWarmResumeClearsCut: re-pressing the playing resume preset only
+// ensures shuffle-off playback (no reload, no skip). No BOS will arrive, so
+// the cut the entry point armed MUST be disarmed, or it would drop the live
+// audio for the whole 30s window.
+func TestPlayWarmResumeClearsCut(t *testing.T) {
+	m, calls, cleanup := mockLibrespot(t)
+	defer cleanup()
+	const ctxURI = "spotify:playlist:abc"
+	makeWarm(m, ctxURI)
+	m.ArmRecallCut()
+
+	if err := m.Play(context.Background(), ctxURI, PlayOptions{Shuffle: false}); err != nil {
+		t.Fatalf("Play: %v", err)
+	}
+
+	for _, p := range pathsOf(*calls) {
+		if p == "/player/play" || p == "/player/next" {
+			t.Errorf("warm resume re-press must not reload or skip, saw %s", p)
+		}
+	}
+	shufBody, ok := bodyForPath(*calls, "/player/shuffle_context")
+	if !ok || !strings.Contains(shufBody, `"shuffle_context":false`) {
+		t.Errorf("warm resume must ensure shuffle OFF, got %q ok=%v", shufBody, ok)
+	}
+	if m.skipCutArmed() {
+		t.Error("warm resume must clear the recall cut (no BOS is coming)")
+	}
+}
+
+// TestPlayColdPathArmsCutBeforePost: a different context (or, below, no sink)
+// must keep today's staged cold reload, with the cut armed by the time the
+// /player/play POST goes out so the box never re-buffers the old track during
+// the load.
+func TestPlayColdPathArmsCutBeforePost(t *testing.T) {
+	var (
+		mu          sync.Mutex
+		mgr         *Manager
+		sawPlay     bool
+		armedAtPost bool
+	)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/status" {
+			_, _ = w.Write([]byte(`{"username":"u","track":{"uri":"spotify:track:cur","name":"Cur"}}`))
+			return
+		}
+		if r.URL.Path == "/player/play" {
+			mu.Lock()
+			sawPlay = true
+			armedAtPost = mgr.skipCutArmed()
+			mu.Unlock()
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+	m := New("", filepath.Join(t.TempDir(), "cfg"), "", nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	m.apiAddr = strings.TrimPrefix(ts.URL, "http://")
+	mu.Lock()
+	mgr = m
+	mu.Unlock()
+	makeWarm(m, "spotify:playlist:OLD") // streaming, but a DIFFERENT context
+
+	if err := m.Play(context.Background(), "spotify:playlist:NEW", PlayOptions{Shuffle: false}); err != nil {
+		t.Fatalf("Play: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !sawPlay {
+		t.Fatal("a cross-context recall must take the cold path (/player/play)")
+	}
+	if !armedAtPost {
+		t.Error("the recall cut must be armed before the /player/play POST")
+	}
+}
+
+// TestPlaySameContextNoSinkTakesColdPath: the warm shortcut requires audio to
+// actually be flowing to a box; the same context with no sink attached (box
+// detached, engine paused) must still get the full staged reload.
+func TestPlaySameContextNoSinkTakesColdPath(t *testing.T) {
+	m, calls, cleanup := mockLibrespot(t)
+	defer cleanup()
+	const ctxURI = "spotify:playlist:abc"
+	m.mu.Lock()
+	m.lastContext = ctxURI // same context, but no sink
+	m.mu.Unlock()
+
+	if err := m.Play(context.Background(), ctxURI, PlayOptions{Shuffle: false}); err != nil {
+		t.Fatalf("Play: %v", err)
+	}
+	if _, ok := bodyForPath(*calls, "/player/play"); !ok {
+		t.Fatal("same context with no sink must reload via /player/play")
+	}
+}
+
+// TestPlayPostFailureDisarmsCut: when the cold path's /player/play fails, no
+// track boundary will ever arrive, so the armed cut must be cleared or it
+// silently drops whatever is still playing for up to 30s.
+func TestPlayPostFailureDisarmsCut(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/status" {
+			_, _ = w.Write([]byte(`{"username":"u","track":{"uri":"spotify:track:cur","name":"Cur"}}`))
+			return
+		}
+		if r.URL.Path == "/player/play" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+	m := New("", filepath.Join(t.TempDir(), "cfg"), "", nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	m.apiAddr = strings.TrimPrefix(ts.URL, "http://")
+
+	if err := m.Play(context.Background(), "spotify:playlist:abc", PlayOptions{}); err == nil {
+		t.Fatal("Play must surface the /player/play failure")
+	}
+	if m.skipCutArmed() {
+		t.Error("a failed /player/play must disarm the recall cut")
+	}
+}
+
+// TestPlayAccountAbortDisarmsCut: PlayAccount bailing out before /player/play
+// (no live session, no credential) is the other no-BOS exit and must disarm
+// the cut the recall entry point armed.
+func TestPlayAccountAbortDisarmsCut(t *testing.T) {
+	cfg := filepath.Join(t.TempDir(), "cfg")
+	if err := os.MkdirAll(cfg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m := New("", cfg, "", nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	m.apiAddr = "127.0.0.1:0" // nothing listening: no live session
+	m.ArmRecallCut()
+
+	err := m.PlayAccount(context.Background(), "spotify:playlist:abc", "", PlayOptions{})
+	if !errors.Is(err, ErrNoSpotifySession) {
+		t.Fatalf("PlayAccount = %v, want ErrNoSpotifySession", err)
+	}
+	if m.skipCutArmed() {
+		t.Error("an aborted recall must disarm the recall cut (no BOS is coming)")
+	}
+}
+
+// TestPlayAccountWarmSingleStatusProbe: the warm recall preamble must cost
+// exactly ONE /status round trip (the old shape probed three times, each a
+// potential 5s timeout on a slow engine).
+func TestPlayAccountWarmSingleStatusProbe(t *testing.T) {
+	var (
+		mu          sync.Mutex
+		statusCount int
+	)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/status" {
+			mu.Lock()
+			statusCount++
+			mu.Unlock()
+			_, _ = w.Write([]byte(`{"username":"u","track":{"uri":"spotify:track:cur","name":"Cur"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+	m := New("", filepath.Join(t.TempDir(), "cfg"), "", nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	m.apiAddr = strings.TrimPrefix(ts.URL, "http://")
+	const ctxURI = "spotify:playlist:abc"
+	makeWarm(m, ctxURI)
+
+	if err := m.PlayAccount(context.Background(), ctxURI, "", PlayOptions{Shuffle: true}); err != nil {
+		t.Fatalf("PlayAccount: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if statusCount != 1 {
+		t.Errorf("warm PlayAccount made %d /status probes, want exactly 1", statusCount)
+	}
+}
+
+// TestRecallCutWindowAndStaleSnapshot covers the mechanics behind the recall
+// cut: the 30s arm that only ever extends, and the boundary-time snapshot of
+// how much stale (non-header) audio the attachment received, which gates the
+// recall re-push (~0 = the cut kept the box clean, no push needed).
+func TestRecallCutWindowAndStaleSnapshot(t *testing.T) {
+	m := New("", filepath.Join(t.TempDir(), "cfg"), "", nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	// A skip's 15s window is extended to the recall's 30s...
+	m.NoteSkip()
+	m.ArmRecallCut()
+	m.mu.Lock()
+	until := m.skipCutUntil
+	m.mu.Unlock()
+	if time.Until(until) < 29*time.Second {
+		t.Errorf("ArmRecallCut after NoteSkip left %v, want ~30s", time.Until(until))
+	}
+	// ...and a re-arm never SHRINKS a longer window.
+	m.mu.Lock()
+	m.skipCutUntil = time.Now().Add(40 * time.Second)
+	m.mu.Unlock()
+	m.ArmRecallCut()
+	m.mu.Lock()
+	until = m.skipCutUntil
+	m.mu.Unlock()
+	if time.Until(until) < 39*time.Second {
+		t.Errorf("ArmRecallCut shrank an armed window to %v", time.Until(until))
+	}
+
+	// Boundary snapshot: sink bytes minus the header pages, in KB.
+	m.mu.Lock()
+	m.headerPages = make([]byte, 4096)
+	m.sinkBytes = 300*1024 + 4096
+	m.mu.Unlock()
+	m.noteSkipBoundary()
+	if got := m.LastBoundaryStaleKB(); got != 300 {
+		t.Errorf("LastBoundaryStaleKB = %d, want 300 (headers subtracted)", got)
+	}
+	if m.LastSkipBoundary().IsZero() {
+		t.Error("noteSkipBoundary must stamp the boundary time")
+	}
+
+	// Clamped at zero when only header bytes (or nothing) flowed.
+	m.mu.Lock()
+	m.sinkBytes = 1024 // less than the header pages
+	m.mu.Unlock()
+	m.noteSkipBoundary()
+	if got := m.LastBoundaryStaleKB(); got != 0 {
+		t.Errorf("LastBoundaryStaleKB = %d, want 0 (never negative)", got)
+	}
+}

--- a/internal/spotify/serve.go
+++ b/internal/spotify/serve.go
@@ -373,6 +373,13 @@ func (m *Manager) ServeOgg(w http.ResponseWriter, r *http.Request) {
 	m.logger.Info("spotify: box detached from Ogg stream",
 		"attachedMs", attachedMs, "forwardedKB", bytes/1024, "pages", pages,
 		"firstAudioAfterMs", firstAudioMs, "kbps", kbps)
+	// Stamp the detach so the warm-recall gate can tell "streaming until a
+	// moment ago" (our own URI re-push tears the sink down right before the
+	// engine call) from "long idle" - lastAttachAt cannot: it ages while a
+	// stable sink plays for minutes.
+	m.mu.Lock()
+	m.lastDetachAt = time.Now()
+	m.mu.Unlock()
 }
 
 // errSinkRetired is returned by a writer whose handler has gone. forward()

--- a/internal/webui/options.go
+++ b/internal/webui/options.go
@@ -301,6 +301,21 @@ func WithSpotifySkipBoundary(boundary func() time.Time) Option {
 	return func(s *Server) { s.spotifySkipBoundary = boundary }
 }
 
+// WithSpotifyArmRecallCut registers the hook that arms the engine's boundary
+// cut for a preset recall, so the box's fresh attachment never re-buffers the
+// old track's audio while the new context loads.
+func WithSpotifyArmRecallCut(arm func()) Option {
+	return func(s *Server) { s.spotifyArmRecallCut = arm }
+}
+
+// WithSpotifyBoundaryStaleKB registers the resolver for how many stale
+// (pre-boundary) KB the box's current attachment was fed before the last cut
+// boundary; the recall re-push uses it to skip the buffer-dropping push when
+// the cut already kept the box clean.
+func WithSpotifyBoundaryStaleKB(staleKB func() int64) Option {
+	return func(s *Server) { s.spotifyBoundaryStaleKB = staleKB }
+}
+
 // WithSpotifyMeta registers the resolver for a Spotify context's stable cover
 // image and human title, stamped onto a newly saved Spotify preset.
 func WithSpotifyMeta(meta func(ctx context.Context, uri string) (cover, title string)) Option {

--- a/internal/webui/playback.go
+++ b/internal/webui/playback.go
@@ -384,6 +384,15 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 		if s.spotifySetRecalling != nil {
 			s.spotifySetRecalling()
 		}
+		// Arm the engine's boundary cut BEFORE the box re-fetches the stream
+		// (the PlayURLMime below): the fresh attachment arrives ~1s after the
+		// press and would otherwise be fed the OLD track's audio for the whole
+		// context-load preamble, which the box then audibly replays before the
+		// new track (the 20+s same-preset re-press, live Portable 2026-08-21).
+		if s.spotifyArmRecallCut != nil {
+			s.spotifyArmRecallCut()
+		}
+		armedAt := time.Now()
 		slotURL := boxurl.SpotifySlot(slot)
 		if err := s.renderer.PlayURLMime(playCtx, slotURL, p.Name, p.Art, "audio/ogg"); err != nil {
 			if isGroupedRejection(err) {
@@ -412,17 +421,26 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 			keyDenied := false
-			if err := s.spotifyPlay(bg, uri, account, shuffle); err != nil {
+			playErr := s.spotifyPlay(bg, uri, account, shuffle)
+			if playErr != nil {
 				// An audio-key denial means Spotify refuses this account/session
 				// the decryption keys: every additional Play just triggers
 				// another engine skip-storm (one key request per track) and feeds
 				// the account throttle that keeps the denial alive (429, field
 				// 2026-07-26: 51-track storms per press). Remember it so the
 				// verify below never fires the recovery re-Play into that state.
-				keyDenied = strings.Contains(err.Error(), "audio key denied")
-				s.logger.Warn("spotify play (initial) failed, will verify+retry", "slot", slot, "err", err, "keyDenied", keyDenied)
+				keyDenied = strings.Contains(playErr.Error(), "audio key denied")
+				s.logger.Warn("spotify play (initial) failed, will verify+retry", "slot", slot, "err", playErr, "keyDenied", keyDenied)
 			}
 			s.logger.Info("spotify soft recall: context load issued", "slot", slot, "warm", warm, "loadAfterMs", time.Since(t0).Milliseconds())
+			// The context loaded: once its track boundary lands in the
+			// forwarded stream, re-push the box IF stale audio reached its
+			// buffer anyway (with the cut working, the common case needs no
+			// push at all). Skipped on a failed play: no boundary is coming,
+			// the verify below owns recovery.
+			if playErr == nil {
+				go s.reattachAfterRecall(gen, recallStart, slot, armedAt)
+			}
 			s.verifyRecall(gen, recallStart, slotURL, func(ctx context.Context, lastAttempt bool) {
 				// Re-point the box at the stream WITHOUT re-Play on the early
 				// tries: ServeOgg resumes go-librespot on attach, so this

--- a/internal/webui/queueplay.go
+++ b/internal/webui/queueplay.go
@@ -770,6 +770,79 @@ func (s *Server) reattachAfterSoftSkip() {
 	}()
 }
 
+// reattachAfterRecall re-pushes the slot's Spotify stream after a preset
+// recall, and ONLY when stale pre-boundary audio actually reached the box's
+// fresh attachment. The recall arms the engine's boundary cut before the box
+// re-fetches the stream, so in the common case the attachment stays clean
+// (staleKB ~0) and no push happens at all: a needless push would flap a stream
+// that is already playing the right track. Only when the cut could not keep
+// the buffer clean (late arm, early wrong BOS, cut expiry) is the box's buffer
+// dropped, sharing the soft-skip burst debounce so recall and skip re-pushes
+// cannot double-tear the stream. Runs in its own goroutine (caller spawns it).
+func (s *Server) reattachAfterRecall(gen uint64, started time.Time, slot int, armedAt time.Time) {
+	if s.renderer == nil || s.spotifySkipBoundary == nil {
+		return
+	}
+	// Same boundary-wait budget as the soft skip: above the slowest observed
+	// engine track load, so a landed boundary is always seen. The recall's
+	// boundary always follows armedAt (the cut was armed before the play was
+	// issued), so no backwards slack is needed here.
+	wait := s.recallReattachWait
+	if wait == 0 {
+		wait = 12 * time.Second
+	}
+	deadline := time.Now().Add(wait)
+	for s.spotifySkipBoundary().Before(armedAt) {
+		if time.Now().After(deadline) {
+			// The engine never delivered the new track: keep the box's
+			// buffered stream and let the recall verify own the recovery.
+			s.logger.Info("recall: no track boundary within the wait, keeping the box's buffered stream")
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	staleKB := int64(0)
+	if s.spotifyBoundaryStaleKB != nil {
+		staleKB = s.spotifyBoundaryStaleKB()
+	}
+	if staleKB < 64 { // under ~3s of audio: the cut kept the box clean
+		s.logger.Info("recall: clean boundary handover, no re-push needed", "staleKB", staleKB)
+		return
+	}
+	// A deliberate stop wins (the push sends Play), and a box that just
+	// rejected the source as not-logged-in (1036) must not be re-pushed into
+	// its re-login bounce.
+	if s.userStoppedRecently() || s.recentLoginError() {
+		return
+	}
+	// A newer play or a power-off supersedes this recall's re-push.
+	if s.recallStandDownReason(gen, started) != "" {
+		return
+	}
+	// Share the soft-skip burst debounce: a skip re-push and a recall re-push
+	// within the window would tear the box's stream down twice back to back.
+	// Deliberately does NOT consult hwSkipAt: a hardware preset PRESS is not a
+	// hardware SKIP, and its own flow ends right here.
+	s.skipRepushMu.Lock()
+	recent := time.Since(s.lastSkipRepushAt) < 8*time.Second
+	if !recent {
+		s.lastSkipRepushAt = time.Now()
+	}
+	s.skipRepushMu.Unlock()
+	if recent {
+		return
+	}
+	s.repushSpotifyStream("recall stale buffer", slot)
+}
+
+// ReattachAfterSpotifyRecall exposes the recall re-push gate to the hardware
+// preset path (cmd/agent), which mirrors the app recall and needs the same
+// "only push when stale audio reached the box" decision. Blocking (boundary
+// wait); the caller runs it in a goroutine.
+func (s *Server) ReattachAfterSpotifyRecall(gen uint64, started time.Time, slot int, armedAt time.Time) {
+	s.reattachAfterRecall(gen, started, slot, armedAt)
+}
+
 // slotFromSpotifyStreamURL extracts the preset slot N from a per-slot Spotify Ogg
 // URL (".../spotify/stream-N.ogg"), or 0 if the URL is the slot-less default.
 func slotFromSpotifyStreamURL(u string) int {

--- a/internal/webui/recall_reattach_test.go
+++ b/internal/webui/recall_reattach_test.go
@@ -1,0 +1,109 @@
+package webui
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/JRpersonal/streborn/internal/upnp"
+)
+
+// reattachAfterRecall drops the box's buffer after a preset recall ONLY when
+// stale pre-boundary audio actually reached the fresh attachment: with the
+// recall cut doing its job the common case must be a no-op (a needless push
+// flaps a stream that is already playing the right track). These tests pin
+// that gating; the debounce stamp (lastSkipRepushAt) is the observable "a
+// push was decided", exactly as in the soft-skip re-attach tests.
+
+func TestReattachAfterRecall(t *testing.T) {
+	disc := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	cases := []struct {
+		name string
+		// boundaryLands: the engine stamped a boundary after armedAt. False
+		// simulates a load that never delivered (the wait must time out).
+		boundaryLands bool
+		nilBoundary   bool // no boundary signal wired at all
+		staleKB       int64
+		userStop      bool // deliberate stop after the recall started
+		loginErr      bool // box answered 1036 (re-login in flight)
+		supersede     bool // a newer play bumped the recall generation
+		priorPush     bool // a re-push happened 2s ago (shared burst debounce)
+		wantPush      bool
+	}{
+		{name: "stale audio reached the box: one push", boundaryLands: true, staleKB: 300, wantPush: true},
+		{name: "clean boundary handover: no push", boundaryLands: true, staleKB: 12, wantPush: false},
+		{name: "no boundary within the wait: keep the buffered stream", boundaryLands: false, staleKB: 300, wantPush: false},
+		{name: "user stop stands the push down", boundaryLands: true, staleKB: 300, userStop: true, wantPush: false},
+		{name: "not-logged-in (1036) stands the push down", boundaryLands: true, staleKB: 300, loginErr: true, wantPush: false},
+		{name: "newer play supersedes", boundaryLands: true, staleKB: 300, supersede: true, wantPush: false},
+		{name: "shared burst debounce: no second push", boundaryLands: true, staleKB: 300, priorPush: true, wantPush: false},
+		{name: "no boundary signal wired: no push", nilBoundary: true, staleKB: 300, wantPush: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Server{logger: disc, renderer: &upnp.Renderer{}}
+			s.recallReattachWait = 300 * time.Millisecond // test seam: shrink the 12s budget
+			started := time.Now()
+			armedAt := started
+			if !tc.nilBoundary {
+				boundary := armedAt.Add(-time.Hour) // never crossed
+				if tc.boundaryLands {
+					boundary = armedAt.Add(time.Millisecond)
+				}
+				s.spotifySkipBoundary = func() time.Time { return boundary }
+			}
+			s.spotifyBoundaryStaleKB = func() int64 { return tc.staleKB }
+			// A non-spotify lastPlay keeps repushSpotifyStream itself a no-op,
+			// so the assertions see the pure push decision (like the soft-skip
+			// tests, which never exercise the UPnP call either).
+			gen := s.setLastPlay("http://127.0.0.1:8888/stream/4", "A", "", "")
+			if tc.supersede {
+				s.setLastPlay("http://127.0.0.1:8888/stream/5", "B", "", "")
+			}
+			if tc.userStop {
+				s.lastUserStopMu.Lock()
+				s.lastUserStop = time.Now()
+				s.lastUserStopMu.Unlock()
+			}
+			if tc.loginErr {
+				s.loginErr.mu.Lock()
+				s.loginErr.last = time.Now()
+				s.loginErr.mu.Unlock()
+			}
+			var prior time.Time
+			if tc.priorPush {
+				prior = time.Now().Add(-2 * time.Second)
+				s.skipRepushMu.Lock()
+				s.lastSkipRepushAt = prior
+				s.skipRepushMu.Unlock()
+			}
+
+			s.reattachAfterRecall(gen, started, 4, armedAt)
+
+			stamped := s.skipRepushArmedAt()
+			switch {
+			case tc.wantPush && (stamped.IsZero() || stamped.Equal(prior)):
+				t.Fatal("expected a re-push (stale audio reached the box), none was armed")
+			case !tc.wantPush && tc.priorPush && !stamped.Equal(prior):
+				t.Fatal("the shared burst debounce must keep a second push from arming")
+			case !tc.wantPush && !tc.priorPush && !stamped.IsZero():
+				t.Fatal("expected NO re-push, but one was armed")
+			}
+		})
+	}
+}
+
+// A recall re-push with no renderer (tests, degraded startup) must be a no-op,
+// not a panic - mirroring the soft-skip guard.
+func TestReattachAfterRecallNoRendererNoPanic(t *testing.T) {
+	s := &Server{
+		logger:              slog.New(slog.NewTextHandler(io.Discard, nil)),
+		spotifySkipBoundary: func() time.Time { return time.Now() },
+	}
+	s.reattachAfterRecall(1, time.Now(), 4, time.Now())
+	if !s.skipRepushArmedAt().IsZero() {
+		t.Fatal("without a renderer there is nothing to push")
+	}
+}

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -143,6 +143,19 @@ type Server struct {
 	// nil when Spotify is not configured (the re-push then stays on a fixed
 	// short delay).
 	spotifySkipBoundary func() time.Time
+	// spotifyArmRecallCut arms the engine's boundary cut for a preset recall,
+	// so the box's fresh attachment is never fed the OLD track's audio while
+	// the new context loads. Armed before PlayURLMime, next to
+	// spotifySetRecalling. nil when Spotify is not configured.
+	spotifyArmRecallCut func()
+	// spotifyBoundaryStaleKB reports how many stale (pre-boundary) KB the
+	// box's current attachment was fed before the last cut boundary. The
+	// recall re-push reads it: ~0 means the cut kept the box clean and no
+	// buffer-dropping re-push is needed. nil when Spotify is not configured.
+	spotifyBoundaryStaleKB func() int64
+	// recallReattachWait overrides reattachAfterRecall's boundary-wait budget.
+	// Test seam only; zero means the production 12s.
+	recallReattachWait time.Duration
 	// spotifyReady reports whether go-librespot has finished authenticating, so
 	// a soft Spotify recall can wait out a cold start instead of pointing the box
 	// at a not-yet-flowing stream (which starves and detaches). nil when Spotify


### PR DESCRIPTION
Re-opened as a fresh PR: the original #669 was auto-closed when its base branch (#663) was merged and deleted. Same code, now based on main.

Live case: pressing an already-playing Spotify preset again correctly jumps to the next shuffled track, but took 20+ seconds to become audible (11.5 s before /player/play even reached the engine, then the box drained its buffered old track because nothing dropped it).

Three mechanisms:
1. Recall cut: recalls arm the existing skip-cut machinery, so the Ogg forwarder drops the old track's tail at the recall's BOS and stamps the boundary; every no-BOS exit disarms it.
2. Warm same-context fast path: a re-press of the context that is already streaming skips the paused-load/pause/wait staging and reseeds shuffle plus next plus resume directly; PlayAccount now costs one /status probe instead of three. The fast path first proves the engine still holds a track, because a transferred-away Spotify session leaves it logged in with an empty queue where the shortcut produces silence. Deliberate semantics change: re-pressing a playing resume-preset no longer restarts the track from 0:00.
3. Conditional post-boundary re-push: the box's stale buffer is dropped via the proven soft-skip re-push, but only when stale bytes actually reached the current sink, sharing the skip debounce and all guards.

Measured live on the Portable: press to audible went from 20+ s to about 8 s, with "warm same-context recall (fast path)" and "clean boundary handover" in the log and no re-push needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)