### PR TITLE
Align STR with the official Bose Web API doc: frames, typed errors, tone-controls bass, SSDP discovery

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -186,6 +186,13 @@ func run() error {
 	}
 
 	logger := newLogger(*logLevel)
+	// The process default routes into the same destination as the named logger.
+	// Library code falls back to slog.Default() when no logger was handed to it
+	// (the boxapi client's 2xx error-envelope survey is the case that exposed
+	// this), and without this line that output went to bare stderr, of which a
+	// diagnostic bundle keeps almost nothing. The survey exists to be read out
+	// of bundles across the fleet, so it has to land where bundles look.
+	slog.SetDefault(logger)
 	logger.Info("streborn starting", "version", version)
 
 	// FIRST, before anything can open a TLS connection. crypto/x509 builds the

--- a/desktop-app/app_discovery.go
+++ b/desktop-app/app_discovery.go
@@ -17,6 +17,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/JRpersonal/streborn/discovery"
+	"github.com/JRpersonal/streborn/dlna"
 )
 
 // discEntry is one cached discovery result plus when it was last
@@ -295,6 +296,58 @@ func (a *App) DiscoverBoxes(timeoutSec int) ([]BoxInfo, error) {
 			upsert(probed)
 		}
 	}()
+	// Third source, costing the LAN nothing: the speakers announce THEMSELVES.
+	// Every SoundTouch on FW 27.0.6 sends periodic SSDP ssdp:alive NOTIFYs for
+	// its :8091 MediaRenderer (measured 2026-08-24 across ST30, ST10 and
+	// Portable), and the dlna package's passive listener has been collecting
+	// them for the app's whole lifetime anyway (#341). That reaches two boxes
+	// the paths above structurally miss: a speaker on a LAN where mDNS is dead
+	// (instancesFromMDNS=0 every cycle, the recurring router-setup case) that
+	// is ALSO outside the sweep's /24, and one the 12 s sweep budget skipped.
+	// Announcements are candidates, never results: each host is probed through
+	// the same classification as a sweep hit, so a stale announcement costs one
+	// failed probe and can never show a speaker that is not there. Self-assigned
+	// addresses are skipped for the reason discovery_coldstart already skips
+	// them: unroutable from an ordinary LAN, and the same box re-announces its
+	// real lease anyway.
+	var ssdpHits int
+	fbWG.Add(1)
+	go func() {
+		defer fbWG.Done()
+		hosts := dlna.AnnouncedBoseHosts()
+		// Bounded so a hostile or absurd multicast neighbourhood cannot turn
+		// discovery into a probe storm; a home fleet is single digits.
+		if len(hosts) > 24 {
+			hosts = hosts[:24]
+		}
+		var wg sync.WaitGroup
+		for _, h := range hosts {
+			if ip := net.ParseIP(h); ip == nil || ip.IsLoopback() ||
+				(ip.IsLinkLocalUnicast() && !hostHasLinkLocalIPv4()) {
+				continue
+			}
+			host := h
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				var found BoxInfo
+				ok := false
+				if b, hit := probeSTR(fallbackCtx, host); hit {
+					found, ok = b, true
+				} else if b, hit := probeStock(fallbackCtx, host); hit {
+					found, ok = b, true
+				}
+				if !ok {
+					return
+				}
+				fbMu.Lock()
+				ssdpHits++
+				upsert(found)
+				fbMu.Unlock()
+			}()
+		}
+		wg.Wait()
+	}()
 	fbWG.Wait()
 	fallbackCancel()
 	// The known-speaker probes finished long ago (single 3 s probes launched
@@ -304,7 +357,7 @@ func (a *App) DiscoverBoxes(timeoutSec int) ([]BoxInfo, error) {
 		knownFound++
 		upsert(b)
 	}
-	a.logger.Info("discovery: TCP fallback done", "stockHits", stockHits, "strHits", strHits, "knownDirect", knownFound)
+	a.logger.Info("discovery: TCP fallback done", "stockHits", stockHits, "strHits", strHits, "ssdpHits", ssdpHits, "knownDirect", knownFound)
 	a.logger.Info("discovery: returning", "totalBoxes", len(seen), "fromMDNS", mdnsHits)
 
 	// Enrich every box with the serial number and model from

--- a/desktop-app/frontend/src/utils.js
+++ b/desktop-app/frontend/src/utils.js
@@ -517,6 +517,34 @@ export function bassControlsDisabled(bass) {
   return !(bass && bass.available);
 }
 
+// bassSliderProps is the ONE mapping between the speaker's bass reading and
+// the settings slider. The slider is RELATIVE to the speaker's default
+// (0 = default), which is why min/max/value all subtract it; the change
+// handlers add it back before posting.
+//
+// step exists because of the capability-gated tone-controls bass route
+// (home-theater systems; the greyed-slider Lifestyle 650 mail of 2026-08-22
+// is the field case): that route imposes a write granularity that can exceed
+// 1, and a slider stepping by 1 would post values the firmware is free to
+// refuse. The agent maps that route's default to 0, so relative equals
+// absolute there. Classic boxes report no step and keep the historic step
+// of 1.
+//
+// Shared helper rather than inline template math for the same reason as
+// bassControlsDisabled above: the settings view renders through innerHTML
+// and the vitest environment is deliberately DOM-free, so this is the only
+// place the mapping can be pinned by a test.
+export function bassSliderProps(bass) {
+  const b = bass || {};
+  const def = b.default || 0;
+  return {
+    min: (b.min || 0) - def,
+    max: (b.max || 0) - def,
+    step: b.step > 1 ? b.step : 1,
+    value: (b.actual || 0) - def,
+  };
+}
+
 // shouldAdoptPresetArt answers one question the preset grid and the status poll
 // have to agree on: may the logo of the station playing right now be written
 // onto the key it was recalled from? Yes only while that key has no logo of its

--- a/desktop-app/frontend/src/utils.test.js
+++ b/desktop-app/frontend/src/utils.test.js
@@ -1,7 +1,7 @@
 // Tests for the pure decision helpers in utils.js.
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { savePresetCase, bassControlsDisabled } from './utils.js';
+import { savePresetCase, bassControlsDisabled, bassSliderProps } from './utils.js';
 
 const FRESH_MS = 2 * 60 * 1000;
 const NOW = 1_000_000_000;
@@ -83,6 +83,43 @@ describe('bassControlsDisabled', () => {
     expect(help, 'the usage help must still exist for speakers that DO have bass').toBeGreaterThan(-1);
     expect(section.slice(Math.min(help, reason), Math.max(help, reason)))
       .toMatch(/[?:]/); // the two sit on opposite sides of one conditional
+  });
+});
+
+// The bass slider's range, step and position come from one shared mapping.
+// The slider is relative to the speaker's default (0 = default); step exists
+// for the capability-gated tone-controls route (the Lifestyle 650 case),
+// whose write granularity can exceed 1. The agent maps that route's default
+// to 0, so relative equals absolute there.
+describe('bassSliderProps', () => {
+  it('maps the classic reading relative to the default with step 1', () => {
+    expect(bassSliderProps({ available: true, min: -9, max: 0, default: 0, actual: -4 }))
+      .toEqual({ min: -9, max: 0, step: 1, value: -4 });
+    // a non-zero default shifts the whole scale so 0 keeps meaning "default"
+    expect(bassSliderProps({ available: true, min: -5, max: 5, default: 2, actual: 4 }))
+      .toEqual({ min: -7, max: 3, step: 1, value: 2 });
+  });
+  it('passes a tone-controls step above 1 through', () => {
+    expect(bassSliderProps({ available: true, min: -100, max: 100, default: 0, step: 50, actual: 50 }))
+      .toEqual({ min: -100, max: 100, step: 50, value: 50 });
+  });
+  it('falls back to step 1 when the speaker reports none', () => {
+    expect(bassSliderProps({ min: -9, max: 0, step: 0, actual: 0 })).toMatchObject({ step: 1 });
+    expect(bassSliderProps({})).toEqual({ min: 0, max: 0, step: 1, value: 0 });
+    expect(bassSliderProps(undefined)).toEqual({ min: 0, max: 0, step: 1, value: 0 });
+  });
+  // Source check in the style of the gate check above: the slider must take
+  // all four properties from the helper. Until 2026-08-24 the template
+  // hardcoded step="1", which posts values a tone-controls speaker is free
+  // to refuse.
+  it('the settings view slider takes min/max/step/value from this helper', () => {
+    const src = readFileSync(new URL('./views/settings.js', import.meta.url), 'utf8');
+    const slider = src.match(/<input type="range" id="boxBass"[\s\S]*?\/>/);
+    expect(slider, 'the bass slider markup must still be findable').not.toBeNull();
+    expect(slider[0]).not.toContain('step="1"');
+    for (const key of ['min', 'max', 'step', 'value']) {
+      expect(slider[0]).toContain('${bassProps.' + key + '}');
+    }
   });
 });
 

--- a/desktop-app/frontend/src/views/settings.js
+++ b/desktop-app/frontend/src/views/settings.js
@@ -27,6 +27,7 @@ import {
   balanceLabel,
   encodeURIStrict,
   bassControlsDisabled,
+  bassSliderProps,
 } from '../utils.js';
 import { t, tLookup, getLocale } from '../i18n/index.js';
 import { COUNTRIES, optFlag } from '../localization.js';
@@ -743,6 +744,10 @@ function renderBoxSettings(s, box) {
   const info = s.info || {};
   const vol = s.volume || {};
   const bass = s.bass || {};
+  // Range, step and position of the bass slider all come from the shared
+  // mapping: tone-controls speakers report a step above 1 that the slider
+  // must honor (see bassSliderProps in utils.js).
+  const bassProps = bassSliderProps(bass);
   const net = s.network || {};
   const sources = rollupSources(s.sources || []);
   // Series-II boxes expose Wi-Fi as a WIFI_INTERFACE in
@@ -814,12 +819,12 @@ function renderBoxSettings(s, box) {
       <h3>${escapeHtml(t('settingsView.bassHeading'))}</h3>
       <div class="setting-row">
         <input type="range" id="boxBass"
-               min="${(bass.min || 0) - (bass.default || 0)}"
-               max="${(bass.max || 0) - (bass.default || 0)}"
-               step="1"
-               value="${(bass.actual || 0) - (bass.default || 0)}"
+               min="${bassProps.min}"
+               max="${bassProps.max}"
+               step="${bassProps.step}"
+               value="${bassProps.value}"
                ${bassControlsDisabled(bass) ? 'disabled' : ''} />
-        <span class="setting-value" id="boxBassVal">${formatRel((bass.actual || 0) - (bass.default || 0))}</span>
+        <span class="setting-value" id="boxBassVal">${formatRel(bassProps.value)}</span>
         <button class="btn btn-mini" id="boxBassReset" title="${escapeAttr(t('settingsView.bassResetTitle'))}" ${bassControlsDisabled(bass) ? 'disabled' : ''}>${escapeHtml(t('settingsView.bassResetBtn'))}</button>
       </div>
       ${bassControlsDisabled(bass)

--- a/dlna/announce.go
+++ b/dlna/announce.go
@@ -32,6 +32,7 @@ import (
 	"bytes"
 	"context"
 	"net"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -139,6 +140,57 @@ func (c *announceCache) candidateLocations(now time.Time) []string {
 			continue
 		}
 		out = append(out, loc)
+	}
+	return out
+}
+
+// boseUSNPrefix is the device-UUID prefix every SoundTouch speaker uses in its
+// SSDP announcements: uuid:BO5EBO5E-F00D-F00D-FEED-<deviceID>. Measured live on
+// 2026-08-24 across three chassis families (ST30 mojo, ST10 rhino, Portable
+// taigan, all FW 27.0.6): each emitted ssdp:alive NOTIFYs for
+// urn:schemas-upnp-org:device:MediaRenderer:1 with this constant, the speaker's
+// own deviceID as the UUID tail, and Location pointing at its :8091 UPnP
+// description. The official Web API doc (v1.1, section 6.1.2) names the URN but
+// not the UUID; the fingerprint is field knowledge.
+const boseUSNPrefix = "uuid:bo5ebo5e"
+
+// AnnouncedBoseHosts returns the host addresses of every SoundTouch speaker the
+// passive NOTIFY listener has heard from, deduped, freshest lifetime rules as
+// candidateLocations. This is the discovery path that still works when mDNS is
+// dead on the LAN (many router setups answer no _streborn._tcp at all,
+// instancesFromMDNS=0 every cycle) and the /24 sweep misses a speaker on
+// another subnet: the speaker itself keeps announcing over multicast
+// regardless, and this process already listens (StartAnnounceListener runs for
+// the app's lifetime). Callers must still PROBE each host before showing
+// anything; an SSDP announcement proves a Bose device spoke, never that it is
+// reachable or what runs on it.
+func AnnouncedBoseHosts() []string {
+	return announces.boseHosts(time.Now())
+}
+
+// boseHosts is AnnouncedBoseHosts over one cache instance, split out so the
+// filter is testable the way the rest of this file is, on a local cache.
+func (c *announceCache) boseHosts(now time.Time) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	seen := map[string]bool{}
+	var out []string
+	for loc, e := range c.entries {
+		if now.After(e.expires.Add(announceExpiredRetention)) {
+			continue // candidateLocations owns the delete; stay read-only here
+		}
+		if !strings.HasPrefix(strings.ToLower(e.usn), boseUSNPrefix) {
+			continue
+		}
+		u, err := url.Parse(loc)
+		if err != nil || u.Hostname() == "" {
+			continue
+		}
+		h := u.Hostname()
+		if !seen[h] {
+			seen[h] = true
+			out = append(out, h)
+		}
 	}
 	return out
 }

--- a/dlna/announce_test.go
+++ b/dlna/announce_test.go
@@ -111,3 +111,59 @@ func TestParseMaxAge(t *testing.T) {
 		}
 	}
 }
