### PR TITLE
fix(phone): media browser reaches a server the speaker cannot find by multicast

### DIFF
--- a/dlna/searchhost.go
+++ b/dlna/searchhost.go
@@ -1,0 +1,98 @@
+package dlna
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+)
+
+// searchHostPort is the SSDP port a unicast search targets. A variable only
+// so the test can stand in a responder on an ephemeral port; real callers
+// always hit 1900.
+var searchHostPort = 1900
+
+// SearchHost probes ONE host for a MediaServer with a unicast M-SEARCH to
+// its :1900. UPnP 1.1 defines unicast search exactly for this: it reaches a
+// server whose multicast traffic never arrives, and APs or routers that
+// filter multicast between Wi-Fi and wire are precisely the networks a
+// speaker sits in while the desktop app on the wire still sees the server
+// (#726). The caller supplies the host; on the speaker that is the firmware's
+// own discovery cache (/listMediaServers), which learns addresses from the
+// server's periodic NOTIFY announcements and so survives filters that
+// swallow the agent's own M-SEARCH round.
+func SearchHost(ctx context.Context, host string, timeout time.Duration) ([]Server, error) {
+	if timeout <= 0 {
+		timeout = 3 * time.Second
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || ip.To4() == nil {
+		return nil, fmt.Errorf("searchhost: not an IPv4 address: %q", host)
+	}
+	dctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	conn, err := net.ListenUDP("udp4", nil)
+	if err != nil {
+		return nil, fmt.Errorf("searchhost: listen: %w", err)
+	}
+	defer conn.Close()
+
+	target := &net.UDPAddr{IP: ip.To4(), Port: searchHostPort}
+	hostPort := net.JoinHostPort(ip.To4().String(), strconv.Itoa(searchHostPort))
+	mkMsg := func(st string) []byte {
+		return []byte("M-SEARCH * HTTP/1.1\r\n" +
+			"HOST: " + hostPort + "\r\n" +
+			"MAN: \"ssdp:discover\"\r\n" +
+			fmt.Sprintf("MX: %d\r\n", defaultMXSecs) +
+			"ST: " + st + "\r\n" +
+			"USER-AGENT: STR/1 UPnP/1.0\r\n\r\n")
+	}
+	// Typed AND broad, same as the multicast sweep: some servers only answer
+	// one of the two. Sent twice because it is one unacknowledged datagram.
+	for i := 0; i < 2; i++ {
+		_, _ = conn.WriteToUDP(mkMsg(mediaServerST), target)
+		_, _ = conn.WriteToUDP(mkMsg("ssdp:all"), target)
+		time.Sleep(80 * time.Millisecond)
+	}
+
+	if deadline, ok := dctx.Deadline(); ok {
+		_ = conn.SetReadDeadline(deadline)
+	}
+	locations := map[string]struct{}{}
+	buf := make([]byte, 4096)
+	for {
+		n, raddr, rerr := conn.ReadFromUDP(buf)
+		if rerr != nil {
+			break
+		}
+		if loc := headerValue(buf[:n], "LOCATION"); loc != "" {
+			Logger.Info("dlna: unicast SSDP response", "src", raddr.String(), "location", loc)
+			locations[loc] = struct{}{}
+		}
+	}
+	Logger.Info("dlna: unicast M-SEARCH done", "host", host, "locations", len(locations))
+	if len(locations) == 0 {
+		return nil, nil
+	}
+
+	// Fresh budget for the description fetches; dctx is spent on the read
+	// window, same split DiscoverServers makes.
+	fctx, fcancel := context.WithTimeout(ctx, 8*time.Second)
+	defer fcancel()
+	out := make([]Server, 0, len(locations))
+	seen := map[string]struct{}{}
+	for loc := range locations {
+		s, ferr := fetchDeviceDescription(fctx, loc)
+		if ferr != nil || s.UDN == "" || s.CDSControlURL == "" {
+			continue
+		}
+		if _, dup := seen[s.UDN]; dup {
+			continue
+		}
+		seen[s.UDN] = struct{}{}
+		out = append(out, s)
+	}
+	return out, nil
+}

--- a/dlna/searchhost_test.go
+++ b/dlna/searchhost_test.go
@@ -1,0 +1,81 @@
+package dlna
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSearchHost stands in a UDP responder for the unicast M-SEARCH (#726):
+// the probe must reach the given host directly, follow the LOCATION it
+// answers with, and come back with a resolved server. No multicast involved.
+func TestSearchHost(t *testing.T) {
+	const descXML = `<?xml version="1.0"?>
+<root xmlns="urn:schemas-upnp-org:device-1-0">
+  <device>
+    <deviceType>urn:schemas-upnp-org:device:MediaServer:1</deviceType>
+    <friendlyName>Unicast Test Server</friendlyName>
+    <UDN>uuid:unicast-42</UDN>
+    <serviceList>
+      <service>
+        <serviceType>urn:schemas-upnp-org:service:ContentDirectory:1</serviceType>
+        <controlURL>/ctl</controlURL>
+      </service>
+    </serviceList>
+  </device>
+</root>`
+	web := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = w.Write([]byte(descXML))
+	}))
+	defer web.Close()
+
+	udp, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("responder listen: %v", err)
+	}
+	defer udp.Close()
+	go func() {
+		buf := make([]byte, 2048)
+		for {
+			n, raddr, rerr := udp.ReadFromUDP(buf)
+			if rerr != nil {
+				return
+			}
+			if !strings.Contains(string(buf[:n]), "M-SEARCH") {
+				continue
+			}
+			resp := "HTTP/1.1 200 OK\r\n" +
+				"ST: urn:schemas-upnp-org:device:MediaServer:1\r\n" +
+				"LOCATION: " + web.URL + "/desc.xml\r\n\r\n"
+			_, _ = udp.WriteToUDP([]byte(resp), raddr)
+		}
+	}()
+
+	oldPort := searchHostPort
+	searchHostPort = udp.LocalAddr().(*net.UDPAddr).Port
+	defer func() { searchHostPort = oldPort }()
+
+	got, err := SearchHost(context.Background(), "127.0.0.1", 2*time.Second)
+	if err != nil {
+		t.Fatalf("SearchHost: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 server, got %d", len(got))
+	}
+	if got[0].UDN != "uuid:unicast-42" || got[0].CDSControlURL == "" {
+		t.Errorf("server = %+v, want UDN uuid:unicast-42 with a control URL", got[0])
+	}
+}
+
+// TestSearchHostRejectsNonIP: the host comes from the firmware's own list and
+// must already be an address; anything else is a caller bug, not a probe.
+func TestSearchHostRejectsNonIP(t *testing.T) {
+	if _, err := SearchHost(context.Background(), "fritz.box", time.Second); err == nil {
+		t.Error("hostname: want error, got nil")
+	}
+}

