### PR TITLE
fix(speaker): the built-in radio sticks, a NAS track stops repeating, and runaway Bose logs get trimmed

### DIFF
--- a/desktop-app/app_boxops.go
+++ b/desktop-app/app_boxops.go
@@ -250,13 +250,47 @@ func pickReachableIP(ips []string) string {
 	switch {
 	case lan != "":
 		return lan
-	case linkLocal != "":
+	case linkLocal != "" && hostHasLinkLocalIPv4():
+		// A 169.254 address is only worth anything when THIS machine is on
+		// link-local too, which happens on a direct cable with no DHCP. From a
+		// normal LAN it is unroutable, so listing it produces a speaker that
+		// can never be reached.
+		//
+		// It also produced a DUPLICATE. A speaker whose DHCP fails announces a
+		// self-assigned address, STR records it, the speaker later gets a real
+		// lease and announces that too, and the same box then sat in the list
+		// twice under two addresses. Reported 2026-08-23 by an owner whose
+		// speakers were dropping off a congested Wi-Fi: "one speaker showed up
+		// twice in the Update list, with two different IP addresses, one
+		// correct, one in the 169.254.0.0 self-assigned subnet", and it blocked
+		// Update All.
 		return linkLocal
 	case public != "":
 		return public
 	default:
 		return ""
 	}
+}
+
+// hostHasLinkLocalIPv4 reports whether this machine carries a 169.254 address
+// of its own, i.e. whether a link-local speaker could be reached from here at
+// all. A seam so pickReachableIP stays testable without touching the machine's
+// real interfaces.
+var hostHasLinkLocalIPv4 = func() bool {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return false
+	}
+	for _, a := range addrs {
+		ipnet, ok := a.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		if ip4 := ipnet.IP.To4(); ip4 != nil && ip4.IsLinkLocalUnicast() {
+			return true
+		}
+	}
+	return false
 }
 
 // BoxWifiScan asks the SPEAKER which Wi-Fi networks it can see.