+
+// Every SoundTouch speaker announces itself over SSDP with the constant
+// uuid:BO5EBO5E-F00D-F00D-FEED-<deviceID> prefix (measured 2026-08-24 on three
+// chassis families, FW 27.0.6). The Bose-host accessor must return exactly the
+// speakers, never the neighbourhood's other UPnP devices, and a byebye must
+// retire the speaker like any other announcement.
+func TestAnnounceCache_BoseHosts(t *testing.T) {
+	c := &announceCache{entries: map[string]announceEntry{}}
+	now := time.Now()
+
+	speaker := notifyPacket(
+		"CACHE-CONTROL: max-age=1800",
+		"LOCATION: http://192.0.2.44:8091/XD/BO5EBO5E-F00D-F00D-FEED-AABBCCDDEEFF.xml",
+		"NT: urn:schemas-upnp-org:device:MediaRenderer:1",
+		"NTS: ssdp:alive",
+		"USN: uuid:BO5EBO5E-F00D-F00D-FEED-AABBCCDDEEFF::urn:schemas-upnp-org:device:MediaRenderer:1",
+	)
+	tv := notifyPacket(
+		"CACHE-CONTROL: max-age=1800",
+		"LOCATION: http://192.0.2.99:9197/dmr",
+		"NT: urn:schemas-upnp-org:device:MediaRenderer:1",
+		"NTS: ssdp:alive",
+		"USN: uuid:12345678-aaaa-bbbb-cccc-dddddddddddd::urn:schemas-upnp-org:device:MediaRenderer:1",
+	)
+	c.handlePacket(speaker, now)
+	c.handlePacket(tv, now)
+
+	hosts := c.boseHosts(now)
+	if len(hosts) != 1 || hosts[0] != "192.0.2.44" {
+		t.Fatalf("boseHosts = %v, want exactly the speaker's host", hosts)
+	}
+
+	// The same speaker announces several service variants under one uuid; the
+	// host must not be duplicated.
+	svc := notifyPacket(
+		"CACHE-CONTROL: max-age=1800",
+		"LOCATION: http://192.0.2.44:8091/XD/BO5EBO5E-F00D-F00D-FEED-AABBCCDDEEFF.xml",
+		"NT: urn:schemas-upnp-org:service:AVTransport:1",
+		"NTS: ssdp:alive",
+		"USN: uuid:BO5EBO5E-F00D-F00D-FEED-AABBCCDDEEFF::urn:schemas-upnp-org:service:AVTransport:1",
+	)
+	c.handlePacket(svc, now)
+	if hosts := c.boseHosts(now); len(hosts) != 1 {
+		t.Fatalf("after a second service announcement: hosts = %v, want one", hosts)
+	}
+
+	byebye := notifyPacket(
+		"NT: urn:schemas-upnp-org:device:MediaRenderer:1",
+		"NTS: ssdp:byebye",
+		"USN: uuid:BO5EBO5E-F00D-F00D-FEED-AABBCCDDEEFF::urn:schemas-upnp-org:device:MediaRenderer:1",
+	)
+	c.handlePacket(byebye, now)
+	if hosts := c.boseHosts(now); len(hosts) != 0 {
+		t.Fatalf("after byebye: hosts = %v, want none", hosts)
+	}
+}

--- a/docs/FIRMWARE-NOTES.md
+++ b/docs/FIRMWARE-NOTES.md
@@ -11,6 +11,16 @@ port numbers, process states). It contains **no** Bose code, no
 firmware binaries, and no decompilation. All device identifiers, IPs,
 and MACs are placeholders.
 
+In August 2026 these notes were cross-checked against the official
+Bose SoundTouch Web API reference (v1.1, dated 2026-04-01). Entries
+from that pass carry one of two provenance markers. **Doc-confirmed**
+means that reference states the same thing; only its identifiers are
+reproduced here, never its text. **Field wins** means the doc says one
+thing, the live FW 27.0.6 fleet demonstrably does another, and STR
+follows the field observation, with the citation given. The field-wins
+entries are the valuable ones: do not "fix" STR toward the doc on any
+of them.
+
 ## The Portable ~27-minute reboot loop (and how STR fixes it)
 
 **Symptom.** On the SoundTouch Portable, internet radio would stop and