--- a/internal/webui/librarybrowse.go
+++ b/internal/webui/librarybrowse.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/JRpersonal/streborn/dlna"
+	"github.com/JRpersonal/streborn/internal/boxapi"
 )
 
 const (
@@ -26,6 +27,9 @@ const (
 	// container time out at 15 s), so this is deliberately looser than the
 	// search's per-server share; it is one user tap, not a fan-out.
 	libraryBrowseTimeout = 20 * time.Second
+	// libraryUnicastProbe bounds the direct unicast M-SEARCH at the address
+	// the firmware's discovery cache names (#726). One host, one answer.
+	libraryUnicastProbe = 3 * time.Second
 )
 
 // handleLibraryServers lists the registered media servers for the phone page.
@@ -61,7 +65,7 @@ func (s *Server) resolveMediaServer(ctx context.Context, udn string) (dlna.Serve
 	}
 	found, err := dlna.DiscoverServers(ctx, librarySearchDiscovery)
 	if err != nil {
-		return dlna.Server{}, false
+		s.logger.Info("library resolve: discovery failed", "err", err)
 	}
 	s.rememberMediaServerLocations(found)
 	for _, srv := range found {
@@ -69,6 +73,55 @@ func (s *Server) resolveMediaServer(ctx context.Context, udn string) (dlna.Serve
 			return srv, true
 		}
 	}
+	// The multicast round came back without this server. On networks whose AP
+	// or router filters multicast between Wi-Fi and wire, the agent's own
+	// M-SEARCH (or its answers) never crosses, while the desktop app on the
+	// wire sees the server fine (#726). The firmware keeps its own discovery
+	// cache fed by the server's NOTIFY announcements; a unicast search at the
+	// address it names passes every multicast filter.
+	return s.resolveViaBoxCache(ctx, key, len(found))
+}
+
+// resolveViaBoxCache asks the speaker's own /listMediaServers cache where the
+// server was last seen and probes that address with a unicast M-SEARCH. Every
+// exit logs its reason: this path only runs when the phone page is about to
+// show "server not answering", and a silent miss here cannot be told apart
+// from a server that is genuinely off (#726).
+func (s *Server) resolveViaBoxCache(ctx context.Context, key string, discovered int) (dlna.Server, bool) {
+	if s.boxHost == "" {
+		return dlna.Server{}, false
+	}
+	known, err := boxapi.New(s.boxHost).ListMediaServers(ctx)
+	if err != nil {
+		s.logger.Warn("library resolve: server unresolved and the speaker's own list could not be read",
+			"discovered", discovered, "err", err)
+		return dlna.Server{}, false
+	}
+	ip := ""
+	for _, m := range known {
+		if udnKey(m.ID) == key {
+			ip = m.IP
+			break
+		}
+	}
+	if ip == "" {
+		s.logger.Warn("library resolve: server unresolved, the speaker's own discovery does not see it either",
+			"discovered", discovered, "boxKnows", len(known))
+		return dlna.Server{}, false
+	}
+	found, err := dlna.SearchHost(ctx, ip, libraryUnicastProbe)
+	if err != nil {
+		s.logger.Warn("library resolve: unicast probe failed", "ip", ip, "err", err)
+		return dlna.Server{}, false
+	}
+	s.rememberMediaServerLocations(found)
+	for _, srv := range found {
+		if udnKey(srv.UDN) == key {
+			s.logger.Info("library resolve: server found via the speaker's discovery cache and a unicast probe", "ip", ip)
+			return srv, true
+		}
+	}
+	s.logger.Warn("library resolve: unicast probe answered, but not with this server", "ip", ip, "answers", len(found))
 	return dlna.Server{}, false
 }
 

