### PR TITLE
fix: preset key never wears the DDG chevron; phone search logs the query and retries narrow

### DIFF
--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -5506,25 +5506,32 @@ function renderPresets() {
         p.art = adoptIcon;
         SetPreset(state.currentBox.host, state.currentBox.port, p.slot, p.name, p.stream_url, adoptIcon, p.bitrate || 0, p.homepage || '', p.codec || '').catch(() => {});
       }
-      const streamHost = extractHost(p.stream_url);
-      const hostsToTry = [];
-      if (streamHost) hostsToTry.push(streamHost);
-      const streamRoot = rootDomain(streamHost);
-      if (streamRoot && streamRoot !== streamHost) hostsToTry.push(streamRoot);
-      for (const h of hostsToTry) {
-        for (const svc of iconServicesFor(h)) {
-          if (!presetCandidates.includes(svc)) presetCandidates.push(svc);
-        }
+      // Render through the same Go-validated hydration the search and
+      // Recently-played tiles use (logoImgTag + ResolveStationLogo): the raw
+      // data-fallbacks cascade cannot reject DuckDuckGo's grey "no icon"
+      // chevron, which the icon service serves as a real image on its 404, so
+      // a station with no logo anywhere wore the chevron on its key while the
+      // search row for the same station correctly fell back to the letter
+      // tile (#696, EPIC CLASSICAL). Spotify keeps its self-contained glyph, a
+      // data URI that needs no resolution. The first DIRECT art candidate is
+      // handed over as the favicon to validate; icon-service entries stored in
+      // older chains are dropped here because the resolver rederives them from
+      // the hosts, status-checked.
+      let logo;
+      if (p.type === 'spotify') {
+        logo = `<img class="preset-logo" alt="" src="${escapeAttr(presetCandidates[0] || SPOTIFY_LOGO)}"/>`;
+      } else {
+        const directArt = presetCandidates.find(
+          (c) => /^https?:\/\//i.test(c) && !c.startsWith('https://icons.duckduckgo.com/')
+        ) || '';
+        logo = logoImgTag({
+          name: p.name,
+          favicon: directArt,
+          homepage: p.homepage || '',
+          url: p.stream_url || '',
+          url_resolved: p.stream_url || '',
+        }, 'preset-logo');
       }
-      // Terminal fallback: a locally generated monogram (data URI, always
-      // loads), appended last so a station with a missing or broken logo ends
-      // on a clean letter tile instead of a broken-image icon. Spotify keeps
-      // its own logo as the first candidate; the monogram only shows if even
-      // that fails.
-      presetCandidates.push(monogramDataUri(p.name));
-      const logo =
-        `<img class="preset-logo" alt="" src="${escapeAttr(presetCandidates[0])}"
-              data-fallbacks="${escapeAttr(presetCandidates.slice(1).join('|'))}"/>`;
       // The active tile mirrors the live now-playing bitrate even when the
       // stored preset bitrate is still 0 (preset saved before the bitrate
       // feature, or radio-browser had none). Persist it so the tile keeps

--- a/desktop-app/frontend/src/presetart.test.js
+++ b/desktop-app/frontend/src/presetart.test.js
@@ -121,6 +121,17 @@ describe('main.js persists no box-form art (#696)', () => {
     // store; the tile must not feed it to the <img> cascade as-is.
     expect(src).toContain('addCands(appArtFromBoxArt(p.art));');
   });
+  it('the tile renders through the validated hydration, not the raw cascade', () => {
+    // The raw data-fallbacks cascade cannot reject DuckDuckGo's grey "no
+    // icon" chevron (served as a real image on its 404), so a station with no
+    // logo anywhere wore the chevron on its key while the search row for the
+    // same station fell back to the letter tile (#696, EPIC CLASSICAL). The
+    // grid must build its radio tiles with logoImgTag, and nothing may
+    // produce a data-fallbacks img any more.
+    expect(src).toContain("logoImgTag({");
+    expect(src, 'a raw data-fallbacks producer is back in main.js')
+      .not.toContain('data-fallbacks="');
+  });
   it('the logo healer treats box-form art as needing a real re-lookup', () => {
     // A key whose stored art is only box-local renders artless everywhere but
     // the box itself, and a key still carrying the wrapper unwraps to a single

--- a/internal/webui/librarysearch.go
+++ b/internal/webui/librarysearch.go
@@ -241,17 +241,31 @@ func (s *Server) searchOneServer(ctx context.Context, srv dlna.Server, q string)
 			res, err = narrow, nil
 		} else {
 			s.logger.Info("library search: Search action unavailable, walking the tree (bounded)",
-				"server", srv.FriendlyName, "err", err, "titleOnlyErr", nerr)
+				"server", srv.FriendlyName, "q", q, "err", err, "titleOnlyErr", nerr)
+		}
+	} else if len(res.Items) == 0 {
+		// A 200 with zero hits is not proof of absence either: the FRITZ!Box
+		// index answers "Fly FRITZ!" with zero and "Fly FRITZ" with one for
+		// the same track, and the widened boolean criteria has its own quirks
+		// per server. One narrow retry is a single cheap SOAP call next to the
+		// walk it can save.
+		if narrow, nerr := dlna.SearchTitleOnly(ctx, srv, q, librarySearchMax); nerr == nil && len(narrow.Items) > 0 {
+			res = narrow
 		}
 	}
 	if err == nil && len(res.Items) > 0 {
 		s.logger.Info("library search: server answered the Search action",
-			"server", srv.FriendlyName, "hits", len(res.Items), "total", res.TotalMatches)
+			"server", srv.FriendlyName, "q", q, "hits", len(res.Items), "total", res.TotalMatches)
 		return res.Items, res.TotalMatches > len(res.Items)
 	}
 	if err == nil {
+		// The query rides along because a bundle without it cannot separate
+		// "the server's index has no such tag" from a search quirk: #666's
+		// bundle carried three zero-hit walks and no way to tell which (the
+		// search matches TAGS, while the folder view the user compares against
+		// shows file names).
 		s.logger.Info("library search: Search answered nothing, walking the tree (bounded)",
-			"server", srv.FriendlyName)
+			"server", srv.FriendlyName, "q", q)
 	}
 	return s.walkOneServer(ctx, srv, q)
 }