@@ -86,6 +96,60 @@ persistent; the firmware answers protocol pings indefinitely. Every gap
 had been a 10-14 s window that lost a hardware press (#435 feeder) and a
 log-churn source that rotated the 32 KB NAND log in ~3.5 h.
 
+### The official notification names (doc-confirmed)
+
+The official doc confirms the `gabbo` subprotocol on `:8080` and maps
+its internal notification names onto the wire elements STR parses:
+
+| Doc notification name   | Wire element                |
+| ----------------------- | --------------------------- |
+| VolumeChange            | `volumeUpdated`             |
+| BassChange              | `bassUpdated`               |
+| NetworkConnectionStatus | `connectionStateUpdated`    |
+| NowSelectionChange      | `nowSelectionUpdated` (a `preset` child carrying a `ContentItem`) |
+| SourcesChange           | `sourcesUpdated`            |
+| InfoChange              | `infoUpdated`               |
+| ZoneMapChange           | `zoneUpdated`               |
+| PresetsChangedNotifyUI  | `presetsUpdated`            |
+| NowPlayingChange        | `nowPlayingUpdated`         |
+| AcctModeChangedNotifyUI | `acctModeUpdated`           |
+
+The doc additionally lists `swUpdateStatusUpdated`,
+`siteSurveyResultsUpdated`, and `recentsUpdated`.
+
+### The doc's blind spots (field-only frames)
+
+The doc's notification chapter is provably not exhaustive for
+FW 27.0.6. All of these are field-observed and appear nowhere in the
+doc: `presetSelectionUpdated`, `powerStateUpdated`, `groupUpdated`,
+`languageUpdated`, `balanceUpdated`, `userInactivityUpdate`, the
+bare-root forms of `userActivityUpdate` and `errorUpdate`, and the
+`signal` attribute on `connectionStateUpdated`. The blind spot runs the
+other way too: no field log has ever shown the doc's value-carrying
+`<updates><volume>` frame, which would surface in the
+unrecognized-frame log as shape `updates/volume` and never has.
+Consequence: the unrecognized-frame capture stays; the doc's list can
+never replace it.
+
+### Frame shape traps
+
+- **`zoneUpdated` carries a body (field wins).** The doc shows the
+  frame bodyless in every sample. FW 27.0.6 sends a full `<zone>`
+  body, and an empty `<zone/>` is the dissolution signal (#70, field
+  capture 2026-06-12). Do not simplify the parse toward the doc.
+- **`playStatus` is dual-shape (field wins).** The doc shows it as a
+  child element only; live firmware builds also ship it as an
+  attribute. The dual capture in `wsNowPlaying` stays.
+- **`ContentItem` case trap (doc-confirmed shapes).** `presetsUpdated`
+  nests `ContentItem`; `recentsUpdated` nests lowercase `contentItem`.
+  Go's `encoding/xml` matches case-sensitively, so a future recents
+  parser must not reuse `wsPreset`.
+- **`updatedOn` vs `updateOn` (doc-internal typo).** The doc's presets
+  endpoint chapter spells the timestamp attribute `updateOn` while its
+  notification chapter spells it `updatedOn`. STR emits `updatedOn`,
+  the spelling proven against the installed base; do not "correct" it
+  to the other one.
+
 ## Reaching the agent on BCO speakers (chipset whitelist)
 
 On the newer "BCO" chassis (the Portable, and every `scm`-module
@@ -120,7 +184,122 @@ Bose's internal HTTP library (used by `BoseApp` on `:8090` and the
 SoftwareUpdate service on `:17008`) caps a POST at ~1536 bytes including
 the request line and headers. Any STR call routed through `:17008`
 without an active shim must stay under that, which is why the agent OTA
-has an SSH fallback for the binary upload.
+has an SSH fallback for the binary upload. The official Web API doc
+documents no request size limit anywhere; the measured cap is field
+knowledge and stands.
+
+## The `:8090` HTTP API vs the official doc
+
+### The error envelope and the code table
+
+An HTTP error is an `<errors deviceID="...">` envelope wrapping one or
+more `<error value="..." name="..." severity="...">` elements; a
+malformed request can instead get a bare `<error>` body with no
+envelope (doc-confirmed). The gabbo `errorUpdate` frame shares only the
+inner `<error>` element shape; the doc's own section on that frame is
+empty in the text extraction we have.
+
+The doc names exactly one error code: 1019 `CLIENT_XML_ERROR`. Every
+other code STR handles is field-learned and appears nowhere in the
+doc, which makes this table the authoritative list:
+
+| Code | Name (field-learned) | Where it shows up |
+| ---- | -------------------- | ----------------- |
+| 1005 | `UNKNOWN_SOURCE_ERROR` | selecting a source the firmware has no live registration for |
+| 1036 | `UNABLE_TO_PROCESS_NOT_LOGGED_IN` | recalling or selecting a source without a live marge login; often paired with an `UpnpRcvdContentItemInWrongState` marker |
+| 3101 | `AUDIO_ERROR_BAD_URL` | stale or unplayable stream URL on recall |
+| 3103 | `AUDIO_ERROR_TIMEOUT` | the stream did not start in time |
+| 4502 | `BMX_JSON_PARSE_ERROR` | malformed body on the BMX JSON paths (#600) |
+| 5510 | `GROUP_ALREADY_EXISTS` | `/addGroup` against a stale stereo pair |
+| 5580 | `GROUP_CREATE_GROUP_ON_MARGE_ERROR` | `/addGroup` while the box's marge session is broken |
+
+### Status enums: values doc-confirmed, one semantic field-corrected
+
+- **`PLAY_STATUS` is a closed five-value enum** (doc-confirmed):
+  `PLAY_STATE`, `PAUSE_STATE`, `STOP_STATE`, `BUFFERING_STATE`,
+  `INVALID_PLAY_STATUS`. STR's busy/idle discriminators over it are
+  therefore provably exhaustive, not best-effort.
+- **`ART_STATUS`** (doc-confirmed): `INVALID`, `SHOW_DEFAULT_IMAGE`,
+  `DOWNLOADING`, `IMAGE_PRESENT`. Field caveat: `IMAGE_PRESENT`
+  promises nothing about rendering. The speaker reports it for SVG and
+  ICO URLs its display cannot draw, and on native radio it reports it
+  and then never fetches the image at all (see the display-logo
+  section below). STR's raster preference at preset-save time stays.
+- **`SOURCE_STATUS` is exactly `{UNAVAILABLE, READY}`**
+  (doc-confirmed), **but its meaning is not what the doc says (field
+  wins).** The doc reads the `/sources` status as availability; on
+  27.0.6 it is a connection indicator. `UPNP` reports `UNAVAILABLE`
+  while it is actively playing, and unpaired Bluetooth reports
+  `UNAVAILABLE` too. This mismatch is the root of the native-vs-UPnP
+  preset split and the whole 1036 story, so STR applies it per path:
+  `READY` is required before writing native `LOCAL_INTERNET_RADIO`
+  presets, and `UNAVAILABLE` is treated as dead only for
+  account-linked cloud presets during write-back, because the firmware
+  itself drops those. The doc also omits the `isLocal` and
+  `multiroomallowed` attributes STR parses off `/sources`.
+
+### Endpoint truths
+
+- **`/setZone` takes a slaves-only member list (field wins).** The
+  doc's zone samples put the master into the member list. FW 27.0.6 on
+  `rhino` and `spotty` silently rejects that body: after commit
+  df7764a shipped the doc shape, a live fleet check showed an empty
+  liveMaster and zero live members everywhere, and 7e58171 reverted
+  it. Do not "align" the zone body with the doc.
+- **`/nowPlaying` vs `/now_playing`.** The doc spells the playback
+  read `/nowPlaying` and offers `/trackInfo` as an identical-shape
+  alias. The underscore `/now_playing` STR uses everywhere is a live
+  firmware alias the doc omits; both spellings answer on live boxes,
+  while `/trackInfo` rests on the doc's word alone, untested here.
+  Renaming for conformance would be churn with zero gain.
+- **`/presets` is officially GET-only** (doc-confirmed). The TAP CLI
+  write path STR uses is the only preset write path there is, not a
+  workaround for a missed HTTP call.
+- **`/key` press-then-release with a `sender` attribute** is exactly
+  what STR sends (doc-confirmed). The doc has no power endpoint beyond
+  the POWER key and defines no power-state notification. The field is
+  split by firmware build: some send the field-only
+  `powerStateUpdated` (blind-spot list above) on a power press, while
+  the Portable (taigan) on 27.0.6 sends no dedicated power frame at
+  all (verified live 2026-06-13); a press then surfaces only through
+  generic frames (a now-selection restore, a `userActivityUpdate`,
+  varying per chassis), which is why `internal/boxws` listens for the
+  dedicated frame and its stand-ins alike. The real
+  power-off STR relies on is the undocumented GET `/standby`, where
+  POST answers 400.
+- **`/volume` POST accepts a `muteenabled` child**, applied before the
+  volume value; per the doc the box unmutes only when the posted
+  volume exceeds the current one. Unverified on 27.0.6: STR never
+  writes mute, so nothing depends on it. Recorded so nobody trusts it
+  untested.
+
+### Endpoints the doc does not know exist
+
+None of these appear in the doc at all; they are field knowledge:
+`/standby`, `/balance`, the `/getGroup` family, `/networkInfo`,
+`/clockDisplay`, `/language`, `/setup`, `/getActiveWirelessProfile`,
+`/performWirelessSiteSurvey`, `/listMediaServers`,
+`/setMusicServiceAccount`, `/navigate`, `/supportedURLs`,
+`/setMargeAccount`.
+
+## Discovery on the wire: mDNS and SSDP
+
+- **mDNS `_soundtouch._tcp.local` is the sanctioned service type**
+  (doc-confirmed), and STR browses it already. The
+  `_bose-soundtouch._tcp` alias STR also browses appears nowhere in
+  the doc: it rests on field observation alone, so keep it or drop it
+  on field evidence only, never on the doc's authority.
+- **SSDP identifiers** (doc-confirmed on paper, not yet
+  Wireshark-verified on FW 27.0.6): speakers are providers under
+  `urn:schemas-upnp-org:device:MediaRenderer:1`, send NOTIFY
+  `ssdp:alive` / `ssdp:byebye`, and advertise a `CACHE-CONTROL`
+  max-age of at least 1800 s. Until a packet capture on 27.0.6
+  confirms this, treat it as the doc's word, not the fleet's.
+- **Announce expiry (field wins, deliberately).** The doc mandates
+  dropping a device when its max-age expires. STR retains expired
+  announces for 24 hours on purpose, because one lost multicast
+  datagram once cost a user their media library (#341). The deviation
+  is intentional and stays.
 
 ## NAND override beats the SD card
 

--- a/internal/boxapi/bassroute_test.go
+++ b/internal/boxapi/bassroute_test.go
@@ -1,0 +1,247 @@
+package boxapi
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+)
+
+// recordingBox is a fake firmware that serves per-path fixtures and records
+// every request (path + body) so a test can assert which routes were used.
+type recordingBox struct {
+	mu     sync.Mutex
+	paths  []string
+	bodies map[string]string // last request body per path
+}
+
+func (r *recordingBox) requested(path string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n := 0
+	for _, p := range r.paths {
+		if p == path {
+			n++
+		}
+	}
+	return n
+}
+
+func (r *recordingBox) lastBody(path string) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.bodies[path]
+}
+
+// newRecordingBox mounts the routes and returns a Client with the given Host
+// (distinct per test: the tone-controls route cache is keyed by it) plus the
+// recorder. Unrouted paths answer 404, like newFakeBox.
+func newRecordingBox(t *testing.T, host string, routes map[string]string) (*Client, *recordingBox) {
+	t.Helper()
+	rec := &recordingBox{bodies: map[string]string{}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(io.LimitReader(r.Body, 64*1024))
+		rec.mu.Lock()
+		rec.paths = append(rec.paths, r.URL.Path)
+		rec.bodies[r.URL.Path] = string(b)
+		rec.mu.Unlock()
+		body, ok := routes[r.URL.Path]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/xml; charset=utf-8")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	t.Cleanup(func() { toneControlsHosts.Delete(host) })
+	return &Client{
+		Host: host,
+		HTTP: &http.Client{Timeout: 2 * time.Second, Transport: &rewriteTransport{to: u}},
+	}, rec
+}
+
+const (
+	bassClassicOK = `<bass deviceID="AABBCCDDEEFF"><targetbass>-4</targetbass><actualbass>-4</actualbass></bass>`
+	bassCapsNone  = `<bassCapabilities deviceID="AABBCCDDEEFF"><bassAvailable>false</bassAvailable><bassMin>0</bassMin><bassMax>0</bassMax><bassDefault>0</bassDefault></bassCapabilities>`
+	bassCapsOK    = `<bassCapabilities deviceID="AABBCCDDEEFF"><bassAvailable>true</bassAvailable><bassMin>-9</bassMin><bassMax>0</bassMax><bassDefault>0</bassDefault></bassCapabilities>`
+	capsWithTone  = `<capabilities deviceID="AABBCCDDEEFF"><capability name="audioproducttonecontrols" url="/audioproducttonecontrols" /><capability name="audiodspcontrols" url="/audiodspcontrols" /></capabilities>`
+	capsNoTone    = `<capabilities deviceID="AABBCCDDEEFF"><capability name="audiodspcontrols" url="/audiodspcontrols" /></capabilities>`
+	toneControls  = `<audioproducttonecontrols><bass value="50" minValue="-100" maxValue="100" step="50" /><treble value="0" minValue="-100" maxValue="100" step="50" /></audioproducttonecontrols>`
+)
+
+// A box that reports bassAvailable=false but advertises the tone-controls
+// capability (the Lifestyle 650 case, support mail 2026-08-22) must surface
+// the gated route's bass: value/min/max/step through, default mapped to 0 for
+// the relative slider, available=true. Before the gate was probed the Bass
+// stayed 0..0 unavailable and the slider sat greyed.
+func TestLoadSettingsToneControlsFallback(t *testing.T) {
+	c, rec := newRecordingBox(t, "tone-fallback-box", map[string]string{
+		"/bass":                     `<bass deviceID="AABBCCDDEEFF"><targetbass>0</targetbass><actualbass>0</actualbass></bass>`,
+		"/bassCapabilities":         bassCapsNone,
+		"/capabilities":             capsWithTone,
+		"/audioproducttonecontrols": toneControls,
+	})
+	s, err := c.LoadSettings(context.Background())
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	want := Bass{Target: 50, Actual: 50, Min: -100, Max: 100, Default: 0, Step: 50, Avail: true}
+	if s.Bass != want {
+		t.Errorf("Bass = %+v, want %+v", s.Bass, want)
+	}
+
+	// SetBass must now go through the gated POST, with the doc's
+	// partial-update body (no <treble>, so it stays untouched). A FRESH
+	// Client with the same host must route the same way: webui builds a new
+	// Client per request, so the verdict may not live on the instance.
+	c2 := &Client{Host: c.Host, HTTP: c.HTTP}
+	if err := c2.SetBass(context.Background(), 100); err != nil {
+		t.Fatalf("SetBass: %v", err)
+	}
+	if got := rec.lastBody("/audioproducttonecontrols"); got != `<audioproducttonecontrols><bass value="100" /></audioproducttonecontrols>` {
+		t.Errorf("tone-controls POST body wrong: %q", got)
+	}
+	if rec.requested("/bass") != 1 { // the LoadSettings read; SetBass must not add one
+		t.Errorf("classic /bass hit %d times, want 1 (read only)", rec.requested("/bass"))
+	}
+	// The gate verdict is cached: a second LoadSettings re-reads the values
+	// but must not re-probe /capabilities.
+	if _, err := c.LoadSettings(context.Background()); err != nil {
+		t.Fatalf("second LoadSettings: %v", err)
+	}
+	if rec.requested("/capabilities") != 1 {
+		t.Errorf("/capabilities probed %d times, want 1 (verdict is per-host cached)", rec.requested("/capabilities"))
+	}
+}
+
+// The six one-piece fleet boxes report bassAvailable=true and must never pay
+// the capability probe; SetBass keeps the classic POST byte for byte.
+func TestLoadSettingsNoProbeWhenBassAvailable(t *testing.T) {
+	c, rec := newRecordingBox(t, "classic-bass-box", map[string]string{
+		"/bass":             bassClassicOK,
+		"/bassCapabilities": bassCapsOK,
+	})
+	s, err := c.LoadSettings(context.Background())
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	want := Bass{Target: -4, Actual: -4, Min: -9, Max: 0, Default: 0, Step: 0, Avail: true}
+	if s.Bass != want {
+		t.Errorf("Bass = %+v, want %+v", s.Bass, want)
+	}
+	if n := rec.requested("/capabilities"); n != 0 {
+		t.Errorf("/capabilities probed %d times on a classic box, want 0", n)
+	}
+	if err := c.SetBass(context.Background(), -5); err != nil {
+		t.Fatalf("SetBass: %v", err)
+	}
+	if got := rec.lastBody("/bass"); got != `<bass>-5</bass>` {
+		t.Errorf("classic POST body wrong: %q", got)
+	}
+	if n := rec.requested("/audioproducttonecontrols"); n != 0 {
+		t.Errorf("tone-controls route hit %d times on a classic box, want 0", n)
+	}
+}
+
+// Capability gate present but without audioproducttonecontrols: today's
+// behavior byte for byte (greyed slider state), classic SetBass route, and
+// the negative verdict is cached so the 30 s pollBoxInfo ticker does not
+// re-probe the box every cycle.
+func TestLoadSettingsCapabilityAbsentKeepsClassicState(t *testing.T) {
+	c, rec := newRecordingBox(t, "no-tone-box", map[string]string{
+		"/bass":             `<bass deviceID="AABBCCDDEEFF"><targetbass>0</targetbass><actualbass>0</actualbass></bass>`,
+		"/bassCapabilities": bassCapsNone,
+		"/capabilities":     capsNoTone,
+	})
+	s, err := c.LoadSettings(context.Background())
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	want := Bass{Target: 0, Actual: 0, Min: 0, Max: 0, Default: 0, Step: 0, Avail: false}
+	if s.Bass != want {
+		t.Errorf("Bass = %+v, want %+v", s.Bass, want)
+	}
+	if err := c.SetBass(context.Background(), 0); err != nil {
+		t.Fatalf("SetBass: %v", err)
+	}
+	if got := rec.lastBody("/bass"); got != `<bass>0</bass>` {
+		t.Errorf("classic POST body wrong: %q", got)
+	}
+	if _, err := c.LoadSettings(context.Background()); err != nil {
+		t.Fatalf("second LoadSettings: %v", err)
+	}
+	if n := rec.requested("/capabilities"); n != 1 {
+		t.Errorf("/capabilities probed %d times, want 1 (negative verdict cached)", n)
+	}
+}
+
+// A tone-controls reply without a usable bass block (only treble, or a
+// collapsed range) must not un-grey the slider.
+func TestToneControlsBassRejectsUnusableBlocks(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"treble only", `<audioproducttonecontrols><treble value="0" minValue="-100" maxValue="100" step="50" /></audioproducttonecontrols>`},
+		{"collapsed range", `<audioproducttonecontrols><bass value="0" minValue="0" maxValue="0" step="1" /></audioproducttonecontrols>`},
+	}
+	for _, tc := range cases {
+		c, _ := newRecordingBox(t, "unusable-tone-box-"+tc.name, map[string]string{
+			"/capabilities":             capsWithTone,
+			"/audioproducttonecontrols": tc.body,
+		})
+		if got, ok := c.toneControlsBass(context.Background()); ok {
+			t.Errorf("%s: toneControlsBass ok with %+v, want rejection", tc.name, got)
+		}
+	}
+}
+
+// A transport failure on the /capabilities probe must not store a verdict:
+// the next LoadSettings may probe again (a booting box's :8090 answers
+// nothing for a while, and that must not permanently misclassify it).
+func TestToneControlsProbeFailureStoresNoVerdict(t *testing.T) {
+	c, rec := newRecordingBox(t, "probe-fail-box", map[string]string{
+		"/bass":             `<bass deviceID="AABBCCDDEEFF"><targetbass>0</targetbass><actualbass>0</actualbass></bass>`,
+		"/bassCapabilities": bassCapsNone,
+		// no /capabilities route: the probe gets a 404
+	})
+	if _, err := c.LoadSettings(context.Background()); err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	if _, cached := toneControlsHosts.Load(c.Host); cached {
+		t.Error("a failed probe must not cache a verdict")
+	}
+	if _, err := c.LoadSettings(context.Background()); err != nil {
+		t.Fatalf("second LoadSettings: %v", err)
+	}
+	if n := rec.requested("/capabilities"); n != 2 {
+		t.Errorf("/capabilities probed %d times, want 2 (no verdict cached on failure)", n)
+	}
+}
+
+// The relative-slider contract the frontend depends on: LoadSettings keeps
+// the classic default in Bass.Default, and the tone-controls path reports
+// Default 0 so relative equals absolute there. Pinned here because
+// settings.js computes slider positions from exactly these fields.
+func TestBassDefaultMapping(t *testing.T) {
+	c, _ := newRecordingBox(t, "default-mapping-box", map[string]string{
+		"/bass":             bassClassicOK,
+		"/bassCapabilities": `<bassCapabilities deviceID="AABBCCDDEEFF"><bassAvailable>true</bassAvailable><bassMin>-9</bassMin><bassMax>3</bassMax><bassDefault>-3</bassDefault></bassCapabilities>`,
+	})
+	s, err := c.LoadSettings(context.Background())
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	if s.Bass.Default != -3 {
+		t.Errorf("classic default = %d, want -3", s.Bass.Default)
+	}
+}

