### PR TITLE
fix(phone): added media server appears in the browse section immediately

### DIFF
--- a/internal/webui/assets/index.html
+++ b/internal/webui/assets/index.html
@@ -1358,6 +1358,12 @@ async function toggleMusicLib(s, btn) {
   musicLibBusy = false;
   btn.disabled = false;
   loadMusicLib();
+  /* The Find tab's browse buttons come straight from the registered store, so
+     an added server is usable there IMMEDIATELY, minutes before the speaker's
+     own source list catches up. Without this refresh, "added, the speaker
+     needs a few minutes" was the only feedback, and two reporters in one day
+     (#721, and mic62 on #666) read that as nothing having happened. */
+  loadBrowseServers().catch(function(){});
 }
 
 // inputLabel prefers what the speaker calls the socket, because that is what


### PR DESCRIPTION
Follow-up to #723, driven by #721's diagnostic and mic62 on #666: every add succeeded agent-side (the speaker acked the source each time), but the only feedback was the needs-a-few-minutes note, which read as failure. The Find tab's browse buttons render from the registered store, so the card now refreshes them right after a successful add. Page script node-checked, phone marker tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)