@@ -400,6 +414,6 @@ func (s *Server) walkOneServer(ctx context.Context, srv dlna.Server, q string) (
 		partial = true
 	}
 	s.logger.Info("library search: bounded walk finished",
-		"server", srv.FriendlyName, "browses", browses, "hits", len(out), "partial", partial)
+		"server", srv.FriendlyName, "q", q, "browses", browses, "hits", len(out), "partial", partial)
 	return out, partial
 }

--- a/internal/webui/librarysearch_test.go
+++ b/internal/webui/librarysearch_test.go
@@ -27,6 +27,10 @@ type fakeCDS struct {
 	// searchHits is what the Search action answers with. Zero items with no
 	// fault is the FRITZ!Box shape that used to end the search.
 	searchHits []fakeTrack
+	// narrowHits, when set, is what a TITLE-ONLY Search (criteria without
+	// upnp:artist) answers: the #666 QNAP shape where the widened boolean
+	// criteria comes back empty while the narrow form hits.
+	narrowHits []fakeTrack
 	// searchFaults makes Search answer a SOAP fault, the Synology shape.
 	searchFaults bool
 	// children maps an object id to its children. Items are paged with the
@@ -74,6 +78,10 @@ func (f *fakeCDS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			// UPnPError 501, what a server without SearchCaps answers.
 			w.WriteHeader(http.StatusInternalServerError)
 			io.WriteString(w, `<?xml version="1.0"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Body><s:Fault><faultcode>s:Client</faultcode><detail><UPnPError xmlns="urn:schemas-upnp-org:control-1-0"><errorCode>501</errorCode></UPnPError></detail></s:Fault></s:Body></s:Envelope>`)
+			return
+		}
+		if f.narrowHits != nil && !strings.Contains(string(body), "upnp:artist") {
+			writeSOAP(w, "Search", didl(nil, f.narrowHits), len(f.narrowHits), len(f.narrowHits))
 			return
 		}
 		writeSOAP(w, "Search", didl(nil, f.searchHits), len(f.searchHits), len(f.searchHits))
@@ -202,6 +210,31 @@ func TestLibrarySearchFallsBackWhenSearchAnswersNothing(t *testing.T) {
 	items, _ := s.searchOneServer(context.Background(), srv, "symbol")
 	if len(items) != 1 || items[0].Title != "symbol" {
 		t.Fatalf("the deep, late track was not found: got %d items %+v", len(items), items)
+	}
+}
+
+// A widened Search that answers 200 with zero hits gets one narrow retry
+// before the walk is paid: per-server criteria quirks make the boolean form
+// answer empty where the title-only form hits (#666's QNAP walked three times
+// for nothing on a query its server could have answered). The walk must not
+// run at all when the retry hits.
+func TestLibrarySearchRetriesNarrowWhenWidenedAnswersNothing(t *testing.T) {
+	f := &fakeCDS{
+		narrowHits: []fakeTrack{{id: "n1", title: "symbol", artist: "Adrianne Lenker",
+			album: "abysskiss", url: "http://192.0.2.9/symbol.mp3"}},
+		children: map[string]fakeContainer{"0": {}},
+	}
+	s, srv := testSearchServer(t, f)
+	items, partial := s.searchOneServer(context.Background(), srv, "symbol")
+	if len(items) != 1 || items[0].Title != "symbol" {
+		t.Fatalf("narrow retry hit not returned: got %d items %+v", len(items), items)
+	}
+	if partial {
+		t.Fatalf("a full narrow answer must not be reported partial")
+	}
+	searches, browses := f.counts()
+	if searches != 2 || browses != 0 {
+		t.Fatalf("want exactly 2 searches (widened + narrow) and no walk, got searches=%d browses=%d", searches, browses)
 	}
 }
 


### PR DESCRIPTION
Two fixes from tonight's post-v0.9.57 reports.

**#696 (chevron on the key):** the preset grid still rendered logos through the raw `data-fallbacks` img cascade, which cannot reject DuckDuckGo's grey no-icon chevron (served as a real image on the 404). EPIC CLASSICAL - Classical Guitar has no favicon in the directory, a broken favicon on its homepage (HTTP 523) and no DDG icon for either host, so the key wore the chevron while the search row (Go-validated hydration) fell back to the letter tile. Radio/queue tiles now render through `logoImgTag` + `ResolveStationLogo`; Spotify keeps its glyph. Source-level guard against a returning `data-fallbacks` producer.

**#666 (search forensics):** the bundle carried three zero-hit walks with no way to tell whether the server's index lacked the tag or the widened criteria hit a server quirk, because the query was never logged and a 200-with-zero Search went straight to the walk. The query now rides on every search log line, and an empty widened answer gets one cheap title-only retry (red-proven with the QNAP shape: widened empty, narrow hits, walk not paid). Walk budgets untouched.

vitest 192 green, go test ./internal/webui green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)