--- a/internal/boxapi/boxapi.go
+++ b/internal/boxapi/boxapi.go
@@ -12,8 +12,10 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 )
@@ -22,6 +24,19 @@ import (
 type Client struct {
 	Host string // e.g. "127.0.0.1" or the box IP
 	HTTP *http.Client
+	// Log receives the client's diagnostics (currently the 2xx error-envelope
+	// detection). A field rather than a constructor argument so the many
+	// boxapi.New call sites stay as they are; nil falls back to the process
+	// default logger.
+	Log *slog.Logger
+}
+
+// logger returns the client's log destination, defaulting to slog.Default().
+func (c *Client) logger() *slog.Logger {
+	if c.Log != nil {
+		return c.Log
+	}
+	return slog.Default()
 }
 
 // New creates a client with defaults.
@@ -86,12 +101,18 @@ type Volume struct {
 
 // Bass + capabilities combined.
 type Bass struct {
-	Target  int  `json:"target"`
-	Actual  int  `json:"actual"`
-	Min     int  `json:"min"`
-	Max     int  `json:"max"`
-	Default int  `json:"default"`
-	Avail   bool `json:"available"`
+	Target  int `json:"target"`
+	Actual  int `json:"actual"`
+	Min     int `json:"min"`
+	Max     int `json:"max"`
+	Default int `json:"default"`
+	// Step is the granularity the firmware imposes on a bass write. The
+	// classic /bass route reports none (0; the app's slider treats that as
+	// 1). The capability-gated tone-controls route of home-theater systems
+	// reports it explicitly and it can exceed 1, and a write off the grid is
+	// the firmware's to refuse, so the slider must honor it.
+	Step  int  `json:"step"`
+	Avail bool `json:"available"`
 }
 
 // Network is the active Wi-Fi state.
@@ -170,7 +191,8 @@ func (c *Client) LoadSettings(ctx context.Context) (Settings, error) {
 			Target int `xml:"targetbass"`
 			Actual int `xml:"actualbass"`
 		}
-		if err := get("/bass", &bass); err == nil {
+		bassRead := get("/bass", &bass) == nil
+		if bassRead {
 			s.Bass.Target = bass.Target
 			s.Bass.Actual = bass.Actual
 		}
@@ -185,6 +207,17 @@ func (c *Client) LoadSettings(ctx context.Context) (Settings, error) {
 			s.Bass.Max = caps.Max
 			s.Bass.Default = caps.Default
 			s.Bass.Avail = strings.EqualFold(caps.Available, "true")
+		}
+		// Home-theater systems keep their adjustable bass behind the
+		// /capabilities gate instead: a Lifestyle 650 answers
+		// bassAvailable=false and its slider sat greyed at 0..0 (support mail
+		// with photo, 2026-08-22) while the documented tone-controls route was
+		// never asked. Probe that route only when the classic one reported
+		// nothing, so the one-piece boxes never pay the extra request.
+		if !s.Bass.Avail || !bassRead {
+			if tc, ok := c.toneControlsBass(ctx); ok {
+				s.Bass = tc
+			}
 		}
 	}
 
@@ -410,9 +443,11 @@ func (c *Client) GetZone(ctx context.Context) (Zone, error) {
 	}
 	for _, m := range raw.Members {
 		dev := strings.TrimSpace(m.DeviceID)
-		// The firmware /getZone body lists the master as a member too (and STR now
-		// sends it that way in /setZone). Members here means the SLAVES, so drop the
-		// master entry: keeps len(Members)==len(slaves) for every consumer (the
+		// The firmware /getZone body lists the master as a member too. STR's own
+		// /setZone body does NOT: it sends the slaves only, because the
+		// master-in-members shape was silently rejected fleet-wide (df7764a,
+		// reverted in 7e58171; see SetZone). Members here means the SLAVES, so drop
+		// the master entry: keeps len(Members)==len(slaves) for every consumer (the
 		// reconcile guard, the "main of {n}" label, the box-selector group count),
 		// regardless of whether a given model echoes the master back.
 		if z.Master != "" && strings.EqualFold(dev, z.Master) {
@@ -676,9 +711,102 @@ func (c *Client) GetVolume(ctx context.Context) (Volume, error) {
 	}, nil
 }
 
+// toneControlsHosts remembers, per box host, the verdict of the
+// /capabilities probe for audioproducttonecontrols. The capability set is a
+// firmware property of the box, so a process-lifetime cache is safe. It
+// exists for two reasons: LoadSettings runs on the agent's 30 s pollBoxInfo
+// ticker and a box without the capability must not be re-probed every cycle,
+// and SetBass runs on a FRESH Client per webui request and needs the routing
+// verdict without a probe of its own on the hot slider path. Only a definite
+// verdict is stored; a transport error stores nothing so a later call may
+// probe again.
+var toneControlsHosts sync.Map // host string -> bool
+
+// toneControlsBass reads the bass block of the capability-gated
+// /audioproducttonecontrols route (home-theater systems; the Lifestyle 650
+// mail of 2026-08-22 is the field case). ok is false when the box does not
+// advertise the capability or the read fails, so the caller keeps the classic
+// bass state byte for byte, greyed slider included.
+//
+// The gate comes first because that is the doc's contract for these URLs:
+// access them only when /capabilities lists them. Its verdict is cached per
+// host (toneControlsHosts); the value read itself is not, values change.
+func (c *Client) toneControlsBass(ctx context.Context) (Bass, bool) {
+	verdict, cached := toneControlsHosts.Load(c.Host)
+	if cached && !verdict.(bool) {
+		return Bass{}, false
+	}
+	if !cached {
+		var caps struct {
+			Capabilities []struct {
+				Name string `xml:"name,attr"`
+			} `xml:"capability"`
+		}
+		// Any failed probe stores no verdict, an HTTP error status included:
+		// the box web server answers errors while the firmware is still
+		// booting, and caching one stray boot-window reply would misroute the
+		// box for the whole process lifetime. Do not "optimize" a 404 into a
+		// cached negative; the retry costs one GET inside a poll cycle that
+		// already runs, and only on boxes whose classic bass route reported
+		// nothing.
+		if err := c.getXML(ctx, "/capabilities", &caps); err != nil {
+			return Bass{}, false
+		}
+		advertised := false
+		for _, entry := range caps.Capabilities {
+			if strings.EqualFold(strings.TrimSpace(entry.Name), "audioproducttonecontrols") {
+				advertised = true
+				break
+			}
+		}
+		toneControlsHosts.Store(c.Host, advertised)
+		if !advertised {
+			return Bass{}, false
+		}
+	}
+	var tc struct {
+		Bass *struct {
+			Value int `xml:"value,attr"`
+			Min   int `xml:"minValue,attr"`
+			Max   int `xml:"maxValue,attr"`
+			Step  int `xml:"step,attr"`
+		} `xml:"bass"`
+	}
+	// A missing <bass> element (a system with only treble) or a collapsed
+	// range means there is nothing to adjust; reporting Avail=true there
+	// would un-grey a slider that cannot move.
+	if err := c.getXML(ctx, "/audioproducttonecontrols", &tc); err != nil || tc.Bass == nil || tc.Bass.Min == tc.Bass.Max {
+		return Bass{}, false
+	}
+	step := tc.Bass.Step
+	if step < 1 {
+		step = 1
+	}
+	// This route has no bassDefault; 0 is its neutral point, so mapping the
+	// default to 0 keeps the app's relative slider (0 = default) honest and
+	// makes relative equal to absolute here.
+	return Bass{
+		Target: tc.Bass.Value, Actual: tc.Bass.Value,
+		Min: tc.Bass.Min, Max: tc.Bass.Max,
+		Default: 0, Step: step, Avail: true,
+	}, true
+}
+
 // SetBass sets the bass value (range from bassCapabilities — typical
 // ST10 range -9..0).
+//
+// On a box whose /capabilities probe advertised audioproducttonecontrols
+// (see toneControlsBass) the value goes through that route's POST instead;
+// omitting <treble> there leaves the treble untouched, which is that route's
+// partial-update contract. The verdict comes from the per-host cache because
+// this Client is constructed fresh for every webui request and must not
+// probe on the hot slider path; a cache miss means the classic route,
+// exactly today's behavior.
 func (c *Client) SetBass(ctx context.Context, b int) error {
+	if verdict, ok := toneControlsHosts.Load(c.Host); ok && verdict.(bool) {
+		body := fmt.Sprintf(`<audioproducttonecontrols><bass value="%d" /></audioproducttonecontrols>`, b)
+		return c.postXML(ctx, "/audioproducttonecontrols", body)
+	}
 	body := fmt.Sprintf(`<bass>%d</bass>`, b)
 	return c.postXML(ctx, "/bass", body)
 }
@@ -796,7 +924,15 @@ func (c *Client) postXML(ctx context.Context, path, body string) error {
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("box %s: %d: %s", path, resp.StatusCode, string(b))
+		return newBoxError(path, resp.StatusCode, b)
+	}
+	// The 2xx body used to be dropped unread. Read it and flag an error
+	// envelope hiding in it (see noteErrorEnvelope): the firmware can answer
+	// 200 while refusing the call, and until the fleet survey settles what
+	// each chassis puts into these bodies, detection stays log-only and the
+	// call still reports success.
+	if b, rerr := io.ReadAll(io.LimitReader(resp.Body, 64*1024)); rerr == nil {
+		c.noteErrorEnvelope(path, b)
 	}
 	return nil
 }
@@ -819,7 +955,7 @@ func (c *Client) postXMLInto(ctx context.Context, path, body string, dst any) er
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("box %s: %d: %s", path, resp.StatusCode, string(b))
+		return newBoxError(path, resp.StatusCode, b)
 	}
 	raw, err := io.ReadAll(io.LimitReader(resp.Body, 512*1024))
 	if err != nil {
@@ -828,6 +964,9 @@ func (c *Client) postXMLInto(ctx context.Context, path, body string, dst any) er
 	if len(bytes.TrimSpace(raw)) == 0 {
 		return nil
 	}
+	// Log-only, like postXML: a 2xx error envelope is flagged for the fleet
+	// survey but the reply is still decoded into dst as it always was.
+	c.noteErrorEnvelope(path, raw)
 	return xml.Unmarshal(ensureUTF8(raw), dst)
 }
 

--- a/internal/boxapi/errors.go
+++ b/internal/boxapi/errors.go
@@ -1,0 +1,146 @@
+// Typed parsing of the firmware's error envelope.
+//
+// The Bose Web API answers failed calls with an <errors deviceID> envelope
+// wrapping one <error value name severity>text</error> element; a malformed
+// request may instead get a bare <error>text</error> body. The deviceID
+// attribute is the raw 12-hex MAC, which is why substring-matching the whole
+// error string for a code like 5510 or 5580 is a latent false positive: a MAC
+// that happens to contain that digit run satisfies the check on EVERY failure
+// of the call (~0.014% of boxes per code). This file gives callers the typed
+// fields so they can stop matching substrings.
+
+package boxapi
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"strings"
+)
+
+// BoxError is a >=400 reply from the box, with the firmware's own error
+// envelope parsed out of the body when it carried one.
+//
+// Value/Name/Severity/Detail hold the first <error> element (the firmware has
+// not been seen sending more than one) and stay empty when the body was not
+// an envelope, so Value == "" means "untyped", never "success". Reach it with
+// errors.As; the webui 5510/5580 helpers are the intended first consumers.
+type BoxError struct {
+	Path     string // request path, e.g. "/addGroup"
+	Status   int    // HTTP status of the reply
+	Value    string // numeric error code, e.g. "5510"; "" when untyped
+	Name     string // e.g. "GROUP_ALREADY_EXISTS"
+	Severity string
+	Detail   string // the error element's own text
+	Body     string // raw reply body as read (callers cap it), verbatim
+}
+
+// Error reproduces the pre-typed message byte for byte. Substring consumers
+// exist (webui's isGroupExistsErr/isMargeGroupErr) and the webui handlers
+// surface this text to the app, so the shape is load-bearing: change it and
+// those checks and their field playbooks go blind.
+func (e *BoxError) Error() string {
+	return fmt.Sprintf("box %s: %d: %s", e.Path, e.Status, e.Body)
+}
+
+// newBoxError builds the typed error for a >=400 reply. Parsing is best
+// effort: a truncated or non-envelope body leaves the typed fields empty and
+// only the verbatim message remains.
+func newBoxError(path string, status int, body []byte) *BoxError {
+	e := &BoxError{Path: path, Status: status, Body: string(body)}
+	if el, ok := decodeErrorEnvelope(body); ok {
+		e.Value = strings.TrimSpace(el.Value)
+		e.Name = strings.TrimSpace(el.Name)
+		e.Severity = strings.TrimSpace(el.Severity)
+		e.Detail = strings.TrimSpace(el.Text)
+	}
+	return e
+}
+
+// errorElement is one <error> element: the value/name/severity attributes
+// plus the element text. Shared by the >=400 envelope parse and the 2xx
+// detection below.
+type errorElement struct {
+	Value    string `xml:"value,attr"`
+	Name     string `xml:"name,attr"`
+	Severity string `xml:"severity,attr"`
+	Text     string `xml:",chardata"`
+}
+
+// decodeErrorEnvelope reports whether body's ROOT element is the firmware's
+// error envelope (<errors>, or the bare <error> a malformed request gets)
+// and returns the first error element when it is. Root-only on purpose: an
+// <error> nested inside a legitimate reply must not count (the 200 bodies in
+// webui's nativeselect carry one), and substring matching over the body is
+// exactly the MAC false positive this file exists to end.
+func decodeErrorEnvelope(body []byte) (errorElement, bool) {
+	switch rootElementName(body) {
+	case "errors":
+		var env struct {
+			Errors []errorElement `xml:"error"`
+		}
+		if xml.Unmarshal(ensureUTF8(body), &env) != nil || len(env.Errors) == 0 {
+			// The root says envelope; a decode failure (truncated body) or an
+			// empty envelope still counts as one, just without typed fields.
+			return errorElement{}, true
+		}
+		return env.Errors[0], true
+	case "error":
+		var el errorElement
+		if xml.Unmarshal(ensureUTF8(body), &el) != nil {
+			return errorElement{}, true
+		}
+		return el, true
+	}
+	return errorElement{}, false
+}
+
+// rootElementName returns the local name of the document's first start
+// element, or "" when the body is not XML.
+func rootElementName(body []byte) string {
+	dec := xml.NewDecoder(bytes.NewReader(ensureUTF8(body)))
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return ""
+		}
+		if se, ok := tok.(xml.StartElement); ok {
+			return se.Name.Local
+		}
+	}
+}
+
+// noteErrorEnvelope logs a 2xx reply whose body is the firmware's error
+// envelope. Log only, and deliberately so: the API doc never binds the
+// envelope to a status code and the firmware demonstrably answers 200 with an
+// <error> body (webui's nativeselect), but nobody has surveyed what the 2xx
+// bodies of /name, /setup or /key carry per chassis. Returning an error here
+// before that fleet survey could turn a working flow with a benign envelope
+// into a failure, so enforcement waits for the survey's verdict.
+func (c *Client) noteErrorEnvelope(path string, body []byte) {
+	if len(bytes.TrimSpace(body)) == 0 {
+		return
+	}
+	el, ok := decodeErrorEnvelope(body)
+	if !ok {
+		return
+	}
+	if v, n := strings.TrimSpace(el.Value), strings.TrimSpace(el.Name); v != "" || n != "" {
+		// Info on purpose: this fires only when the box smuggles a real error
+		// code into a success reply, which is the one signal the fleet survey
+		// needs inside default bundles (the NAND ring keeps Info and above).
+		c.logger().Info("box answered 2xx with an error envelope", "path", path, "value", v, "name", n)
+		return
+	}
+	// Envelope-shaped body with no code: not actionable, keep it out of the
+	// NAND ring.
+	c.logger().Debug("box answered 2xx with an error element", "path", path, "detail", clip(strings.TrimSpace(el.Text), 200))
+}
+
+// clip bounds a log payload so a pathological body cannot bloat a log line.
+func clip(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/internal/boxapi/errors_test.go
+++ b/internal/boxapi/errors_test.go
@@ -1,0 +1,235 @@
+package boxapi
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newRawBox serves fn for every request (any path, any status) and returns a
+// Client aimed at it via rewriteTransport, so Client.url's hardcoded :8090
+// still lands on the test server. Complements newFakeBox, which can only
+// answer 200 with fixed bodies.
+func newRawBox(t *testing.T, fn http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(fn)
+	t.Cleanup(srv.Close)
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	return &Client{
+		Host: "ignored",
+		HTTP: &http.Client{Timeout: 2 * time.Second, Transport: &rewriteTransport{to: u}},
+	}
+}
+
+// A >=400 envelope reply must come back as an errors.As-able *BoxError whose
+// typed fields are taken from the <error> element's ATTRIBUTES alone. The
+// fixture's deviceID deliberately contains the digit run 5580: the raw MAC in
+// the envelope is what makes the webui substring helpers fire on every
+// failure of a box with an unlucky MAC, and the typed Value is how that false
+// positive dies.
+func TestPostXMLTypedErrorEnvelope(t *testing.T) {
+	body := `<errors deviceID="AC5580123456"><error value="1019" name="CLIENT_XML_ERROR" severity="Unknown">1019</error></errors>`
+	c := newRawBox(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(body))
+	})
+	err := c.SetName(context.Background(), "Kitchen")
+	if err == nil {
+		t.Fatal("expected an error from a 500 reply")
+	}
+	var be *BoxError
+	if !errors.As(err, &be) {
+		t.Fatalf("error is not errors.As-able to *BoxError: %T %v", err, err)
+	}
+	if be.Path != "/name" || be.Status != 500 {
+		t.Errorf("path/status wrong: %+v", be)
+	}
+	if be.Value != "1019" || be.Name != "CLIENT_XML_ERROR" || be.Severity != "Unknown" || be.Detail != "1019" {
+		t.Errorf("typed fields wrong: %+v", be)
+	}
+	if strings.Contains(be.Value, "5580") {
+		t.Errorf("MAC digits leaked into the typed value: %q", be.Value)
+	}
+	// The message must stay byte for byte what fmt.Errorf produced before the
+	// type existed: webui's isGroupExistsErr/isMargeGroupErr parse substrings
+	// of it and the webui handlers surface it to the app.
+	want := fmt.Sprintf("box %s: %d: %s", "/name", 500, body)
+	if err.Error() != want {
+		t.Errorf("Error() text drifted:\n got %q\nwant %q", err.Error(), want)
+	}
+}
+
+// The malformed-request form is a bare <error> body with no attributes; the
+// typed value stays empty and the element text lands in Detail. The fixture
+// text is invented: only the element shape is the firmware's.
+func TestPostXMLTypedErrorBareElement(t *testing.T) {
+	body := `<error>request rejected as malformed</error>`
+	c := newRawBox(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(body))
+	})
+	err := c.SetName(context.Background(), "Kitchen")
+	var be *BoxError
+	if !errors.As(err, &be) {
+		t.Fatalf("error is not a *BoxError: %T %v", err, err)
+	}
+	if be.Value != "" || be.Name != "" {
+		t.Errorf("bare element must not invent a code: %+v", be)
+	}
+	if be.Detail != "request rejected as malformed" {
+		t.Errorf("detail wrong: %q", be.Detail)
+	}
+	want := fmt.Sprintf("box %s: %d: %s", "/name", 400, body)
+	if err.Error() != want {
+		t.Errorf("Error() text drifted:\n got %q\nwant %q", err.Error(), want)
+	}
+}
+
+// A non-XML error body stays untyped but keeps the verbatim message.
+func TestPostXMLTypedErrorNonEnvelopeBody(t *testing.T) {
+	c := newRawBox(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("Bad Gateway"))
+	})
+	err := c.SetName(context.Background(), "Kitchen")
+	var be *BoxError
+	if !errors.As(err, &be) {
+		t.Fatalf("error is not a *BoxError: %T %v", err, err)
+	}
+	if be.Value != "" || be.Name != "" || be.Detail != "" {
+		t.Errorf("non-envelope body must stay untyped: %+v", be)
+	}
+	want := fmt.Sprintf("box %s: %d: %s", "/name", 502, "Bad Gateway")
+	if err.Error() != want {
+		t.Errorf("Error() text drifted:\n got %q\nwant %q", err.Error(), want)
+	}
+}
+
+// postXMLInto shares the >=400 contract with postXML.
+func TestPostXMLIntoTypedErrorEnvelope(t *testing.T) {
+	body := `<errors deviceID="AABBCCDDEEFF"><error value="5510" name="GROUP_ALREADY_EXISTS" severity="Unknown">5510</error></errors>`
+	c := newRawBox(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(body))
+	})
+	var dst struct{}
+	err := c.postXMLInto(context.Background(), "/navigate", "<x/>", &dst)
+	var be *BoxError
+	if !errors.As(err, &be) {
+		t.Fatalf("error is not a *BoxError: %T %v", err, err)
+	}
+	if be.Value != "5510" || be.Name != "GROUP_ALREADY_EXISTS" {
+		t.Errorf("typed fields wrong: %+v", be)
+	}
+	want := fmt.Sprintf("box %s: %d: %s", "/navigate", 409, body)
+	if err.Error() != want {
+		t.Errorf("Error() text drifted:\n got %q\nwant %q", err.Error(), want)
+	}
+}
+
+// A 2xx reply whose body is the error envelope must stay a SUCCESS (log-only
+// until the fleet survey settles what 2xx bodies carry per chassis) and must
+// put value/name into the log for that survey to read.
+func TestPostXML2xxErrorEnvelopeIsLogOnly(t *testing.T) {
+	body := `<errors deviceID="AABBCCDDEEFF"><error value="1005" name="UNKNOWN_SOURCE_ERROR" severity="Unknown">1005</error></errors>`
+	c := newRawBox(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	})
+	var buf bytes.Buffer
+	c.Log = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	if err := c.SetName(context.Background(), "Kitchen"); err != nil {
+		t.Fatalf("2xx envelope must stay log-only, got error: %v", err)
+	}
+	logged := buf.String()
+	for _, want := range []string{"1005", "UNKNOWN_SOURCE_ERROR", "/name"} {
+		if !strings.Contains(logged, want) {
+			t.Errorf("log line missing %q:\n%s", want, logged)
+		}
+	}
+	if !strings.Contains(logged, "level=INFO") {
+		t.Errorf("an envelope with a code must log at Info so it reaches default bundles:\n%s", logged)
+	}
+}
+
+// Detection is root-element-only: an <error> nested inside a legitimate 2xx
+// reply, or a normal <status> body, must not trip it. Substring matching over
+// the body is exactly the false-positive class the typed parse retires.
+func TestPostXML2xxNormalBodiesNotFlagged(t *testing.T) {
+	for _, body := range []string{
+		`<status>/name</status>`,
+		`<status>OK<error>nested, not an envelope</error></status>`,
+		``,
+	} {
+		c := newRawBox(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(body))
+		})
+		var buf bytes.Buffer
+		c.Log = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		if err := c.SetName(context.Background(), "Kitchen"); err != nil {
+			t.Fatalf("body %q: unexpected error: %v", body, err)
+		}
+		if buf.Len() != 0 {
+			t.Errorf("body %q must not be flagged, logged:\n%s", body, buf.String())
+		}
+	}
+}
+
+// postXMLInto flags a 2xx envelope the same way and still decodes dst as it
+// always did (here: nothing to decode, no error).
+func TestPostXMLInto2xxErrorEnvelopeIsLogOnly(t *testing.T) {
+	body := `<errors deviceID="AABBCCDDEEFF"><error value="1036" name="UNABLE_TO_PROCESS_NOT_LOGGED_IN" severity="Unknown">1036</error></errors>`
+	c := newRawBox(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	})
+	var buf bytes.Buffer
+	c.Log = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	var dst struct{}
+	if err := c.postXMLInto(context.Background(), "/navigate", "<x/>", &dst); err != nil {
+		t.Fatalf("2xx envelope must stay log-only, got error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "1036") || !strings.Contains(buf.String(), "/navigate") {
+		t.Errorf("log line missing envelope data:\n%s", buf.String())
+	}
+}
+
+// decodeErrorEnvelope table: what counts as an envelope and what the typed
+// element carries.
+func TestDecodeErrorEnvelope(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		envelope bool
+		value    string
+	}{
+		{"full envelope", `<errors deviceID="AABBCCDDEEFF"><error value="5580" name="GROUP_CREATE_GROUP_ON_MARGE_ERROR" severity="Unknown">5580</error></errors>`, true, "5580"},
+		{"bare error", `<error>parse trouble</error>`, true, ""},
+		{"empty envelope", `<errors deviceID="AABBCCDDEEFF"></errors>`, true, ""},
+		{"truncated envelope", `<errors deviceID="AABBCCDDEEFF"><error value="5510"`, true, ""},
+		{"status reply", `<status>/setup</status>`, false, ""},
+		{"nested error", `<info><error>not root</error></info>`, false, ""},
+		{"not xml", `Bad Request`, false, ""},
+		{"empty", ``, false, ""},
+		{"xml decl then envelope", `<?xml version="1.0" encoding="UTF-8" ?><errors deviceID="AABBCCDDEEFF"><error value="1019" name="CLIENT_XML_ERROR" severity="Unknown">1019</error></errors>`, true, "1019"},
+	}
+	for _, tc := range cases {
+		el, ok := decodeErrorEnvelope([]byte(tc.body))
+		if ok != tc.envelope {
+			t.Errorf("%s: envelope = %v, want %v", tc.name, ok, tc.envelope)
+			continue
+		}
+		if el.Value != tc.value {
+			t.Errorf("%s: value = %q, want %q", tc.name, el.Value, tc.value)
+		}
+	}
+}

