### PR TITLE
fix(app): right-click cut/copy/paste works in text fields again

### DIFF
--- a/desktop-app/main.go
+++ b/desktop-app/main.go
@@ -93,6 +93,13 @@ func main() {
 			Assets: assets,
 		},
 		BackgroundColour: &options.RGBA{R: 27, G: 38, B: 54, A: 1},
+		// Without this, production builds suppress the webview's context menu
+		// entirely (wails gates it on debug || this option), so right-click
+		// paste/copy in text fields was dead for users (Hermann, Win11,
+		// 2026-08-26; reproduced locally). With it, the wails runtime still
+		// limits the menu to editable fields and selected text, which is the
+		// behaviour we want: no browser menu on the app chrome.
+		EnableDefaultContextMenu: true,
 		// Pin the WebView2 profile to a stable path so localStorage (favorites,
 		// language, last speaker, search country, cached boxes, setup region)
 		// survives updates instead of resetting with every versioned executable.


### PR DESCRIPTION
Production wails builds suppress the webview context menu entirely unless `EnableDefaultContextMenu` is set (`frontend.go:569`: `PutAreDefaultContextMenusEnabled(f.debug || f.frontendOptions.EnableDefaultContextMenu)`), so right-clicking the station search field did nothing for users. Reported for Windows 11 on v0.9.59 (mail), reproduced locally: right-click in the search field shows nothing on the unpatched build.

With the option set, the wails runtime JS still limits the menu to editable fields and selected text (`--default-contextmenu: auto`), so the app chrome keeps no browser menu; text fields get cut/copy/paste back.

Local verification of the patched build is running; result lands here as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)