### PR TITLE
fix(relnotes): subject stays listed next to its trailers

### DIFF
--- a/cmd/relnotes/main.go
+++ b/cmd/relnotes/main.go
@@ -152,12 +152,17 @@ func collect(start, end string) ([]change, error) {
 			continue
 		}
 		subject, body, _ := strings.Cut(rest, "\t")
-		// Trailers REPLACE the subject, they do not add to it. A commit that
-		// spells out its user-visible changes has already said what it wants
-		// said, and listing its subject as well produced pairs of near-identical
-		// lines, which reads as sloppiness in the one place users actually look.
-		// A commit that wants its subject listed too simply repeats it as a
-		// trailer.
+		// The subject is ALWAYS listed (when it is a user-facing type), and
+		// trailers ADD entries. Trailers used to REPLACE the subject, on the
+		// theory that a commit spelling out its changes had already said what
+		// it wants said; in practice that rule swallowed real entries three
+		// times in one day (2026-08-25): a commit fixing one thing and carrying
+		// a Release-Note trailer for a DIFFERENT change it also made lost its
+		// own subject line, silently. A commit that fixes one thing does not
+		// think of itself as "declaring entries". Exact repeats are folded by
+		// the type|scope|summary dedup below, so an author who restates the
+		// subject as a trailer still gets one line; an author who wants the
+		// subject GONE says so with a Release-Note-Drop.
 		// Withdrawals are read FIRST and unconditionally: a commit whose only
 		// purpose is to take back an entry carries no trailers of its own, and
 		// reading drops inside the trailer branch silently ignored exactly that
@@ -165,14 +170,10 @@ func collect(start, end string) ([]change, error) {
 		for _, d := range parseNoteDrops(body) {
 			dropped[strings.ToLower(d)] = true
 		}
-		trailers := parseNoteTrailers(body)
-		if len(trailers) == 0 {
-			if c, keep := parseSubject(subject); keep {
-				add(c, hash)
-			}
-			continue
+		if c, keep := parseSubject(subject); keep {
+			add(c, hash)
 		}
-		for _, c := range trailers {
+		for _, c := range parseNoteTrailers(body) {
 			add(c, hash)
 		}
 	}

--- a/cmd/relnotes/main_test.go
+++ b/cmd/relnotes/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 )
@@ -99,19 +101,59 @@ func TestParseNoteTrailers(t *testing.T) {
 	}
 }
 
-// A commit that declares its own entries has said what it wants said; listing
-// its subject as well produced near-duplicate lines in the user-facing notes.
-func TestTrailersReplaceTheSubject(t *testing.T) {
-	body := "Prose.\n\nRelease-Note: fix(app): the precise thing that changed\n"
-	got := parseNoteTrailers(body)
-	if len(got) != 1 || got[0].Summary != "The precise thing that changed" {
-		t.Fatalf("trailer parse: %+v", got)
+// Trailers ADD entries next to the subject, they do not replace it. The old
+// replace rule swallowed real entries three times in one day (2026-08-25): a
+// fix commit carrying a Release-Note trailer for a DIFFERENT change it also
+// made lost its own subject line silently. An exact restatement still folds to
+// one line via the dedup, and a chore commit still contributes only its
+// trailers because its subject is not a user-facing type.
+func TestSubjectAndTrailersBothListed(t *testing.T) {
+	run := func(t *testing.T, log string) []change {
+		t.Helper()
+		dir := t.TempDir()
+		git := func(args ...string) {
+			cmd := exec.Command("git", args...)
+			cmd.Dir = dir
+			cmd.Env = append(os.Environ(),
+				"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+				"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git %v: %v\n%s", args, err, out)
+			}
+		}
+		git("init", "-q")
+		git("commit", "--allow-empty", "-q", "-m", log)
+		old, _ := os.Getwd()
+		_ = os.Chdir(dir)
+		defer func() { _ = os.Chdir(old) }()
+		got, err := collect("", "HEAD")
+		if err != nil {
+			t.Fatalf("collect: %v", err)
+		}
+		return got
 	}
-	// The replacement itself lives in collect(); this documents the contract so
-	// a future change that re-adds the subject fails a test rather than a reader.
-	if c, keep := parseSubject("feat(update): a broader restatement of the same thing"); !keep || c.Summary == got[0].Summary {
-		t.Log("subject and trailer are distinct texts, which is exactly why both being listed read as duplication")
-	}
+
+	t.Run("fix subject plus foreign trailer yields two lines", func(t *testing.T) {
+		got := run(t, "fix(app): the thing this commit is about\n\n"+
+			"Release-Note: fix(phone): the other thing it also changed\n")
+		if len(got) != 2 {
+			t.Fatalf("want subject AND trailer, got %d: %+v", len(got), got)
+		}
+	})
+	t.Run("exact restatement folds to one line", func(t *testing.T) {
+		got := run(t, "fix(app): the thing this commit is about\n\n"+
+			"Release-Note: fix(app): the thing this commit is about\n")
+		if len(got) != 1 {
+			t.Fatalf("want the restatement deduped, got %d: %+v", len(got), got)
+		}
+	})
+	t.Run("chore subject stays out, its trailers stay in", func(t *testing.T) {
+		got := run(t, "chore(relnotes): bookkeeping\n\n"+
+			"Release-Note: fix(app): the restored entry\n")
+		if len(got) != 1 || got[0].Summary != "The restored entry" {
+			t.Fatalf("want only the trailer, got %+v", got)
+		}
+	})
 }
 
 // Work announced and then reversed inside the same release window must not be


### PR DESCRIPTION
Trailers replaced the subject, which swallowed real entries three times on 2026-08-25 (a fix commit with a Release-Note trailer for a second change it also made lost its own line); docs/RELEASE-NOTES.md had always documented trailers as ADDING. Subject is now always parsed (user-facing types only), trailers add, exact restatements dedup, Release-Note-Drop stays the deliberate removal. New collect()-level test over a real git repo covers the three shapes; the pipeline-visible effect on the pending range is nil (the chore trailers dedup against the restored subjects). The commit drops its own subject from the notes via its own trailer, relnotes is not a user-facing surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)