--- a/internal/boxws/client.go
+++ b/internal/boxws/client.go
@@ -46,6 +46,10 @@ type Client struct {
 	// storm so bundles can correlate it with the boot clock and marge trail.
 	err1036Times   []time.Time
 	lastStormLogAt time.Time
+	// lastAcctModeLogAt gates the acctModeUpdated INFO line so a flapping box
+	// cannot spam the NAND ring (the frame's cadence on 27.0.6 is unknown; it
+	// has never appeared in a field bundle). Guarded by mu.
+	lastAcctModeLogAt time.Time
 	// boxErrors is a small ring of the errors the BOX reported, newest last.
 	// The log already carries each one, but a bundle then needs someone to
 	// find them by eye among thousands of lines, and the code alone does not
@@ -342,6 +346,32 @@ func (c *Client) noteLanguageUpdated(v string) {
 		return
 	}
 	c.logger.Info("box ws: languageUpdated", "sysLanguage", v, "prev", prev)
+}
+
+// acctModeLogEvery bounds the acctModeUpdated INFO line. The frame's cadence
+// on 27.0.6 is unknown because it has never been seen in a field bundle, so
+// the gate is insurance against a flapping box turning a diagnostic timestamp
+// into NAND churn.
+const acctModeLogEvery = 5 * time.Minute
+
+// noteAcctModeUpdated records that the box announced a change of its cloud
+// account association (acctModeUpdated, in either wire form). Stated plainly:
+// no field bundle has ever shown this frame on 27.0.6 and it may never fire.
+// It exists so that IF it does, the association flip behind a 1036 storm gets
+// its own timestamp to correlate with clock_status and the marge trail, the
+// way the storm WARN already tells bundle readers to (the install pins
+// acctMode=local, so a later frame is a direct flip marker). INFO on purpose:
+// rare by construction, and being visible in a bundle is the whole point.
+func (c *Client) noteAcctModeUpdated() {
+	now := time.Now()
+	c.mu.Lock()
+	if !c.lastAcctModeLogAt.IsZero() && now.Sub(c.lastAcctModeLogAt) < acctModeLogEvery {
+		c.mu.Unlock()
+		return
+	}
+	c.lastAcctModeLogAt = now
+	c.mu.Unlock()
+	c.logger.Info("box ws: box account association changed")
 }
 
 // storm1036Threshold / storm1036Window / storm1036LogEvery bound the 1036-storm

