### PR TITLE
fix: 2026-08-25 sweep batch (foreign preset survives restarts, recently-played badge on the right speaker)

### DIFF
--- a/cmd/agent/foreignpresets.go
+++ b/cmd/agent/foreignpresets.go
@@ -86,19 +86,28 @@ func isForeignBoxPreset(location string) bool {
 	return location != "" && !isOwnBoxPresetLocation(location) && !isNativeRadioLocation(location)
 }
 
-// NoteBoxList ingests a FULL box preset report (gabbo presetsUpdated frame or
-// the boot seed read) and replaces the foreign set with what the report says.
+// NoteBoxList ingests a box preset report (gabbo presetsUpdated frame or the
+// boot seed read) and updates the foreign set from what the report says.
 //
-// An EMPTY report while entries are held is deliberately ignored: the known
-// firmware wipe (the box dropping its whole list around a re-login) reports
-// exactly that, and honouring it would erase the memory this store exists to
-// keep. A foreign slot therefore only disappears when a NON-empty report no
-// longer carries it - e.g. the user overwrote the slot with an STR preset.
+// A held foreign slot is dropped ONLY when the report assigns that slot to
+// something else (the one gesture that exists: the slot was overwritten). A
+// report that merely does not mention the slot keeps it: around a reboot or
+// re-onboarding the box emits PARTIAL lists while it rebuilds its own store,
+// and trusting one of those erased the memory this store exists to keep
+// (field case 2026-08-24: the boot-window frame carried only the STR slots,
+// the Deezer slot 3 fell out of the store and the next cloud re-read starved
+// it off the box for good). The fully-empty firmware-wipe report is just the
+// extreme partial list and is kept by the same rule.
 func (s *foreignPresetStore) NoteBoxList(bps []webui.BoxPreset) {
 	fresh := map[int]foreignPreset{}
+	reported := map[int]bool{}
 	for _, p := range bps {
+		if p.Slot < 1 || p.Slot > 6 {
+			continue
+		}
+		reported[p.Slot] = true
 		loc := xmlEntityUnescape(p.Location)
-		if p.Slot < 1 || p.Slot > 6 || !isForeignBoxPreset(loc) {
+		if !isForeignBoxPreset(loc) {
 			continue
 		}
 		fresh[p.Slot] = foreignPreset{
@@ -112,8 +121,10 @@ func (s *foreignPresetStore) NoteBoxList(bps []webui.BoxPreset) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if len(bps) == 0 && len(s.entries) > 0 {
-		return
+	for slot, e := range s.entries {
+		if !reported[slot] {
+			fresh[slot] = e
+		}
 	}
 	if reflect.DeepEqual(fresh, s.entries) {
 		return // no change, no NAND write (presetsUpdated arrives in bursts)

--- a/cmd/agent/foreignpresets_test.go
+++ b/cmd/agent/foreignpresets_test.go
@@ -38,10 +38,11 @@ func TestIsForeignBoxPreset(t *testing.T) {
 	}
 }
 
-// A full box report replaces the foreign set: STR-written slots are ignored,
-// foreign ones are kept, and a later NON-empty report without a slot drops it
-// (the user overwrote it), while an EMPTY report - the firmware wipe shape -
-// must not erase anything.
+// A box report updates the foreign set: STR-written slots are ignored, foreign
+// ones are kept, and a held slot is dropped only when a report ASSIGNS it to
+// something else. Reports that do not mention a held slot - the empty
+// firmware-wipe shape and the partial lists the box emits while rebuilding its
+// store around a reboot - must not erase anything.
 func TestForeignStoreNoteBoxList(t *testing.T) {
 	s := testForeignStore(t)
 	s.NoteBoxList([]webui.BoxPreset{
@@ -59,7 +60,18 @@ func TestForeignStoreNoteBoxList(t *testing.T) {
 		t.Fatalf("empty report erased the preservation, got %+v", got)
 	}
 
-	// Non-empty report without slot 3: the user overwrote it, so it goes.
+	// Partial non-empty report that does not mention slot 3 (the boot-window
+	// shape from the 2026-08-24 field bundle): the held slot must survive.
+	s.NoteBoxList([]webui.BoxPreset{
+		{Slot: 1, Source: "LOCAL_INTERNET_RADIO", Type: "stationurl", Location: "/station?data=x", Name: "France Inter"},
+		{Slot: 4, Source: "UPNP", Type: "audio", Location: "http://127.0.0.1:8888/stream/4", Name: "Europe 2"},
+	})
+	if got := s.MargePresets(nil); len(got) != 1 || got[0].ID != 3 {
+		t.Fatalf("partial report erased the held slot, got %+v", got)
+	}
+
+	// A report assigning slot 3 to something else: the user overwrote it, so
+	// it goes.
 	s.NoteBoxList([]webui.BoxPreset{
 		{Slot: 3, Source: "UPNP", Type: "audio", Location: "http://127.0.0.1:8888/stream/3", Name: "Now STR"},
 	})

--- a/desktop-app/app_discovery.go
+++ b/desktop-app/app_discovery.go
@@ -441,9 +441,23 @@ func (a *App) mergeDiscoveryCacheWith(seen map[string]BoxInfo, presenceOnly map[
 			continue
 		}
 		// Same physical box found at a NEW IP this cycle -> this cached record is its
-		// dead old IP. Evict it so the speaker shows once, at its live address.
+		// dead old IP. Carry its display identity over to the live record first:
+		// a speaker that comes back from an install/reboot on a fresh DHCP lease
+		// has no cache entry at the new IP, so the fresh record arrives thin
+		// (agent up, name not readable yet) and deleting the old record with it
+		// threw the name memory away. The tile then renamed to the technical
+		// fallback ("STR-xxxxxx" / "str-<ip>") until the box could serve its
+		// name again (#709, triple-ST10 install). Then evict the dead IP so the
+		// speaker shows once, at its live address.
 		if e.box.DeviceID != "" {
 			if liveHost, moved := freshDevices[e.box.DeviceID]; moved && liveHost != key {
+				if cur, ok := a.discCache[liveHost]; ok {
+					cur.box = mergeBoxInfo(e.box, cur.box)
+					a.discCache[liveHost] = cur
+					if _, inSeen := seen[liveHost]; inSeen {
+						seen[liveHost] = cur.box
+					}
+				}
 				delete(a.discCache, key)
 				continue
 			}

--- a/desktop-app/detection_test.go
+++ b/desktop-app/detection_test.go
@@ -288,6 +288,40 @@ func TestDiscoveryDropsStaleIPWhenDeviceMovesToNewIP(t *testing.T) {
 	}
 }
 
+// A device that moves to a new IP mid-reboot arrives THIN (agent answering, name
+// not readable yet). The dead old-IP record must hand its display identity over
+// before it is evicted, or the tile renames to the technical fallback until the
+// box can serve its name again (#709, triple-ST10 install on fresh DHCP leases).
+func TestDiscoveryCarriesNameToNewIP(t *testing.T) {
+	a := &App{
+		discCache: map[string]discEntry{
+			"192.168.0.50": {box: BoxInfo{Kind: "stock", Host: "192.168.0.50", DeviceID: "DEV#MOVE", FriendlyName: "Bose 1", Model: "SoundTouch 10"}, seen: time.Now()},
+		},
+	}
+	// The post-install cycle finds the SAME device at a new IP, freshly flashed:
+	// STR agent up, but no FriendlyName served yet.
+	seen := map[string]BoxInfo{
+		"192.168.0.77": {Kind: "str", Host: "192.168.0.77", DeviceID: "DEV#MOVE", Name: "str-192.168.0.77"},
+	}
+	a.mergeDiscoveryCache(seen)
+	live, ok := seen["192.168.0.77"]
+	if !ok {
+		t.Fatalf("live new-IP entry missing from the returned list")
+	}
+	if live.FriendlyName != "Bose 1" {
+		t.Errorf("FriendlyName = %q, want the old-IP record's %q carried over", live.FriendlyName, "Bose 1")
+	}
+	if live.Kind != "str" || live.Host != "192.168.0.77" {
+		t.Errorf("carried-over identity must not touch Kind/Host, got %+v", live)
+	}
+	if cached := a.discCache["192.168.0.77"].box; cached.FriendlyName != "Bose 1" {
+		t.Errorf("cache at the new IP must carry the name too, got %q", cached.FriendlyName)
+	}
+	if _, stale := a.discCache["192.168.0.50"]; stale {
+		t.Errorf("dead old-IP entry must still be evicted")
+	}
+}
+
 // A cached box the current cycle simply missed (still at the SAME IP, just a flaky
 // cycle) must NOT be evicted by the dedup: only a genuine move to a new IP drops it.
 func TestDiscoveryKeepsCachedBoxOnFlakyCycleSameIP(t *testing.T) {

--- a/desktop-app/frontend/src/recentbadge.test.js
+++ b/desktop-app/frontend/src/recentbadge.test.js
@@ -1,0 +1,47 @@
+// The Recently-played "now playing" badge belongs to the CURRENT speaker only.
+//
+// Field evidence (#710, 2026-08-24, three-ST10 bundle): speaker A (the app's
+// current box) played "Exclusively Rush"; the user scoped the Recently-played
+// view to speaker B, whose history also contains a Rush card from an earlier
+// session. state.nowName describes speaker A, but cardIsPlaying compared every
+// card against it regardless of the card's box, so speaker B's Rush card wore
+// the green badge while B was actually playing "101 SMOOTH JAZZ".
+import { describe, it, expect, beforeEach } from 'vitest';
+import { state } from './state.js';
+import { cardIsPlaying } from './views/recent.js';
+
+const boxA = { deviceID: 'DEV-A', host: '192.0.2.10', port: 8888 };
+const boxB = { deviceID: 'DEV-B', host: '192.0.2.11', port: 8888 };
+
+function radioCard(boxKey, name) {
+  return { boxKey, source: 'radio', name, url: 'http://example.com/' + name };
+}
+
+describe('cardIsPlaying box scoping', () => {
+  beforeEach(() => {
+    state.currentBox = boxA;
+    state.nowName = 'Exclusively Rush';
+    state.nowLocation = '';
+    state.nowSpotifySlot = null;
+  });
+
+  it('matches a card on the current speaker by now-playing name', () => {
+    expect(cardIsPlaying(radioCard('DEV-A', 'Exclusively Rush'))).toBe(true);
+  });
+
+  it('never matches a card from another speaker (the #710 wrong badge)', () => {
+    expect(cardIsPlaying(radioCard('DEV-B', 'Exclusively Rush'))).toBe(false);
+  });
+
+  it('matches nothing when no speaker is current', () => {
+    state.currentBox = null;
+    expect(cardIsPlaying(radioCard('DEV-A', 'Exclusively Rush'))).toBe(false);
+  });
+
+  it('keys host:port speakers without a deviceID consistently', () => {
+    state.currentBox = { host: '192.0.2.11', port: 8888 };
+    state.nowName = 'X';
+    expect(cardIsPlaying(radioCard('192.0.2.11:8888', 'X'))).toBe(true);
+    expect(cardIsPlaying(radioCard('192.0.2.10:8888', 'X'))).toBe(false);
+  });
+});

--- a/desktop-app/frontend/src/views/recent.js
+++ b/desktop-app/frontend/src/views/recent.js
@@ -214,7 +214,15 @@ function cardWebURL(c) {
 // (or the remembered slot, so a next/prev that drops the slot still counts)
 // against the card's preset slot, since nowName for Spotify is the song, not the
 // playlist. Best-effort: a card with no matching preset slot cannot be matched.
-function cardIsPlaying(c) {
+//
+// state.nowName / nowLocation describe the CURRENT speaker only, so a card from
+// any other speaker can never match them: without this guard, viewing speaker
+// B's history while speaker A plays a station that also sits in B's history put
+// the badge on the wrong card (#710). A non-current speaker's cards simply show
+// no badge; polling every box's now-playing just for it is not worth the box
+// traffic.
+export function cardIsPlaying(c) {
+  if (!state.currentBox || c.boxKey !== recentBoxKey(state.currentBox)) return false;
   const loc = state.nowLocation || '';
   if (c.source === 'spotify') {
     if (!/\/spotify\/stream/.test(loc)) return false;


### PR DESCRIPTION
## What

A preset the user stored on the speaker itself for a service STR does not serve (Deezer Flow in the field case, same shape for TuneIn or STORED_MUSIC slots) vanished from the hardware key after a reboot or re-onboarding, even though the foreign-preset store exists precisely to preserve it.

## Why

`foreignPresetStore.NoteBoxList` replaced its memory with every non-empty box preset report. Around a reboot the box emits partial lists while it rebuilds its own store. The 2026-08-24 Portable field bundle shows it end to end: the persisted store loads with the Deezer slot (count=1) at 23:38:24, a boot-window gabbo frame carrying only the STR slots erases it at 23:38:41 (count=0), and the box's next cloud re-read then starves slot 3 off the speaker for good. The existing guard only covered the fully empty wipe report.

## How

A held foreign slot is now dropped only when a report assigns that slot to something else, which is the one gesture that actually exists on these speakers (slots can be overwritten, never cleared). A report that merely does not mention the slot keeps it; the empty wipe report is the extreme case of the same rule.

## Testing

- New subtest: a partial non-empty report without the held slot keeps it. Proven red on the old code.
- Existing subtests (empty wipe report, overwrite drops the slot, persistence, escaping) unchanged and green.
- `make build-arm` and `go test ./cmd/agent/` green.

The field case arrived by mail (Portable, Deezer Flow on key 3), no GitHub issue to link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Third fix: name survives an IP move (`11f4a0a`)

`mergeDiscoveryCacheWith`'s new-IP dedup evicted the cached record at the dead old IP outright. A speaker that comes back from an install/reboot on a fresh DHCP lease arrives thin at the new IP (agent answering, FriendlyName not readable yet), so the name memory died with the old record and the tile renamed to the technical fallback (`STR-xxxxxx` / `str-<ip>`) until the box could serve its name again. Reported as "name of speaker was slightly renamed into something strange" in the #709 triple-ST10 install. The dead record now hands its display identity to the live one via `mergeBoxInfo` before eviction. Test proven red on the old code; full `go test` green.