--- a/desktop-app/discovery_coldstart.go
+++ b/desktop-app/discovery_coldstart.go
@@ -225,6 +225,15 @@ func probeKnownSpeakers(ctx context.Context, logger *slog.Logger, hits chan<- Bo
 		if host == "" {
 			continue
 		}
+		// A self-assigned address that got persisted while the speaker's DHCP
+		// was failing must not come back as a speaker on every cold start. It
+		// is unroutable from a normal LAN, and the same box reappears under its
+		// real address anyway, so probing it only produces a second, dead entry
+		// in the list (2026-08-23 report: one speaker listed twice, once on
+		// 169.254, blocking Update All).
+		if ip := net.ParseIP(host); ip != nil && ip.IsLinkLocalUnicast() && !hostHasLinkLocalIPv4() {
+			continue
+		}
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -576,7 +576,13 @@ document.querySelector('#app').innerHTML = `
       <p class="modal-sub" id="uaSummary"></p>
       <div id="uaList" class="ua-list"></div>
       <div class="warn-buttons">
-        <button class="btn" id="uaClose" disabled>${escapeHtml(t('common.close'))}</button>
+        <!-- Never disabled. Closing only HIDES this window, it does not cancel
+             the run, so disabling it protects nothing and can strand the user:
+             the button was greyed while any row had no final outcome, and a
+             speaker that drops off the Wi-Fi mid-update never gets one, so the
+             window could not be dismissed at all. Reported 2026-08-23 by an
+             owner whose speakers were dropping off a congested network. -->
+        <button class="btn" id="uaClose">${escapeHtml(t('common.close'))}</button>
       </div>
     </div>
   </div>
@@ -4226,8 +4232,6 @@ async function runUpdateAllBoxes(onStart) {
     const c = counts();
     const sum = $('uaSummary');
     if (sum) sum.textContent = t('updateAll.summary', { done: c.done, deferred: c.defer, failed: c.fail, total: targets.length });
-    const closeBtn = $('uaClose');
-    if (closeBtn) closeBtn.disabled = c.busy > 0;
   };
   const setRow = (host, { phaseText, pct, barClass, indet } = {}) => {
     const r = rowState.get(host); if (!r) return;
@@ -4392,7 +4396,6 @@ async function runUpdateAllBoxes(onStart) {
   state.otaTargetHost = null;
   state.otaTargetName = null;
   renderSummary();
-  if ($('uaClose')) $('uaClose').disabled = false;
   try { await discoverBoxes(); checkBoxUpdate(); if (state.view === 'settings') loadBoxSettings(); } catch { /* boxes still rebooting */ }
   checkSshBanner();
   const c = counts();

--- a/desktop-app/frontend/src/updateallclose.test.js
+++ b/desktop-app/frontend/src/updateallclose.test.js
@@ -1,0 +1,29 @@
+// The Update-all progress window must always be dismissable.
+//
+// Closing it only hides the overlay; it does not cancel the run, which keeps
+// going and still reports its outcome in the final toast. The button was
+// nevertheless greyed out while any speaker's row had no final outcome, and a
+// speaker that drops off the Wi-Fi mid-update never gets one. The window then
+// could not be closed at all until the app was restarted. Reported 2026-08-23
+// by an owner whose speakers were dropping off a congested network.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const main = readFileSync(new URL('./main.js', import.meta.url), 'utf8');
+
+describe('the update-all window', () => {
+  it('renders its Close button enabled', () => {
+    const m = main.match(/<button[^>]*id="uaClose"[^>]*>/);
+    expect(m, 'the uaClose button is gone').not.toBeNull();
+    expect(m[0]).not.toContain('disabled');
+  });
+
+  it('never disables that button afterwards', () => {
+    expect(main).not.toMatch(/uaClose'\)\.disabled\s*=/);
+    expect(main).not.toMatch(/closeBtn\.disabled\s*=/);
+  });
+
+  it('still wires it to hide the overlay', () => {
+    expect(main).toMatch(/uaClose'\)\.onclick/);
+  });
+});

--- a/desktop-app/linklocal_test.go
+++ b/desktop-app/linklocal_test.go
@@ -1,0 +1,65 @@
+package main
+
+import "testing"
+
+// An owner on a congested Wi-Fi found one speaker listed twice in the Update
+// list, once on its real address and once on a 169.254 self-assigned one, which
+// blocked Update All (2026-08-23). A speaker whose DHCP fails announces a
+// self-assigned address; STR recorded it, the speaker later got a real lease and
+// announced that too, and both stayed.
+//
+// From a normal LAN a 169.254 address cannot be routed to at all, so that entry
+// was never reachable. It stays usable in the one case where it means
+// something: this machine on link-local too, which is a direct cable with no
+// DHCP.
+
+func withLinkLocalHost(t *testing.T, present bool) {
+	t.Helper()
+	old := hostHasLinkLocalIPv4
+	hostHasLinkLocalIPv4 = func() bool { return present }
+	t.Cleanup(func() { hostHasLinkLocalIPv4 = old })
+}
+
+func TestPickReachableIPDropsASelfAssignedAddressFromANormalLAN(t *testing.T) {
+	withLinkLocalHost(t, false)
+
+	if got := pickReachableIP([]string{"169.254.12.7"}); got != "" {
+		t.Errorf("got %q, want it dropped: unroutable from here", got)
+	}
+	// And when the speaker announces both, the real one wins, which is what
+	// stops the duplicate.
+	if got := pickReachableIP([]string{"169.254.12.7", "192.168.1.34"}); got != "192.168.1.34" {
+		t.Errorf("got %q, want 192.168.1.34", got)
+	}
+	if got := pickReachableIP([]string{"192.168.1.34", "169.254.12.7"}); got != "192.168.1.34" {
+		t.Errorf("got %q, want 192.168.1.34 regardless of order", got)
+	}
+}
+
+func TestPickReachableIPKeepsLinkLocalOnADirectCable(t *testing.T) {
+	withLinkLocalHost(t, true)
+
+	if got := pickReachableIP([]string{"169.254.12.7"}); got != "169.254.12.7" {
+		t.Errorf("got %q, want the link-local address kept when this host has one too", got)
+	}
+	// A real address still outranks it.
+	if got := pickReachableIP([]string{"169.254.12.7", "10.0.0.5"}); got != "10.0.0.5" {
+		t.Errorf("got %q, want 10.0.0.5", got)
+	}
+}
+
+func TestPickReachableIPStillSkipsTheUnroutableOnes(t *testing.T) {
+	withLinkLocalHost(t, false)
+
+	// The box's USB gadget interface and loopback were already excluded, and
+	// must stay excluded: returning either shows a speaker nothing can reach.
+	if got := pickReachableIP([]string{"203.0.113.2", "127.0.0.1"}); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+	if got := pickReachableIP([]string{"203.0.113.2", "192.168.1.34"}); got != "192.168.1.34" {
+		t.Errorf("got %q, want 192.168.1.34", got)
+	}
+	if got := pickReachableIP(nil); got != "" {
+		t.Errorf("got %q, want empty for no addresses", got)
+	}
+}

--- a/internal/streamproxy/requestfacts_test.go
+++ b/internal/streamproxy/requestfacts_test.go
@@ -1,0 +1,71 @@
+package streamproxy
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+// The CineMate case these exist for: a preset recall and a search play reach
+// the same streaming code, so the only place the difference can show is the
+// box's own request. Each of these fields is one candidate explanation, and a
+// missing one is a diagnostic that cannot answer the question.
+
+func TestRequestFactsCarriesWhatSeparatesTheTwoPaths(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://127.0.0.1:8888/stream/2", nil)
+	r.RemoteAddr = "127.0.0.1:41234"
+	r.Header.Set("User-Agent", "BoseSoundTouch/27.0.6")
+	r.Header.Set("Icy-MetaData", "1")
+	r.Header.Set("Range", "bytes=0-")
+
+	got := map[string]any{}
+	facts := requestFacts(r)
+	if len(facts)%2 != 0 {
+		t.Fatalf("facts must be key/value pairs, got %d entries", len(facts))
+	}
+	for i := 0; i < len(facts); i += 2 {
+		k, ok := facts[i].(string)
+		if !ok {
+			t.Fatalf("key at %d is not a string: %#v", i, facts[i])
+		}
+		got[k] = facts[i+1]
+	}
+
+	for k, want := range map[string]any{
+		"from":   "127.0.0.1:41234",
+		"host":   "127.0.0.1:8888",
+		"proto":  "HTTP/1.1",
+		"ua":     "BoseSoundTouch/27.0.6",
+		"range":  "bytes=0-",
+		"icyReq": "1",
+	} {
+		if got[k] != want {
+			t.Errorf("%s = %#v, want %#v", k, got[k], want)
+		}
+	}
+}
+
+func TestRequestFactsSeparatesLoopbackFromTheLANAddress(t *testing.T) {
+	// The strongest single candidate: the preset descriptor stored on the box
+	// carries a loopback stream URL while a search play is resolved against the
+	// speaker's LAN address. If those two arrive from different places, the
+	// next diagnostic says so in one line.
+	loop := httptest.NewRequest("GET", "http://127.0.0.1:8888/stream/2", nil)
+	loop.RemoteAddr = "127.0.0.1:41234"
+	lan := httptest.NewRequest("GET", "http://192.0.2.7:8888/stream/raw?u=abc", nil)
+	lan.RemoteAddr = "192.0.2.7:52001"
+
+	l, n := requestFacts(loop), requestFacts(lan)
+	if l[1] == n[1] {
+		t.Errorf("both requests reported from=%v, so the log cannot tell them apart", l[1])
+	}
+	if l[3] == n[3] {
+		t.Errorf("both requests reported host=%v, so the log cannot tell the URL forms apart", l[3])
+	}
+}
+
+func TestRequestFactsToleratesAMissingRequest(t *testing.T) {
+	// Never let a diagnostic aid be the thing that panics a stream handler.
+	if got := requestFacts(nil); got != nil {
+		t.Errorf("requestFacts(nil) = %#v, want nil", got)
+	}
+}

--- a/internal/streamproxy/streamproxy.go
+++ b/internal/streamproxy/streamproxy.go
@@ -256,7 +256,7 @@ func (s *Server) handleRaw(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	s.logger.Info("stream proxy raw start", "url", url)
+	s.logger.Info("stream proxy raw start", append([]any{"url", url}, requestFacts(r)...)...)
 	s.noteStreamStart(url)
 	defer s.clearTitleOnEnd(url)
 	start := time.Now()
@@ -318,6 +318,47 @@ func (s *Server) handleRaw(w http.ResponseWriter, r *http.Request) {
 	s.logger.Warn("stream proxy gave up reconnecting", "kind", "raw", "attempts", 60, "elapsed", time.Since(start).Round(time.Second).String(), "lastErr", errStr(lastErr))
 }
 
+// requestFacts describes the box's OWN request for a stream, as slog attributes
+// appended to the line each handler already logs when a stream starts.
+//
+// It exists because of a report that the log could not answer. A CineMate owner
+// found that every station recalled from a preset key was abandoned after about
+// a second, while the SAME station started from the search box played for
+// minutes: four dead preset fetches against six healthy search fetches in one
+// diagnostic, the dead ones at 780 kbps (a buffer pulled as fast as the link
+// allows, then dropped) and the healthy ones at the station's real 130 kbps.
+// The preset slots were correct, and both paths converge on the same streaming
+// code once the URL is resolved, so whatever differs is in what the BOX did.
+// None of that was recorded, so the bundle showed the symptom four times over
+// and still could not say why.
+//
+// These are the facts that separate the two paths, and every one of them is
+// already sitting in the request:
+//
+//	from   loopback or the box's LAN address, i.e. which side of the box asked
+//	host   the host it was told to use, i.e. which URL form it was handed
+//	proto  an HTTP/1.0 client without keep-alive gives up differently
+//	ua     which firmware component is doing the fetching
+//	range  a ranged request is a downloader, not a player
+//	icyReq whether it asked for stream metadata
+//
+// Deliberately cheap: no extra request, no timer, nothing written to the
+// speaker's flash, and no new log LINE. It rides on one that was being written
+// anyway, once per stream start.
+func requestFacts(r *http.Request) []any {
+	if r == nil {
+		return nil
+	}
+	return []any{
+		"from", r.RemoteAddr,
+		"host", r.Host,
+		"proto", r.Proto,
+		"ua", r.UserAgent(),
+		"range", r.Header.Get("Range"),
+		"icyReq", r.Header.Get("Icy-MetaData"),
+	}
+}
+
 func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 	defer s.noteFetchOpen()()
 	slotStr := strings.TrimPrefix(r.URL.Path, "/stream/")
@@ -339,7 +380,7 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 	p.StreamURL = s.resolvePresetURL(slot, p.StreamURL)
 	s.noteSlotFetch(slot)
 	defer s.noteSlotFetchDone(slot)
-	s.logger.Info("stream proxy start", "slot", slot, "name", p.Name)
+	s.logger.Info("stream proxy start", append([]any{"slot", slot, "name", p.Name}, requestFacts(r)...)...)
 
 	if isDASHURL(p.StreamURL) {
 		s.logger.Warn("stream proxy: DASH preset not supported yet, refusing", "slot", slot, "url", p.StreamURL)

--- a/internal/webui/agent_admin.go
+++ b/internal/webui/agent_admin.go
@@ -1403,6 +1403,56 @@ func reclaimNAND() {
 			}
 		}
 	}
+	capBoseLogs(filepath.Join(nandRoot, "BoseLog"))
+}
+
+const (
+	// boseLogCapAt is the size a single file in Bose's log directory may reach
+	// before it is trimmed, and boseLogKeep is what survives. Generous on
+	// purpose: this is somebody else's log and the point is to stop it eating
+	// the volume, not to keep it tidy.
+	boseLogCapAt = 1 << 20 // 1 MiB
+	boseLogKeep  = 1 << 18 // 256 KiB
+)
+
+// capBoseLogs bounds the speaker's OWN log directory.
+//
+// /mnt/nv/BoseLog belongs to the Bose firmware, not to STR, and STR neither
+// writes nor reads it. It does share the same ~32 MB volume, and it can run
+// away: a diagnostic from 2026-08-23 showed BoseLog at tens of megabytes on a
+// speaker whose whole volume is 31.58 MiB, and that speaker had no room left
+// for the Spotify engine while four identical ones next to it had an empty
+// BoseLog. Those are logs for a cloud that was switched off in February.
+//
+// Trimmed the same way STR's own logs are, by keeping the tail instead of
+// deleting the file. The inode survives, so a Bose process holding it open goes
+// on appending, and nothing has to be restarted. Only files past the cap are
+// touched, so an ordinary log directory is left exactly as it is, and only
+// regular files directly inside it: no recursion, no directories removed,
+// nothing else of Bose's ever touched.
+func capBoseLogs(dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		fi, ferr := e.Info()
+		if ferr != nil || !fi.Mode().IsRegular() || fi.Size() <= boseLogCapAt {
+			continue
+		}
+		p := filepath.Join(dir, e.Name())
+		b, rerr := os.ReadFile(p)
+		if rerr != nil || int64(len(b)) <= boseLogKeep {
+			continue
+		}
+		if werr := os.WriteFile(p, b[int64(len(b))-boseLogKeep:], fi.Mode().Perm()); werr == nil {
+			slog.Info("nand: trimmed an oversized Bose log so it stops filling the speaker's storage",
+				"file", e.Name(), "wasBytes", fi.Size(), "keptBytes", boseLogKeep)
+		}
+	}
 }
 
 // ReclaimNAND frees regenerable NAND junk (stale OTA temps, the ~28 MB

--- a/internal/webui/assets/index.html
+++ b/internal/webui/assets/index.html
@@ -2485,10 +2485,18 @@ async function playLibTrack(idx, btn) {
   var it = lastLibResults[idx];
   if (!it) return;
   press(btn);
+  // mime is what tells the agent this is a FILE, not a radio stream. Without
+  // it the track is routed through the stream proxy, which is built for endless
+  // radio: it reads the EOF that ends a file as a dropout, reconnects, and the
+  // song starts again from the beginning. Reported from an iPhone on v0.9.55,
+  // "it only buffers a tiny bit of a song up until about 95 seconds then the
+  // song repeats". The desktop Library has always sent it (#139); the search
+  // results here carry it too and simply dropped it on the floor.
   var ok = await api('/api/play', 'POST', {
     url: it.url,
     title: it.title || '',
-    icon: it.art || ''
+    icon: it.art || '',
+    mime: it.mime || ''
   });
   if (ok) { showTab('Play'); setNow(T.starting + ' ' + (it.title || ''), T.pleaseWait); setTimeout(refreshStatus, 1500); setTimeout(refreshStatus, 3500); }
   else { searchMsg(T.cantStart, true); }

--- a/internal/webui/boselogcap_test.go
+++ b/internal/webui/boselogcap_test.go
@@ -1,0 +1,99 @@
+package webui
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A speaker arrived with Bose's own log directory at tens of megabytes on a
+// 31.58 MiB volume, leaving no room for the Spotify engine while four identical
+// speakers beside it had an empty BoseLog (2026-08-23). Those logs are for a
+// cloud that was switched off in February.
+
+func withNANDRoot(t *testing.T) string {
+	t.Helper()
+	return t.TempDir()
+}
+
+func TestCapBoseLogsTrimsARunawayLogAndKeepsItsTail(t *testing.T) {
+	root := withNANDRoot(t)
+	logDir := filepath.Join(root, "BoseLog")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	big := filepath.Join(logDir, "bose.log")
+	body := append(bytes.Repeat([]byte("old junk\n"), 400_000), []byte("THE-NEWEST-LINE\n")...)
+	if err := os.WriteFile(big, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	capBoseLogs(logDir)
+
+	after, err := os.ReadFile(big)
+	if err != nil {
+		t.Fatalf("the file must survive, only shrink: %v", err)
+	}
+	if int64(len(after)) != boseLogKeep {
+		t.Errorf("kept %d bytes, want %d", len(after), boseLogKeep)
+	}
+	// The TAIL is what matters: a log trimmed to its beginning is useless.
+	if !bytes.HasSuffix(after, []byte("THE-NEWEST-LINE\n")) {
+		t.Error("the newest lines were thrown away instead of the oldest")
+	}
+}
+
+func TestCapBoseLogsLeavesAnOrdinaryLogDirectoryAlone(t *testing.T) {
+	root := withNANDRoot(t)
+	logDir := filepath.Join(root, "BoseLog")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	small := filepath.Join(logDir, "bose.log")
+	want := []byte("a perfectly normal log\n")
+	if err := os.WriteFile(small, want, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	capBoseLogs(logDir)
+
+	got, err := os.ReadFile(small)
+	if err != nil || !bytes.Equal(got, want) {
+		t.Errorf("a small log must not be touched at all, got %q err %v", got, err)
+	}
+}
+
+func TestCapBoseLogsTouchesNothingElseOfBoses(t *testing.T) {
+	root := withNANDRoot(t)
+	logDir := filepath.Join(root, "BoseLog")
+	sub := filepath.Join(logDir, "archive")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The box's own persistence lives next door and must never be involved.
+	persist := filepath.Join(root, "BoseApp-Persistence")
+	if err := os.MkdirAll(persist, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	keep := filepath.Join(persist, "NetworkProfiles.xml")
+	huge := bytes.Repeat([]byte("x"), boseLogCapAt+1)
+	if err := os.WriteFile(keep, huge, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	capBoseLogs(logDir)
+
+	if fi, err := os.Stat(sub); err != nil || !fi.IsDir() {
+		t.Error("a subdirectory of BoseLog must be left in place")
+	}
+	if got, err := os.ReadFile(keep); err != nil || len(got) != len(huge) {
+		t.Errorf("the box's own persistence was touched: %d bytes, err %v", len(got), err)
+	}
+}
+
+func TestCapBoseLogsIsFineWithoutTheDirectory(t *testing.T) {
+	root := withNANDRoot(t)
+	// A stock box that has no BoseLog at all must not panic.
+	capBoseLogs(filepath.Join(root, "BoseLog"))
+}

--- a/internal/webui/debug.go
+++ b/internal/webui/debug.go
@@ -241,6 +241,16 @@ func (s *Server) handleDebugState(w http.ResponseWriter, r *http.Request) {
 		// remnants without SSH (do NOT blanket-wipe /mnt/nv: it holds the box's
 		// own Wi-Fi/AirPlay/account persistence).
 		"nv_root_listing": listDir("/mnt/nv"),
+		// The speaker's OWN log directory, by name and size. It is not STR's and
+		// STR does not read it, but it shares the same 32 MB volume and it can
+		// run away: one speaker arrived with it at 37 MB on a volume of 31.6,
+		// with no room left for the Spotify engine, while four identical
+		// speakers beside it had it empty (2026-08-23). The bundle could show
+		// the SIZE and nothing else, so "are these the firmware's own logs or
+		// something another mod left behind" could not be answered at all, and
+		// the owner could not be told where his storage had gone. The names
+		// answer both.
+		"boselog_listing": listDir("/mnt/nv/BoseLog"),
 		"proc_mounts":     readTail("/proc/mounts"),
 		// Writable-volume usage: df for /mnt/nv + / and the per-entry sizes that
 		// answer "is this box genuinely tighter or carrying foreign firmware

--- a/internal/webui/phone_remote_test.go
+++ b/internal/webui/phone_remote_test.go
@@ -363,3 +363,33 @@ func TestPhoneRemoteTabbarStaysAtTheBottom(t *testing.T) {
 		t.Fatal("a short page must still fill the display, or the browser toolbar lifts the bar")
 	}
 }
+
+// #139 fixed the "a library file replays or garbles mid-track" bug by handing a
+// plain-HTTP file to the box directly instead of through the stream proxy,
+// which is built for endless radio and reads the EOF that ends a file as a
+// dropout. That fix keys entirely off the MIME the caller sends.
+//
+// The phone remote never sent it, so every NAS track played from a phone took
+// the radio route and started over. Reported from an iPhone on v0.9.55: "it
+// only buffers a tiny bit of a song up until about 95 seconds then the song
+// repeats". The search results already carried the MIME.
+func TestPhonePlaysALibraryTrackAsAFileNotAStation(t *testing.T) {
+	page := string(indexHTML)
+	i := strings.Index(page, "async function playLibTrack")
+	if i < 0 {
+		t.Fatal("playLibTrack is gone; the library play path moved")
+	}
+	body := page[i : i+900]
+	if !strings.Contains(body, "mime:") {
+		t.Error("playLibTrack sends no mime, so the agent routes the file through the radio proxy and it repeats")
+	}
+	// The station play path must NOT gain one: a MIME there makes the agent
+	// treat a stream as a finite file and skip the native radio route (#252).
+	j := strings.Index(page, "async function playStation")
+	if j < 0 {
+		t.Fatal("playStation is gone")
+	}
+	if strings.Contains(page[j:j+700], "mime:") {
+		t.Error("playStation must not send a mime; radio derives it from the codec")
+	}
+}

--- a/internal/webui/resume_standby.go
+++ b/internal/webui/resume_standby.go
@@ -1234,6 +1234,29 @@ func (s *Server) nudgeDeadSource() {
 	}
 }
 
+// resumeSafeSource reports whether STR may push a dropped stream back while the
+// box reports this source.
+//
+// An ALLOWLIST, never a list of sources to avoid, for the same reason the
+// preset reconcile uses one (see resyncSafeSource in cmd/agent): input sources
+// are named differently per model and we do not know them all. A Wave calls its
+// tuner LOCAL, a CineMate calls its TV input LOCAL too, an SA-5 answers AUX with
+// three different sourceAccounts, and a Wave's CD is invisible to STR entirely.
+// With an allowlist an unrecognised name counts as "the user chose this", and
+// the cost is one station the user restarts himself. A denylist would silently
+// override every source name we forgot.
+//
+// The empty string is safe on purpose: it means the probe failed, and a failed
+// probe must not disable the recovery. See the call site.
+func resumeSafeSource(src string) bool {
+	switch src {
+	case "", "UPNP", "INVALID_SOURCE", "STANDBY", "LOCAL_INTERNET_RADIO":
+		return true
+	default:
+		return false
+	}
+}
+
 // boxSourceNow reads the box's current source attribute ("" on any error).
 // Used by the spontaneous-off recovery to tell "the firmware dropped the
 // source while the box stayed awake" (recoverable right now) from "the box is
@@ -1464,6 +1487,35 @@ func (s *Server) maybeRePush() {
 			s.lastPlay.rePushes = 0
 		}
 		s.lastPlayMu.Unlock()
+		return
+	}
+
+	// The user switching to one of the speaker's OWN sources looks exactly like
+	// a dropped stream too, and busy above does not catch it: a Wave's built-in
+	// tuner (source LOCAL) reports no PLAY_STATE at all, because it is not a
+	// transport the firmware exposes. So the watchdog read "the stream died
+	// while the box sat idle" and pushed the station back on top of the radio
+	// the user had just tuned to.
+	//
+	// Reported as "I switch from SoundTouch to FM and it jumps straight back,
+	// the second press sticks", and his diagnostic has the whole sequence
+	// (Wave, 2026-08-23):
+	//
+	//   17:59:13.454  source changed  LOCAL_INTERNET_RADIO -> LOCAL
+	//   17:59:15.539  re-push: box dropped the stream while idle, resuming
+	//   17:59:15.674  source changed  LOCAL -> UPNP
+	//
+	// Two seconds, and he is back on the station he was leaving. Whether it
+	// happened at all depended on a race: the same log shows an earlier switch
+	// where the box's STOP_STATE was read as a deliberate stop and the push
+	// correctly stood down. That is the "sometimes it sticks" he described.
+	//
+	// An unreadable source deliberately does NOT stand down. This must only
+	// suppress a recovery when the box positively names a source the user
+	// chose; a probe that failed says nothing, and treating silence as "leave
+	// it alone" would quietly disable the recovery this whole path exists for.
+	if src := s.boxSourceNow(); !resumeSafeSource(src) {
+		s.logger.Info("re-push: not resuming, the speaker is on a source the user chose", "source", src)
 		return
 	}
 

--- a/internal/webui/resumesource_test.go
+++ b/internal/webui/resumesource_test.go
@@ -1,0 +1,55 @@
+package webui
+
+import "testing"
+
+// A Wave owner reported that switching from an internet station to FM jumped
+// straight back to the station, and that pressing FM a second time stuck. His
+// diagnostic (2026-08-23) shows STR doing it:
+//
+//	17:59:13.454  source changed  LOCAL_INTERNET_RADIO -> LOCAL
+//	17:59:15.539  re-push: box dropped the stream while idle, resuming
+//	17:59:15.674  source changed  LOCAL -> UPNP
+//
+// The busy check could not catch it, because the Wave's own tuner reports no
+// PLAY_STATE: it is not a transport the firmware exposes. So the source has to
+// be consulted as well.
+
+func TestResumeSafeSourceLeavesAUserChosenSourceAlone(t *testing.T) {
+	// Every one of these is the user having picked something on the speaker
+	// itself. Pushing a stream over it is taking the speaker off them.
+	for _, src := range []string{
+		"LOCAL",     // the Wave's FM tuner, and a CineMate's TV input
+		"AUX",       // a cable somebody plugged in
+		"BLUETOOTH", // a phone that just connected
+		"SPOTIFY",   // Spotify Connect, driven from their phone
+		"PRODUCT",   // a soundbar's HDMI source
+		"ALEXA",
+		"STORED_MUSIC",
+		"QPLAY",
+		"SOMETHING_A_FUTURE_MODEL_CALLS_ITS_TUNER",
+	} {
+		if resumeSafeSource(src) {
+			t.Errorf("%s is the user's choice, a stream must never be pushed over it", src)
+		}
+	}
+}
+
+func TestResumeSafeSourceStillRecoversSTRsOwnSources(t *testing.T) {
+	// These are the states a genuine drop leaves behind, and the recovery
+	// exists for exactly them.
+	for _, src := range []string{"UPNP", "INVALID_SOURCE", "STANDBY", "LOCAL_INTERNET_RADIO"} {
+		if !resumeSafeSource(src) {
+			t.Errorf("%s must stay recoverable", src)
+		}
+	}
+}
+
+func TestResumeSafeSourceTreatsAFailedProbeAsRecoverable(t *testing.T) {
+	// boxSourceNow returns "" on any error. Reading that as "leave it alone"
+	// would turn one unanswered request into a silently disabled recovery,
+	// which is worse than the fault being fixed here: the user would simply
+	// never get their station back and nothing would say why.
+	if !resumeSafeSource("") {
+		t.Error("an unreadable source must not suppress the recovery")
+	}
+}


### PR DESCRIPTION
Five commits, all from diagnostics that arrived on 2026-08-23.

## Switching a Wave to its own FM tuner jumped straight back

The reporter answered the one question that decided it: it does **not** happen when nothing is playing. His bundle then has the whole thing.

```
17:59:13.454  source changed  LOCAL_INTERNET_RADIO -> LOCAL     (he presses UKW)
17:59:15.539  re-push: box dropped the stream while idle, resuming
17:59:15.674  source changed  LOCAL -> UPNP                     (back on the station)
```

The re-push watchdog checks whether the box is playing, and a Wave's own tuner **reports no playback state at all**: it is not a transport the firmware drives. So "the user chose FM" was indistinguishable from "the stream died while idle". His "the second press sticks" is in the same log, where an earlier switch was read as a deliberate stop and correctly stood down. A race.

An **allowlist**, never a denylist, for the reason the preset reconcile uses one: a Wave calls its tuner `LOCAL` and so does a CineMate's TV socket. An unfamiliar name counts as the user's choice. An unreadable source still recovers, or one failed probe silently disables the recovery.

## A NAS track restarted after about 95 seconds

`playback.go` already names this bug: the proxy is *"built for endless radio, it treats the upstream EOF that ends a file as a dropout and reconnects, replaying or garbling the track"*. #139 fixed it by handing plain-HTTP files straight to the box, keyed entirely on the caller sending `mime`.

**The phone never sent it.** Its own search results carry the MIME and `playLibTrack` dropped it. The regression test also pins the reverse: the station path must never send one, or radio loses its native route.

## The speaker's own logs eat the volume

One speaker arrived with `BoseLog` at 37 MB on a volume that holds 31.6, and no room left for the Spotify engine, while four identical speakers beside it had it empty.

Trimmed alongside the logs STR already trims, at agent start and before a tight update. Only past 1 MiB, so an ordinary log directory is untouched. **Trimmed, not deleted**: the tail is kept and the file keeps its inode, so whatever Bose process holds it open goes on appending. That one folder only, no recursion, no directories removed, and a test that `BoseApp-Persistence` next door survives even holding a file over the cap.

## A speaker listed twice

A failed DHCP makes a speaker announce a self-assigned `169.254` address; STR wrote it down, the real lease came back, and both entries stayed, blocking Update All. Ignored now at announce time and in the remembered list. The one case where such an address means something is kept: this machine on link-local too, i.e. a direct cable.

## The update window could not be closed

Greyed while any row had no final outcome, and a speaker that drops off the network never gets one, so the window could not be dismissed until the app was restarted. Closing only hides it; the run continues either way, so there was nothing for the greying to protect.

## Also

The stream-start log line now records what the speaker actually asked for (`from`, `host`, `proto`, `ua`, `range`), and a bundle lists the speaker's own log files rather than only their total size. No new log line, no extra request, no timer.

## Verification

ARM cross-build, all 30 packages, desktop build and vet, frontend tests. Hardware: none.

Refs #139