--- a/internal/boxws/dispatch.go
+++ b/internal/boxws/dispatch.go
@@ -363,6 +363,32 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 	case f.LanguageUpdated != nil:
 		known = true
 		c.noteLanguageUpdated(strings.TrimSpace(f.LanguageUpdated.Sys))
+	case f.SourcesUpdated != nil:
+		// The wrapped form of the sources-changed signal; the bare-root form is
+		// recovered below. Same callback as the bare form: this is what flips
+		// the "native radio ready" verdict, and until this parse existed the
+		// wrapped-form chassis never fired it, so the agent kept a stale "not
+		// available" answer past the radio source's late registration and wrote
+		// UPnP presets during that window. Debug where the bare case logs Info:
+		// the Portable emits this frame on every source change and the NAND
+		// ring keeps Info and above.
+		known = true
+		c.logger.Debug("box ws: the box changed its registered sources (wrapped form)")
+		c.fireSourcesChanged()
+	case f.SwUpdateStatus != nil, f.SiteSurveyResults != nil,
+		f.RecentsUpdated != nil, f.InfoUpdated != nil:
+		// Documented no-ops, known and ignored (see the field comments in
+		// frames.go for why each carries nothing STR wants, including why
+		// recentsUpdated's value-carrying body is discarded on purpose).
+		// Deliberately NOT noteExplainedActivity: swUpdateStatusUpdated fires
+		// on source changes, not user presses, and feeding it to the thumb
+		// heuristic would swallow real thumb presses. Debug only; these repeat
+		// with routine housekeeping and must not churn the NAND ring.
+		known = true
+		c.logger.Debug("box ws: documented no-op frame", "shape", frameShape(data))
+	case f.AcctModeUpdated != nil:
+		known = true
+		c.noteAcctModeUpdated()
 	}
 
 	pe := f.NowSelection
@@ -388,6 +414,22 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 				// the box then refuses to activate itself.
 				c.logger.Info("box ws: the box changed its registered sources")
 				c.fireSourcesChanged()