--- a/internal/webui/librarysearch.go
+++ b/internal/webui/librarysearch.go
@@ -131,6 +131,12 @@ func (s *Server) handleLibrarySearch(w http.ResponseWriter, r *http.Request) {
 			srv, ok = s.recallMediaServer(ctx, key)
 		}
 		if !ok {
+			// Same last resort the browse path takes: the firmware's own
+			// discovery cache plus a unicast probe, for networks that filter
+			// the agent's multicast round (#726).
+			srv, ok = s.resolveViaBoxCache(ctx, key, len(found))
+		}
+		if !ok {
 			missing = append(missing, reg.Name)
 			continue
 		}


### PR DESCRIPTION
A registered media server browsed fine from the desktop app but the phone page answered "server not responding" (#726, and likely part of #721). The desktop searches from the PC on the wire; the phone page makes the speaker search, and on networks whose router or AP filters multicast between Wi-Fi and wire, the speaker's own M-SEARCH round comes back empty every time.

The firmware keeps its own discovery cache (/listMediaServers), fed by the server's NOTIFY announcements, so it still knows the server's address. When the multicast round misses a registered server, the agent now asks that cache and probes the named address directly with a unicast M-SEARCH (new dlna.SearchHost), which no multicast filter can swallow. The phone search path takes the same last resort.

Every miss in the resolution chain now logs its reason, so the next diagnostic bundle says which step failed instead of a silent "offline" (the resolve path logged nothing at all before).

Tested: new UDP-responder test for SearchHost, full dlna + webui suites green, make build-arm green.

Refs #726, refs #721.

🤖 Generated with [Claude Code](https://claude.com/claude-code)