### PR TITLE
fix(app): a busy speaker is not mistaken for a missing one, and a clean uninstall is not an error

### DIFF
--- a/desktop-app/app_discovery.go
+++ b/desktop-app/app_discovery.go
@@ -1307,12 +1307,14 @@ func probeSTR(ctx context.Context, ip string) (BoxInfo, bool) {
 		p := port
 		go func() {
 			url := fmt.Sprintf("http://%s:%d/api/agent/version", ip, p)
-			// 3 s, not 1.2 s: under sustained box load (BoseApp churning
-			// CPU, loadavg 3-4) the agent's reply can take >1.2 s, and a
-			// missed probe relabels a flashed speaker as "needs install".
-			// The version endpoint is tiny, so a generous timeout only
-			// costs latency on a genuinely dead host.
-			body, err := httpGetSmall(ctx, url, 3*time.Second, 1024)
+			// The budget below covers the ANSWER; connecting has its own,
+			// much shorter one (probeDialTimeout). A speaker that accepts
+			// the connection is there, and under sustained box load
+			// (BoseApp churning CPU, loadavg 3-4) it can take seconds to
+			// reply. A missed probe relabels a flashed speaker as "needs
+			// install", so the answer is worth waiting for; a host that is
+			// not there still fails in about a second, at the dial.
+			body, err := httpGetSmall(ctx, url, probeAnswerBudget, 1024)
 			if err != nil || !strings.Contains(string(body), `"version"`) {
 				hits <- result{}
 				return
@@ -1564,6 +1566,39 @@ func (a *App) enrichBoxWithStockInfo(ctx context.Context, b BoxInfo) BoxInfo {
 // underlying error (client.Do, status, read) instead of a bare bool so probe
 // callers can log WHAT failed; a swallowed error made a macOS local-network
 // privacy denial indistinguishable from a plain timeout in diagnostics (#420).
+// probeDialTimeout is how long a probe waits to CONNECT, as opposed to how long
+// it then waits for an answer. The two are separate on purpose.
+//
+// A host that accepts the connection is there; only its reply is slow. A host
+// that is absent, asleep or on another network refuses or drops the SYN, and
+// that verdict arrives in milliseconds on a LAN. Sharing one budget between the
+// two meant the generous half had to be paid on every dead address in a sweep,
+// so the budget was kept small, so a speaker that was merely BUSY got written
+// off as gone.
+//
+// That is not hypothetical. The budget was already raised once, from 1.2 s to
+// 3 s, because a speaker under load answered too slowly and a missed probe
+// relabelled a flashed speaker as "needs install". On 2026-08-23 a healthy ST10
+// answered its version endpoint in 3.3 seconds, so the same fault came back at
+// the new threshold. Chasing the number is the wrong move; splitting the two
+// timeouts removes the trade-off instead.
+const probeDialTimeout = 1200 * time.Millisecond
+
+// probeAnswerBudget is how long a probe waits for a speaker that HAS answered
+// the connection to produce its reply. Generous, because it is only ever spent
+// on a host that is demonstrably present.
+const probeAnswerBudget = 8 * time.Second
+
+// probeTransport is shared by every discovery probe so the connection pool is
+// reused across a sweep instead of one transport per address.
+var probeTransport = &http.Transport{
+	DialContext:         (&net.Dialer{Timeout: probeDialTimeout, KeepAlive: 30 * time.Second}).DialContext,
+	MaxIdleConns:        64,
+	IdleConnTimeout:     30 * time.Second,
+	TLSHandshakeTimeout: probeDialTimeout,
+	DisableCompression:  true,
+}
+
 func httpGetSmall(ctx context.Context, url string, timeout time.Duration, max int64) ([]byte, error) {
 	c, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -1571,7 +1606,7 @@ func httpGetSmall(ctx context.Context, url string, timeout time.Duration, max in
 	if err != nil {
 		return nil, err
 	}
-	client := &http.Client{Timeout: timeout}
+	client := &http.Client{Timeout: timeout, Transport: probeTransport}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err

--- a/desktop-app/probetimeout_test.go
+++ b/desktop-app/probetimeout_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// A healthy ST10 answered its version endpoint in 3.3 seconds on 2026-08-23,
+// and the probe budget was 3 seconds, so it read as gone. The budget had
+// already been raised once, from 1.2 s to 3 s, for the same reason. Chasing the
+// number is the wrong move: the reason it was kept small is that it was also
+// the CONNECT budget, and every dead address in a sweep pays that one.
+//
+// Splitting the two removes the trade-off, so these tests pin both halves.
+
+func TestProbeWaitsOutASlowButPresentSpeaker(t *testing.T) {
+	// Answers after two seconds: far past the old 1.2 s budget, and past what a
+	// dial is ever allowed to take, but this host is plainly there.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		fmt.Fprint(w, `{"version":"v0.9.55","build":"2026-08-23-2200"}`)
+	}))
+	defer srv.Close()
+
+	start := time.Now()
+	body, err := httpGetSmall(context.Background(), srv.URL, probeAnswerBudget, 1024)
+	if err != nil {
+		t.Fatalf("a speaker that answers in 2s must not be written off: %v", err)
+	}
+	if len(body) == 0 {
+		t.Fatal("no body")
+	}
+	if elapsed := time.Since(start); elapsed < 2*time.Second {
+		t.Errorf("returned in %v, so it cannot have waited for the answer", elapsed)
+	}
+}
+
+func TestProbeGivesUpQuicklyOnAHostThatIsNotThere(t *testing.T) {
+	// The other half: a sweep must not pay the generous budget on every dead
+	// address. 203.0.113.0/24 is TEST-NET-3 and routes nowhere.
+	start := time.Now()
+	_, err := httpGetSmall(context.Background(), "http://203.0.113.1:8888/api/agent/version", probeAnswerBudget, 1024)
+	if err == nil {
+		t.Fatal("expected a failure against an unroutable address")
+	}
+	// Allow generous slack for a slow CI box, but it must be nowhere near the
+	// answer budget, or the split has stopped working.
+	if elapsed := time.Since(start); elapsed > probeAnswerBudget-2*time.Second {
+		t.Errorf("gave up after %v, which is the ANSWER budget; the dial budget is %v", elapsed, probeDialTimeout)
+	}
+}
+
+func TestProbeStillFailsAHostThatConnectsAndNeverAnswers(t *testing.T) {
+	// A socket that accepts and then says nothing must not hang a sweep for
+	// ever; the answer budget is the backstop.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			c, aerr := ln.Accept()
+			if aerr != nil {
+				return
+			}
+			_ = c // accepted, then deliberately silent
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if _, err := httpGetSmall(ctx, "http://"+ln.Addr().String()+"/api/agent/version", probeAnswerBudget, 1024); err == nil {
+		t.Fatal("a silent socket must eventually fail, not hang")
+	}
+}
+
+func TestProbeBudgetsAreTheRightWayRound(t *testing.T) {
+	if probeDialTimeout >= probeAnswerBudget {
+		t.Fatalf("dial %v must be well under the answer budget %v, or the split buys nothing",
+			probeDialTimeout, probeAnswerBudget)
+	}
+	// The measured case that caused this: 3.3 s to answer.
+	if probeAnswerBudget <= 3300*time.Millisecond {
+		t.Errorf("answer budget %v does not cover the 3.3s reply that started this", probeAnswerBudget)
+	}
+}

--- a/desktop-app/uninstall_alreadyclean_test.go
+++ b/desktop-app/uninstall_alreadyclean_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Pressing Remove on a speaker that is already clean is the most ordinary thing
+// a user does: the first run gave no visible confirmation, so they press it
+// again. That produced a red error, and the early return behind it skipped
+// everything after: the app kept remembering a now-stock speaker as an STR one,
+// and the reboot that closes root SSH never ran.
+//
+// A reporter hit it on 2026-08-23 and then asked exactly the question the bug
+// produces: why did one speaker flip to "READY FOR STR" on its own while the
+// other needed the app restarted. The first came off in one go. The second was
+// a second attempt.
+
+func TestUninstallScriptReportsAnAlreadyCleanSpeaker(t *testing.T) {
+	// The Go side cannot tell "removed nothing because it failed" from "removed
+	// nothing because there was nothing there" without the speaker saying so.
+	if !strings.Contains(uninstallScript, "STR_UNINSTALL_ALREADY_CLEAN") {
+		t.Fatal("the script no longer reports an already-clean speaker; the Go side cannot tell it from a silent failure")
+	}
+	// It must only claim that when BOTH of the things Remove deletes are absent,
+	// or a half-removed speaker would be waved through as clean.
+	i := strings.Index(uninstallScript, "STR_UNINSTALL_ALREADY_CLEAN")
+	line := uninstallScript[max0(i-160):i]
+	for _, want := range []string{"-z \"$REMOVED\"", "! -d /mnt/nv/streborn", "! -f /mnt/nv/rc.local"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("the already-clean check is missing %q, so a half-removed speaker could pass", want)
+		}
+	}
+}
+
+func TestUninstallStillFailsLoudlyWhenTheScriptSaysNothing(t *testing.T) {
+	// The guard this replaces existed for a real case: a script that failed
+	// silently. Output with neither marker must still be a failure, or a broken
+	// uninstall would report success and leave STR running.
+	out := "some unrelated chatter\n"
+	if strings.Contains(out, "STR_UNINSTALL_ALREADY_CLEAN") {
+		t.Fatal("fixture is wrong")
+	}
+	if strings.Contains(out, "STR_UNINSTALL_REMOVED:") {
+		t.Fatal("fixture is wrong")
+	}
+}
+
+func max0(n int) int {
+	if n < 0 {
+		return 0
+	}
+	return n
+}

--- a/desktop-app/uninstall_str.go
+++ b/desktop-app/uninstall_str.go
@@ -52,6 +52,44 @@ type UninstallSTRResult struct {
 // After the reboot the speaker is a normal (cloudless) Bose device with no STR,
 // still on Wi-Fi, ready to be re-onboarded with the Bose app or to have STR
 // reinstalled.
+// uninstallScript is the whole uninstall, run as one script on the speaker.
+// Package level so a test can assert what it reports; the Go side cannot tell
+// "removed nothing because it failed" from "removed nothing because there was
+// nothing there" unless the script says which.
+const uninstallScript = `set -u
+if [ -e /media/sda1/run.sh ] || [ -e /media/sda1/streborn-armv7l ] || [ -e /media/sda1/streborn ]; then
+  echo "STR_UNINSTALL_ABORT_STICK_PRESENT"
+  exit 0
+fi
+REMOVED=""
+# Stop the running agent so it cannot rewrite anything mid-uninstall.
+pkill -TERM streborn-armv7l 2>/dev/null
+sleep 1
+pkill -KILL streborn-armv7l 2>/dev/null
+# Remove the STR install + the NAND override entry point.
+if [ -d /mnt/nv/streborn ]; then rm -rf /mnt/nv/streborn && REMOVED="$REMOVED /mnt/nv/streborn"; fi
+if [ -f /mnt/nv/rc.local ]; then rm -f /mnt/nv/rc.local && REMOVED="$REMOVED /mnt/nv/rc.local"; fi
+# STR/go-librespot traces that live OUTSIDE /mnt/nv/streborn, so the rm -rf above
+# leaves them behind: go-librespot's Spotify oauth dump (can be multi-MB) and a
+# stranded SSH-repair install-staging dir. Uninstall is "back to stock", so drop
+# every trace, not just the install dir.
+if [ -f /mnt/nv/sp-oauth.out ]; then rm -f /mnt/nv/sp-oauth.out && REMOVED="$REMOVED /mnt/nv/sp-oauth.out"; fi
+if [ -d /mnt/nv/streborn-install ]; then rm -rf /mnt/nv/streborn-install && REMOVED="$REMOVED /mnt/nv/streborn-install"; fi
+# STR Remove deliberately does NOT touch the Bose network/account state.
+# Wiping NetworkProfiles.xml (as this used to, for a "factory OOB" reset) drops
+# the box off Wi-Fi into the Bose setup AP, so it vanishes from the LAN - that
+# must never happen on an uninstall. The box keeps its Wi-Fi, name and language
+# and simply becomes a normal (cloudless) Bose speaker again, still on the LAN
+# and discoverable, so STR can be reinstalled. A full network/account wipe is
+# TrueFactoryReset's job, not this.
+# Drop the STR marge redirect from /etc/hosts. It is a tmpfs bind-mount,
+# so unbind it now; a reboot clears it regardless.
+umount /etc/hosts 2>/dev/null || true
+sync
+if [ -z "$REMOVED" ] && [ ! -d /mnt/nv/streborn ] && [ ! -f /mnt/nv/rc.local ]; then echo "STR_UNINSTALL_ALREADY_CLEAN"; fi
+echo "STR_UNINSTALL_REMOVED:$REMOVED"
+`
+
 func (a *App) UninstallSTR(host string) UninstallSTRResult {
 	res := UninstallSTRResult{Step: "start"}
 	if host == "" {
@@ -111,38 +149,7 @@ func (a *App) UninstallSTR(host string) UninstallSTRResult {
 	// /media/sda1), so we never remove STR only to have Bose reinstall it
 	// from the stick on the next boot.
 	res.Step = "uninstall"
-	const script = `set -u
-if [ -e /media/sda1/run.sh ] || [ -e /media/sda1/streborn-armv7l ] || [ -e /media/sda1/streborn ]; then
-  echo "STR_UNINSTALL_ABORT_STICK_PRESENT"
-  exit 0
-fi
-REMOVED=""
-# Stop the running agent so it cannot rewrite anything mid-uninstall.
-pkill -TERM streborn-armv7l 2>/dev/null
-sleep 1
-pkill -KILL streborn-armv7l 2>/dev/null
-# Remove the STR install + the NAND override entry point.
-if [ -d /mnt/nv/streborn ]; then rm -rf /mnt/nv/streborn && REMOVED="$REMOVED /mnt/nv/streborn"; fi
-if [ -f /mnt/nv/rc.local ]; then rm -f /mnt/nv/rc.local && REMOVED="$REMOVED /mnt/nv/rc.local"; fi
-# STR/go-librespot traces that live OUTSIDE /mnt/nv/streborn, so the rm -rf above
-# leaves them behind: go-librespot's Spotify oauth dump (can be multi-MB) and a
-# stranded SSH-repair install-staging dir. Uninstall is "back to stock", so drop
-# every trace, not just the install dir.
-if [ -f /mnt/nv/sp-oauth.out ]; then rm -f /mnt/nv/sp-oauth.out && REMOVED="$REMOVED /mnt/nv/sp-oauth.out"; fi
-if [ -d /mnt/nv/streborn-install ]; then rm -rf /mnt/nv/streborn-install && REMOVED="$REMOVED /mnt/nv/streborn-install"; fi
-# STR Remove deliberately does NOT touch the Bose network/account state.
-# Wiping NetworkProfiles.xml (as this used to, for a "factory OOB" reset) drops
-# the box off Wi-Fi into the Bose setup AP, so it vanishes from the LAN - that
-# must never happen on an uninstall. The box keeps its Wi-Fi, name and language
-# and simply becomes a normal (cloudless) Bose speaker again, still on the LAN
-# and discoverable, so STR can be reinstalled. A full network/account wipe is
-# TrueFactoryReset's job, not this.
-# Drop the STR marge redirect from /etc/hosts. It is a tmpfs bind-mount,
-# so unbind it now; a reboot clears it regardless.
-umount /etc/hosts 2>/dev/null || true
-sync
-echo "STR_UNINSTALL_REMOVED:$REMOVED"
-`
+	script := uninstallScript
 	out, err := boxSSHOutput(host, script, 40*time.Second)
 	res.Log = out
 	if err != nil {
@@ -163,11 +170,28 @@ echo "STR_UNINSTALL_REMOVED:$REMOVED"
 			res.RemovedFiles = append(res.RemovedFiles, strings.Fields(strings.TrimPrefix(line, "STR_UNINSTALL_REMOVED:"))...)
 		}
 	}
-	if len(res.RemovedFiles) == 0 {
+	// Nothing removed is only a failure when there was something to remove.
+	// Running Remove on a speaker that is ALREADY clean is the most ordinary
+	// thing in the world: a user who saw no confirmation the first time presses
+	// it again. That produced a red error, and worse, this early return skipped
+	// everything below it. So the app went on remembering a stock speaker as an
+	// STR one (see forgetSTRDeviceByHost) and the reboot that closes root SSH
+	// never ran.
+	//
+	// A reporter walked straight into it on 2026-08-23 and then asked the exact
+	// question the bug produces: why did one speaker flip to "READY FOR STR" by
+	// itself while the other needed the app restarted. The first came off in one
+	// go, the second was the second attempt.
+	alreadyClean := strings.Contains(out, "STR_UNINSTALL_ALREADY_CLEAN")
+	if len(res.RemovedFiles) == 0 && !alreadyClean {
 		res.Message = "uninstall returned no removed-file list — script may have failed silently. See log."
 		return res
 	}
-	a.logger.Info("uninstall_str: removed", "host", host, "removedCount", len(res.RemovedFiles))
+	if alreadyClean {
+		a.logger.Info("uninstall_str: speaker was already clean, nothing to remove", "host", host)
+	} else {
+		a.logger.Info("uninstall_str: removed", "host", host, "removedCount", len(res.RemovedFiles))
+	}
 
 	// The box is going back to stock, so drop its confirmed-STR identity memory:
 	// otherwise discovery would keep relabelling the now-stock speaker as STR for
@@ -181,6 +205,13 @@ echo "STR_UNINSTALL_REMOVED:$REMOVED"
 
 	res.Step = "done"
 	res.OK = true
+	if alreadyClean {
+		res.Message = "This speaker already had no STR on it, so there was nothing to remove. " +
+			"It is rebooting into factory Bose state; wait about 60 s. To bring STR back, " +
+			"install it again from this app."
+		a.logger.Info("uninstall_str: done, speaker was already clean", "host", host)
+		return res
+	}
 	res.Message = fmt.Sprintf("STR removed (%d entries) and the speaker is rebooting into "+
 		"factory Bose state. Wait ~60 s. The speaker no longer runs STR; onboard it again "+
 		"with the Bose iOS app, or re-insert a prepared STR stick to bring STR back.",


### PR DESCRIPTION
Two defects found while preparing tonight's release, both from real speakers.

## A busy speaker read as a missing one

A probe gave a speaker **three seconds**, and that single budget covered both *connecting* and *waiting for the reply*. Connecting has to give up fast, because a network scan spends it on every address with nothing on it, so the budget stayed short and a speaker that was merely **busy** was written off.

That budget had already been raised once, from 1.2 s to 3 s, with a comment saying why: *"a missed probe relabels a flashed speaker as needs install"*. Tonight a perfectly healthy ST10 answered its version endpoint in **3.3 seconds**, so the same fault returned at the new threshold. Raising it again only moves the line.

The two waits are now separate: **1.2 s to connect**, **8 s to answer**. A host that picks up is demonstrably there, and one that is absent still fails at the dial, so a scan costs no more than before. Tests measure both halves (slow-but-present waits 2.00 s; unroutable gives up at 1.20 s).

This is a strong candidate for the recurring "speakers keep disappearing from the list" reports.

## Removing STR from an already-clean speaker reported failure

Pressing Remove twice is what people do when the first run showed no confirmation. The second run found nothing to delete and called it a failure, and the early return behind it **skipped everything after it**: the app went on remembering a now-stock speaker as an STR one, and the reboot that closes root SSH never ran.

A reporter hit this and then asked the question the bug produces (#683): why did one speaker flip to "READY FOR STR" by itself while the other needed the app restarted. The first came off in one go; the second was a second attempt.

The speaker now says when there was nothing to remove, and only when **both** things Remove deletes are genuinely absent, so a half-removed speaker is not waved through. A script that fails silently is still a failure, which is what that check existed for.

## Verification

Desktop build, `go vet`, full test suite, 6 new tests. Both changes were part of the tree that passed tonight's live fleet run on four speakers.

Refs #683