+				return
+			case "swUpdateStatusUpdated", "siteSurveyResultsUpdated",
+				"recentsUpdated", "infoUpdated":
+				// The same documented no-ops arrive bare-root on some chassis (a
+				// bare <swUpdateStatusUpdated/> is field-measured noise on every
+				// source change). Same handling as the wrapped forms in the
+				// switch above: known, ignored, Debug only, and never
+				// noteExplainedActivity.
+				c.logger.Debug("box ws: documented no-op frame", "shape", frameShape(data))
+				return
+			case "acctModeUpdated":
+				// Bare-root twin of the wrapped case above (sourcesUpdated shows
+				// the firmware uses both forms for the same event, so cover both
+				// here too). The dedupe inside noteAcctModeUpdated is shared
+				// across the forms.
+				c.noteAcctModeUpdated()
 				return
 			case "userActivityUpdate":
 				// Lone thumb ping (see noteUserActivity). Regressed for bare frames
@@ -488,6 +530,10 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 			// on every source change. Measured 2026-08-06, unrecognized frames
 			// were 15.6 % of the 32 KB NAND log, the only log that survives a
 			// reboot on a box with no shell, at up to 1800 bytes per line.
+			// (sourcesUpdated and swUpdateStatusUpdated have since been typed
+			// above; balanceUpdated and userInactivityUpdate still land here,
+			// deliberately: the doc's frame list is provably incomplete for
+			// 27.0.6, so this capture is how new shapes get discovered.)
 			//
 			// The forensic value is in learning that a frame SHAPE exists, not
 			// in the hundredth copy of it. So the first of each shape is logged

--- a/internal/boxws/frames.go
+++ b/internal/boxws/frames.go
@@ -126,6 +126,40 @@ type gabboFrame struct {
 	LanguageUpdated *struct {
 		Sys string `xml:"sysLanguage"`
 	} `xml:"languageUpdated"`
+
+	// SourcesUpdated is the WRAPPED form of the sources-changed signal
+	// (<updates><sourcesUpdated/></updates>, doc 13.1.11). The box also sends
+	// it as a bare root element, recovered in the bare-root switch; both forms
+	// are on the wire. Only the bare form was handled at first, and three days
+	// later the wrapped one was measured as unrecognized noise on a live
+	// Portable, one per source change (2026-08-06), meaning the sources-changed
+	// callback never fired on wrapped-form chassis at all.
+	SourcesUpdated *struct{} `xml:"sourcesUpdated"`
+
+	// Known-and-ignored frames, named so routine box housekeeping stops
+	// surfacing as unmapped events in bundles and the hourly roll-up. The doc
+	// marks swUpdateStatusUpdated and siteSurveyResultsUpdated as requiring no
+	// client action, and swUpdateStatusUpdated rides along with every source
+	// change in the field. RecentsUpdated's documented body carries the box's
+	// new recents list; it is deliberately discarded because STR has no
+	// consumer for it (STR's own recents store is fed from its recall paths
+	// and the Spotify hook, never from the box). InfoUpdated just says a /info
+	// field such as the device name changed, which STR re-reads on demand.
+	// NONE of these feed noteExplainedActivity: they accompany source changes
+	// and box housekeeping, not user presses, and marking them "explained"
+	// would suppress real thumb detections.
+	SwUpdateStatus    *struct{} `xml:"swUpdateStatusUpdated"`
+	SiteSurveyResults *struct{} `xml:"siteSurveyResultsUpdated"`
+	RecentsUpdated    *struct{} `xml:"recentsUpdated"`
+	InfoUpdated       *struct{} `xml:"infoUpdated"`
+
+	// AcctModeUpdated announces that the box's cloud-account association
+	// changed (doc 13.1.3). Stated plainly: no field bundle has ever shown
+	// this frame on 27.0.6 and it may never fire. It is parsed anyway because
+	// the install pins acctMode=local, so IF it fires it is a direct marker of
+	// the association flipping, which would timestamp the state behind a 1036
+	// storm independently of the first rejected recall.
+	AcctModeUpdated *struct{} `xml:"acctModeUpdated"`
 }
 
 // wsGroupUpdated is the <groupUpdated> body. A self-closing <group /> still

--- a/internal/boxws/knownframes_test.go
+++ b/internal/boxws/knownframes_test.go
@@ -1,0 +1,162 @@
+// Dispatch coverage for the frames the official doc names that STR previously
+// let fall through as unrecognized: the wrapped sourcesUpdated form (a real
+// missed signal), the documented no-op frames, and acctModeUpdated.
+
+package boxws
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newLogClient builds a Client with a buffer-backed logger at the given level
+// and no handler, so a test can assert exactly what reaches the log (the NAND
+// ring keeps Info and above, so "nothing at INFO" is a real requirement here,
+// not cosmetics).
+func newLogClient(buf *bytes.Buffer, level slog.Level) *Client {
+	return New(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: level})),
+		"ws://127.0.0.1:8080/", nil)
+}
+
+func waitFired(t *testing.T, ch <-chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("%s: the sources-changed callback never fired", what)
+	}
+}
+
+// The box sends the sources-changed signal in BOTH wire forms: bare-root
+// <sourcesUpdated/> and wrapped <updates><sourcesUpdated/></updates> (the
+// Portable emits the wrapped one on every source change). Until the wrapped
+// form was parsed, wrapped-form chassis NEVER fired the callback, so the agent
+// kept a stale "native radio not ready" verdict and wrote UPnP presets during
+// the registration window. Both forms must fire the same callback.
+func TestHandleMessage_SourcesUpdatedFiresCallbackBothWireForms(t *testing.T) {
+	frames := map[string]string{
+		"bare root": `<sourcesUpdated deviceID="AABBCCDDEEFF" />`,
+		"wrapped":   `<updates deviceID="AABBCCDDEEFF"><sourcesUpdated /></updates>`,
+	}
+	for form, frame := range frames {
+		var buf bytes.Buffer
+		c := newLogClient(&buf, slog.LevelDebug)
+		fired := make(chan struct{}, 1)
+		c.SetOnSourcesChanged(func() {
+			select {
+			case fired <- struct{}{}:
+			default:
+			}
+		})
+		c.handleMessage(context.Background(), []byte(frame))
+		waitFired(t, fired, form)
+		if strings.Contains(buf.String(), "unrecognized frame") {
+			t.Errorf("%s: a handled sources signal must not also count as unrecognized:\n%s", form, buf.String())
+		}
+	}
+}
+
+// The wrapped form arrives once per source change on the Portable, so it must
+// stay OFF the INFO level entirely: the 32 KB NAND ring keeps Info and above,
+// and churning it is a defect (the bare form keeps its INFO line because it is
+// the rare startup-registration signal).
+func TestHandleMessage_WrappedSourcesUpdatedLogsAtDebugOnly(t *testing.T) {
+	frame := []byte(`<updates deviceID="AABBCCDDEEFF"><sourcesUpdated /></updates>`)
+
+	var info bytes.Buffer
+	newLogClient(&info, slog.LevelInfo).handleMessage(context.Background(), frame)
+	if info.Len() != 0 {
+		t.Errorf("the wrapped sourcesUpdated form must produce nothing at INFO, got:\n%s", info.String())
+	}
+
+	var debug bytes.Buffer
+	newLogClient(&debug, slog.LevelDebug).handleMessage(context.Background(), frame)
+	if !strings.Contains(debug.String(), "registered sources") {
+		t.Errorf("the wrapped hit must still be visible at DEBUG, got:\n%s", debug.String())
+	}
+}
+
+// swUpdateStatusUpdated / siteSurveyResultsUpdated are documented as requiring
+// no client action, and recentsUpdated / infoUpdated carry nothing STR
+// consumes. Each must be known-and-ignored in BOTH wire forms: no INFO line
+// (the old path logged the first of each shape in full at INFO), and no
+// noteExplainedActivity stamp (swUpdateStatusUpdated fires on source changes,
+// not user presses, so an "explained" mark here would swallow real thumb
+// presses).
+func TestHandleMessage_DocumentedNoOpFramesAreKnownAndSilent(t *testing.T) {
+	frames := []string{
+		`<updates deviceID="AABBCCDDEEFF"><swUpdateStatusUpdated /></updates>`,
+		`<swUpdateStatusUpdated deviceID="AABBCCDDEEFF" />`,
+		`<updates deviceID="AABBCCDDEEFF"><siteSurveyResultsUpdated /></updates>`,
+		`<siteSurveyResultsUpdated deviceID="AABBCCDDEEFF" />`,
+		// recentsUpdated with its documented value-carrying body (lowercase
+		// contentItem): the body is deliberately discarded, and it must not
+		// confuse the presence-only parse.
+		`<updates deviceID="AABBCCDDEEFF"><recentsUpdated><recents>` +
+			`<recent deviceID="AABBCCDDEEFF" utcTime="1">` +
+			`<contentItem source="TUNEIN" location="stationid" sourceAccount="" isPresetable="true">` +
+			`<itemName>x</itemName></contentItem></recent></recents></recentsUpdated></updates>`,
+		`<recentsUpdated deviceID="AABBCCDDEEFF" />`,
+		`<updates deviceID="AABBCCDDEEFF"><infoUpdated /></updates>`,
+		`<infoUpdated deviceID="AABBCCDDEEFF" />`,
+	}
+	for _, frame := range frames {
+		var buf bytes.Buffer
+		c := newLogClient(&buf, slog.LevelInfo)
+		c.handleMessage(context.Background(), []byte(frame))
+		if strings.Contains(buf.String(), "unrecognized frame") {
+			t.Errorf("frame %q still hits the unrecognized path:\n%s", frame, buf.String())
+		}
+		if buf.Len() != 0 {
+			t.Errorf("frame %q must produce nothing at INFO, got:\n%s", frame, buf.String())
+		}
+		c.thumbMu.Lock()
+		explained := !c.thumbExplained.IsZero()
+		c.thumbMu.Unlock()
+		if explained {
+			t.Errorf("frame %q must not count as explained activity (it is not a user press)", frame)
+		}
+	}
+}
+
+// acctModeUpdated has never been seen in a field bundle on 27.0.6 and may
+// never fire; it is parsed so that IF it does, the account-association flip
+// behind a 1036 storm gets a timestamp. One INFO line, deduped so a flapping
+// box cannot spam the NAND ring, shared across both wire forms.
+func TestHandleMessage_AcctModeUpdatedLogsOnceDeduped(t *testing.T) {
+	const marker = "box account association changed"
+	wrapped := []byte(`<updates deviceID="AABBCCDDEEFF"><acctModeUpdated></acctModeUpdated></updates>`)
+	bare := []byte(`<acctModeUpdated deviceID="AABBCCDDEEFF" />`)
+
+	var buf bytes.Buffer
+	c := newLogClient(&buf, slog.LevelInfo)
+
+	// First frame: exactly one INFO line, and not the unrecognized path.
+	c.handleMessage(context.Background(), wrapped)
+	if n := strings.Count(buf.String(), marker); n != 1 {
+		t.Fatalf("first acctModeUpdated must log exactly one INFO line, got %d:\n%s", n, buf.String())
+	}
+	if strings.Contains(buf.String(), "unrecognized frame") {
+		t.Fatalf("acctModeUpdated must not count as unrecognized:\n%s", buf.String())
+	}
+
+	// A flap right after (in either wire form) is swallowed by the gate.
+	c.handleMessage(context.Background(), wrapped)
+	c.handleMessage(context.Background(), bare)
+	if n := strings.Count(buf.String(), marker); n != 1 {
+		t.Fatalf("a flapping box must not add INFO lines inside the dedupe window, got %d:\n%s", n, buf.String())
+	}
+
+	// Once the gate ages out, the next frame is logged again.
+	c.mu.Lock()
+	c.lastAcctModeLogAt = time.Now().Add(-acctModeLogEvery - time.Second)
+	c.mu.Unlock()
+	c.handleMessage(context.Background(), bare)
+	if n := strings.Count(buf.String(), marker); n != 2 {
+		t.Fatalf("an aged gate must let the next association change through, got %d lines:\n%s", n, buf.String())
+	}
+}

