### PR TITLE
fix(wifi): live network switch refreshes the speaker's own state (#697)

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -593,6 +593,10 @@ func run() error {
 	// the codename at least still sits in some routers' caches. So the name is
 	// only handed over once it means something, and a responder that cannot
 	// start leaves everything exactly as it is today.
+	// Captured for the post-switch network refresh (#697): after a live Wi-Fi
+	// move the responder must be repointed at the new address, or it keeps
+	// answering the box's own name with the boot address, cache-flush bit set.
+	var mdnsHostResp *mdnshost.Responder
 	if label := mdnshost.LabelFor(deviceID); label != "" {
 		if ip := routableIPv4(); ip != nil {
 			if resp, err := mdnshost.Start(context.Background(), logger.With("comp", "mdnshost"), label, ip); err != nil {
@@ -607,6 +611,7 @@ func run() error {
 				// the desktop app takes the address out of the service answer
 				// instead of looking the name up.
 				mdnsHostLabel = resp.Label()
+				mdnsHostResp = resp
 				// Put the counters in the diagnostic bundle. The open question
 				// they answer: a SoundTouch 30 here is missing from four
 				// browses in a row while its engine runs and is logged in. If
@@ -1216,6 +1221,31 @@ func run() error {
 		n, _ := ann.Snapshot()
 		return n
 	}
+	// The roster's second self-signal: the deviceID this agent announces. Same
+	// value the announcer carries in its TXT record, so an entry adopted from
+	// our own stale announcement compares equal even under a placeholder name
+	// and an address we no longer hold (#697).
+	peerSelfDeviceIDFn = func() string { return deviceID }
+	// Post-switch network refresh (#697): fired by the webui after a CONFIRMED
+	// live Wi-Fi switch. Runs on its own goroutine (the webui hook spawns it)
+	// and waits for the new DHCP lease itself before repointing the mDNS
+	// responder, re-registering the announcer, purging the roster's stale
+	// self-entries, and deleting REDIRECT rules for addresses no longer held.
+	webuiSrv.SetNetworkChangedFn(func(reason string) {
+		refreshAfterNetworkChange(reason, netRefreshDeps{
+			setMDNSHostAddr: func(ip net.IP) {
+				if mdnsHostResp != nil {
+					mdnsHostResp.SetAddress(ip)
+				}
+			},
+			reannounce: func(r string) error {
+				mdnsMu.Lock()
+				ann := mdnsAnnouncer
+				mdnsMu.Unlock()
+				return ann.Reannounce(r)
+			},
+		}, logger)
+	})
 	webuiSrv.SetBoxNameFn(func() (string, string) {
 		mdnsMu.Lock()
 		ann := mdnsAnnouncer

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1238,6 +1238,12 @@ func run() error {
 					mdnsHostResp.SetAddress(ip)
 				}
 			},
+			currentMDNSAddr: func() net.IP {
+				if mdnsHostResp == nil {
+					return nil
+				}
+				return mdnsHostResp.Addr()
+			},
 			reannounce: func(r string) error {
 				mdnsMu.Lock()
 				ann := mdnsAnnouncer

--- a/cmd/agent/netrefresh.go
+++ b/cmd/agent/netrefresh.go
@@ -1,0 +1,164 @@
+package main
+
+// Post-switch network state refresh (#697).
+//
+// A live Wi-Fi switch (the wpaConfirmed arm in internal/webui/wlan.go, and the
+// boot guard's finishCorrection) can land the box on a NEW address, and until
+// v0.9.57 nothing derived from the old one was ever told: the mDNS host
+// responder and the service announcer kept answering with the boot address,
+// the peer roster then re-adopted that stale self-announcement as a peer and
+// dialed the dead address every sweep, and the per-IP REDIRECT rules from
+// run.sh piled up for both addresses. Only a cold boot healed all three
+// (field report on #697, ST20 moved 192.168.178.x -> 10.10.50.x live).
+//
+// The refresh is self-computing: everything stale is recognisable as "carries
+// our identity or our rule shape, but not one of our CURRENT addresses", so no
+// pre-switch snapshot has to survive the switch.
+
+import (
+	"log/slog"
+	"net"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/JRpersonal/streborn/internal/netutil"
+)
+
+// netRefreshDeps is what the refresh needs from run()'s wiring. Funcs rather
+// than the objects themselves: the mDNS announcer and host responder are
+// locals of run(), guarded by its own mutexes.
+type netRefreshDeps struct {
+	// setMDNSHostAddr repoints the A-record responder for str-<id>.local
+	// (mdnshost.Responder.SetAddress). nil when the responder never started;
+	// SetAddress itself no-ops and re-announces only on an actual change.
+	setMDNSHostAddr func(ip net.IP)
+	// reannounce tears down and re-registers the service announcer with
+	// freshly picked interfaces and addresses (discovery.Announcer.Reannounce).
+	reannounce func(reason string) error
+}
+
+// refreshAfterNetworkChange runs on its own goroutine, fired by the webui's
+// networkChangedFn hook right after renewDHCPLease. The udhcpc renew is
+// asynchronous, so the first job is waiting for the lease to actually land.
+func refreshAfterNetworkChange(reason string, deps netRefreshDeps, logger *slog.Logger) {
+	logger = logger.With("comp", "netrefresh")
+	ip := waitForLeaseAfterSwitch(45*time.Second, 2*time.Second)
+	if ip == nil {
+		logger.Warn("network refresh: no LAN address after the switch, refreshing with what there is", "reason", reason)
+	} else {
+		logger.Info("network refresh: address settled", "reason", reason, "address", ip.String())
+	}
+	if deps.setMDNSHostAddr != nil && ip != nil {
+		deps.setMDNSHostAddr(ip)
+	}
+	if deps.reannounce != nil {
+		if err := deps.reannounce("network change: " + reason); err != nil {
+			logger.Warn("network refresh: mDNS re-announce failed", "err", err)
+		}
+	}
+	purgeSelfPeers(logger)
+	cleanupStaleRedirects(logger)
+}
+
+// waitForLeaseAfterSwitch polls the primary LAN address until it CHANGES from
+// what it read first (with one confirming read, since a mid-renew gap can
+// surface transient values), or the budget runs out. A switch inside the same
+// subnet legitimately keeps the same address, so running out of budget is the
+// normal outcome there, not a failure; the refresh steps behind it are
+// idempotent either way.
+func waitForLeaseAfterSwitch(budget, step time.Duration) net.IP {
+	start := netutil.FirstLANIPv4()
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		time.Sleep(step)
+		cur := netutil.FirstLANIPv4()
+		if cur == nil {
+			continue // interface mid-renew
+		}
+		if start == nil || !cur.Equal(start) {
+			time.Sleep(step)
+			if again := netutil.FirstLANIPv4(); again != nil && again.Equal(cur) {
+				return cur
+			}
+		}
+	}
+	return netutil.FirstLANIPv4()
+}
+
+// strRedirectPorts are the destination ports of the REDIRECT rules run.sh
+// installs with a -d <LANIP> scope (REDIRECT_PORTS plus the BCO 17008->8888
+// rule). Only rules matching this tuple shape are ever touched.
+var strRedirectPorts = map[string]bool{
+	"8888": true, "9080": true, "8081": true, "8443": true, "17008": true,
+}
+
+// staleRedirectDeleteArgs parses `iptables -w -t nat -S PREROUTING` output and
+// returns the argument vectors that delete every streborn-shaped REDIRECT rule
+// whose -d address is not one of ours any more. Pure, for tests.
+//
+// run.sh installs the rules idempotently per (port, LANIP) tuple and its 30 s
+// watchdog re-resolves the CURRENT address each pass, so after a live subnet
+// move the old-IP rules linger next to the new-IP ones until reboot. The
+// xt_comment marker is absent on kernels without the module (taigan), so the
+// match is on the tuple shape, never on the comment; replaying the -S line
+// with -A swapped for -D matches the rule exactly as iptables holds it,
+// comment or not.
+func staleRedirectDeleteArgs(rules string, own map[string]bool) [][]string {
+	var out [][]string
+	for _, line := range strings.Split(rules, "\n") {
+		tok := strings.Fields(strings.TrimSpace(line))
+		if len(tok) < 4 || tok[0] != "-A" || tok[1] != "PREROUTING" {
+			continue
+		}
+		dst, dport, redirect := "", "", false
+		for i := 0; i < len(tok); i++ {
+			switch tok[i] {
+			case "-d":
+				if i+1 < len(tok) {
+					dst = strings.TrimSuffix(tok[i+1], "/32")
+				}
+			case "--dport":
+				if i+1 < len(tok) {
+					dport = tok[i+1]
+				}
+			case "-j":
+				if i+1 < len(tok) && tok[i+1] == "REDIRECT" {
+					redirect = true
+				}
+			}
+		}
+		if !redirect || dst == "" || !strRedirectPorts[dport] || own[dst] {
+			continue
+		}
+		args := append([]string{"-w", "-t", "nat", "-D"}, tok[1:]...)
+		out = append(out, args)
+	}
+	return out
+}
+
+// cleanupStaleRedirects removes the REDIRECT rules scoped to addresses this
+// box no longer holds. First place the agent itself touches iptables; scope
+// is deletion-only, tuple-matched, and only for -d addresses outside
+// ownIPv4s(), so the current rules and anything non-STR stay untouched.
+// A dev host without iptables (or a box without the nat table) is a no-op.
+func cleanupStaleRedirects(logger *slog.Logger) {
+	ipt, err := exec.LookPath("iptables")
+	if err != nil {
+		return
+	}
+	out, err := exec.Command(ipt, "-w", "-t", "nat", "-S", "PREROUTING").CombinedOutput()
+	if err != nil {
+		logger.Debug("network refresh: could not list nat PREROUTING", "err", err)
+		return
+	}
+	for _, args := range staleRedirectDeleteArgs(string(out), ownIPv4s()) {
+		if derr := exec.Command(ipt, args...).Run(); derr != nil {
+			logger.Warn("network refresh: could not delete a stale REDIRECT rule",
+				"rule", strings.Join(args, " "), "err", derr)
+		} else {
+			logger.Info("network refresh: deleted a REDIRECT rule for a previous address",
+				"rule", strings.Join(args, " "))
+		}
+	}
+}

--- a/cmd/agent/netrefresh.go
+++ b/cmd/agent/netrefresh.go
@@ -33,6 +33,11 @@ type netRefreshDeps struct {
 	// (mdnshost.Responder.SetAddress). nil when the responder never started;
 	// SetAddress itself no-ops and re-announces only on an actual change.
 	setMDNSHostAddr func(ip net.IP)
+	// currentMDNSAddr reports the address the responder hands out right now
+	// (mdnshost.Responder.Addr), nil when the responder never started. Used to
+	// recognise a confirmed switch that kept the address, where tearing down a
+	// working registration would only risk losing it.
+	currentMDNSAddr func() net.IP
 	// reannounce tears down and re-registers the service announcer with
 	// freshly picked interfaces and addresses (discovery.Announcer.Reannounce).
 	reannounce func(reason string) error
@@ -43,21 +48,55 @@ type netRefreshDeps struct {
 // asynchronous, so the first job is waiting for the lease to actually land.
 func refreshAfterNetworkChange(reason string, deps netRefreshDeps, logger *slog.Logger) {
 	logger = logger.With("comp", "netrefresh")
+	// Two-stage wait, both bounded, same goroutine: 45 s at a tight cadence
+	// for the common fast renew, then a slow tail for a DHCP server that
+	// answers late, which is exactly the network where live switches happen.
 	ip := waitForLeaseAfterSwitch(45*time.Second, 2*time.Second)
 	if ip == nil {
-		logger.Warn("network refresh: no LAN address after the switch, refreshing with what there is", "reason", reason)
-	} else {
-		logger.Info("network refresh: address settled", "reason", reason, "address", ip.String())
+		logger.Warn("network refresh: no LAN address yet, keeping a slow watch before touching anything", "reason", reason)
+		ip = waitForLeaseAfterSwitch(4*time.Minute, 5*time.Second)
 	}
-	if deps.setMDNSHostAddr != nil && ip != nil {
+	// The stale-self purge is address-independent and safe in every outcome.
+	purgeSelfPeers(logger)
+	if ip == nil {
+		// Never tear working state down while the box holds no address at all:
+		// a failed re-register would leave the box announcing NOTHING, which
+		// is strictly worse than the stale announcement (adversarial review of
+		// d842293), and deleting REDIRECT rules against an empty own-address
+		// set would drop them ALL. The pre-switch state stays; the wlan guard
+		// or a reboot handles a network that stays down this long.
+		logger.Warn("network refresh: still no LAN address, leaving mDNS and REDIRECT rules untouched", "reason", reason)
+		return
+	}
+	logger.Info("network refresh: address settled", "reason", reason, "address", ip.String())
+	// A confirmed switch that KEPT the address (same-subnet move, password
+	// correction) has nothing stale to re-announce, and a teardown at the most
+	// network-unstable moment risks ending unregistered for nothing.
+	if deps.currentMDNSAddr != nil {
+		if cur := deps.currentMDNSAddr(); cur != nil && cur.Equal(ip.To4()) {
+			logger.Info("network refresh: address unchanged, mDNS left as it is", "address", ip.String())
+			cleanupStaleRedirects(logger)
+			return
+		}
+	}
+	if deps.setMDNSHostAddr != nil {
 		deps.setMDNSHostAddr(ip)
 	}
 	if deps.reannounce != nil {
-		if err := deps.reannounce("network change: " + reason); err != nil {
-			logger.Warn("network refresh: mDNS re-announce failed", "err", err)
+		// Bounded retries: reannounce tears down before it registers, and a
+		// register at this moment can fail transiently (multicast join while
+		// the interface is still replumbing). One failure must not leave the
+		// box unannounced until the next rename or reboot.
+		for attempt, wait := range []time.Duration{0, 10 * time.Second, 30 * time.Second} {
+			time.Sleep(wait)
+			err := deps.reannounce("network change: " + reason)
+			if err == nil {
+				break
+			}
+			logger.Warn("network refresh: mDNS re-announce failed",
+				"attempt", attempt+1, "err", err)
 		}
 	}
-	purgeSelfPeers(logger)
 	cleanupStaleRedirects(logger)
 }
 

--- a/cmd/agent/netrefresh_test.go
+++ b/cmd/agent/netrefresh_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The stale-rule selector must delete exactly the streborn-shaped REDIRECT
+// rules whose -d address the box no longer holds: nothing for current
+// addresses, nothing for foreign ports, nothing that is not a REDIRECT, and
+// the comment-less taigan shape must match just like the commented one (#697).
+func TestStaleRedirectDeleteArgs(t *testing.T) {
+	rules := strings.Join([]string{
+		"-P PREROUTING ACCEPT",
+		// stale, commented (xt_comment kernels)
+		`-A PREROUTING -d 192.168.178.174/32 ! -i lo -p tcp -m tcp --dport 8888 -m comment --comment streborn-redirect -j REDIRECT --to-ports 8888`,
+		// stale, comment-less (taigan)
+		`-A PREROUTING -d 192.168.178.174/32 ! -i lo -p tcp -m tcp --dport 17008 -j REDIRECT --to-ports 8888`,
+		// current address: keep
+		`-A PREROUTING -d 10.10.50.101/32 ! -i lo -p tcp -m tcp --dport 8888 -m comment --comment streborn-redirect -j REDIRECT --to-ports 8888`,
+		// stale address but a port that is not ours: keep
+		`-A PREROUTING -d 192.168.178.174/32 ! -i lo -p tcp -m tcp --dport 5000 -j REDIRECT --to-ports 5000`,
+		// stale address but not a REDIRECT: keep
+		`-A PREROUTING -d 192.168.178.174/32 -p tcp -m tcp --dport 8888 -j DNAT --to-destination 127.0.0.1:9080`,
+		// no -d at all: keep
+		`-A PREROUTING -p tcp -m tcp --dport 17008 -j REDIRECT --to-ports 8888`,
+	}, "\n")
+	own := map[string]bool{"10.10.50.101": true, "127.0.0.1": true}
+
+	got := staleRedirectDeleteArgs(rules, own)
+	if len(got) != 2 {
+		t.Fatalf("want exactly the two stale streborn rules deleted, got %d: %v", len(got), got)
+	}
+	for _, args := range got {
+		joined := strings.Join(args, " ")
+		if !strings.HasPrefix(joined, "-w -t nat -D PREROUTING ") {
+			t.Errorf("delete must replay the rule with -D: %q", joined)
+		}
+		if !strings.Contains(joined, "-d 192.168.178.174/32") {
+			t.Errorf("delete must target only the stale address: %q", joined)
+		}
+	}
+	// The comment-less rule must be replayed WITHOUT comment args, or -D
+	// cannot match it on a taigan kernel.
+	if strings.Contains(strings.Join(got[1], " "), "comment") {
+		t.Errorf("comment-less rule replayed with comment args: %v", got[1])
+	}
+}
+
+// purgeSelfPeers must drop entries that carry this speaker's own deviceID even
+// under a placeholder name (the #697 shape: the box's stale self-announcement
+// re-adopted at the old address as "str-<old-ip>"), plus name-matching ones,
+// and leave real peers alone.
+func TestPurgeSelfPeers(t *testing.T) {
+	prevDev, prevName := peerSelfDeviceIDFn, peerSelfNameFn
+	defer func() { peerSelfDeviceIDFn, peerSelfNameFn = prevDev, prevName }()
+	peerSelfDeviceIDFn = func() string { return "AABBCCDDEEFF" }
+	peerSelfNameFn = func() string { return "Küche" }
+
+	peersMu.Lock()
+	peersByIP = map[string]*peerEntry{
+		"192.168.178.174": {name: "str-192.168.178.174", deviceID: "AABBCCDDEEFF", lastSeen: time.Now()}, // self, placeholder name
+		"192.168.178.175": {name: "Küche", lastSeen: time.Now()},                                         // self by name, no deviceID
+		"10.10.50.100":    {name: "Wohnzimmer", deviceID: "112233445566", lastSeen: time.Now()},          // a real peer
+	}
+	peersBrowseAt = time.Now()
+	peersMu.Unlock()
+
+	purgeSelfPeers(slog.Default())
+
+	peersMu.Lock()
+	defer peersMu.Unlock()
+	if len(peersByIP) != 1 {
+		t.Fatalf("want only the real peer left, got %d entries: %v", len(peersByIP), peersByIP)
+	}
+	if _, ok := peersByIP["10.10.50.100"]; !ok {
+		t.Fatalf("the real peer was purged")
+	}
+	if !peersBrowseAt.IsZero() {
+		t.Errorf("purge must force a fresh sweep on the next browse")
+	}
+}

--- a/cmd/agent/netrefresh_test.go
+++ b/cmd/agent/netrefresh_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/JRpersonal/streborn/internal/webui"
 )
 
 // The stale-rule selector must delete exactly the streborn-shaped REDIRECT
@@ -46,6 +48,40 @@ func TestStaleRedirectDeleteArgs(t *testing.T) {
 	// cannot match it on a taigan kernel.
 	if strings.Contains(strings.Join(got[1], " "), "comment") {
 		t.Errorf("comment-less rule replayed with comment args: %v", got[1])
+	}
+}
+
+// A seed that is really this box itself at a previous address must be dropped:
+// after a live switch the app's roster can still carry the old IP, and a seed
+// re-created the stale self-entry the refresh had just purged, with reachable
+// forced true (#697, adversarial review of d842293). Both identity forms must
+// hold, the deviceID (new apps) and the display name (apps that send none).
+func TestSeedPeersDropsSelf(t *testing.T) {
+	prevDev, prevName := peerSelfDeviceIDFn, peerSelfNameFn
+	defer func() { peerSelfDeviceIDFn, peerSelfNameFn = prevDev, prevName }()
+	peerSelfDeviceIDFn = func() string { return "AABBCCDDEEFF" }
+	peerSelfNameFn = func() string { return "Küche" }
+	peersMu.Lock()
+	peersByIP = map[string]*peerEntry{}
+	peersMu.Unlock()
+
+	seedPeers([]webui.PeerSeed{
+		{Name: "str-192.168.178.174", Host: "192.168.178.174", Port: 8888, DeviceID: "AABBCCDDEEFF"}, // self by deviceID
+		{Name: "Küche", Host: "192.168.178.175", Port: 8888},                                         // self by name, legacy app
+		{Name: "Wohnzimmer", Host: "10.10.50.100", Port: 17008, DeviceID: "112233445566"},            // a real peer
+	}, slog.Default())
+
+	peersMu.Lock()
+	defer peersMu.Unlock()
+	if len(peersByIP) != 1 {
+		t.Fatalf("want only the real peer adopted, got %d entries: %v", len(peersByIP), peersByIP)
+	}
+	e, ok := peersByIP["10.10.50.100"]
+	if !ok {
+		t.Fatalf("the real peer was not adopted")
+	}
+	if e.deviceID != "112233445566" {
+		t.Errorf("the seed's deviceID must be kept for the self-guards, got %q", e.deviceID)
 	}
 }
 

--- a/cmd/agent/peers.go
+++ b/cmd/agent/peers.go
@@ -222,6 +222,11 @@ func seedPeers(seeds []webui.PeerSeed, logger *slog.Logger) {
 		return
 	}
 	mine := ownIPv4s()
+	selfDev := peerSelfDeviceID()
+	selfName := ""
+	if peerSelfNameFn != nil {
+		selfName = strings.TrimSpace(peerSelfNameFn())
+	}
 	now := time.Now()
 	peersMu.Lock()
 	added := 0
@@ -230,11 +235,25 @@ func seedPeers(seeds []webui.PeerSeed, logger *slog.Logger) {
 		if ip == "" || mine[ip] {
 			continue
 		}
+		// A seed can be this box ITSELF at an address it no longer holds: right
+		// after a live network switch the app's roster still carries the old IP
+		// for a moment, and a seed re-created exactly the stale self-entry the
+		// switch refresh had just purged, with reachable forced true and no
+		// deviceID for the other guards to catch (#697). The identity check
+		// mirrors the browse path: announced deviceID first, display name as
+		// the fallback for apps that send no deviceID yet.
+		if (selfDev != "" && s.DeviceID == selfDev) ||
+			(selfName != "" && strings.EqualFold(strings.TrimSpace(s.Name), selfName)) {
+			continue
+		}
 		e := peersByIP[ip]
 		if e == nil {
 			e = &peerEntry{}
 			peersByIP[ip] = e
 			added++
+		}
+		if s.DeviceID != "" && e.deviceID == "" {
+			e.deviceID = s.DeviceID
 		}
 		// Same guard as the mDNS merge: a placeholder seed must never clobber a
 		// real name (#494 by the back door).

--- a/cmd/agent/peers.go
+++ b/cmd/agent/peers.go
@@ -172,6 +172,51 @@ func savePersistedPeersLocked(logger *slog.Logger) {
 // announcer, which is the same source the version envelope uses.
 var peerSelfNameFn func() string
 
+// peerSelfDeviceIDFn reports this speaker's own announced deviceID: the one
+// signal that survives BOTH an address change and a placeholder name. The
+// name-based self-purge below missed exactly that combination after a live
+// subnet move (#697): the box's own stale announcement came back with the old
+// IP and the "str-<ip>" placeholder, so the roster adopted the box as its own
+// peer and dialed the dead address every sweep. Wired at startup from the same
+// value the announcer puts into its TXT record, so the comparison is against
+// what the stale announcement actually carries.
+var peerSelfDeviceIDFn func() string
+
+func peerSelfDeviceID() string {
+	if peerSelfDeviceIDFn == nil {
+		return ""
+	}
+	return strings.TrimSpace(peerSelfDeviceIDFn())
+}
+
+// purgeSelfPeers drops every roster entry that is really this speaker (by
+// announced deviceID or display name), persists immediately, and forces the
+// next browse to run a fresh mDNS sweep. Called from the post-switch network
+// refresh: the entry for the address the box just left would otherwise be
+// re-dialed every sweep until its 12 h TTL.
+func purgeSelfPeers(logger *slog.Logger) {
+	selfDev := peerSelfDeviceID()
+	selfName := ""
+	if peerSelfNameFn != nil {
+		selfName = strings.TrimSpace(peerSelfNameFn())
+	}
+	peersMu.Lock()
+	defer peersMu.Unlock()
+	removed := 0
+	for ip, e := range peersByIP {
+		if (selfDev != "" && e.deviceID == selfDev) ||
+			(selfName != "" && strings.EqualFold(e.name, selfName)) {
+			delete(peersByIP, ip)
+			removed++
+		}
+	}
+	if removed > 0 {
+		savePersistedPeersLocked(logger)
+		logger.Info("peers: dropped stale entries for this speaker itself", "removed", removed)
+	}
+	peersBrowseAt = time.Time{} // next browsePeers call sweeps fresh
+}
+
 func seedPeers(seeds []webui.PeerSeed, logger *slog.Logger) {
 	if len(seeds) == 0 {
 		return
@@ -357,6 +402,16 @@ func browsePeers(ctx context.Context, logger *slog.Logger) []webui.PeerLink {
 						ip = a
 					}
 				}
+				// The current-address check cannot recognise our own STALE
+				// announcement: after a live subnet move the multicast caches
+				// (and our own frozen registration, until the re-announce
+				// lands) still carry the OLD address, which is no longer
+				// "mine", so the box adopted itself as a peer and dialed the
+				// dead address every sweep (#697). The announced deviceID is
+				// ours no matter which address the record carries.
+				if selfDev := peerSelfDeviceID(); selfDev != "" && inst.DeviceID == selfDev {
+					self = true
+				}
 				if self || ip == "" {
 					continue
 				}
@@ -463,6 +518,13 @@ func browsePeers(ctx context.Context, logger *slog.Logger) []webui.PeerLink {
 		// until the entry aged out (seen live on an ST30, 2026-07-28). Our own
 		// name is the one signal that survives an address change.
 		if selfName != "" && strings.EqualFold(e.name, selfName) {
+			delete(peersByIP, ip)
+			continue
+		}
+		// And by deviceID, which also survives a PLACEHOLDER name: the stale
+		// self-entry after a live subnet move carried "str-<old-ip>" and sailed
+		// past the name check above (#697).
+		if selfDev := peerSelfDeviceID(); selfDev != "" && e.deviceID == selfDev {
 			delete(peersByIP, ip)
 			continue
 		}

--- a/desktop-app/discovery_coldstart.go
+++ b/desktop-app/discovery_coldstart.go
@@ -143,6 +143,12 @@ func (a *App) distributeKnownSpeakers() {
 		Name string `json:"name"`
 		Host string `json:"host"`
 		Port int    `json:"port"`
+		// DeviceID lets the receiving agent recognise a seed that is really
+		// itself at an address it no longer holds (#697): after a live network
+		// switch the app's roster can briefly still carry the box's old IP, and
+		// a seed without identity re-created exactly the stale self-entry the
+		// agent had just purged.
+		DeviceID string `json:"deviceID,omitempty"`
 	}
 	a.discMu.Lock()
 	var seeds []seed
@@ -169,7 +175,7 @@ func (a *App) distributeKnownSpeakers() {
 		if name == "" {
 			name = b.Name
 		}
-		s := seed{Name: name, Host: b.Host, Port: port}
+		s := seed{Name: name, Host: b.Host, Port: port, DeviceID: b.DeviceID}
 		seeds = append(seeds, s)
 		targets = append(targets, s)
 	}

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -223,6 +223,22 @@ func (a *Announcer) reannounceLocked(reason, oldV, newV string) error {
 	return a.register()
 }
 
+// Reannounce tears the registration down and registers again with freshly
+// picked interfaces and addresses. UpdateFriendlyName/UpdateModel re-announce
+// only when their VALUE changes; this is the address-triggered entry point
+// for a live network move (#697): registration freezes the A records at
+// register time, so a speaker that changed subnet keeps announcing its old
+// address, and the roster then adopts that stale self-announcement as a peer,
+// until someone calls this.
+func (a *Announcer) Reannounce(reason string) error {
+	if a == nil {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.reannounceLocked(reason, "", "")
+}
+
 // UpdateFriendlyName updates the display name in the TXT record and
 // re-announces both service types. No-op if the name has not changed.
 func (a *Announcer) UpdateFriendlyName(name string) error {

--- a/internal/mdnshost/mdnshost.go
+++ b/internal/mdnshost/mdnshost.go
@@ -161,6 +161,15 @@ func (r *Responder) Name() string { return strings.TrimSuffix(r.fqdn, ".") }
 // already ends in ".local" produces "<name>.local.local".
 func (r *Responder) Label() string { return r.label }
 
+// Addr reports the address the responder currently hands out, so the network
+// refresh can tell a switch that kept the address (nothing to re-announce)
+// from one that moved it (#697).
+func (r *Responder) Addr() net.IP {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.ip
+}
+
 // SetAddress updates the address handed out, for a speaker that changes network.
 func (r *Responder) SetAddress(ip net.IP) {
 	if ip == nil || ip.To4() == nil {

--- a/internal/webui/options.go
+++ b/internal/webui/options.go
@@ -29,6 +29,15 @@ func (s *Server) SetWifiSignalFn(fn func() string) { s.wifiSignalFn = fn }
 // this after the announcer is up.
 func (s *Server) SetBoxNameFn(fn func() (name, model string)) { s.boxNameFn = fn }
 
+// SetNetworkChangedFn wires the post-switch state refresh (#697): called after
+// a CONFIRMED live Wi-Fi switch (the wpaConfirmed arm and the boot guard's
+// finishCorrection), once the DHCP renew has been requested. cmd/agent owns
+// the refresh because the stale state lives there: the mDNS announcers frozen
+// on the boot address, the peer roster's self-entry at the old IP, and the
+// per-IP REDIRECT rules. The callback is invoked on its own goroutine; it is
+// expected to wait for the new lease itself.
+func (s *Server) SetNetworkChangedFn(fn func(reason string)) { s.networkChangedFn = fn }
+
 // SetNativePresetLocatorFn wires the decision of whether a preset slot can be
 // stored as a native LOCAL_INTERNET_RADIO station instead of a UPnP stream.
 // The function returns the orion station location, or "" when the box has not

--- a/internal/webui/options.go
+++ b/internal/webui/options.go
@@ -259,6 +259,10 @@ type PeerSeed struct {
 	Name string `json:"name"`
 	Host string `json:"host"`
 	Port int    `json:"port"`
+	// DeviceID identifies the seeded speaker independently of its address, so
+	// the agent can drop a seed that is really itself at a previous address
+	// (#697). Optional: apps predating it send none.
+	DeviceID string `json:"deviceID,omitempty"`
 }
 
 // WithPeerSeed registers the sink for externally pushed peers (POST

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -117,6 +117,9 @@ type Server struct {
 	// peersFn lists the other STR speakers on the LAN for the on-box page's
 	// "Other speakers" section. nil hides the section.
 	peersFn func(ctx context.Context) []PeerLink
+	// networkChangedFn is the post-switch state refresh, fired after a
+	// CONFIRMED live Wi-Fi switch (see SetNetworkChangedFn). nil = no refresh.
+	networkChangedFn func(reason string)
 	// spotifyUser returns go-librespot's currently logged-in account, used to
 	// stamp the account onto a newly saved Spotify preset. nil when Spotify
 	// is not configured.

--- a/internal/webui/wlan.go
+++ b/internal/webui/wlan.go
@@ -293,6 +293,16 @@ func (s *Server) applyWLANChange(iface, mech, ssid, password string, hidden bool
 			// is why the wpaCannotApply and rollback arms never touch it.
 			s.raiseFirmwareProfilePriority(ssid)
 			renewDHCPLease()
+			// The switch can land the box on a NEW address (another subnet's
+			// DHCP), and everything derived from the old one goes stale: the
+			// mDNS announcers keep answering with the boot address, the peer
+			// roster then re-adopts that stale self-announcement as a peer and
+			// dials it forever, and the per-IP REDIRECT rules pile up for both
+			// addresses (#697; only a cold boot healed all three). The refresh
+			// runs on its own goroutine and waits for the new lease itself.
+			if s.networkChangedFn != nil {
+				go s.networkChangedFn("live switch")
+			}
 		case wpaCannotApply:
 			// The conf could not be written live (read-only /etc and the
 			// bind-mount overlay both failed). The new creds are already on NAND,

--- a/internal/webui/wlanguard.go
+++ b/internal/webui/wlanguard.go
@@ -262,6 +262,12 @@ func (s *Server) finishCorrection(ctx context.Context, iface string, tgt wlanTar
 	s.logger.Warn("wlan guard: the speaker came up on another network and was moved back",
 		"wantTag", ssidTag(tgt.SSID), "gotTag", ssidTag(cameUpOn), "attempt", attempt)
 	noteWlanTargetVerdict("moved-back", budgetReset)
+	// Same refresh as the user-initiated live switch (#697): the guard's move
+	// changes the address just as much, and hooking only the wpaConfirmed arm
+	// would leave the boot-guard path with the stale mDNS/peers/REDIRECT state.
+	if s.networkChangedFn != nil {
+		go s.networkChangedFn("wlan guard correction")
+	}
 }
 
 // wlanGuardWeakVerify is the BCO/scm chassis (taigan Portable, mojo ST30).


### PR DESCRIPTION
Implements the immediate post-switch refresh confirmed on #697: after a live Wi-Fi switch the agent now waits for the new DHCP lease, repoints the str-<id>.local responder, re-registers the mDNS announcer (new exported `Announcer.Reannounce`), purges peer-roster entries that are really the box itself (deviceID + name, permanent guards on the browse, listing AND seed paths), and deletes iptables REDIRECT rules whose `-d` address the box no longer holds (tuple-matched `-S` replay, comment-less taigan shape included; `run.sh`/`iptables-setup.sh` untouched).

Built with an ultracode understand pass (4 subsystem maps) and hardened by an adversarial review workflow (4 lenses, refute-verify); all four confirmed findings are fixed in the second commit (bounded reannounce retries, bounded slow lease tail + never tearing down while addressless, same-address short-circuit, deviceID-carrying app seeds).

Not covered, noted on #697: a stereo pair's stored MasterIP / marge group XML still carries pair-time addresses.

Hardware note: the live subnet move itself is not reproducible on my fleet tonight (needs a second SSID/VLAN); the reporter has the exact setup and a retest ask is drafted.

Tests: staleRedirectDeleteArgs table (commented + comment-less shapes), purgeSelfPeers, seed self-guard (red-proven), full agent/webui/mdnshost/discovery suites, make build-arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)