### PR TITLE
Three field reports implemented: Wi-Fi switch priority, OpenCloudTouch leftovers, preset artwork

### DIFF
--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -208,6 +208,8 @@ import {
   clearNoticeDismissal,
   balanceLabel,
   shouldAdoptPresetArt,
+  appArtFromBoxArt,
+  artCarriesBoxForm,
 } from './utils.js';
 
 // Group membership (who follows master X) and the shared zoneLive poll live
@@ -4683,7 +4685,19 @@ let healingInProgress = false;
 async function healPresetLogos() {
   if (healingInProgress) return;
   if (!state.currentBox) return;
-  const missing = state.presets.filter(p => !p.art && p.name);
+  // "No logo" includes two shapes older saves left behind (#696 aftermath):
+  // art that is ONLY box-local (the agent's /icon.png stand-in or a broken
+  // art-proxy wrapper), which renders artless on every machine but this box,
+  // and art still CARRYING any box-form candidate (see artCarriesBoxForm).
+  // The latter must be re-looked-up, not merely unwrapped at render:
+  // unwrapping yields the single URL the agent had picked as box-drawable,
+  // and on the reporter's playing key that is a DuckDuckGo icon URL answering
+  // 404 with the grey-chevron image body (probed 2026-08-24), which the
+  // webview draws without firing onerror, so the tile's cascade ends on the
+  // chevron anyway. Healing writes a full real chain once and the filter goes
+  // false, so this adds no recurring work for healthy keys.
+  const missing = state.presets.filter(p =>
+    p.name && (!appArtFromBoxArt(p.art) || artCarriesBoxForm(p.art)));
   if (missing.length === 0) return;
   healingInProgress = true;
   try {
@@ -5446,20 +5460,30 @@ function renderPresets() {
           if (t && !presetCandidates.includes(t)) presetCandidates.push(t);
         }
       };
+      // For a native play the box's <art> tag is the agent's own loopback
+      // art-proxy URL (built for the speaker's display); adopting THAT would
+      // persist a URL that is dead from this machine and hand the tile to the
+      // DDG grey-chevron fallback, the exact poisoning the hold-save had
+      // (#696). Unwrap first, and gate + persist on the unwrapped value.
+      const adoptIcon = appArtFromBoxArt(state.nowIcon);
       if (p.type === 'spotify') {
         // Show the Spotify logo so the tile is instantly recognisable as a
         // Spotify playlist; the account name is shown small under the title.
         // (Chosen over the album/playlist cover, which changes or lags.)
         addCands(SPOTIFY_LOGO);
       } else if (p.art) {
-        addCands(p.art);
-      } else if (isActive && shouldAdoptPresetArt(state.nowIcon, p)) {
+        // Same unwrap on the STORED art: keys hold-saved by v0.9.56 and older
+        // already carry the box-loopback wrapper (the reporter's six keys in
+        // the #696 bundle do), so unwrapping at render gives them back their
+        // real image URL without rewriting the store.
+        addCands(appArtFromBoxArt(p.art));
+      } else if (isActive && shouldAdoptPresetArt(adoptIcon, p)) {
         // Same gate refreshStatus uses to decide whether a late-arriving logo
         // is worth a redraw, so the two cannot drift apart.
-        addCands(state.nowIcon);
+        addCands(adoptIcon);
         // Auto-persist so the preset has its logo on the next load.
-        p.art = state.nowIcon;
-        SetPreset(state.currentBox.host, state.currentBox.port, p.slot, p.name, p.stream_url, state.nowIcon, p.bitrate || 0, p.homepage || '', p.codec || '').catch(() => {});
+        p.art = adoptIcon;
+        SetPreset(state.currentBox.host, state.currentBox.port, p.slot, p.name, p.stream_url, adoptIcon, p.bitrate || 0, p.homepage || '', p.codec || '').catch(() => {});
       }
       const streamHost = extractHost(p.stream_url);
       const hostsToTry = [];
@@ -5715,7 +5739,19 @@ async function saveCurrentToSlot(slot) {
   // Which save path applies is a pure decision (savePresetCase in utils.js,
   // unit-tested): spotify / app-play / copy-slot / direct.
   const sourceSlot = activeSlotFromLocation(state.nowLocation);
-  const saveCase = savePresetCase(state.nowLocation, sourceSlot, state.lastAppPlay, Date.now(), APP_PLAY_FRESH_MS);
+  // What the box report actually resolves to: a NATIVE ad-hoc play reports
+  // the ORION descriptor (no slot in it, so sourceSlot is null) and a
+  // non-native one the /stream/raw wrapper; both unwrap to the exact URL the
+  // app handed to PlayURL. Passing it lets savePresetCase tell "the box is
+  // playing what the app just started" (save the app's own record, with the
+  // station's real logo chain) from "someone started something else". Without
+  // it every hold-save of an app-started native play fell to 'direct' and
+  // persisted the descriptor's box-loopback art-proxy URL as the key's
+  // artwork, dead from this machine, so the tile ended on the grey chevron
+  // (#696).
+  const nowOrion = orionStationPayload(state.nowLocation);
+  const nowStreamUrl = decodeProxyUrl((nowOrion && nowOrion.streamUrl) || state.nowLocation);
+  const saveCase = savePresetCase(state.nowLocation, sourceSlot, state.lastAppPlay, Date.now(), APP_PLAY_FRESH_MS, nowStreamUrl);
 
   // Case Spotify: the speaker is playing a Spotify playlist. Save a REAL
   // Spotify preset (type=spotify with the playlist URI), not a radio link to
@@ -5864,10 +5900,19 @@ async function saveCurrentToSlot(slot) {
   const orion = orionStationPayload(state.nowLocation);
   if (orion && orion.streamUrl) {
     const oname = orion.name || state.nowName || t('preset.placeholderSender');
+    // The descriptor's imageUrl is built for the SPEAKER, not for us: it is
+    // the agent's loopback art proxy (or its /icon.png stand-in), which only
+    // resolves on the box itself. Persisting it verbatim was the #696 bug:
+    // every hold-saved key held art that is dead from the user's machine, the
+    // tile's <img> fell through to the DuckDuckGo stream-host icon, and DDG's
+    // 404 body is the grey chevron the webview renders without firing onerror
+    // (see app_library.go). Unwrap to the real image URL; when that leaves
+    // nothing (stand-in logo), try the now-playing icon the same way.
+    const oart = appArtFromBoxArt(orion.imageUrl) || appArtFromBoxArt(state.nowIcon);
     try {
       await SetPreset(
         state.currentBox.host, state.currentBox.port,
-        slot, oname, decodeProxyUrl(orion.streamUrl), orion.imageUrl || state.nowIcon || '',
+        slot, oname, decodeProxyUrl(orion.streamUrl), oart,
         state.nowBitrate || 0, '', ''
       );
       showToast(t('preset.savedToKey', { n: slot, name: oname }));
@@ -5885,9 +5930,13 @@ async function saveCurrentToSlot(slot) {
   const appRec = state.lastAppPlay;
   const codec = (appRec && appRec.url === decodeProxyUrl(state.nowLocation)) ? (appRec.codec || '') : '';
   try {
+    // state.nowIcon carries the box's <art> tag, which for anything the agent
+    // wrapped is its loopback art-proxy URL: unwrap so the store keeps the
+    // real image URL, never a URL only the box can fetch (#696, same poison
+    // shape as the orion branch above).
     await SetPreset(
       state.currentBox.host, state.currentBox.port,
-      slot, name, decodeProxyUrl(state.nowLocation), state.nowIcon || '', state.nowBitrate || 0, '', codec
+      slot, name, decodeProxyUrl(state.nowLocation), appArtFromBoxArt(state.nowIcon), state.nowBitrate || 0, '', codec
     );
     showToast(t('preset.savedToKey', { n: slot, name }));
     await loadPresets();
@@ -6592,7 +6641,12 @@ async function refreshStatus() {
       } else if (!newLoc) {
         state.nowIcon = '';
       }
-      iconAdoptable = shouldAdoptPresetArt(state.nowIcon, ap);
+      // Mirror of the grid's adopt gate in renderPresets: judge the UNWRAPPED
+      // icon, because for a native play the box's <art> is the agent's own
+      // loopback art-proxy URL and can leave nothing adoptable once unwrapped
+      // (#696). Judging the raw value here while the grid persists the
+      // unwrapped one would re-render for an adopt that never happens.
+      iconAdoptable = shouldAdoptPresetArt(appArtFromBoxArt(state.nowIcon), ap);
       // Keep the now-playing bitrate in sync with the active preset
       // (hardware key press or app restart did not go through the play
       // path that sets it). Cleared when nothing is playing.

--- a/desktop-app/frontend/src/presetart.test.js
+++ b/desktop-app/frontend/src/presetart.test.js
@@ -1,0 +1,132 @@
+// #696: station artwork on a hold-saved preset was covered by the grey
+// chevron. The hold-to-save path persisted the playing ORION descriptor's
+// imageUrl as the key's art. That value is built for the SPEAKER (the agent's
+// loopback art proxy, internal/webui/lir.go: the box cannot fetch https, so
+// the agent wraps the image), and from the user's machine 127.0.0.1:8888 is
+// nothing, so the tile's <img> errored over to the DuckDuckGo stream-host
+// icon, whose 404 answer is a grey-chevron image body the webview renders
+// without firing onerror (documented in app_library.go). The reporter's one
+// surviving key, WDCB 90.9, is the one station whose stream host has a real
+// DDG icon, which is exactly the discriminator he suspected.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { appArtFromBoxArt, artCarriesBoxForm } from './utils.js';
+
+// The wrapper exactly as the #696 bundle carries it (box-2.json, the playing
+// slot's <art> tag): the loopback art proxy around the DDG icon URL the agent
+// picked as box-drawable for EPIC CLASSICAL.
+const WRAPPED = 'http://127.0.0.1:8888/art?u=aHR0cHM6Ly9pY29ucy5kdWNrZHVja2dvLmNvbS9pcDMvZXBpYy1jbGFzc2ljYWwuY29tLmljbw';
+const ORIGIN = 'https://icons.duckduckgo.com/ip3/epic-classical.com.ico';
+
+const b64url = (s) => Buffer.from(s).toString('base64')
+  .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+describe('appArtFromBoxArt', () => {
+  it('unwraps the box-loopback art-proxy URL from the #696 bundle', () => {
+    expect(appArtFromBoxArt(WRAPPED)).toBe(ORIGIN);
+  });
+  it('unwraps a LAN-addressed wrapper too, the store rule is the origin URL', () => {
+    expect(appArtFromBoxArt('http://192.0.2.60:8888/art?u=' + b64url('https://static.example/logo.png')))
+      .toBe('https://static.example/logo.png');
+  });
+  it('drops the /icon.png stand-in: STR\'s own logo is not the station\'s art', () => {
+    expect(appArtFromBoxArt('http://127.0.0.1:8888/icon.png')).toBe('');
+  });
+  it('drops a wrapper whose payload does not decode to a URL', () => {
+    expect(appArtFromBoxArt('http://127.0.0.1:8888/art?u=YWJj')).toBe(''); // "abc"
+  });
+  it('passes a clean logo chain through byte-identical', () => {
+    const chain = 'https://static.example/logo.png|https://icons.duckduckgo.com/ip3/example.com.ico';
+    expect(appArtFromBoxArt(chain)).toBe(chain);
+  });
+  it('heals only the wrapped candidate inside a mixed chain', () => {
+    expect(appArtFromBoxArt('https://static.example/logo.png|' + WRAPPED))
+      .toBe('https://static.example/logo.png|' + ORIGIN);
+  });
+  it('keeps data: URIs and unparsable values untouched', () => {
+    expect(appArtFromBoxArt('data:image/svg+xml;utf8,x')).toBe('data:image/svg+xml;utf8,x');
+    expect(appArtFromBoxArt('not a url')).toBe('not a url');
+  });
+  it('returns empty for empty', () => {
+    expect(appArtFromBoxArt('')).toBe('');
+    expect(appArtFromBoxArt(null)).toBe('');
+    expect(appArtFromBoxArt(undefined)).toBe('');
+  });
+});
+
+// Unwrapping alone cannot give a #696 key its artwork back: the wrapped value
+// is the ONE URL the agent had picked as box-drawable, and for the reporter's
+// playing key that is icons.duckduckgo.com/ip3/epic-classical.com.ico, which
+// answers 404 with the grey-chevron image body (probed live 2026-08-24). The
+// webview draws that body without firing onerror (app_library.go), so the
+// tile's cascade ends on the chevron with the unwrapped URL as its only
+// candidate. Such keys must therefore reach healPresetLogos for a real
+// re-lookup, which is what this predicate gates.
+describe('artCarriesBoxForm', () => {
+  it('flags the #696 bundle wrapper', () => {
+    expect(artCarriesBoxForm(WRAPPED)).toBe(true);
+  });
+  it('flags the /icon.png stand-in', () => {
+    expect(artCarriesBoxForm('http://127.0.0.1:8888/icon.png')).toBe(true);
+  });
+  it('flags a mixed chain with one wrapped candidate', () => {
+    expect(artCarriesBoxForm('https://static.example/logo.png|' + WRAPPED)).toBe(true);
+  });
+  it('passes a clean chain', () => {
+    expect(artCarriesBoxForm('https://static.example/logo.png|https://icons.duckduckgo.com/ip3/example.com.ico')).toBe(false);
+  });
+  it('passes empty and non-URL values', () => {
+    expect(artCarriesBoxForm('')).toBe(false);
+    expect(artCarriesBoxForm(null)).toBe(false);
+    expect(artCarriesBoxForm('not a url')).toBe(false);
+    expect(artCarriesBoxForm('data:image/svg+xml;utf8,x')).toBe(false);
+  });
+});
+
+// The defect was never in a helper, it was the persist sites handing box-form
+// art to SetPreset. There is no DOM here (the vitest environment is
+// deliberately DOM-free and renderPresets writes innerHTML), so main.js is
+// read as source and every site that persists or adopts art is checked for
+// the unwrap, the same way utils.test.js pins the bass gate onto the settings
+// view. Matched on the helper NAME so refactoring the calls stays possible;
+// what must never come back is art persisted raw off the box report.
+describe('main.js persists no box-form art (#696)', () => {
+  const src = readFileSync(new URL('./main.js', import.meta.url), 'utf8');
+
+  it('the hold-save orion branch unwraps the descriptor imageUrl', () => {
+    // The exact poisoned shape that shipped in v0.9.56:
+    expect(src).not.toMatch(/orion\.imageUrl \|\| state\.nowIcon/);
+    expect(src).toContain('appArtFromBoxArt(orion.imageUrl)');
+  });
+  it('the direct branch and the adopt path unwrap the box <art> value', () => {
+    expect(src).toContain('appArtFromBoxArt(state.nowIcon)');
+    // No SetPreset argument list may carry state.nowIcon raw any more. The
+    // sanitizer call itself contains the name, so blank it out first and
+    // require that nothing else in the call still touches the raw icon.
+    for (const call of src.match(/SetPreset\([^;]*?\);/gs) || []) {
+      const scrubbed = call.replace(/appArtFromBoxArt\([^)]*\)/g, 'UNWRAPPED');
+      expect(scrubbed, 'a SetPreset call persists the raw box icon:\n' + call)
+        .not.toContain('state.nowIcon');
+    }
+  });
+  it('the tile adopts and persists only the unwrapped icon', () => {
+    expect(src).toContain('const adoptIcon = appArtFromBoxArt(state.nowIcon);');
+    expect(src).toContain('p.art = adoptIcon;');
+    // The redraw gate in refreshStatus must judge the same unwrapped value,
+    // or it re-renders for an adopt the grid never performs.
+    expect(src).toContain('shouldAdoptPresetArt(appArtFromBoxArt(state.nowIcon), ap)');
+  });
+  it('stored art from older saves is unwrapped at render time', () => {
+    // Keys hold-saved by v0.9.56 and older still carry the wrapper in the
+    // store; the tile must not feed it to the <img> cascade as-is.
+    expect(src).toContain('addCands(appArtFromBoxArt(p.art));');
+  });
+  it('the logo healer treats box-form art as needing a real re-lookup', () => {
+    // A key whose stored art is only box-local renders artless everywhere but
+    // the box itself, and a key still carrying the wrapper unwraps to a single
+    // URL that can itself be the DDG chevron 404 (the reporter's playing key
+    // does, probed 2026-08-24); truthy p.art used to keep healPresetLogos
+    // away from both.
+    expect(src).toContain('p.name && (!appArtFromBoxArt(p.art) || artCarriesBoxForm(p.art))');
+  });
+});

--- a/desktop-app/frontend/src/utils.js
+++ b/desktop-app/frontend/src/utils.js
@@ -125,12 +125,26 @@ export function sleep(ms) {
 //   'direct'    a non-proxy stream — save the box-reported now-playing.
 // sourceSlot is activeSlotFromLocation(nowLocation), passed in so the caller
 // computes it once; null means "not a proxy location".
-export function savePresetCase(nowLocation, sourceSlot, lastAppPlay, nowMs, freshMs) {
+// nowStreamUrl is the real upstream URL the box report resolves to (the
+// caller unwraps the ORION descriptor and the /stream/raw proxy; '' when
+// unknown). It exists because a NATIVE ad-hoc play has no slot: the box
+// reports the descriptor, sourceSlot is null, and this function used to fall
+// through to 'direct' even when the app itself had started the station
+// seconds earlier. 'direct' then persisted the descriptor's box-loopback
+// art-proxy URL as the key's artwork, which is dead from the user's machine,
+// so every hold-saved key lost its logo to the grey-chevron fallback (#696,
+// six ST10 keys, MacBook). Unlike the proxy branch above, the app record is
+// trusted here ONLY when it matches what the box actually plays: there is no
+// wake-resume race to excuse a mismatch (#252's reason does not apply), so a
+// station someone started elsewhere still saves from the box report.
+export function savePresetCase(nowLocation, sourceSlot, lastAppPlay, nowMs, freshMs, nowStreamUrl) {
   if (/\/spotify\/stream|\/playback\/container/.test(nowLocation || '')) return 'spotify';
+  const fresh = !!(lastAppPlay && lastAppPlay.url && nowMs - lastAppPlay.at < freshMs);
   if (sourceSlot !== null && sourceSlot !== undefined) {
-    if (lastAppPlay && lastAppPlay.url && nowMs - lastAppPlay.at < freshMs) return 'app-play';
+    if (fresh) return 'app-play';
     return 'copy-slot';
   }
+  if (fresh && nowStreamUrl && lastAppPlay.url === nowStreamUrl) return 'app-play';
   return 'direct';
 }
 
@@ -538,4 +552,90 @@ export function bassControlsDisabled(bass) {
 // place this rule can be pinned down by a test.
 export function shouldAdoptPresetArt(icon, preset) {
   return !!icon && !!preset && !preset.art && preset.type !== 'spotify';
+}
+
+// appArtFromBoxArt turns art the way the BOX carries it into art the app may
+// persist or draw. It is the artwork mirror of decodeProxyUrl (main.js): the
+// preset store must hold the station's real image URL, never one of the
+// agent's own wrappers.
+//
+// Two box-only shapes exist, both built for the SPEAKER's display by
+// internal/webui/lir.go (the speaker fetches its artwork itself and cannot do
+// https, so the agent wraps the image in its loopback art proxy):
+//   http://127.0.0.1:8888/art?u=<base64url real URL>   the wrapped station art
+//   http://127.0.0.1:8888/icon.png                     STR's stand-in logo
+// Both reach the app through the ORION descriptor's imageUrl and through the
+// box's now-playing <art> tag. Persisted app-side they are poison: 127.0.0.1
+// is not the agent on the user's machine, so the tile's <img> errors over to
+// the DuckDuckGo stream-host icon, whose 404 answer is a grey-chevron image
+// body the webview renders without firing onerror (see app_library.go). That
+// is exactly how six hold-saved keys on an ST10 lost their artwork while the
+// one station whose stream host has a real DDG icon, WDCB 90.9, kept it
+// (#696).
+//
+// So, per candidate of the pipe-separated chain: an /art?u= wrapper (any
+// host: the LAN form dies with the next DHCP lease, and the store rule is the
+// origin URL, same as for streams) is unwrapped back to the real image URL; a
+// box-loopback URL that is not a wrapper (above all the /icon.png stand-in,
+// which is STR's logo, not the station's) is dropped; everything else,
+// including data: URIs and unparsable values, passes through untouched.
+// boxArtKind classifies one parsed art candidate: 'wrapper' for the agent's
+// /art?u= form, 'local' for any other box-loopback URL (above all the
+// /icon.png stand-in), null for everything else, non-URLs included, which are
+// not the box's shapes. Shared by appArtFromBoxArt (which rewrites) and
+// artCarriesBoxForm (which only detects), so the two can never disagree on
+// what counts as box-form.
+function boxArtKind(u) {
+  if (!u || (u.protocol !== 'http:' && u.protocol !== 'https:')) return null;
+  if (u.pathname === '/art' && u.searchParams.has('u')) return 'wrapper';
+  if (u.hostname === '127.0.0.1' || u.hostname === 'localhost' || u.hostname === '[::1]' || u.hostname === '::1') {
+    return 'local';
+  }
+  return null;
+}
+
+export function appArtFromBoxArt(art) {
+  const out = [];
+  for (const c of String(art || '').split('|')) {
+    const cand = c.trim();
+    if (!cand) continue;
+    let u = null;
+    try { u = new URL(cand); } catch { /* not a URL: keep as-is below */ }
+    const kind = boxArtKind(u);
+    if (kind === 'wrapper') {
+      try {
+        // Unpadded base64url, like the agent writes it; pad and swap the
+        // alphabet the same way orionStationPayload does.
+        let b64 = u.searchParams.get('u').replace(/-/g, '+').replace(/_/g, '/');
+        while (b64.length % 4) b64 += '=';
+        const real = atob(b64);
+        if (/^https?:\/\//i.test(real)) { if (!out.includes(real)) out.push(real); }
+      } catch { /* undecodable wrapper: certainly not station art, drop */ }
+      continue;
+    }
+    if (kind === 'local') {
+      continue; // box-local, unreachable from the app and not the station's art
+    }
+    if (!out.includes(cand)) out.push(cand);
+  }
+  return out.join('|');
+}
+
+// artCarriesBoxForm reports whether a stored art chain holds ANY box-form
+// candidate (the agent's /art?u= wrapper or a box-loopback URL). A key saved
+// that way needs a real logo re-lookup, not only the render-time unwrap:
+// unwrapping gives back the ONE URL the agent had picked as box-drawable, and
+// for the #696 reporter's playing key that is a DuckDuckGo icon URL which
+// answers 404 (probed 2026-08-24), whose body is the grey-chevron image the
+// webview draws without firing onerror, so the tile's fallback cascade ends
+// right there. Only healPresetLogos can put a full working chain back.
+export function artCarriesBoxForm(art) {
+  for (const c of String(art || '').split('|')) {
+    const cand = c.trim();
+    if (!cand) continue;
+    let u = null;
+    try { u = new URL(cand); } catch { continue; }
+    if (boxArtKind(u) !== null) return true;
+  }
+  return false;
 }

--- a/desktop-app/frontend/src/utils.test.js
+++ b/desktop-app/frontend/src/utils.test.js
@@ -25,6 +25,34 @@ describe('savePresetCase', () => {
     expect(savePresetCase('http://radio.example.com/live.mp3', null, freshPlay, NOW, FRESH_MS)).toBe('direct');
     expect(savePresetCase('', null, null, NOW, FRESH_MS)).toBe('direct');
   });
+
+  // #696: a NATIVE ad-hoc play reports the ORION descriptor, which carries no
+  // slot, so sourceSlot is null and the old decision fell to 'direct'. That
+  // path saved the descriptor's box-loopback art-proxy URL as the key's
+  // artwork (dead from the user's machine, so the tile ended on the grey
+  // chevron), even though the app had started the station seconds earlier
+  // and holds its full logo chain. When the box report resolves to the SAME
+  // URL the app played (the caller passes it as nowStreamUrl), the app's
+  // record must win.
+  describe('native ad-hoc play, no slot in the location (#696)', () => {
+    const orionLoc = '/station?data=irrelevant-here-the-caller-decodes-it';
+    it('prefers the fresh app record when the box plays exactly that URL', () => {
+      expect(savePresetCase(orionLoc, null, freshPlay, NOW, FRESH_MS, freshPlay.url)).toBe('app-play');
+    });
+    it('still trusts the box report when it plays something else', () => {
+      // No wake-resume race to excuse a mismatch here (unlike #252's proxy
+      // branch): a station started from a hardware key or another client
+      // must be saved as the box reports it.
+      expect(savePresetCase(orionLoc, null, freshPlay, NOW, FRESH_MS, 'http://other.example.com/live')).toBe('direct');
+    });
+    it('still trusts the box report when the app record has gone stale', () => {
+      expect(savePresetCase(orionLoc, null, stalePlay, NOW, FRESH_MS, stalePlay.url)).toBe('direct');
+    });
+    it('falls back to direct when the caller cannot resolve the box URL', () => {
+      expect(savePresetCase(orionLoc, null, freshPlay, NOW, FRESH_MS, '')).toBe('direct');
+      expect(savePresetCase(orionLoc, null, freshPlay, NOW, FRESH_MS)).toBe('direct');
+    });
+  });
 });
 
 // The bass slider and the "default" reset button next to it must read the SAME

--- a/internal/hosts/hosts.go
+++ b/internal/hosts/hosts.go
@@ -7,15 +7,42 @@ import (
 	"bytes"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"strings"
+	"sync"
 )
 
 const (
 	defaultPath = "/etc/hosts"
 	beginMarker = "# >>> streborn begin >>>"
 	endMarker   = "# <<< streborn end <<<"
+
+	// OpenCloudTouch (SoundTouch Hybrid) marks its redirect block in the
+	// persistent /etc/hosts with these two lines. On a box migrated from that
+	// mod the block (13 Bose hostnames pointed at the mod's LAN server)
+	// survives on the read-only rootfs and gets copied into STR's live hosts
+	// file at boot, see removeForeignRedirects (#698).
+	octBeginMarker = "# OCT-START"
+	octEndMarker   = "# OCT-END"
 )
+
+// boseCloudDomains are the cloud domains the Bose firmware talks to. Any
+// hosts line that points a hostname under one of these at a non-loopback
+// address is a rival mod's redirect: STR needs the box to resolve the Bose
+// hosts it emulates to its own loopback listeners, and the dead domains it
+// does not emulate must fall through to real DNS (NXDOMAIN/time out is the
+// benign state, see DefaultEntries). The list covers the 13 hostnames seen
+// in the field OpenCloudTouch block (#698) plus the TuneIn partner domain
+// STR itself redirects.
+var boseCloudDomains = []string{
+	"bose.com",
+	"bose.io",
+	"bosecm.com",
+	"bosesoundtouch.com",
+	"vtuner.com",
+	"radiotime.com",
+}
 
 // Entry describes a line that is inserted into /etc/hosts.
 type Entry struct {
@@ -69,9 +96,30 @@ func (m *Manager) Apply(entries []Entry) error {
 	}
 
 	stripped := removeBlock(current)
+
+	// Filter a rival mod's redirects out of the base BEFORE appending our own
+	// block (#698). A box migrated from OpenCloudTouch still carries that mod's
+	// "# OCT-START".."# OCT-END" block (Bose hostnames pointed at the mod's LAN
+	// server) in the persistent /etc/hosts on the read-only rootfs, and run.sh
+	// seeds the live copy from that file. libc hosts resolution is
+	// first-match-wins and the leftover block sits above our appended one, so
+	// its LAN IP won even for the hostnames both mods redirect: the reporter's
+	// box had BoseApp and STSCertified stuck in SYN_SENT against the long-dead
+	// OCT server on every boot, and removing the block from the live copy
+	// stopped the connections completely. The persistent file itself is NOT
+	// touched: that would need remounting the rootfs rw, which is firmware
+	// bending and off the table by standing rule. Neutralizing the live copy
+	// on every Apply is the whole fix.
+	cleaned, foreign := removeForeignRedirects(stripped, entries)
+	setForeignFiltered(foreign)
+	if len(foreign) > 0 && m.logger != nil {
+		m.logger.Info("foreign hosts redirects filtered", "path", m.path,
+			"lines", len(foreign), "issue", "#698")
+	}
+
 	block := renderBlock(entries)
 
-	merged := append(bytes.TrimRight(stripped, "\n"), '\n', '\n')
+	merged := append(bytes.TrimRight(cleaned, "\n"), '\n', '\n')
 	merged = append(merged, block...)
 
 	if err := writeAtomic(m.path, merged); err != nil {
@@ -133,6 +181,147 @@ func removeBlock(in []byte) []byte {
 		}
 	}
 	return []byte(strings.Join(out, "\n"))
+}
+
+// removeForeignRedirects drops a rival mod's Bose redirects from the hosts
+// base and returns the dropped lines verbatim (#698). Two layers, so the fix
+// does not depend on the rival mod's exact markers:
+//
+//  1. The marked OpenCloudTouch block ("# OCT-START".."# OCT-END"), markers
+//     included. Block mode is only honored when the end marker actually
+//     exists, so a truncated block cannot eat the rest of the file; the
+//     per-line layer below still neutralizes the redirects themselves.
+//  2. Any remaining line that maps a Bose cloud hostname to an address that
+//     is neither loopback nor one of our own entries. A rival mod's redirect
+//     by definition fights ours, whatever its markers look like.
+//
+// Every unrelated line is kept: users may have legitimate custom entries
+// (NAS names etc.) in there. Field caveat: only one migrated box has been
+// measured so far (a SoundTouch 10, issue #698); other OCT versions may
+// write slightly different blocks, which is what layer 2 is for.
+func removeForeignRedirects(in []byte, own []Entry) ([]byte, []string) {
+	lines := strings.Split(string(in), "\n")
+	out := make([]string, 0, len(lines))
+	var removed []string
+	inOCT := false
+	for i, l := range lines {
+		t := strings.TrimSpace(l)
+		switch {
+		// Guard: only enter block mode when a closing marker actually follows,
+		// otherwise an unterminated block would swallow everything below the
+		// opening marker, custom user entries included.
+		case t == octBeginMarker && !inOCT && octEndFollows(lines[i+1:]):
+			inOCT = true
+			removed = append(removed, l)
+		case t == octEndMarker && inOCT:
+			inOCT = false
+			removed = append(removed, l)
+		case inOCT:
+			removed = append(removed, l)
+		case isForeignBoseRedirect(l, own):
+			removed = append(removed, l)
+		default:
+			out = append(out, l)
+		}
+	}
+	return []byte(strings.Join(out, "\n")), removed
+}
+
+func octEndFollows(rest []string) bool {
+	for _, l := range rest {
+		if strings.TrimSpace(l) == octEndMarker {
+			return true
+		}
+	}
+	return false
+}
+
+// isForeignBoseRedirect reports whether the hosts line points a Bose cloud
+// hostname at a foreign address. Loopback stays: that is where STR's own
+// listeners sit, so such a line cannot steer the box away from STR even if
+// STR did not write it. Unparseable lines stay too; this filter only ever
+// drops lines it positively understands.
+func isForeignBoseRedirect(line string, own []Entry) bool {
+	text := line
+	if i := strings.IndexByte(text, '#'); i >= 0 {
+		text = text[:i]
+	}
+	fields := strings.Fields(text)
+	if len(fields) < 2 {
+		return false
+	}
+	ip := net.ParseIP(fields[0])
+	if ip == nil || ip.IsLoopback() {
+		return false
+	}
+	for _, h := range fields[1:] {
+		if !isBoseCloudHost(h) {
+			continue
+		}
+		if isOwnEntry(own, fields[0], h) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func isBoseCloudHost(host string) bool {
+	h := strings.ToLower(strings.TrimSuffix(host, "."))
+	for _, d := range boseCloudDomains {
+		if h == d || strings.HasSuffix(h, "."+d) {
+			return true
+		}
+	}
+	return false
+}
+
+func isOwnEntry(own []Entry, ip, host string) bool {
+	for _, e := range own {
+		if e.IP == ip && strings.EqualFold(e.Host, host) {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsOCTBlock reports whether the hosts content carries an
+// OpenCloudTouch marker block. Used by the conflicting-mod detection in the
+// webui against the LIVE bind-mounted /etc/hosts, never against the verbatim
+// boot copy (/tmp/hosts.original): the boot copy keeps the block forever
+// because the persistent file on the read-only rootfs cannot be cleaned, so
+// keying on it would pin the warning banner even after run.sh and Apply have
+// neutralized the redirects (#698).
+func ContainsOCTBlock(b []byte) bool {
+	for _, l := range strings.Split(string(b), "\n") {
+		if strings.TrimSpace(l) == octBeginMarker {
+			return true
+		}
+	}
+	return false
+}
+
+// foreignFiltered is the package-level snapshot of the lines the last Apply
+// dropped, so /api/debug/state can show in a diagnostic bundle exactly which
+// rival redirects a box carried and that they were neutralized (#698). One
+// small slice, written once per Apply (agent start), read on demand.
+var (
+	foreignFilteredMu sync.Mutex
+	foreignFiltered   []string
+)
+
+func setForeignFiltered(lines []string) {
+	foreignFilteredMu.Lock()
+	defer foreignFilteredMu.Unlock()
+	foreignFiltered = append([]string(nil), lines...)
+}
+
+// ForeignFiltered returns a copy of the hosts lines the last Apply filtered
+// out, empty when the base was clean.
+func ForeignFiltered() []string {
+	foreignFilteredMu.Lock()
+	defer foreignFilteredMu.Unlock()
+	return append([]string(nil), foreignFiltered...)
 }
 
 // writeAtomic writes content to path. It first tries the classic

--- a/internal/hosts/hosts_test.go
+++ b/internal/hosts/hosts_test.go
@@ -1,0 +1,180 @@
+package hosts
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The block OpenCloudTouch left in the persistent /etc/hosts of the migrated
+// SoundTouch 10 in #698, verbatim except the mod's LAN server IP, which is
+// replaced with a documentation placeholder per the repo's no-real-LAN-IPs
+// rule (the filter keys on non-loopback, not on any specific address). Only
+// that one box has been measured; the unmarked-line tests below cover
+// variants.
+const octBlock = `# OCT-START
+192.0.2.8	bose.vtuner.com	# OpenCloudTouch redirect
+192.0.2.8	bose2.vtuner.com	# OpenCloudTouch redirect
+192.0.2.8	primary5.vtuner.com	# OpenCloudTouch redirect
+192.0.2.8	primary6.vtuner.com	# OpenCloudTouch redirect
+192.0.2.8	streaming.bose.com	# OpenCloudTouch redirect
+192.0.2.8	bmx.bose.com	# OpenCloudTouch redirect
+192.0.2.8	api.bosesoundtouch.com	# OpenCloudTouch redirect
+192.0.2.8	content.api.bose.io	# OpenCloudTouch redirect
+192.0.2.8	events.api.bosecm.com	# OpenCloudTouch redirect
+192.0.2.8	worldwide.bose.com	# OpenCloudTouch redirect
+192.0.2.8	update.bose.com	# OpenCloudTouch redirect
+192.0.2.8	analytics.bose.com	# OpenCloudTouch redirect
+192.0.2.8	telemetry.bose.com	# OpenCloudTouch redirect
+# OCT-END`
+
+func applyTo(t *testing.T, content string, entries []Entry) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "hosts")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := New(path, nil)
+	if err := m.Apply(entries); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+// A base carrying the marked OpenCloudTouch block must come out without it:
+// with first-match-wins resolution the leftover block sat above STR's
+// appended one and kept BoseApp/STSCertified in SYN_SENT against the dead
+// OCT server (#698). Unrelated user entries must survive.
+func TestApplyFiltersOCTBlock(t *testing.T) {
+	base := "127.0.0.1\tlocalhost.localdomain\t\tlocalhost\n\n" +
+		octBlock + "\n" +
+		"192.168.1.50\tmynas.local\n"
+	got := applyTo(t, base, DefaultEntries())
+
+	if strings.Contains(got, "OCT") {
+		t.Errorf("OCT markers survived Apply:\n%s", got)
+	}
+	if strings.Contains(got, "192.0.2.8") {
+		t.Errorf("OCT server IP survived Apply:\n%s", got)
+	}
+	if !strings.Contains(got, "192.168.1.50\tmynas.local") {
+		t.Errorf("unrelated user entry was dropped:\n%s", got)
+	}
+	if !strings.Contains(got, "localhost.localdomain") {
+		t.Errorf("localhost line was dropped:\n%s", got)
+	}
+	if n := strings.Count(got, beginMarker); n != 1 {
+		t.Errorf("want exactly 1 STR block, got %d:\n%s", n, got)
+	}
+	// The resolver must now only ever see loopback for the redirected hosts.
+	for _, l := range strings.Split(got, "\n") {
+		if strings.Contains(l, "streaming.bose.com") && !strings.HasPrefix(l, "127.0.0.1") {
+			t.Errorf("streaming.bose.com still resolves foreign: %q", l)
+		}
+	}
+	if len(ForeignFiltered()) != 15 { // 13 redirects + 2 marker lines
+		t.Errorf("ForeignFiltered: want 15 lines, got %d: %v",
+			len(ForeignFiltered()), ForeignFiltered())
+	}
+}
+
+// A clean base must produce byte-identical output to the pre-#698 composition:
+// boxes that never saw another mod must not change at all.
+func TestApplyCleanBaseByteIdentical(t *testing.T) {
+	base := "127.0.0.1\tlocalhost.localdomain\t\tlocalhost\n"
+	entries := []Entry{{IP: "127.0.0.1", Host: "streaming.bose.com"}}
+	got := applyTo(t, base, entries)
+
+	want := "127.0.0.1\tlocalhost.localdomain\t\tlocalhost\n\n" +
+		beginMarker + "\n" +
+		"127.0.0.1\tstreaming.bose.com\n" +
+		endMarker + "\n"
+	if got != want {
+		t.Errorf("clean base changed:\nwant %q\ngot  %q", want, got)
+	}
+	if len(ForeignFiltered()) != 0 {
+		t.Errorf("ForeignFiltered on clean base: %v", ForeignFiltered())
+	}
+}
+
+// A rival redirect without the OCT markers (another mod version, or a
+// hand-edited leftover) must be filtered by the generic layer: any Bose cloud
+// hostname pointed at a non-loopback address fights STR's own redirect.
+// Loopback mappings and unrelated hosts stay.
+func TestApplyFiltersUnmarkedForeignRedirect(t *testing.T) {
+	base := "127.0.0.1\tlocalhost\n" +
+		"192.0.2.8\tstreaming.bose.com\n" +
+		"192.0.2.8\tbose.vtuner.com\n" +
+		"127.0.0.1\tbmx.bose.com\n" + // loopback: cannot steer the box away from STR
+		"192.168.1.50\tmynas.local\n"
+	got := applyTo(t, base, DefaultEntries())
+
+	if strings.Contains(got, "192.0.2.8") {
+		t.Errorf("foreign bose redirect survived:\n%s", got)
+	}
+	if !strings.Contains(got, "127.0.0.1\tbmx.bose.com") {
+		t.Errorf("loopback bose mapping was dropped:\n%s", got)
+	}
+	if !strings.Contains(got, "192.168.1.50\tmynas.local") {
+		t.Errorf("unrelated user entry was dropped:\n%s", got)
+	}
+	filtered := ForeignFiltered()
+	if len(filtered) != 2 {
+		t.Errorf("ForeignFiltered: want 2 lines, got %v", filtered)
+	}
+}
+
+// An opening marker without a closing one must not swallow the rest of the
+// file; the per-line layer still neutralizes the actual redirects.
+func TestApplyUnterminatedOCTBlockKeepsTail(t *testing.T) {
+	base := "127.0.0.1\tlocalhost\n" +
+		"# OCT-START\n" +
+		"192.0.2.8\tstreaming.bose.com\n" +
+		"192.168.1.50\tmynas.local\n"
+	got := applyTo(t, base, DefaultEntries())
+
+	if !strings.Contains(got, "192.168.1.50\tmynas.local") {
+		t.Errorf("unterminated block swallowed user entry:\n%s", got)
+	}
+	if strings.Contains(got, "192.0.2.8") {
+		t.Errorf("foreign redirect survived unterminated block:\n%s", got)
+	}
+}
+
+// Apply must stay idempotent with the filter in place: a second run replaces
+// STR's own block instead of stacking a new one.
+func TestApplyTwiceKeepsOneBlock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hosts")
+	base := "127.0.0.1\tlocalhost\n" + octBlock + "\n"
+	if err := os.WriteFile(path, []byte(base), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := New(path, nil)
+	for i := 0; i < 2; i++ {
+		if err := m.Apply(DefaultEntries()); err != nil {
+			t.Fatalf("Apply #%d: %v", i+1, err)
+		}
+	}
+	b, _ := os.ReadFile(path)
+	if n := strings.Count(string(b), beginMarker); n != 1 {
+		t.Errorf("want exactly 1 STR block after two Applies, got %d:\n%s", n, b)
+	}
+}
+
+func TestContainsOCTBlock(t *testing.T) {
+	if !ContainsOCTBlock([]byte("x\n# OCT-START\ny\n")) {
+		t.Error("marker block not detected")
+	}
+	if ContainsOCTBlock([]byte("127.0.0.1\tlocalhost\n")) {
+		t.Error("clean file misdetected")
+	}
+	// The marker must be a line of its own, not a substring of a comment.
+	if ContainsOCTBlock([]byte("# see docs about # OCT-START markers\n")) {
+		t.Error("substring misdetected as marker line")
+	}
+}

--- a/internal/webui/agent_admin.go
+++ b/internal/webui/agent_admin.go
@@ -25,6 +25,8 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/JRpersonal/streborn/internal/hosts"
 )
 
 // handleAgentVersion returns the running stick agent version. Used by
@@ -1043,26 +1045,77 @@ func hasSavedWLANCreds() bool {
 // leftovers (an /mnt/nv/aftertouch directory) carried neither. Detection now
 // keys on AfterTouch's actual footprint: its NAND directory, its resolv.conf
 // override, and an rc.local hook mentioning it. Best-effort.
+//
+// #698 added OpenCloudTouch (SoundTouch Hybrid). If both tools somehow left
+// artifacts, AfterTouch wins the single return value; the desktop app shows
+// the string verbatim, so no i18n is involved.
 func detectConflictingMod() string {
-	if fi, err := os.Stat(filepath.Join(nandRoot, "aftertouch")); err == nil && fi.IsDir() {
+	if detectAfterTouch() {
 		return "AfterTouch"
 	}
+	if detectOpenCloudTouch() {
+		return "OpenCloudTouch"
+	}
+	return ""
+}
+
+func detectAfterTouch() bool {
+	if fi, err := os.Stat(filepath.Join(nandRoot, "aftertouch")); err == nil && fi.IsDir() {
+		return true
+	}
 	if _, err := os.Stat(filepath.Join(nandRoot, "aftertouch.resolv.conf")); err == nil {
-		return "AfterTouch"
+		return true
 	}
 	// STR's own rc.local never references the rival tool, so a hook line in
 	// the boot script is an unambiguous fingerprint.
 	if b, err := os.ReadFile(filepath.Join(nandRoot, "rc.local")); err == nil &&
 		strings.Contains(strings.ToLower(string(b)), "aftertouch") {
-		return "AfterTouch"
+		return true
 	}
-	return ""
+	return false
+}
+
+// octBackupPath and hostsLivePath / hostsOriginalPath are vars so the
+// OpenCloudTouch detection test can point them at a temp tree; in production
+// they are the real paths. hostsOriginalPath is run.sh's verbatim boot copy
+// of the persistent /etc/hosts, taken BEFORE the OCT block is stripped from
+// the live copy, so it is where the leftover stays visible for diagnostics.
+var (
+	octBackupPath     = "/mnt/nv/OverrideSdkPrivateCfg.xml.oct-backup"
+	hostsLivePath     = "/etc/hosts"
+	hostsOriginalPath = "/tmp/hosts.original"
+)
+
+// detectOpenCloudTouch reports OpenCloudTouch (SoundTouch Hybrid) leftovers
+// (#698). The mod's footprint on the reporter's migrated ST10 was its
+// SDK-config backup on NAND and a "# OCT-START".."# OCT-END" redirect block
+// in the persistent /etc/hosts, which kept BoseApp and STSCertified in
+// SYN_SENT against the mod's long-dead LAN server. Only that one box has
+// been measured; other OCT installs may differ.
+//
+// The hosts block counts here only while it is LIVE, i.e. still present in
+// the bind-mounted /etc/hosts the resolver actually reads. run.sh strips it
+// at boot and hosts.Apply filters it at agent start, so on a healthy fixed
+// box the live file is clean and only the removable backup file keeps the
+// warning up. Keying on the verbatim boot copy instead would pin the banner
+// forever: the persistent block sits on the read-only rootfs and removing it
+// would need a rw remount, firmware bending, off the table by standing rule.
+// The boot copy is still surfaced in /api/debug/state for bundles.
+func detectOpenCloudTouch() bool {
+	if _, err := os.Stat(octBackupPath); err == nil {
+		return true
+	}
+	if b, err := os.ReadFile(hostsLivePath); err == nil && hosts.ContainsOCTBlock(b) {
+		return true
+	}
+	return false
 }
 
 // handleRemoveConflictingMod removes the leftovers of a rival cloud-free
-// SoundTouch tool (AfterTouch) that clash with STR: its /mnt/nv/aftertouch
-// directory, its resolv.conf override, and any aftertouch hook line in rc.local.
-// It touches ONLY those artifacts, never the rest of /mnt/nv (which holds the
+// SoundTouch tool that clash with STR: AfterTouch's /mnt/nv/aftertouch
+// directory, its resolv.conf override, and any aftertouch hook line in
+// rc.local, plus OpenCloudTouch's SDK-config backup on NAND (#698). It
+// touches ONLY those artifacts, never the rest of /mnt/nv (which holds the
 // box's own Wi-Fi/AirPlay/account persistence and STR's own streborn/ dir). The
 // desktop app surfaces this as a one-click button so users never need SSH; a
 // reboot afterwards fully clears the rival tool's already-running processes.
@@ -1119,6 +1172,23 @@ func (s *Server) handleRemoveConflictingMod(w http.ResponseWriter, r *http.Reque
 			}
 			removed = append(removed, fmt.Sprintf("rc.local (%d line)", dropped))
 		}
+	}
+	// 4. OpenCloudTouch's SDK-config backup on NAND (#698). Its OTHER
+	// fingerprint, the redirect block in the persistent /etc/hosts, is NOT
+	// removable from here: the file sits on the read-only rootfs and cleaning
+	// it would mean remounting the rootfs rw, which is firmware bending and
+	// off the table by standing rule (the reporter's own workaround did
+	// exactly that; do not "improve" this handler that way). The block is
+	// neutralized instead: run.sh strips it from the live hosts copy at boot
+	// and hosts.Apply filters it at agent start, and detectOpenCloudTouch
+	// only counts the LIVE file, so removing this backup is enough for
+	// stillDetected to converge to false on a healthy box.
+	if _, err := os.Stat(octBackupPath); err == nil {
+		if err := os.Remove(octBackupPath); err != nil {
+			http.Error(w, "could not remove OCT backup: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		removed = append(removed, filepath.Base(octBackupPath))
 	}
 	_ = exec.Command("sync").Run()
 	s.logger.Info("removed conflicting-mod leftovers", "mod", mod, "removed", removed)

--- a/internal/webui/debug.go
+++ b/internal/webui/debug.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/JRpersonal/streborn/internal/hosts"
 	"github.com/JRpersonal/streborn/internal/netutil"
 )
 
@@ -255,7 +256,21 @@ func (s *Server) handleDebugState(w http.ResponseWriter, r *http.Request) {
 		// the owner could not be told where his storage had gone. The names
 		// answer both.
 		"boselog_listing": listDir("/mnt/nv/BoseLog"),
-		"proc_mounts":     readTail("/proc/mounts"),
+		// The hosts picture, three views (#698). hosts_live is what the box's
+		// resolver actually reads (the bind-mounted /etc/hosts). hosts_original
+		// is run.sh's verbatim boot copy of the persistent file, which is where
+		// a rival mod's redirect block (OpenCloudTouch's "# OCT-START" block on
+		// the reporter's migrated ST10) stays visible: the persistent file
+		// lives on the read-only rootfs and is deliberately never cleaned, only
+		// neutralized in the live copy. hosts_filtered is what the agent's
+		// hosts filter dropped this boot. Together a bundle proves both the
+		// leftover and its neutralization without SSH, where before all three
+		// were invisible and the box silently hammered the dead rival server
+		// (BoseApp and STSCertified in SYN_SENT).
+		"hosts_live":     readTail(hostsLivePath),
+		"hosts_original": readTail(hostsOriginalPath),
+		"hosts_filtered": hosts.ForeignFiltered(),
+		"proc_mounts":    readTail("/proc/mounts"),
 		// Writable-volume usage: df for /mnt/nv + / and the per-entry sizes that
 		// answer "is this box genuinely tighter or carrying foreign firmware
 		// leftovers" without needing SSH (#ST30 OTA no-space, 2026-06-24).

--- a/internal/webui/oct_detect_test.go
+++ b/internal/webui/oct_detect_test.go
@@ -1,0 +1,94 @@
+// Tests for the OpenCloudTouch leftover detection (#698). The fingerprints
+// come from the one migrated box measured so far, the reporter's ST10: the
+// SDK-config backup on NAND and the "# OCT-START" redirect block in the
+// persistent /etc/hosts, which kept BoseApp and STSCertified in SYN_SENT
+// against the mod's long-dead LAN server.
+
+package webui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// redirectOCTPaths points the detection at a temp tree and restores the
+// production paths afterwards.
+func redirectOCTPaths(t *testing.T) (backup, live, original string) {
+	t.Helper()
+	dir := t.TempDir()
+	backup = filepath.Join(dir, "OverrideSdkPrivateCfg.xml.oct-backup")
+	live = filepath.Join(dir, "hosts.live")
+	original = filepath.Join(dir, "hosts.original")
+	oldB, oldL, oldO := octBackupPath, hostsLivePath, hostsOriginalPath
+	octBackupPath, hostsLivePath, hostsOriginalPath = backup, live, original
+	t.Cleanup(func() {
+		octBackupPath, hostsLivePath, hostsOriginalPath = oldB, oldL, oldO
+	})
+	return backup, live, original
+}
+
+const octLiveHosts = "127.0.0.1\tlocalhost\n" +
+	"# OCT-START\n" +
+	"192.0.2.8\tstreaming.bose.com\t# OpenCloudTouch redirect\n" +
+	"# OCT-END\n"
+
+func TestDetectOpenCloudTouch(t *testing.T) {
+	backup, live, original := redirectOCTPaths(t)
+
+	// Nothing there: an STR-only box must stay silent.
+	if detectOpenCloudTouch() {
+		t.Fatal("clean box misdetected as OpenCloudTouch")
+	}
+
+	// The SDK-config backup alone is enough: it is the removable artifact the
+	// one-click cleanup can act on.
+	if err := os.WriteFile(backup, []byte("<x/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !detectOpenCloudTouch() {
+		t.Error("oct-backup file not detected")
+	}
+	if err := os.Remove(backup); err != nil {
+		t.Fatal(err)
+	}
+
+	// A LIVE hosts block means the boot/agent filters have not neutralized it
+	// yet: a real, active conflict.
+	if err := os.WriteFile(live, []byte(octLiveHosts), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !detectOpenCloudTouch() {
+		t.Error("live OCT hosts block not detected")
+	}
+
+	// A block only in the verbatim boot copy, with a clean live file, is the
+	// healthy post-fix state: the persistent block on the read-only rootfs can
+	// never be removed without firmware bending, so it must NOT keep the
+	// warning banner up forever. It stays visible to bundles via
+	// /api/debug/state instead.
+	if err := os.WriteFile(live, []byte("127.0.0.1\tlocalhost\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(original, []byte(octLiveHosts), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if detectOpenCloudTouch() {
+		t.Error("neutralized (boot-copy-only) block must not re-raise the banner")
+	}
+}
+
+func TestDetectConflictingModNamesOpenCloudTouch(t *testing.T) {
+	backup, _, _ := redirectOCTPaths(t)
+	if detectAfterTouch() {
+		// This dev/CI host genuinely carries AfterTouch fingerprints under
+		// /mnt/nv; the priority order would mask the OCT result.
+		t.Skip("host machine has AfterTouch artifacts")
+	}
+	if err := os.WriteFile(backup, []byte("<x/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := detectConflictingMod(); got != "OpenCloudTouch" {
+		t.Errorf("detectConflictingMod = %q, want OpenCloudTouch", got)
+	}
+}

--- a/internal/webui/preset_art_heal_test.go
+++ b/internal/webui/preset_art_heal_test.go
@@ -1,0 +1,79 @@
+package webui
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+// The #696 shape, verbatim from the reporter's bundle: a hold-to-save in the
+// v0.9.56 desktop app copied the playing ORION descriptor's imageUrl into the
+// preset art. That imageUrl is the loopback art-proxy wrapper stationImageURL
+// builds for the SPEAKER's display, so from the user's machine the art is a
+// dead URL and the tile ends on the grey-chevron icon-service placeholder.
+// The store must hold the ORIGIN image URL instead; the box side re-wraps at
+// write time, so the display loses nothing.
+
+// wrapLoopbackArt builds the exact wrapper the agent writes into a descriptor
+// (ArtProxyURL with the loopback authority), so the tests exercise the real
+// shape rather than a hand-typed imitation.
+func wrapLoopbackArt(imageURL string) string {
+	return "http://127.0.0.1:8888/art?u=" +
+		base64.RawURLEncoding.EncodeToString([]byte(imageURL))
+}
+
+func TestHealSelfArtProxy(t *testing.T) {
+	const origin = "https://icons.duckduckgo.com/ip3/epic-classical.com.ico"
+	cases := []struct {
+		name, in, want string
+	}{
+		{"unwraps the loopback wrapper (#696 bundle, slot 5)",
+			wrapLoopbackArt(origin), origin},
+		{"unwraps a LAN-addressed wrapper too (dies with the next DHCP lease)",
+			"http://192.0.2.60:8888/art?u=" + base64.RawURLEncoding.EncodeToString([]byte(origin)), origin},
+		{"drops the /icon.png stand-in, STR's logo is not the station's art",
+			"http://127.0.0.1:8888/icon.png", ""},
+		{"drops a broken wrapper instead of storing a dead URL",
+			"http://127.0.0.1:8888/art?u=%%%not-base64", ""},
+		{"a clean chain passes byte-identical",
+			"https://static.example/logo.png|https://icons.duckduckgo.com/ip3/example.com.ico",
+			"https://static.example/logo.png|https://icons.duckduckgo.com/ip3/example.com.ico"},
+		{"heals only the wrapped candidate inside a mixed chain",
+			"https://static.example/logo.png|" + wrapLoopbackArt(origin),
+			"https://static.example/logo.png|" + origin},
+		{"empty stays empty", "", ""},
+		{"a data: URI is not ours to judge",
+			"data:image/svg+xml;utf8,x", "data:image/svg+xml;utf8,x"},
+	}
+	for _, c := range cases {
+		if got := healSelfArtProxy(c.in); got != c.want {
+			t.Errorf("%s: healSelfArtProxy(%q) = %q, want %q", c.name, c.in, got, c.want)
+		}
+	}
+}
+
+// The heal must actually sit on the save path: a PUT carrying the poisoned
+// art (what a v0.9.56 app sends on hold-to-save) stores the origin image URL.
+// This is the request-level regression for #696; it failed before the heal
+// was added to handlePresetSlot.
+func TestPresetSaveHealsBoxLoopbackArt(t *testing.T) {
+	s := newSaveGateServer(t)
+	art := wrapLoopbackArt("https://cdn-profiles.tunein.com/s74982/images/logod.png")
+	w := putPreset(t, s, 5,
+		`{"name":"EPIC CLASSICAL - Classical Guitar","type":"radio",`+
+			`"stream_url":"https://stream.epic-classical.example/classical-guitar",`+
+			`"art":"`+art+`"}`)
+	if w.Code != 200 {
+		t.Fatalf("save with wrapped art: status = %d (body %s)", w.Code, w.Body.String())
+	}
+	p, ok := s.presets.Get(5)
+	if !ok {
+		t.Fatal("preset was not stored")
+	}
+	if p.Art != "https://cdn-profiles.tunein.com/s74982/images/logod.png" {
+		t.Errorf("stored art = %q, want the unwrapped origin URL", p.Art)
+	}
+	if strings.Contains(p.Art, "/art?u=") || strings.Contains(p.Art, "127.0.0.1") {
+		t.Errorf("stored art still points at the agent: %q", p.Art)
+	}
+}

--- a/internal/webui/presets_http.go
+++ b/internal/webui/presets_http.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/base64"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -76,6 +77,17 @@ func (s *Server) handlePresetSlot(w http.ResponseWriter, r *http.Request) {
 		if p.Type == "" {
 			p.Type = "radio"
 		}
+		// Art pointing at THIS agent's own art proxy (or its /icon.png
+		// stand-in) is the box-display form, not the station's artwork: the
+		// proxy URL is built for the SPEAKER (lir.go stationImageURL) and only
+		// resolves on the box's loopback. Desktop apps up to v0.9.56 persisted
+		// exactly that on a hold-to-save (they copied the playing ORION
+		// descriptor's imageUrl), which left every such key's tile on the grey
+		// chevron because the URL is dead from the user's machine (#696, six
+		// ST10 keys). The store keeps the origin image URL, same rule as the
+		// self-proxy stream heal below; the box side re-wraps at write time
+		// anyway, so the display loses nothing.
+		p.Art = healSelfArtProxy(p.Art)
 		// A queue preset (a saved DLNA folder, #queue-preset) has no single
 		// StreamURL/URI: it carries an ordered Items list and a Shuffle flag and
 		// recalls into the agent play-queue. It skips the radio/spotify URL gates
@@ -455,4 +467,64 @@ func legacySpotifyURI(streamURL string) string {
 		}
 	}
 	return ""
+}
+
+// healSelfArtProxy rewrites preset art that points back at this agent so the
+// store holds the station's ORIGIN image URL, the art analogue of the
+// self-proxy stream heal (#252) above. Desktop apps up to v0.9.56 hold-saved
+// the playing ORION descriptor's imageUrl, which is the loopback art-proxy
+// wrapper stationImageURL builds for the SPEAKER's display; from the user's
+// machine that URL is dead, so the app tile fell through to a grey-chevron
+// placeholder (#696). Healing here (not only in the app) means a fixed agent
+// stores clean art no matter how old the client that saved is.
+//
+// Per candidate of the pipe-separated chain: an /art?u= wrapper is unwrapped
+// back to the image URL it carries whatever its host says, because the
+// desktop app persists the wrapper with whichever authority the descriptor
+// carried and a LAN-addressed one dies with the next DHCP lease; the
+// /icon.png stand-in (STR's own logo, put in place by the agent when a
+// station has no art, never chosen by the user) and broken wrappers are
+// dropped; every other value passes through untouched. An input with nothing
+// to heal comes back byte-identical.
+func healSelfArtProxy(art string) string {
+	var out []string
+	keep := func(c string) {
+		for _, have := range out {
+			if have == c {
+				return
+			}
+		}
+		out = append(out, c)
+	}
+	for _, c := range strings.Split(art, "|") {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			continue
+		}
+		u, err := url.Parse(c)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+			keep(c) // data: URIs and anything unparsable are not ours to judge
+			continue
+		}
+		if u.Path == artProxyPath {
+			if enc := u.Query().Get("u"); enc != "" {
+				for _, d := range []*base64.Encoding{base64.RawURLEncoding, base64.URLEncoding} {
+					if b, err := d.DecodeString(enc); err == nil && isHTTPURL(string(b)) {
+						keep(string(b))
+						break
+					}
+				}
+			}
+			continue // a wrapper never survives as-is, decoded or broken
+		}
+		// Same authority test as selfProxySlot: the agent's own ports, or a
+		// loopback host (the wrapper is written with boxurl.Authority, but be
+		// as tolerant here as the stream heal is).
+		if u.Port() == "8888" || u.Port() == "17008" ||
+			u.Hostname() == "127.0.0.1" || u.Hostname() == "localhost" || u.Hostname() == "::1" {
+			continue // box-local (above all /icon.png): not the station's art
+		}
+		keep(c)
+	}
+	return strings.Join(out, "|")
 }

--- a/internal/webui/wlan.go
+++ b/internal/webui/wlan.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -259,6 +260,14 @@ func (s *Server) applyWLANChange(iface, mech, ssid, password string, hidden bool
 			// rewrites the firmware's own profile, and the marker is consumed on
 			// read so this cannot loop.
 			touchWLANApplyMarker()
+			// Make the firmware's OWN store rank the new network highest (#697):
+			// NetManager keeps the old profile in NetworkProfiles.xml at a higher
+			// priority than the new one, so every boot (and every runtime
+			// reassertion of its stored state) put the speaker silently back on
+			// the old Wi-Fi. Only here, after a CONFIRMED association: a wrong
+			// password must leave the old ranking intact as the fallback, which
+			// is why the wpaCannotApply and rollback arms never touch it.
+			s.raiseFirmwareProfilePriority(ssid)
 			renewDHCPLease()
 		case wpaCannotApply:
 			// The conf could not be written live (read-only /etc and the
@@ -417,6 +426,12 @@ func wpaAddNetwork(iface, ssid, password string, hidden bool) bool {
 		out, _ := exec.Command("wpa_cli", append([]string{"-i", iface}, args...)...).Output()
 		return strings.TrimSpace(string(out))
 	}
+	return wpaAddNetworkVia(run, ssid, password, hidden)
+}
+
+// wpaAddNetworkVia is the command sequence of wpaAddNetwork with the wpa_cli
+// runner injected, so the sequence itself stays unit-testable off-box.
+func wpaAddNetworkVia(run func(args ...string) string, ssid, password string, hidden bool) bool {
 	id := run("add_network")
 	if id == "" || strings.Contains(id, "FAIL") {
 		return false
@@ -432,6 +447,12 @@ func wpaAddNetwork(iface, ssid, password string, hidden bool) bool {
 	if hidden {
 		run("set_network", id, "scan_ssid", "1")
 	}
+	// Without an explicit priority the added block sits at 0, BELOW the blocks
+	// NetManager injects from its own store (priority 1 observed in #697's
+	// list_networks: the old SSID ended up [CURRENT] over the freshly added
+	// one). Set it before enable/select so save_config persists the winning
+	// rank in the same write.
+	run("set_network", id, "priority", strconv.Itoa(wlanChosenPriority))
 	run("enable_network", id)
 	run("select_network", id)
 	run("save_config")
@@ -546,6 +567,15 @@ func buildWPAConfig(ssid, psk string, hidden bool) string {
 		b.WriteString("    psk=\"" + escapeWPAValue(psk) + "\"\n")
 		b.WriteString("    key_mgmt=WPA-PSK\n")
 	}
+	// The single block must not only exist but WIN. The conf is written with
+	// one network on purpose (dead networks first is the documented failure
+	// mode), yet NetManager injects its own stored profiles into the RUNNING
+	// supplicant on top of it, and those carry the firmware's ranking: on the
+	// #697 ST10 the injected old SSID sat at priority 1 and became [CURRENT]
+	// while this block, at the implicit default of 0, lost the selection. An
+	// explicit priority strictly above every value the firmware has been seen
+	// to write (0 and 1) keeps wpa_supplicant on the network the user chose.
+	b.WriteString("    priority=" + strconv.Itoa(wlanChosenPriority) + "\n")
 	b.WriteString("}\n")
 	return b.String()
 }

--- a/internal/webui/wlanpriority.go
+++ b/internal/webui/wlanpriority.go
@@ -1,0 +1,275 @@
+// NetworkProfiles.xml priority assertion after a deliberate runtime Wi-Fi
+// switch (#697).
+//
+// STR's live switch wins the running session but used to lose the ranking war:
+// Bose NetManager keeps its own profile store at
+// /mnt/nv/BoseApp-Persistence/<N>/NetworkProfiles.xml, and after a switch that
+// store still ranked the OLD network highest. On the reporter's ST10 (rhino,
+// v0.9.53) the file held the old SSID at priority="1" and the new one at
+// priority="0", and `wpa_cli list_networks` showed the old SSID as [CURRENT]:
+// every time the firmware reasserted its stored ranking, the speaker silently
+// reconnected to the old Wi-Fi. The reporter proved the end state on his own
+// box: raising the new profile to priority="10" and demoting the old one to
+// "0" made the new network stick reliably. That repair is the specification
+// this file implements.
+//
+// The rewrite edits ONLY priority attribute values (inserting the attribute on
+// the chosen profile if it has none). Everything else is preserved byte for
+// byte on purpose: the passphrase/wepKey attributes hold AES ciphertext only
+// NetManager can produce, so an XML round-trip that re-escaped or reordered
+// anything could corrupt the one copy of the credential the firmware trusts.
+// For the same reason the old profile is demoted, never deleted: it stays the
+// user's working fallback if the new network later disappears.
+//
+// One claim is deliberately not made: BoseApp may hold this file in memory and
+// flush it later, which could overwrite the edit on some boxes. The field
+// evidence (#697: the reporter's manual edit of the same file on a running box
+// stuck) is the strongest support available, so the rewrite is logged and
+// best-effort rather than treated as guaranteed.
+
+package webui
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/JRpersonal/streborn/internal/atomicfile"
+)
+
+// networkProfilesGlob matches NetManager's persisted Wi-Fi profile store. Same
+// pattern the settings and diagnostic readers already use; BCO boxes never
+// create the file (their profile lives in AirplayConfiguration.xml), which is
+// one more reason this assert only runs on the wpa chassis path.
+const networkProfilesGlob = "/mnt/nv/BoseApp-Persistence/*/NetworkProfiles.xml"
+
+const (
+	// wlanChosenPriority is what the deliberately chosen network is raised to,
+	// and wlanDemotedPriority what every other profile is set to. 10/0 are the
+	// exact values the #697 reporter verified on his own ST10; the firmware's
+	// own writes have only ever been observed at 0 (fresh add) and 1, so 10
+	// keeps the chosen profile strictly on top of anything NetManager assigns.
+	wlanChosenPriority  = 10
+	wlanDemotedPriority = 0
+)
+
+// raiseFirmwareProfilePriority makes the firmware's own profile store prefer
+// ssid: the chosen profile goes to wlanChosenPriority, all others to
+// wlanDemotedPriority. Called only after a CONFIRMED live association (the
+// wpaConfirmed arm): on an unverified password the old ranking must survive so
+// the box can fall back to its previous network.
+//
+// When the chosen SSID is not in the store yet (first switch to a network the
+// firmware never saw), only the demotions happen; the profile itself is added
+// by the firmware on the apply-marker boot (/addWirelessProfile), which STR
+// cannot pre-empt because the passphrase attribute must be NetManager's own
+// ciphertext.
+func (s *Server) raiseFirmwareProfilePriority(ssid string) {
+	matches, _ := filepath.Glob(networkProfilesGlob)
+	if len(matches) == 0 {
+		// Nothing to assert. Normal on a box whose firmware store was wiped
+		// (True Factory Reset) or never populated; the wpa-side priority in
+		// the conf still protects the running session.
+		s.logger.Info("WLAN: no NetworkProfiles.xml on this box, firmware ranking not asserted", "ssid", ssid)
+		return
+	}
+	for _, p := range matches {
+		found, changed, err := rewriteProfilePriorityFile(p, ssid)
+		switch {
+		case err != nil:
+			s.logger.Warn("WLAN: NetworkProfiles priority rewrite failed", "path", p, "ssid", ssid, "err", err)
+		case changed:
+			s.logger.Info("WLAN: NetworkProfiles ranking asserted for new network", "path", p, "ssid", ssid, "profilePresent", found)
+		default:
+			s.logger.Info("WLAN: NetworkProfiles ranking already prefers new network", "path", p, "ssid", ssid, "profilePresent", found)
+		}
+	}
+}
+
+// rewriteProfilePriorityFile applies setProfilePriorities to one profile store
+// file, atomically and durably (these boxes cut power at standby, and a torn
+// profile store would cost the user every stored network). No write happens
+// when the ranking is already correct, so repeated switches to the same
+// network do not wear the NAND.
+func rewriteProfilePriorityFile(path, ssid string) (found, changed bool, err error) {
+	b, rerr := os.ReadFile(path)
+	if rerr != nil {
+		return false, false, rerr
+	}
+	out, found, changed := setProfilePriorities(string(b), ssid)
+	if !changed {
+		return found, false, nil
+	}
+	mode := os.FileMode(0o644)
+	if fi, serr := os.Stat(path); serr == nil {
+		mode = fi.Mode().Perm()
+	}
+	if werr := atomicfile.WriteFile(path, []byte(out), mode); werr != nil {
+		return found, false, werr
+	}
+	return found, true, nil
+}
+
+// setProfilePriorities rewrites the priority attributes in a NetworkProfiles
+// document so the profile whose SSID equals ssid ranks strictly highest.
+// Attribute NAMES are matched case-insensitively (the firmware writes SSID
+// uppercase, priority lowercase); the SSID VALUE is compared exactly, after
+// undoing XML attribute escaping. Only priority values change; every other
+// byte of the document survives untouched.
+func setProfilePriorities(doc, ssid string) (out string, found, changed bool) {
+	type edit struct {
+		start, end int
+		text       string
+	}
+	var edits []edit
+	for _, tag := range scanProfileTags(doc) {
+		var ssidVal string
+		var prio *profileAttr
+		for k := range tag.attrs {
+			a := &tag.attrs[k]
+			switch {
+			case strings.EqualFold(a.name, "ssid"):
+				ssidVal = doc[a.valStart:a.valEnd]
+			case strings.EqualFold(a.name, "priority"):
+				prio = a
+			}
+		}
+		// xmlAttrUnescape (recall_verify.go): the store holds XML-escaped
+		// attribute values, the switch request holds what the user typed.
+		isTarget := xmlAttrUnescape(ssidVal) == ssid
+		if isTarget {
+			found = true
+		}
+		want := wlanDemotedPriority
+		if isTarget {
+			want = wlanChosenPriority
+		}
+		switch {
+		case prio != nil:
+			if doc[prio.valStart:prio.valEnd] != strconv.Itoa(want) {
+				edits = append(edits, edit{prio.valStart, prio.valEnd, strconv.Itoa(want)})
+			}
+		case isTarget:
+			// The chosen profile carries no priority attribute: insert one right
+			// after the tag name so the rank is explicit rather than relying on
+			// NetManager's default.
+			edits = append(edits, edit{tag.nameEnd, tag.nameEnd, ` priority="` + strconv.Itoa(want) + `"`})
+		default:
+			// A non-target profile without a priority attribute already ranks at
+			// the firmware default (0, per every observed store): leave its
+			// bytes alone.
+		}
+	}
+	if len(edits) == 0 {
+		return doc, found, false
+	}
+	var b strings.Builder
+	last := 0
+	for _, e := range edits { // edits arrive in document order
+		b.WriteString(doc[last:e.start])
+		b.WriteString(e.text)
+		last = e.end
+	}
+	b.WriteString(doc[last:])
+	return b.String(), found, true
+}
+
+// profileAttr is one name="value" attribute inside a <profile> start tag, with
+// the value's byte range so an edit can replace exactly those bytes.
+type profileAttr struct {
+	name             string
+	valStart, valEnd int
+}
+
+// profileTag is one located <profile .../> start tag.
+type profileTag struct {
+	// nameEnd is the offset right after "<profile", the insertion point for an
+	// attribute the tag lacks.
+	nameEnd int
+	attrs   []profileAttr
+}
+
+// scanProfileTags finds every <profile ...> start tag. A hand-rolled scanner
+// instead of a regexp or an XML decoder on purpose: the tag can span lines
+// (the #697 report shows attributes wrapped mid-tag), attribute values may
+// legally contain '>' (an SSID is arbitrary bytes), and a decoder round-trip
+// would re-serialize the ciphertext-carrying attributes this file must never
+// touch. Byte offsets into the ORIGINAL document are the whole point.
+func scanProfileTags(doc string) []profileTag {
+	const open = "<profile"
+	var tags []profileTag
+	i := 0
+	for i+len(open) <= len(doc) {
+		if doc[i] != '<' || !strings.EqualFold(doc[i:i+len(open)], open) {
+			i++
+			continue
+		}
+		nameEnd := i + len(open)
+		if nameEnd < len(doc) {
+			switch doc[nameEnd] {
+			case ' ', '\t', '\n', '\r', '/', '>':
+				// A real <profile> tag; attributes (or the tag end) follow.
+			default:
+				// A longer element name that merely starts with "profile".
+				i = nameEnd
+				continue
+			}
+		}
+		tag, next := parseProfileAttrs(doc, nameEnd)
+		tag.nameEnd = nameEnd
+		tags = append(tags, tag)
+		i = next
+	}
+	return tags
+}
+
+// parseProfileAttrs walks the attribute list from pos to the tag-closing '>',
+// honouring quotes so a quoted value can contain '>', '/', or newlines without
+// ending the tag. Returns the tag and the offset just past the '>'.
+func parseProfileAttrs(doc string, pos int) (profileTag, int) {
+	isSpace := func(c byte) bool { return c == ' ' || c == '\t' || c == '\n' || c == '\r' }
+	var tag profileTag
+	i := pos
+	for i < len(doc) {
+		for i < len(doc) && (isSpace(doc[i]) || doc[i] == '/') {
+			i++
+		}
+		if i >= len(doc) {
+			return tag, i
+		}
+		if doc[i] == '>' {
+			return tag, i + 1
+		}
+		ns := i
+		for i < len(doc) && doc[i] != '=' && doc[i] != '>' && !isSpace(doc[i]) {
+			i++
+		}
+		name := doc[ns:i]
+		for i < len(doc) && isSpace(doc[i]) {
+			i++
+		}
+		if i >= len(doc) || doc[i] != '=' {
+			continue // bare attribute without a value: keep scanning
+		}
+		i++
+		for i < len(doc) && isSpace(doc[i]) {
+			i++
+		}
+		if i >= len(doc) || (doc[i] != '"' && doc[i] != '\'') {
+			continue // malformed value: skip rather than guess
+		}
+		q := doc[i]
+		i++
+		vs := i
+		for i < len(doc) && doc[i] != q {
+			i++
+		}
+		ve := i
+		if i < len(doc) {
+			i++ // consume the closing quote
+		}
+		tag.attrs = append(tag.attrs, profileAttr{name: name, valStart: vs, valEnd: ve})
+	}
+	return tag, i
+}

--- a/internal/webui/wlanpriority_test.go
+++ b/internal/webui/wlanpriority_test.go
@@ -1,0 +1,207 @@
+package webui
+
+// Tests for the NetworkProfiles.xml priority assertion (#697).
+//
+// The document under test mirrors the store from the #697 report: two
+// profiles survive a deliberate switch, the OLD network ranked higher
+// (priority="1" vs "0"), tags wrapped across lines, the SSID attribute
+// uppercase, and ciphertext in passphrase/wepKey that must survive byte for
+// byte. The values here are placeholders, not captured material.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const reporterProfileStore = `<?xml version="1.0" encoding="UTF-8"?>
+<WiFiProfiles>
+  <profile SSID="WLAN10"
+           priority="1" security="wpa_or_wpa2"
+           passphrase="cGxhY2Vob2xkZXItY2lwaGVydGV4dA==" wepKey="cGxhY2Vob2xkZXItaXY="
+           encrypted="true" lastConnected="1755900000" />
+  <profile SSID="WLAN50"
+           priority="0" security="wpa_or_wpa2"
+           passphrase="YW5vdGhlci1wbGFjZWhvbGRlcg==" wepKey="c2Vjb25kLXBsYWNlaG9sZGVy"
+           encrypted="true" lastConnected="1755990000" />
+</WiFiProfiles>
+`
+
+// TestSetProfilePrioritiesReporterState is the #697 regression: after a
+// deliberate switch to WLAN50 the store must rank WLAN50 strictly highest and
+// change NOTHING but the two priority values. The expected output is built
+// from the input by exactly those two replacements, so any other byte
+// changing (ciphertext, whitespace, attribute order) fails the test.
+func TestSetProfilePrioritiesReporterState(t *testing.T) {
+	out, found, changed := setProfilePriorities(reporterProfileStore, "WLAN50")
+	if !found {
+		t.Fatalf("WLAN50 profile not found in store")
+	}
+	if !changed {
+		t.Fatalf("expected a rewrite, got changed=false")
+	}
+	want := strings.Replace(reporterProfileStore, `priority="1"`, `priority="0"`, 1)
+	want = strings.Replace(want, `priority="0" security="wpa_or_wpa2"
+           passphrase="YW5vdGhlci1wbGFjZWhvbGRlcg=="`, `priority="10" security="wpa_or_wpa2"
+           passphrase="YW5vdGhlci1wbGFjZWhvbGRlcg=="`, 1)
+	if out != want {
+		t.Errorf("rewrite mismatch:\ngot:\n%s\nwant:\n%s", out, want)
+	}
+
+	// Idempotent: asserting the same choice again must not rewrite (repeat
+	// switches to the same network must not wear the NAND).
+	again, found2, changed2 := setProfilePriorities(out, "WLAN50")
+	if !found2 || changed2 {
+		t.Errorf("second assert: found=%v changed=%v, want found=true changed=false", found2, changed2)
+	}
+	if again != out {
+		t.Errorf("second assert altered the document:\n%s", again)
+	}
+}
+
+// TestSetProfilePrioritiesTargetAbsent covers the first switch to a network
+// the firmware never stored: the profile cannot be added agent-side (its
+// passphrase must be NetManager's own ciphertext), so the existing profiles
+// are demoted to 0 and found=false tells the caller the add is still owed by
+// the firmware's boot path.
+func TestSetProfilePrioritiesTargetAbsent(t *testing.T) {
+	out, found, changed := setProfilePriorities(reporterProfileStore, "WLAN99")
+	if found {
+		t.Fatalf("WLAN99 must not be found")
+	}
+	if !changed {
+		t.Fatalf("the priority=1 profile must be demoted")
+	}
+	if strings.Contains(out, `priority="1"`) {
+		t.Errorf("old profile still ranked above the firmware default:\n%s", out)
+	}
+	if got := strings.Count(out, `priority="0"`); got != 2 {
+		t.Errorf("expected both profiles at priority 0, got %d:\n%s", got, out)
+	}
+
+	// All profiles already at 0: nothing to demote, no write.
+	_, found2, changed2 := setProfilePriorities(out, "WLAN99")
+	if found2 || changed2 {
+		t.Errorf("re-run on demoted store: found=%v changed=%v, want false/false", found2, changed2)
+	}
+}
+
+// TestSetProfilePrioritiesInsertsMissingAttr: a chosen profile that carries no
+// priority attribute gets an explicit one, and a lowercase ssid attribute name
+// still matches (the attribute NAME casing varies, the VALUE is compared
+// exactly).
+func TestSetProfilePrioritiesInsertsMissingAttr(t *testing.T) {
+	doc := `<WiFiProfiles><profile ssid="HomeNet" encrypted="true" /></WiFiProfiles>`
+	out, found, changed := setProfilePriorities(doc, "HomeNet")
+	if !found || !changed {
+		t.Fatalf("found=%v changed=%v, want true/true", found, changed)
+	}
+	if !strings.Contains(out, `<profile priority="10" ssid="HomeNet"`) {
+		t.Errorf("priority attribute not inserted on the chosen profile:\n%s", out)
+	}
+
+	// SSID values are case-sensitive: a different casing is a different network.
+	_, found, _ = setProfilePriorities(doc, "homenet")
+	if found {
+		t.Errorf("SSID value match must be case-sensitive")
+	}
+}
+
+// TestSetProfilePrioritiesEscapedSSID: the store holds XML-escaped attribute
+// values, the switch request holds what the user typed.
+func TestSetProfilePrioritiesEscapedSSID(t *testing.T) {
+	doc := `<WiFiProfiles>
+  <profile SSID="Caf&amp;e &gt;5GHz&lt;" priority="0" />
+  <profile SSID="Other" priority="1" />
+</WiFiProfiles>`
+	out, found, changed := setProfilePriorities(doc, `Caf&e >5GHz<`)
+	if !found || !changed {
+		t.Fatalf("found=%v changed=%v, want true/true", found, changed)
+	}
+	if !strings.Contains(out, `SSID="Caf&amp;e &gt;5GHz&lt;" priority="10"`) {
+		t.Errorf("escaped-SSID profile not raised:\n%s", out)
+	}
+	if !strings.Contains(out, `SSID="Other" priority="0"`) {
+		t.Errorf("other profile not demoted:\n%s", out)
+	}
+}
+
+// TestSetProfilePrioritiesRawGtInValue: an attribute value may legally contain
+// '>', and an SSID is arbitrary bytes, so the tag scanner must not mistake a
+// quoted '>' for the end of the tag.
+func TestSetProfilePrioritiesRawGtInValue(t *testing.T) {
+	doc := `<WiFiProfiles><profile SSID="a>b" priority="1" /><profile SSID="New" priority="0" /></WiFiProfiles>`
+	out, found, changed := setProfilePriorities(doc, "New")
+	if !found || !changed {
+		t.Fatalf("found=%v changed=%v, want true/true", found, changed)
+	}
+	if !strings.Contains(out, `SSID="a>b" priority="0"`) || !strings.Contains(out, `SSID="New" priority="10"`) {
+		t.Errorf("quoted '>' broke the tag scan:\n%s", out)
+	}
+}
+
+// TestSetProfilePrioritiesNoProfiles: an empty or unrelated document is left
+// alone and reports nothing to do.
+func TestSetProfilePrioritiesNoProfiles(t *testing.T) {
+	for _, doc := range []string{
+		"",
+		"<WiFiProfiles />",
+		"<profiles><entry ssid=\"x\"/></profiles>",
+		// An element whose name merely STARTS with "profile" is not a profile:
+		// the scanner must not edit it even when it carries a matching ssid.
+		`<profileList ssid="WLAN50" priority="1"/>`,
+	} {
+		out, found, changed := setProfilePriorities(doc, "WLAN50")
+		if found || changed || out != doc {
+			t.Errorf("doc %q: found=%v changed=%v out=%q, want untouched", doc, found, changed, out)
+		}
+	}
+}
+
+// TestRewriteProfilePriorityFile drives the file-level path: the store on
+// disk ends in the reporter's verified end state, and a second run performs
+// no write at all.
+func TestRewriteProfilePriorityFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "NetworkProfiles.xml")
+	if err := os.WriteFile(p, []byte(reporterProfileStore), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	found, changed, err := rewriteProfilePriorityFile(p, "WLAN50")
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	if !found || !changed {
+		t.Fatalf("found=%v changed=%v, want true/true", found, changed)
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	if !strings.Contains(got, `SSID="WLAN50"
+           priority="10"`) {
+		t.Errorf("new network not ranked highest on disk:\n%s", got)
+	}
+	if !strings.Contains(got, `SSID="WLAN10"
+           priority="0"`) {
+		t.Errorf("old network not demoted on disk:\n%s", got)
+	}
+	// The ciphertext attributes must survive untouched.
+	for _, keep := range []string{"cGxhY2Vob2xkZXItY2lwaGVydGV4dA==", "YW5vdGhlci1wbGFjZWhvbGRlcg=="} {
+		if !strings.Contains(got, keep) {
+			t.Errorf("ciphertext attribute lost: %s\n%s", keep, got)
+		}
+	}
+
+	found, changed, err = rewriteProfilePriorityFile(p, "WLAN50")
+	if err != nil || !found || changed {
+		t.Errorf("second run: found=%v changed=%v err=%v, want true/false/nil", found, changed, err)
+	}
+
+	if _, _, err := rewriteProfilePriorityFile(filepath.Join(dir, "missing.xml"), "WLAN50"); err == nil {
+		t.Errorf("missing file must return an error")
+	}
+}

--- a/internal/webui/wpa_test.go
+++ b/internal/webui/wpa_test.go
@@ -24,12 +24,20 @@ func TestEscapeWPAValue(t *testing.T) {
 }
 
 func TestBuildWPAConfig(t *testing.T) {
-	// WPA network: psk + key_mgmt=WPA-PSK, single network block.
+	// WPA network: psk + key_mgmt=WPA-PSK, single network block. priority=10
+	// is load-bearing (#697): NetManager injects its stored profiles into the
+	// running supplicant at priority 1, and without an explicit higher rank
+	// STR's block lost the selection and the box slid back to the old network.
 	wpa := buildWPAConfig("MyNet", "supersecret", false)
-	for _, want := range []string{`ssid="MyNet"`, `psk="supersecret"`, "key_mgmt=WPA-PSK", "update_config=1"} {
+	for _, want := range []string{`ssid="MyNet"`, `psk="supersecret"`, "key_mgmt=WPA-PSK", "update_config=1", "priority=10"} {
 		if !strings.Contains(wpa, want) {
 			t.Errorf("wpa config missing %q:\n%s", want, wpa)
 		}
+	}
+	// The priority must sit INSIDE the network block (a global priority line
+	// is meaningless to wpa_supplicant).
+	if open, closing, prio := strings.Index(wpa, "network={"), strings.LastIndex(wpa, "}"), strings.Index(wpa, "priority=10"); prio < open || prio > closing {
+		t.Errorf("priority=10 must be inside the network block:\n%s", wpa)
 	}
 	if strings.Count(wpa, "network={") != 1 {
 		t.Errorf("expected exactly one network block:\n%s", wpa)
@@ -40,10 +48,15 @@ func TestBuildWPAConfig(t *testing.T) {
 		t.Errorf("non-hidden network must not set scan_ssid:\n%s", wpa)
 	}
 
-	// Open network (empty password): key_mgmt=NONE, no psk line.
+	// Open network (empty password): key_mgmt=NONE, no psk line, and the same
+	// winning priority (an open network is outranked by an injected profile
+	// just the same).
 	open := buildWPAConfig("OpenNet", "", false)
 	if !strings.Contains(open, "key_mgmt=NONE") || strings.Contains(open, "psk=") {
 		t.Errorf("open network must be key_mgmt=NONE with no psk:\n%s", open)
+	}
+	if !strings.Contains(open, "priority=10") {
+		t.Errorf("open network config missing priority=10:\n%s", open)
 	}
 
 	// A quote in the SSID must be escaped, not break the block.
@@ -118,6 +131,67 @@ func TestWriteWlanCredsFile(t *testing.T) {
 	}
 	if string(got) != "SSID=Stealth\nPASS=supersecret\nHIDDEN=1\n" {
 		t.Errorf("hidden wlan-creds mismatch:\n%s", got)
+	}
+}
+
+// TestWpaAddNetworkVia pins the M4 fallback's command sequence, in particular
+// that the added network gets an explicit priority BEFORE enable/select and
+// that save_config comes last, so the persisted config carries the winning
+// rank (#697: without the priority the added block sat at 0 and the profile
+// NetManager injected at 1 stayed [CURRENT]).
+func TestWpaAddNetworkVia(t *testing.T) {
+	var calls [][]string
+	run := func(args ...string) string {
+		calls = append(calls, args)
+		if args[0] == "add_network" {
+			return "3"
+		}
+		return "OK"
+	}
+	if !wpaAddNetworkVia(run, "MyNet", "supersecret", false) {
+		t.Fatal("wpaAddNetworkVia returned false on a healthy sequence")
+	}
+	find := func(want ...string) int {
+		for i, c := range calls {
+			if len(c) != len(want) {
+				continue
+			}
+			match := true
+			for j := range c {
+				if c[j] != want[j] {
+					match = false
+					break
+				}
+			}
+			if match {
+				return i
+			}
+		}
+		t.Fatalf("call %v missing in %v", want, calls)
+		return -1
+	}
+	prio := find("set_network", "3", "priority", "10")
+	enable := find("enable_network", "3")
+	sel := find("select_network", "3")
+	save := find("save_config")
+	if prio > enable || prio > sel {
+		t.Errorf("priority must be set before enable/select: %v", calls)
+	}
+	if save != len(calls)-1 {
+		t.Errorf("save_config must be the last call: %v", calls)
+	}
+
+	// A failed add_network aborts the sequence before any set_network.
+	calls = nil
+	failRun := func(args ...string) string {
+		calls = append(calls, args)
+		return "FAIL"
+	}
+	if wpaAddNetworkVia(failRun, "MyNet", "supersecret", false) {
+		t.Error("wpaAddNetworkVia must return false when add_network fails")
+	}
+	if len(calls) != 1 {
+		t.Errorf("no commands may follow a failed add_network: %v", calls)
 	}
 }
 

--- a/usb-stick/run.sh
+++ b/usb-stick/run.sh
@@ -1547,6 +1547,74 @@ WLAN_SOURCE=""
 # credential channel was empty on the next boot, and the box dropped
 # straight into Setup-AP. Centralising persistence here means every
 # M-winner benefits without per-branch boilerplate.
+
+# assert_profile_priority makes the JUST-PROVISIONED network the one the
+# firmware prefers, in NetManager's own store. #697: a deliberate switch left
+# the OLD profile at priority="1" while the new one landed at "0" (NetManager
+# adds at 0), so the box silently rejoined the old network on the next boot.
+# The reporter proved the end state on his own box: chosen high, others zero.
+# Runs ONLY in a provisioning run's winner path, right after persist_wlan_creds,
+# never on an ordinary boot, so a network change made elsewhere later is not
+# fought. The agent applies the same ranking on a runtime switch; this covers
+# the first switch to a never-stored network, whose profile only exists in the
+# store AFTER NetManager processed the add in this very run.
+#
+# awk with RS=">", not sed: the profile tags in the field file span several
+# lines (the #697 report shows the attributes on separate lines), and record-
+# splitting on the tag terminator makes each tag one record regardless of its
+# line layout. Everything outside the matched priority attribute is passed
+# through byte for byte; the store's AES ciphertext attributes must survive
+# untouched. The SSID comparison is literal (index, not regex) so metacharacters
+# in a network name cannot derail it, and the attribute NAME is matched in
+# either case while the value must match exactly.
+assert_profile_priority() {
+    [ -n "$SSID" ] || return 0
+    for _pp_f in /mnt/nv/BoseApp-Persistence/*/NetworkProfiles.xml; do
+        [ -s "$_pp_f" ] || continue
+        grep -q "<profile " "$_pp_f" 2>/dev/null || continue
+        awk -v want="$SSID" '
+            BEGIN { RS = ">"; ORS = ">" }
+            {
+                rec = $0
+                if (rec ~ /^[ \t\r\n]*<profile /) {
+                    lower = tolower(rec)
+                    hit = 0
+                    # literal SSID match against SSID="..."/ssid="..."
+                    pat = "ssid=\"" tolower(want) "\""
+                    if (index(lower, pat) > 0) hit = 1
+                    pri = hit ? "10" : "0"
+                    if (rec ~ /priority[ \t\r\n]*=[ \t\r\n]*"[^"]*"/) {
+                        sub(/priority[ \t\r\n]*=[ \t\r\n]*"[^"]*"/, "priority=\"" pri "\"", rec)
+                    } else {
+                        sub(/^([ \t\r\n]*<profile )/, "&priority=\"" pri "\" ", rec)
+                    }
+                }
+                printf "%s", rec ORS
+            }
+        ' "$_pp_f" > "$_pp_f.strnew" 2>/dev/null
+        # awk appends one trailing ORS the file did not have; drop the last byte
+        # only when the original did not end in the terminator.
+        if [ -s "$_pp_f.strnew" ]; then
+            _pp_orig_tail=$(tail -c 1 "$_pp_f" 2>/dev/null)
+            if [ "$_pp_orig_tail" != ">" ]; then
+                # trim the synthetic trailing ">" via head on byte count
+                _pp_len=$(wc -c < "$_pp_f.strnew")
+                head -c "$((_pp_len - 1))" "$_pp_f.strnew" > "$_pp_f.strnew2" 2>/dev/null \
+                    && mv "$_pp_f.strnew2" "$_pp_f.strnew"
+            fi
+            if ! cmp -s "$_pp_f" "$_pp_f.strnew"; then
+                mv "$_pp_f.strnew" "$_pp_f" && sync 2>/dev/null
+                setup_log "profile-priority: '$SSID' outranked in $(basename "$(dirname "$_pp_f")")/NetworkProfiles.xml (#697)"
+            else
+                rm -f "$_pp_f.strnew" 2>/dev/null
+            fi
+        else
+            rm -f "$_pp_f.strnew" 2>/dev/null
+        fi
+    done
+    return 0
+}
+
 persist_wlan_creds() {
     [ -n "$SSID" ] || return 0
     [ -n "$PASS" ] || return 0
@@ -3064,7 +3132,7 @@ WPAEOF
     # TFR left the box with no credential source at all.
     case "$WINNER" in
         none|ethernet-only) ;;
-        *) persist_wlan_creds ;;
+        *) persist_wlan_creds; assert_profile_priority ;;
     esac
 
     # Last-resort AirplayConfiguration reboot for NON-BCO boxes: if no
@@ -3163,6 +3231,34 @@ fi
 mount | grep -q '/etc/hosts' || {
     cp /etc/hosts /tmp/hosts.original 2>/dev/null
     cp /etc/hosts /tmp/hosts.live 2>/dev/null
+    # #698: a box migrated from OpenCloudTouch still carries that mod's
+    # "# OCT-START".."# OCT-END" redirect block (Bose hostnames -> the mod's
+    # LAN server) in the persistent /etc/hosts on the read-only rootfs.
+    # Seeded verbatim it wins first-match resolution over STR's appended
+    # block: the reporter's ST10 had BoseApp and STSCertified in SYN_SENT
+    # against the dead OCT server on every boot. Strip it from the LIVE copy
+    # before the bind mount so even the resolutions between now and agent
+    # start are clean; the agent's hosts.Apply repeats the filter more
+    # generically at start. hosts.original deliberately keeps the block: it
+    # is the detection evidence for the "OpenCloudTouch leftovers" warning.
+    # The persistent file itself stays untouched. Cleaning it would mean
+    # remounting the rootfs rw, which is firmware bending and off the table
+    # by standing rule; do not "improve" this that way. Neutralizing the
+    # live copy each boot is the fix.
+    # Both markers must exist before the range delete runs: with no matching
+    # end address sed deletes to end of file, which would swallow every line
+    # below the opening marker (the same guard hosts.Apply has in Go). A
+    # truncated block is left for the agent's per-line filter instead.
+    if grep -q '^# OCT-START' /tmp/hosts.live 2>/dev/null \
+       && grep -q '^# OCT-END' /tmp/hosts.live 2>/dev/null; then
+        if sed '/^# OCT-START/,/^# OCT-END/d' /tmp/hosts.live > /tmp/hosts.live.new 2>/dev/null \
+           && mv /tmp/hosts.live.new /tmp/hosts.live 2>/dev/null; then
+            log "OpenCloudTouch hosts redirect block stripped from live hosts copy (#698)"
+        else
+            rm -f /tmp/hosts.live.new 2>/dev/null
+            log "OCT hosts strip: sed/mv failed, live hosts left as copied (agent filters at start)"
+        fi
+    fi
     mount --bind /tmp/hosts.live /etc/hosts 2>/dev/null
 }
 


### PR DESCRIPTION
Three reports from 2026-08-24, two of them from a reporter who root-caused his own speaker with wpa_cli and netstat and whose measured repairs served as the specification.

## #697: after a Wi-Fi switch the OLD network stayed preferred

The switch never outranked the old profile anywhere: NetManager's store kept the old SSID at priority 1 over the new one's 0, and NetManager injects stored profiles into the running supplicant, where STR's block carried no priority and lost the selection — exactly the reporter's `list_networks` output. Fixed at three sites: a confirmed switch rewrites the priorities in `NetworkProfiles.xml` (touching ONLY priority values, ciphertext byte-preserved, idempotent, never on rollback), `buildWPAConfig` emits an explicit high priority, and the wpa_cli fallback sets it before `save_config`. The old profile is demoted, never deleted — the wrong-password rollback depends on it. `run.sh`'s provisioning winner path asserts the same ranking, closing the first-switch window where the profile only exists after that boot's own add. The awk rewrite was tested against the reporter's exact multi-line file shape, and the CI shellcheck gate was replicated locally (exit 0).

## #698: OpenCloudTouch redirects survived the migration

The persistent hosts file kept OCT's marked block (13 Bose hostnames → a dead LAN server); STR composed its live file FROM that base and appended its own block BELOW it, and first-match-wins resolution let the dead redirects keep winning — BoseApp and STSCertified in permanent SYN_SENT. Fixed entirely inside STR's own tmpfs composition (**no firmware bending** — the reporter's rw-remount repair is explicitly named in a comment as the path this project does not take): the marked block is stripped with an unterminated-block guard, plus generically any Bose cloud hostname mapped to a non-loopback, non-STR address. OCT is now detected like AfterTouch, and bundles show live hosts, original, and exactly what was filtered.

## #696: hold-saved presets lost their artwork to the grey chevron

The long-press save persisted the speaker-internal loopback art URL (`127.0.0.1:8888/art?u=…`); from the user's machine that is dead, the tile fell back to DuckDuckGo's icon service, and DDG answers an unknown host with a grey-chevron IMAGE on a 404, which the webview drew as the logo. The one surviving station (WDCB) has a stream host DDG knows. The save now takes the same path as a plus-button save; wrapped loopback art is unwrapped at save, render, and by an agent-side heal, so poisoned keys recover on their own where the station is still findable.

## Review notes

Adversarial review per track. It caught, among others: a **privacy issue** (the reporter's real LAN IP hardcoded 16× in test fixtures, plus his username in a comment — replaced with documentation addresses), an unterminated-OCT-block sed that would have swallowed every line below the marker, and an artwork-recovery overclaim that was then actually fixed rather than reworded.

## Verification

ARM cross-build, 31 root packages, desktop build + vet, 175 frontend tests, shellcheck with CI's exact flags. **Agent-runtime changes throughout: fleet verification via str-fleet-test before the next release.** Known adjacency: open PR #671 touches `wlan.go` in the same area and will conflict; the pieces are complementary (#671 = runtime retirement + boot re-switch, this = deterministic ranking #671 deferred).

Fixes #697, fixes #698, fixes #696