--- a/internal/boxws/unknownframe_test.go
+++ b/internal/boxws/unknownframe_test.go
@@ -10,7 +10,7 @@ import (
 func TestFrameShape(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{`<userInactivityUpdate deviceID="AA" />`, "userInactivityUpdate"},
-		{`<updates deviceID="AA"><sourcesUpdated /></updates>`, "updates/sourcesUpdated"},
+		{`<updates deviceID="AA"><userInactivityUpdate /></updates>`, "updates/userInactivityUpdate"},
 		{`<updates deviceID='AA'><balanceUpdated></balanceUpdated></updates>`, "updates/balanceUpdated"},
 		{`<SoundTouchSdkInfo serverVersion="4" />`, "SoundTouchSdkInfo"},
 		{`<swUpdateStatusUpdated/>`, "swUpdateStatusUpdated"},
@@ -39,13 +39,17 @@ func TestUnrecognizedFrameLogsTheFirstOfEachShapeOnly(t *testing.T) {
 	var buf bytes.Buffer
 	c := &Client{logger: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))}
 
+	// balanceUpdated stands in for the frames that STILL fall through: the doc's
+	// frame list is provably incomplete for 27.0.6 (balanceUpdated and
+	// userInactivityUpdate are field-only), which is why this path must survive
+	// the typed no-op handling of sourcesUpdated / swUpdateStatusUpdated.
 	inactivity := []byte(`<userInactivityUpdate deviceID="08DF1F0C9870" />`)
 	for i := 0; i < 40; i++ {
 		c.logUnrecognizedFrame(inactivity)
 	}
-	c.logUnrecognizedFrame([]byte(`<updates deviceID="AA"><sourcesUpdated /></updates>`))
+	c.logUnrecognizedFrame([]byte(`<updates deviceID="AA"><balanceUpdated /></updates>`))
 	for i := 0; i < 10; i++ {
-		c.logUnrecognizedFrame([]byte(`<updates deviceID="BB"><sourcesUpdated /></updates>`))
+		c.logUnrecognizedFrame([]byte(`<updates deviceID="BB"><balanceUpdated /></updates>`))
 	}
 
 	out := buf.String()
@@ -56,7 +60,7 @@ func TestUnrecognizedFrameLogsTheFirstOfEachShapeOnly(t *testing.T) {
 	if n := strings.Count(out, "box ws unrecognized frame"); n != 2 {
 		t.Errorf("%d INFO lines for 51 frames, want 2\n%s", n, out)
 	}
-	for _, want := range []string{"userInactivityUpdate", "updates/sourcesUpdated"} {
+	for _, want := range []string{"userInactivityUpdate", "updates/balanceUpdated"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("shape %q never reached the log", want)
 		}

--- a/internal/webui/zoneerrcode_test.go
+++ b/internal/webui/zoneerrcode_test.go
@@ -1,0 +1,65 @@
+package webui
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/JRpersonal/streborn/internal/boxapi"
+)
+
+// The two /addGroup error helpers used to substring-match the WHOLE error
+// string, and that string embeds the reply body, whose envelope carries the
+// box's raw 12-hex MAC as deviceID. A MAC containing the digit run 5510 or
+// 5580 therefore satisfied the check on EVERY failed /addGroup of that box.
+// The consequences are not symmetric noise: a false 5510 runs
+// healStaleStereoGroups, which dissolves pairs on BOTH speakers, and a false
+// 5580 arms the ForcePair retry path.
+
+// envErr builds the typed error the boxapi POST helpers now return, with the
+// poisoned MAC in the raw body exactly where the firmware puts it.
+func envErr(value, name, mac string) error {
+	body := fmt.Sprintf(`<errors deviceID="%s"><error value="%s" name="%s" severity="Unknown">x</error></errors>`, mac, value, name)
+	return &boxapi.BoxError{Path: "/addGroup", Status: 500, Value: value, Name: name, Body: body}
+}
+
+func TestGroupErrHelpersUseTheTypedCodeNotTheMAC(t *testing.T) {
+	// A box whose MAC contains 5580, failing with a code that is NOT 5580:
+	// the old substring match fired here on every failure, forever.
+	otherErr := envErr("5005", "SOME_OTHER_ERROR", "AA5580BB0C11")
+	if isMargeGroupErr(otherErr) {
+		t.Error("a MAC containing 5580 must not read as the marge-group rejection")
+	}
+	if isGroupExistsErr(envErr("5005", "SOME_OTHER_ERROR", "AB5510CD0E22")) {
+		t.Error("a MAC containing 5510 must not read as GROUP_ALREADY_EXISTS")
+	}
+
+	// The genuine rejections still hit, by value and by name.
+	if !isGroupExistsErr(envErr("5510", "GROUP_ALREADY_EXISTS", "AABBCCDDEEFF")) {
+		t.Error("a real 5510 must still be recognised")
+	}
+	if !isMargeGroupErr(envErr("5580", "GROUP_CREATE_GROUP_ON_MARGE_ERROR", "AABBCCDDEEFF")) {
+		t.Error("a real 5580 must still be recognised")
+	}
+	// Name-only match on a typed envelope (a firmware that renames a code but
+	// keeps the constant) still counts.
+	if !isGroupExistsErr(envErr("9999", "GROUP_ALREADY_EXISTS", "AABBCCDDEEFF")) {
+		t.Error("the constant name must be enough on a typed envelope")
+	}
+}
+
+func TestGroupErrHelpersKeepTheUntypedFallback(t *testing.T) {
+	// Transport failures and bare bodies produce untyped errors; the old
+	// behaviour is the only signal there and must survive.
+	if !isGroupExistsErr(fmt.Errorf("box /addGroup: 500: GROUP_ALREADY_EXISTS")) {
+		t.Error("an untyped error naming the constant must still be recognised")
+	}
+	// A typed envelope with an empty Value means the body was NOT an envelope;
+	// the fallback may then match the text, which carries no envelope MAC.
+	bare := &boxapi.BoxError{Path: "/addGroup", Status: 500, Body: "GROUP_CREATE_GROUP_ON_MARGE_ERROR"}
+	if !isMargeGroupErr(fmt.Errorf("wrapped: %w", bare)) {
+		t.Error("an untyped bare-body error must fall back to the text match")
+	}
+	if isGroupExistsErr(nil) {
+		t.Error("nil is not an error")
+	}
+}

--- a/internal/webui/zones_stereo.go
+++ b/internal/webui/zones_stereo.go
@@ -1154,23 +1154,44 @@ func (s *Server) formStereoPair(w http.ResponseWriter, ctx context.Context, c *b
 
 // isGroupExistsErr reports whether an /addGroup error is the firmware's 5510
 // GROUP_ALREADY_EXISTS rejection.
+//
+// The typed envelope is consulted first. The old substring match ran over the
+// WHOLE error string, which embeds the reply body, and the body's errors
+// element carries the box's raw 12-hex MAC as deviceID: a MAC containing the
+// digit run 5510 satisfied the check on EVERY failed /addGroup of that box,
+// forever, and this helper's hit triggers healStaleStereoGroups, which
+// dissolves pairs on BOTH speakers. About one box in seven thousand per code,
+// invisible until it is somebody's living room. The substring fallback stays
+// only for the untyped path (a bare error body parses to Value ""), where the
+// name match cannot collide with a MAC and the numeric match is the risk we
+// have always carried there.
 func isGroupExistsErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToUpper(err.Error())
-	return strings.Contains(msg, "5510") || strings.Contains(msg, "GROUP_ALREADY_EXISTS")
+	return boxErrCodeIs(err, "5510", "GROUP_ALREADY_EXISTS")
 }
 
 // isMargeGroupErr reports whether an /addGroup error is the firmware's 5580
 // GROUP_CREATE_GROUP_ON_MARGE_ERROR: the box could not register the group
 // with its marge, which on an STR box means its marge session is stale.
+// Same typed-first contract as isGroupExistsErr, and the same MAC trap: this
+// helper's hit arms the ForcePair retry path.
 func isMargeGroupErr(err error) bool {
+	return boxErrCodeIs(err, "5580", "GROUP_CREATE_GROUP_ON_MARGE_ERROR")
+}
+
+// boxErrCodeIs is the shared decision behind the two helpers above: the typed
+// envelope decides when the reply carried one, the substring fallback only
+// covers untyped errors (transport failures, bare error bodies), where a MAC
+// cannot leak into the match via the envelope's deviceID.
+func boxErrCodeIs(err error, value, name string) bool {
 	if err == nil {
 		return false
 	}
+	var be *boxapi.BoxError
+	if errors.As(err, &be) && be.Value != "" {
+		return be.Value == value || strings.EqualFold(be.Name, name)
+	}
 	msg := strings.ToUpper(err.Error())
-	return strings.Contains(msg, "5580") || strings.Contains(msg, "GROUP_CREATE_GROUP_ON_MARGE_ERROR")
+	return strings.Contains(msg, value) || strings.Contains(msg, name)
 }
 
 // healStaleStereoGroups clears a stale stereo pair from both speakers'


### PR DESCRIPTION
Bose published an official SoundTouch Web API document (v1.1, April 2026, post shutdown). A four-area comparison against STR, each finding adversarially verified before implementation, with the standing rule that **field evidence beats the doc**: this firmware is frozen at 27.0.6 and the running code is field-proven against it. Sixteen plausible-looking "alignments" were explicitly rejected for that reason and are recorded in FIRMWARE-NOTES so they do not get re-proposed.

## The one confirmed live defect

The firmware sends its sources-changed notification in two wire forms, and STR parsed only the bare one. On wrapping chassis the signal **never fired**, so after a re-association the agent kept a stale "native radio not ready" verdict for up to two minutes and wrote presets in the fallback form during the window. The wrapped form was measured landing in the unrecognized-frame log on a live Portable on 2026-08-06; the doc settles that it is the announced form. Four documented no-op frames stop logging as unknown (Debug, both wire forms, never wired into the thumbs heuristic), and the unrecognized path stays for everything else, because the doc's list is provably incomplete for 27.0.6.

## Typed error envelope, and the MAC trap it closes

Error replies were handled as flat strings embedding the reply body, whose envelope carries the box's raw 12-hex MAC. A MAC containing the digit run **5510 or 5580** satisfied the stereo-pair error checks on every failed /addGroup of that box, and a false 5510 runs the heal that dissolves pairs on **both** speakers. The envelope is now parsed typed; `Error()` reproduces the old text byte for byte (tested), so every substring consumer keeps working; the 5510/5580 checks read the typed value first, with a poisoned-MAC test proving the trap is closed. 2xx bodies carrying the envelope are detected **log-only** for a fleet survey before any enforcement, and the agent's default logger now routes into the agent log so that survey actually reaches bundles.

## Tone-controls bass (the Lifestyle 650 report)

The doc's home-theatre route: when a speaker reports no plain bass capability, `/capabilities` is consulted once, and where `audioproducttonecontrols` is advertised, bass reads and writes go through it, with step and range taken from the speaker. Capability absent = byte-for-byte today's behaviour, so the fleet is untouched. Whether it revives the reporter's bass module only his system can say; the reply to him stays gated on that.

## SSDP speaker discovery

Gated on a live capture first: all four awake fleet speakers emit `ssdp:alive` for `MediaRenderer:1` with the constant `uuid:BO5EBO5E-…` device prefix (field knowledge; the doc names only the URN). Discovery now feeds those already-collected announcements through the same probe classification as a sweep hit. That reaches speakers on mDNS-dead LANs and outside the sweep's /24, costs the speakers nothing (they were sending these packets all along), and a stale announcement costs one failed probe, never a phantom tile.

## Verification

ARM cross-build, all 30 root packages, desktop build + vet, 157 frontend tests. Adversarial review per track caught and fixed one **copyright blocker** (doc prose in a test fixture) before it ever hit a commit. The boxws and boxapi changes run on the speaker: **fleet verification via str-fleet-test before the next release.**

Refs #530