### PR TITLE
fix(dlna): give a slow media server (WD Twonky) time to answer its device description

### DIFF
--- a/dlna/dlna.go
+++ b/dlna/dlna.go
@@ -279,7 +279,10 @@ func DiscoverServers(ctx context.Context, timeout time.Duration) ([]Server, erro
 	// expired by the time we get here; using it for the HTTP
 	// fetches would have every fetch fail with deadline exceeded.
 	// Parent ctx is still alive (caller's overall budget).
-	fctx, fcancel := context.WithTimeout(ctx, 8*time.Second)
+	// 12s (was 8s): the whole set of description fetches runs in parallel under
+	// this one deadline, so a slow NAS (WD Twonky, #733) is the one that needs
+	// the headroom; the fast ones still return in well under a second.
+	fctx, fcancel := context.WithTimeout(ctx, 12*time.Second)
 	defer fcancel()
 
 	type result struct {
@@ -433,9 +436,15 @@ func fetchDeviceDescription(ctx context.Context, location string) (Server, error
 	if err != nil {
 		return Server{}, err
 	}
-	// 6s (was 4s): a NAS can serve its device.xml slowly. Without logging,
-	// a fetch failure made a NAS that DID answer SSDP vanish with no trace (#110).
-	client := &http.Client{Timeout: 6 * time.Second}
+	// The per-fetch deadline comes from ctx, so a caller can give a known-slow
+	// server (a WD Twonky answers its device.xml far slower than a FRITZ!Box,
+	// #733) more room than a bulk discovery sweep grants each candidate. A
+	// hard-coded 6s client timeout used to cut the Twonky off with
+	// "context deadline exceeded" while faster servers on the same LAN came
+	// through, so its native STORED_MUSIC source worked but the phone browse
+	// reported it offline. The 20s ceiling only guards a caller that passed a
+	// deadline-less ctx; every real caller sets one.
+	client := &http.Client{Timeout: 20 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
 		Logger.Warn("dlna: device description fetch failed", "location", location, "err", err.Error())

--- a/dlna/searchhost.go
+++ b/dlna/searchhost.go
@@ -77,9 +77,11 @@ func SearchHost(ctx context.Context, host string, timeout time.Duration) ([]Serv
 		return nil, nil
 	}
 
-	// Fresh budget for the description fetches; dctx is spent on the read
-	// window, same split DiscoverServers makes.
-	fctx, fcancel := context.WithTimeout(ctx, 8*time.Second)
+	// Fresh, generous budget for the description fetch. This path is the
+	// targeted fallback for ONE server the multicast round already missed, and
+	// on a slow WD Twonky that miss is exactly the too-short-timeout it exists
+	// to recover (#733), so it gets 15s where the bulk sweep shares 12s.
+	fctx, fcancel := context.WithTimeout(ctx, 15*time.Second)
 	defer fcancel()
 	out := make([]Server, 0, len(locations))
 	seen := map[string]struct{}{}

--- a/internal/webui/librarybrowse.go
+++ b/internal/webui/librarybrowse.go
@@ -25,8 +25,10 @@ const (
 	// libraryBrowseTimeout bounds one page fetch, resolution included. A slow
 	// NAS answering a first page can take a while (the #666 QNAP let one
 	// container time out at 15 s), so this is deliberately looser than the
-	// search's per-server share; it is one user tap, not a fan-out.
-	libraryBrowseTimeout = 20 * time.Second
+	// search's per-server share; it is one user tap, not a fan-out. 35s, not
+	// 20: resolving a slow WD Twonky through the unicast fallback can itself
+	// take up to ~18 s now (#733), and the Browse SOAP still has to follow.
+	libraryBrowseTimeout = 35 * time.Second
 	// libraryUnicastProbe bounds the direct unicast M-SEARCH at the address
 	// the firmware's discovery cache names (#726). One host, one answer.
 	libraryUnicastProbe = 3 * time.Second


### PR DESCRIPTION
A WD Twonky serves its `device.xml` far slower than a FRITZ!Box. The 6s per-fetch client timeout cut it off with `context deadline exceeded` while faster servers on the same LAN came through (#733). The speaker still registered it as a native STORED_MUSIC source (so it works in the Bose app), but the phone media browser could not resolve it and showed "server did not answer".

Evidence from the reporter's v0.9.60 desktop log: every WD description fetch times out at the same millisecond while other servers return, and the native `/sources` shows the WD accounts as `READY`.

**Fix**: the per-fetch deadline comes from the caller ctx (a 20s client timeout only guards a deadline-less caller). The bulk discovery sweep shares 12s (was 8s); the targeted unicast fallback, which exists precisely to recover a server the multicast round missed, gets 15s; and the phone-browse budget grows to 35s so the slower resolve still leaves room for the Browse SOAP.

Not a v0.9.60 regression: the phone media browser is a newer feature, and the Twonky was simply always slower than the timeout allowed. dlna + webui suites and `make build-arm` green.

The resolve chain logs every miss (from #727), so the reporter's next bundle after a browse attempt on the fixed build will confirm whether the extra time is enough.

Refs #733.

🤖 Generated with [Claude Code](https://claude.com/claude-code)