### PR TITLE
feat(github): issue + discussion templates that ask for a diagnostic up front

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,28 @@
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Ask away. If your question is about a speaker that misbehaves, one thing
+        helps most.
+
+        ### A diagnostic file answers most questions  ·  Eine Diagnosedatei klärt die meisten Fragen
+
+        It carries your speaker model, firmware, and the agent log, with **no
+        passwords and no account data**.
+
+        **Desktop app (Windows / macOS / Linux):** the **Save diagnostic logs**
+        button (deutsch: **Diagnose-Log speichern**) at the very bottom of the app.
+
+        **Phone page** (`http://<speaker-ip>:8888` in your browser):
+        **More → Report a problem → Save diagnostic file**
+        (deutsch: **Mehr → Problem melden → Diagnosedatei speichern**).
+
+        Then drag the saved file into your post.
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: In your own language is fine. Include your speaker model if it is about a specific box.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug report
+description: Something is broken or misbehaving on your speaker or in the app.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. One thing settles almost every report, so please read this first.
+
+        ### Please attach a diagnostic file  ·  Bitte häng eine Diagnosedatei an
+
+        It carries your speaker model, firmware, and the agent log, and it is
+        what lets the maintainer find the cause instead of guessing. It contains
+        **no passwords and no account data**.
+
+        **In the desktop app (Windows / macOS / Linux):**
+        the **Save diagnostic logs** button (deutsch: **Diagnose-Log speichern**)
+        at the very bottom of the app.
+
+        **On the phone page** (the `http://<speaker-ip>:8888` page in your browser):
+        open **More → Report a problem → Save diagnostic file**
+        (deutsch: **Mehr → Problem melden → Diagnosedatei speichern**).
+
+        Then drag the saved file into this issue. A report with a diagnostic is
+        answered far faster than one without.
+  - type: textarea
+    id: what
+    attributes:
+      label: What happens
+      description: What goes wrong, and what did you expect instead? In your own language is fine.
+      placeholder: e.g. Preset 3 flashes on the display, then the speaker turns itself off after a few seconds.
+    validations:
+      required: true
+  - type: dropdown
+    id: model
+    attributes:
+      label: Speaker model
+      options:
+        - SoundTouch 10
+        - SoundTouch 20
+        - SoundTouch 30
+        - SoundTouch 300
+        - SoundTouch Portable
+        - Wave SoundTouch
+        - CineMate / soundbar
+        - Other / not sure
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: STR version
+      description: Shown at the top of the desktop app window. If you are not sure, leave it blank, the diagnostic contains it.
+      placeholder: e.g. v0.9.60
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce (optional)
+      description: If you can trigger it on purpose, the steps help. If it just happens, skip this.
+  - type: checkboxes
+    id: diagnostic
+    attributes:
+      label: Diagnostic
+      options:
+        - label: I attached a diagnostic file (or I will add it in a comment right after opening this).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question, setup help, or "is this expected?"
+    url: https://github.com/JRpersonal/streborn/discussions/new?category=q-a
+    about: Not sure it is a bug? Ask in Q&A. Attaching a diagnostic (Save diagnostic logs in the app, or More → Report a problem → Save diagnostic file on the phone page) still helps.
+  - name: Feature idea or request
+    url: https://github.com/JRpersonal/streborn/discussions/new?category=ideas
+    about: Suggest a feature or vote on one. Ideas are collected and prioritised on the backlog.
+  - name: Which speaker models work
+    url: https://github.com/JRpersonal/streborn/blob/main/docs/MODELS.md
+    about: Current hardware support state per SoundTouch model.


### PR DESCRIPTION
Nearly every report needs the diagnostic file, and asking for it after the fact costs a round trip every time. New templates lead with how to save one, with the exact button path for **both** surfaces, in English and German:

- **Desktop app**: **Save diagnostic logs** / **Diagnose-Log speichern**, at the very bottom.
- **Phone page** (`:8888`): **More → Report a problem → Save diagnostic file** / **Mehr → Problem melden → Diagnosedatei speichern**.

Files:
- `.github/ISSUE_TEMPLATE/bug_report.yml` — bug form: diagnostic hint first, then what-happens, model, version, steps, and a diagnostic checkbox.
- `.github/ISSUE_TEMPLATE/config.yml` — blank issues off so the form (and its hint) is unmissable; questions → Q&A, ideas → Ideas, plus a models link.
- `.github/DISCUSSION_TEMPLATE/q-a.yml` — Q&A discussions carry the same diagnostic hint, since support questions land there too.

YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)