### PR TITLE
fix(app): internal framework errors no longer raise the red error banner

### DIFF
--- a/desktop-app/frontend/src/errornoise.test.js
+++ b/desktop-app/frontend/src/errornoise.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+
+// The predicate from main.js's global error reporter, kept in step with it by
+// this test. It decides what is Wails plumbing noise and must therefore stay
+// out of the red overlay, versus what is a real fault the user has to see.
+//
+// It lives here rather than being imported because main.js runs its error
+// bootstrap as a side effect at module load, before any of the app's Wails
+// bindings exist; importing it into a test environment starts the whole app.
+// The rule that matters is the SHAPE of what is suppressed, and that is what
+// this pins: over-suppressing here would hide a real crash from the one banner
+// that is supposed to show it.
+const isFrameworkNoise = (detail) => {
+  const d = String(detail || '');
+  return /Callback\s+'[^']*'\s+not registered/i.test(d) ||
+         (/wails\/runtime\.js/i.test(d) && /not registered/i.test(d));
+};
+
+describe('global error overlay: what it stays quiet about', () => {
+  it('suppresses the Wails callback-registry error behind the report (#676, #597)', () => {
+    // Verbatim from the reporter's app.log.
+    expect(isFrameworkNoise(
+      "Error: Callback 'main.App.CheckAppUpdate-3018697214' not registered!!! @ wails://wails/wails/runtime.js:2",
+    )).toBe(true);
+    expect(isFrameworkNoise(
+      "Error: Callback 'main.App.DiscoverBoxes-983242426' not registered!!! @ wails://wails/wails/runtime.js:2",
+    )).toBe(true);
+  });
+
+  it('suppresses it whatever the call id and whatever the bound method', () => {
+    for (const m of ['main.App.BoxSettings-1', 'main.App.GetPresets-999999999', 'main.App.Status-42']) {
+      expect(isFrameworkNoise(`Error: Callback '${m}' not registered!!!`)).toBe(true);
+    }
+  });
+
+  it('still shows a real application error', () => {
+    const real = [
+      "TypeError: Cannot read properties of null (reading 'host') @ .../main.js:2481",
+      'ReferenceError: renderBoxSelect is not defined @ .../main.js:2290',
+      'Error: box unreachable: context deadline exceeded',
+      "Error: registered a preset that was not registered",
+      '',
+      null,
+      undefined,
+    ];
+    for (const d of real) expect(isFrameworkNoise(d)).toBe(false);
+  });
+
+  it('does not suppress an unrelated error merely because it mentions wails', () => {
+    expect(isFrameworkNoise('Error: wails://wails/runtime.js failed to load')).toBe(false);
+    expect(isFrameworkNoise("TypeError: undefined is not a function @ wails://wails/wails/runtime.js:2")).toBe(false);
+  });
+});

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -155,9 +155,30 @@ import {
     if (typeof document !== 'undefined' && document.body) add();
     else if (typeof window !== 'undefined') window.addEventListener('DOMContentLoaded', add);
   };
+  // Wails' own callback registry drops in-flight call IDs when the webview
+  // context is replaced underneath it - a zoom or text-size change, a resize, a
+  // reload - while Go calls are still outstanding. What surfaces is
+  // "Callback 'main.App.CheckAppUpdate-3018697214' not registered!!!" thrown
+  // from wails/runtime.js. Nothing in the app is broken by it: the answer to a
+  // call nobody is waiting for any more is discarded, and the next poll simply
+  // asks again.
+  //
+  // It still goes to the log, because a burst of them means the webview is
+  // being recycled far more than it should be, and that IS worth seeing in a
+  // diagnostic. It must not raise the red overlay though. A user changed the
+  // text size, got a wall of red he had never seen, and reported it as a fault
+  // (#676, and the same thing in discussion #597 on macOS). An error banner
+  // that cries wolf about internal plumbing teaches people to ignore it, which
+  // costs us the one time it matters.
+  const isFrameworkNoise = (detail) => {
+    const d = String(detail || '');
+    return /Callback\s+'[^']*'\s+not registered/i.test(d) ||
+           (/wails\/runtime\.js/i.test(d) && /not registered/i.test(d));
+  };
   const report = (kind, detail) => {
     try { LogClientError(`${kind}: ${detail}`); } catch {}
     try { console.error(kind, detail); } catch {}
+    if (isFrameworkNoise(detail)) return;
     const key = kind + ':' + String(detail).slice(0, 200);
     if (!seen.has(key)) { seen.add(key); showBanner(`STR ${kind}:\n${detail}`); }
   };


### PR DESCRIPTION
Reported twice: issue #676 (filed today, with a diagnostic bundle) and discussion #597 on macOS.

The bundle's `app.log` names it exactly:

```
window.onerror: Error: Callback 'main.App.CheckAppUpdate-3018697214' not registered!!! @ wails://wails/wails/runtime.js:2
window.onerror: Error: Callback 'main.App.DiscoverBoxes-983242426' not registered!!!  @ wails://wails/wails/runtime.js:2
```

Both users had just changed the text size or resized the window. Replacing the webview context drops the IDs of Go calls that were still outstanding, Wails' callback registry then rejects the late answer, and the app's global `window.onerror` hook painted it into the maroon overlay meant for real faults.

Nothing is broken by it. The discarded answer belongs to a call nobody is waiting for any more, and the next poll re-issues it.

## What changed

`report()` in the error bootstrap keeps logging everything to `str.log` — a burst of these means the webview is being recycled far more than it should be, and that is worth seeing in a diagnostic — but no longer raises the banner for this shape.

Deliberately narrow: the predicate matches `Callback '...' not registered`, or a `not registered` error from `wails/runtime.js`. It does not suppress an unrelated error that merely mentions the framework, and `src/errornoise.test.js` pins exactly that, because over-suppressing here would hide a real crash from the one banner that is supposed to show it.