### PR TITLE
feat(app): frame and name every stereo pair, not just the first

### DIFF
--- a/desktop-app/frontend/src/groups.js
+++ b/desktop-app/frontend/src/groups.js
@@ -307,27 +307,44 @@ export function resetZoneLivePoll() {
 // usually not a paired one, so undo was sent to an uninvolved speaker twice in
 // a row while the pair stayed up (field, 2026-08-04).
 
-// stereoPairOf returns the live firmware stereo pair as
-// {id, master, members:[{deviceID, ip, role}]}, or null when no speaker
-// reports one. Any member's self-report describes the whole pair, so the
-// first one found wins.
-export function stereoPairOf(zoneLive) {
+// stereoPairsOf returns EVERY distinct live firmware stereo pair as
+// [{id, master, members:[{deviceID, ip, role}]}], in first-seen order. Both
+// halves of one pair self-report the same group, so entries are deduped on
+// stereoPairKey (the sorted member set); a transient record that carries an id
+// but not yet two members has no such key, so it is bucketed under 'id:'+id
+// instead, which keeps two distinct in-formation pairs from collapsing under
+// the same empty key. A household with two pairs (field: Buero + Wohnwagen)
+// gets both, so the picker and the multi-room view can frame and name each.
+export function stereoPairsOf(zoneLive) {
+  const out = [];
+  const seen = new Set();
   for (const key of Object.keys(zoneLive || {})) {
     const st = (zoneLive[key] || {}).stereo;
-    if (st && ((st.members || []).length || st.id)) {
-      return {
-        id: st.id || '',
-        // The agent names this field masterDeviceID. Reading only st.master
-        // left pair.master empty on every pair, so "ask the pair's MASTER for
-        // the balance" silently asked whichever half happened to be selected,
-        // which is the bug that was supposed to be fixed (#70). Both spellings
-        // are accepted so an older agent keeps working.
-        master: String(st.masterDeviceID || st.master || '').toUpperCase(),
-        members: st.members || [],
-      };
-    }
+    if (!st || !((st.members || []).length || st.id)) continue;
+    const rec = {
+      id: st.id || '',
+      // The agent names this field masterDeviceID. Reading only st.master
+      // left pair.master empty on every pair, so "ask the pair's MASTER for
+      // the balance" silently asked whichever half happened to be selected,
+      // which is the bug that was supposed to be fixed (#70). Both spellings
+      // are accepted so an older agent keeps working.
+      master: String(st.masterDeviceID || st.master || '').toUpperCase(),
+      members: st.members || [],
+    };
+    const k = stereoPairKey(rec) || (rec.id ? 'id:' + rec.id : '');
+    if (!k || seen.has(k)) continue;
+    seen.add(k);
+    out.push(rec);
   }
-  return null;
+  return out;
+}
+
+// stereoPairOf returns the FIRST live stereo pair, or null. Kept as a thin
+// wrapper over stereoPairsOf so the callers that only need one (the balance
+// source box, the undo fallback) and the existing tests keep their exact
+// first-pair/null contract.
+export function stereoPairOf(zoneLive) {
+  return stereoPairsOf(zoneLive)[0] || null;
 }
 
 // stereoPairKey turns a live pair into a stable, order-independent key for the

--- a/desktop-app/frontend/src/groups.test.js
+++ b/desktop-app/frontend/src/groups.test.js
@@ -18,6 +18,7 @@ import {
   fetchZoneLive,
   resetZoneLivePoll,
   stereoPairOf,
+  stereoPairsOf,
   stereoPairKey,
   pairMemberBoxes,
   inStereoPair,
@@ -495,6 +496,59 @@ describe('balanceSourceBox', () => {
 
   it('falls back to the selected speaker when the master is not discovered', () => {
     expect(balanceSourceBox(right, pair, [right])).toBe(right);
+  });
+});
+
+describe('stereoPairsOf', () => {
+  const pairEntry = {
+    stereo: {
+      id: 'str-grp-AAA', master: 'AAA',
+      members: [
+        { deviceID: 'BBB', ip: '192.0.2.32', role: 'RIGHT' },
+        { deviceID: 'AAA', ip: '192.0.2.19', role: 'LEFT' },
+      ],
+    },
+  };
+  const pairEntry2 = {
+    stereo: {
+      id: 'str-grp-CCC', master: 'CCC',
+      members: [
+        { deviceID: 'CCC', ip: '192.0.2.40', role: 'LEFT' },
+        { deviceID: 'DDD', ip: '192.0.2.41', role: 'RIGHT' },
+      ],
+    },
+  };
+
+  it('returns [] when nothing reports a pair', () => {
+    expect(stereoPairsOf({})).toEqual([]);
+    expect(stereoPairsOf(null)).toEqual([]);
+    expect(stereoPairsOf({ AAA: { members: [] }, BBB: { members: [] } })).toEqual([]);
+  });
+
+  it('dedupes the two self-reports of one pair into a single entry', () => {
+    const got = stereoPairsOf({ AAA: pairEntry, BBB: pairEntry });
+    expect(got).toHaveLength(1);
+    expect(got[0].master).toBe('AAA');
+  });
+
+  it('returns two distinct pairs, in first-seen order', () => {
+    const got = stereoPairsOf({ AAA: pairEntry, CCC: pairEntry2 });
+    expect(got).toHaveLength(2);
+    expect(got.map(p => p.master)).toEqual(['AAA', 'CCC']);
+  });
+
+  it('[0] equals stereoPairOf for a multi-pair map', () => {
+    const zl = { AAA: pairEntry, CCC: pairEntry2 };
+    expect(stereoPairsOf(zl)[0]).toEqual(stereoPairOf(zl));
+  });
+
+  it('keeps two transient (<2-member) records apart via their ids', () => {
+    const got = stereoPairsOf({
+      A: { stereo: { id: 'x', members: [] } },
+      B: { stereo: { id: 'y', members: [] } },
+    });
+    expect(got).toHaveLength(2);
+    expect(got.map(p => p.id).sort()).toEqual(['x', 'y']);
   });
 });
 

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -248,6 +248,7 @@ import {
   parsePlayRejection,
   resolveBoxByRef,
   stereoPairOf,
+  stereoPairsOf,
   pairMemberBoxes,
   balanceSourceBox,
 } from './groups.js';
@@ -2368,29 +2369,40 @@ function renderBoxSelect() {
   // speakers. That is misleading twice over: they play as one, and pressing a
   // preset on the pair is refused by the firmware (#528) with nothing on screen
   // explaining why. Framing them like a group says what is going on.
-  const livePair = stereoPairOf(zlMap);
+  const livePairs = stereoPairsOf(zlMap);
   // Balance is read once when the selected speaker changes, never on the status
   // poll (the speaker hangs on that endpoint while it is asleep). Pairing and
   // unpairing happen without changing the selection, so without this the value
   // would stay stale, or stay hidden for a pair formed after the speaker was
-  // picked. Keyed on the pair identity, so an unchanged pair re-reads nothing.
-  const pairStamp = livePair ? `${livePair.id}|${livePair.master}` : '';
+  // picked. Keyed over ALL pairs, so a second pair forming after a speaker was
+  // selected still re-reads once; an unchanged set re-reads nothing.
+  const pairStamp = livePairs.map(p => `${p.id}|${p.master}`).sort().join(',');
   if (pairStamp !== state.lastBalancePair) {
     state.lastBalancePair = pairStamp;
     setTimeout(() => { refreshBalance().catch(() => {}); }, 0);
   }
-  const pairBoxes = pairMemberBoxes(livePair, state.boxes).map(x => x.box).filter(Boolean);
-  const pairHosts = new Set(pairBoxes.map(b => b.host));
-  const pairMasterBox = pairBoxes.find(b =>
-    livePair && String(b.deviceID || '').toUpperCase() === String(livePair.master || '').toUpperCase()) || pairBoxes[0] || null;
-  const pairKey = pairMasterBox ? String(pairMasterBox.deviceID || '').toUpperCase() : '';
+  // Every live pair frames under its own key (its master box's discovered
+  // deviceID). pairHostToKey routes any paired box to its frame; pairByKey
+  // gives the frame its pair, so each pair shows its OWN stored name. Matched on
+  // host, not deviceID: a two-chip chassis announces a different id over
+  // discovery than the one the firmware puts in the pair.
+  const pairHostToKey = new Map();
+  const pairByKey = new Map();
+  for (const p of livePairs) {
+    const boxes = pairMemberBoxes(p, state.boxes).map(x => x.box).filter(Boolean);
+    const masterBox = boxes.find(b =>
+      String(b.deviceID || '').toUpperCase() === String(p.master || '').toUpperCase()) || boxes[0] || null;
+    const key = masterBox ? String(masterBox.deviceID || '').toUpperCase() : '';
+    if (!key) continue;
+    pairByKey.set(key, p);
+    for (const b of boxes) pairHostToKey.set(b.host, key);
+  }
   const masterOf = (b) => {
     if (b.kind === 'stock') return '';
     const z = zoneMasterOf(b.deviceID, zlMap);
     if (z) return z;
-    // Matched on host, not deviceID: a two-chip chassis announces a different
-    // id over discovery than the one the firmware puts in the pair.
-    if (pairKey && pairHosts.has(b.host)) return pairKey;
+    const k = pairHostToKey.get(b.host);
+    if (k) return k;
     return '';
   };
   const memberCount = {};
@@ -2514,11 +2526,12 @@ function renderBoxSelect() {
       // A stereo pair gets its own wording and its own mark. Reusing the
       // multiroom label would call two speakers acting as one channel pair a
       // "group led by X", which is not what it is.
-      const isPair = pairKey && m === pairKey;
+      const framePair = pairByKey.get(m) || null;
+      const isPair = !!framePair;
       const pairIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="12" height="12" aria-hidden="true"><rect x="3" y="3" width="7" height="18" rx="1"></rect><rect x="14" y="3" width="7" height="18" rx="1"></rect></svg>';
       const zoneIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="12" height="12" aria-hidden="true"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path><circle cx="9" cy="7" r="4"></circle><path d="M23 21v-2a4 4 0 0 0-3-3.87"></path><path d="M16 3.13a4 4 0 0 1 0 7.75"></path></svg>';
       const groupLabel = groupName
-        ? `<span class="box-group-label" title="${escapeAttr(isPair ? t('speaker.stereoPairTitle') : t('speaker.groupLabelTitle', { name: groupName }))}">${isPair ? pairIcon : zoneIcon} ${escapeHtml(isPair ? (pairDisplayName(livePair, renderBoxSelect) || t('multiroom.stereoHeading')) : groupName)}</span>`
+        ? `<span class="box-group-label" title="${escapeAttr(isPair ? t('speaker.stereoPairTitle') : t('speaker.groupLabelTitle', { name: groupName }))}">${isPair ? pairIcon : zoneIcon} ${escapeHtml(isPair ? (pairDisplayName(framePair, renderBoxSelect) || t('multiroom.stereoHeading')) : groupName)}</span>`
         : '';
       html += `<div class="box-group box-group-c${colorOf[m]}">${groupLabel}${members.map(pill).join('')}</div>`;
     }

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -247,8 +247,8 @@ import {
   sameBoxIdentity,
   parsePlayRejection,
   resolveBoxByRef,
-  stereoPairOf,
   stereoPairsOf,
+  inStereoPair,
   pairMemberBoxes,
   balanceSourceBox,
 } from './groups.js';
@@ -6477,7 +6477,11 @@ async function refreshBalance() {
   if (!el) return;
   const selected = state.currentBox;
   if (!selected || selected.kind === 'stock') { el.classList.add('hidden'); return; }
-  const box = balanceSourceBox(selected, stereoPairOf(state.zoneLive || {}), state.boxes) || selected;
+  // Resolve the pair that CONTAINS the selected box, not just the first: either
+  // half of any pair must show that pair's balance (#70), which was only true
+  // for the first pair while stereoPairOf returned it alone.
+  const balPair = stereoPairsOf(state.zoneLive || {}).find(p => inStereoPair(selected, p)) || null;
+  const box = balanceSourceBox(selected, balPair, state.boxes) || selected;
   if (box.kind === 'stock') { el.classList.add('hidden'); return; }
   const v = await readBoxBalance(box);
   if (v === null) { el.classList.add('hidden'); return; }

--- a/desktop-app/frontend/src/views/multiroom.js
+++ b/desktop-app/frontend/src/views/multiroom.js
@@ -11,7 +11,7 @@ import { t } from '../i18n/index.js';
 import { FormZone, DissolveZone, DissolveStereoPair, WakeBox, BrowserOpenURL, readBoxBalance } from '../api.js';
 // Group membership + the shared zoneLive poll live in groups.js: ONE
 // implementation for this tab, the music-tab frames and the group chips.
-import { masterOf as zoneMasterOf, fetchZoneLive, groupMembersOf, stereoPairOf, pairMemberBoxes, stereoUndoTargets } from '../groups.js';
+import { masterOf as zoneMasterOf, fetchZoneLive, groupMembersOf, stereoPairsOf, stereoPairKey, pairMemberBoxes, stereoUndoTargets } from '../groups.js';
 // App-side pair display name (STR keeps its own, survives updates): see stereoNames.js.
 import { pairDisplayName, setPairName } from '../stereoNames.js';
 
@@ -213,17 +213,31 @@ export function renderMultiroom(fetchLive) {
   // SoundTouch 10s the controls sat on two speakers that were not the paired
   // ones and every repaint put them back there ("die Lautsprecherauswahl
   // springt immer auf den nicht gepaarten Lautsprecher", field 2026-08-04).
-  const livePair = stereoPairOf(state.zoneLive);
+  const livePairs = stereoPairsOf(state.zoneLive);
+  const livePair = livePairs[0] || null;
   const liveBoxes = pairMemberBoxes(livePair, strBoxes).map(x => x.box).filter(Boolean);
   const stillThere = (id) => id && pairCands.some(b => b.deviceID === id);
+  // A remembered selection that names a LIVE pair wins, so a user holding the
+  // dropdowns on a SECOND live pair is not snapped back to the first on every
+  // poll repaint. When the remembered pick is NOT a live pair, snap to the live
+  // one (the 2026-08-04 fix: controls must not sit on an unpaired speaker).
+  const remKey = stereoPairKey({ members: [{ deviceID: state.stereoLeft }, { deviceID: state.stereoRight }] });
+  const remIsLive = !!remKey && livePairs.some(p => stereoPairKey(p) === remKey);
   const pairPick = [0, 1].map(i => {
-    if (liveBoxes[i]) return liveBoxes[i].deviceID;
     const remembered = i === 0 ? state.stereoLeft : state.stereoRight;
+    if (remIsLive && stillThere(remembered)) return remembered;
+    if (liveBoxes[i]) return liveBoxes[i].deviceID;
     if (stillThere(remembered)) return remembered;
     return pairCands[i] ? pairCands[i].deviceID : '';
   });
   state.stereoLeft = pairPick[0];
   state.stereoRight = pairPick[1];
+  // The pair the dropdowns describe: match the L/R selection against the live
+  // pairs (stereoPairKey normalizes case+order, so a swapped L/R still matches).
+  // Everything below (status, name, balance, save, dissolve) tracks THIS pair,
+  // so a household with two pairs renames/undoes whichever one is selected.
+  const formingPair = livePairs.find(p =>
+    stereoPairKey(p) === stereoPairKey({ members: [{ deviceID: pairPick[0] }, { deviceID: pairPick[1] }] })) || livePairs[0] || null;
   const pairOpts = (sel) => pairCands
     .map(b => `<option value="${escapeAttr(b.deviceID)}"${b.deviceID === pairPick[sel] ? ' selected' : ''}>${escapeHtml(zoneLabel(b))}</option>`)
     .join('') || `<option>${escapeHtml(t('multiroom.noSpeaker'))}</option>`;
@@ -231,16 +245,16 @@ export function renderMultiroom(fetchLive) {
   // Say whether a pair exists at all. Until now the section gave no sign
   // either way, so a user could not tell a dissolve that did nothing from one
   // that worked.
-  const pairStatus = livePair
+  const pairStatus = formingPair
     ? `<div class="muted small">${escapeHtml(t('multiroom.stereoCurrent', {
-        names: pairMemberBoxes(livePair, strBoxes)
+        names: pairMemberBoxes(formingPair, strBoxes)
           .map(x => x.box ? zoneLabel(x.box) : (x.member.ip || x.member.deviceID)).join(' + '),
       }))}</div>`
     : `<div class="muted small">${escapeHtml(t('multiroom.stereoNoPair'))}</div>`;
 
   // The pair's own display name, kept app-side (stereoNames.js). Prefilled from
-  // the store for an existing pair; the async lookup repaints once it lands.
-  const pairName = livePair ? (pairDisplayName(livePair, () => renderMultiroom(false)) || '') : '';
+  // the store for the SELECTED pair; the async lookup repaints once it lands.
+  const pairName = formingPair ? (pairDisplayName(formingPair, () => renderMultiroom(false)) || '') : '';
 
   // The pair's balance belongs here, where the pair is made and undone, and
   // nowhere near a volume slider: it is a READ-OUT, not a control. The firmware
@@ -248,7 +262,7 @@ export function renderMultiroom(fetchLive) {
   // the speaker was woken), so shown beside a slider it reads as a control that
   // is broken. An owner said exactly that: "steht neben dem Lautstaerkeregler
   // und hat auch keinen Effekt" (2026-08-09), and #70 asked twice where it was.
-  const pairBalance = livePair
+  const pairBalance = formingPair
     ? `<div class="muted small" id="pairBalance" hidden></div>`
     : '';
 
@@ -283,14 +297,14 @@ export function renderMultiroom(fetchLive) {
          <input id="stereoName" type="text" maxlength="40" placeholder="${escapeAttr(t('multiroom.stereoNamePlaceholder'))}" value="${escapeAttr(state.stereoName != null ? state.stereoName : pairName)}"${pairDis}></label>
        <div class="zone-actions">
          <button id="stereoCreate" class="btn"${pairDis}>${escapeHtml(t('multiroom.stereoCreateBtn'))}</button>
-         ${livePair ? `<button id="stereoNameSave" class="btn btn-mini">${escapeHtml(t('multiroom.stereoNameSaveBtn'))}</button>` : ''}
+         ${formingPair ? `<button id="stereoNameSave" class="btn btn-mini">${escapeHtml(t('multiroom.stereoNameSaveBtn'))}</button>` : ''}
          <button id="stereoDissolve" class="btn btn-mini"${pairDis}>${escapeHtml(t('multiroom.stereoDissolveBtn'))}</button>
        </div>
        <div id="stereoResult">${state.stereoMsg || ''}</div>
      </div>`;
 
   // Read-only, filled after the markup exists, and only when a pair does.
-  if (livePair) fillPairBalance(livePair, strBoxes).catch(() => {});
+  if (formingPair) fillPairBalance(formingPair, strBoxes).catch(() => {});
 
   const issueLink = $('multiroomIssueLink');
   if (issueLink) issueLink.onclick = (e) => { e.preventDefault(); try { BrowserOpenURL('https://github.com/JRpersonal/streborn/issues/70'); } catch {} };
@@ -343,8 +357,11 @@ export function renderMultiroom(fetchLive) {
     // Remember the user's choice so the next repaint (they happen on every
     // live-zone poll) does not throw it away.
     const left = $('stereoLeft'), right = $('stereoRight');
-    if (left) left.onchange = () => { state.stereoLeft = left.value; };
-    if (right) right.onchange = () => { state.stereoRight = right.value; };
+    // Dropping the in-progress name on a selection change re-seeds the single
+    // Name field from the newly selected pair's stored name, so typing for one
+    // pair never leaks onto another.
+    if (left) left.onchange = () => { state.stereoLeft = left.value; delete state.stereoName; renderMultiroom(false); };
+    if (right) right.onchange = () => { state.stereoRight = right.value; delete state.stereoName; renderMultiroom(false); };
     $('stereoCreate').onclick = () => doFormStereo(pairCands);
     // Keep the typed name across the automatic live-poll repaints (which rebuild
     // this markup wholesale), the same way the L/R selects persist to state.
@@ -356,7 +373,7 @@ export function renderMultiroom(fetchLive) {
     // the freshly stored name.
     const ns = $('stereoNameSave');
     if (ns) ns.onclick = async () => {
-      try { await setPairName(livePair, $('stereoName').value); } catch {}
+      try { await setPairName(formingPair, $('stereoName').value); } catch {}
       delete state.stereoName;
       renderMultiroom(false);
     };
@@ -538,7 +555,12 @@ async function doFormZone(strBoxes) {
 // harmless (a speaker not in a pair answers "nothing to undo" and is left
 // alone) and it is the only way a one-sided leftover can be cleared at all.
 async function doDissolveStereo(pairCands) {
-  const pair = stereoPairOf(state.zoneLive);
+  // Undo the pair the user has SELECTED in the dropdowns, not just the first
+  // live one, so a household with two pairs dissolves the right one.
+  const livePairs = stereoPairsOf(state.zoneLive);
+  const pair = livePairs.find(p =>
+    stereoPairKey(p) === stereoPairKey({ members: [{ deviceID: state.stereoLeft }, { deviceID: state.stereoRight }] }))
+    || livePairs[0] || null;
   const targets = stereoUndoTargets(pair, state.boxes || []);
   if (!targets.length) {
     const guess = pairCands.find(b => b.deviceID === ($('stereoLeft') || {}).value);

--- a/desktop-app/frontend/src/views/multiroom.js
+++ b/desktop-app/frontend/src/views/multiroom.js
@@ -214,30 +214,33 @@ export function renderMultiroom(fetchLive) {
   // ones and every repaint put them back there ("die Lautsprecherauswahl
   // springt immer auf den nicht gepaarten Lautsprecher", field 2026-08-04).
   const livePairs = stereoPairsOf(state.zoneLive);
-  const livePair = livePairs[0] || null;
+  // The controls act on the live pair that CONTAINS whichever speaker is
+  // selected, so a household with two pairs can reach the second one: picking
+  // one of its members snaps the whole pair in. Default is the first live pair,
+  // which keeps the controls on a real pair rather than an unpaired speaker
+  // (the 2026-08-04 fix), and forming a NEW pair (no live match) leaves the raw
+  // selection alone via pairPick below.
+  const selUp = (id) => String(id || '').toUpperCase();
+  const pairHasSel = (p) => (p.members || []).some(m => {
+    const id = selUp(m && m.deviceID);
+    return id && (id === selUp(state.stereoLeft) || id === selUp(state.stereoRight));
+  });
+  const livePair = livePairs.find(pairHasSel) || livePairs[0] || null;
   const liveBoxes = pairMemberBoxes(livePair, strBoxes).map(x => x.box).filter(Boolean);
   const stillThere = (id) => id && pairCands.some(b => b.deviceID === id);
-  // A remembered selection that names a LIVE pair wins, so a user holding the
-  // dropdowns on a SECOND live pair is not snapped back to the first on every
-  // poll repaint. When the remembered pick is NOT a live pair, snap to the live
-  // one (the 2026-08-04 fix: controls must not sit on an unpaired speaker).
-  const remKey = stereoPairKey({ members: [{ deviceID: state.stereoLeft }, { deviceID: state.stereoRight }] });
-  const remIsLive = !!remKey && livePairs.some(p => stereoPairKey(p) === remKey);
   const pairPick = [0, 1].map(i => {
-    const remembered = i === 0 ? state.stereoLeft : state.stereoRight;
-    if (remIsLive && stillThere(remembered)) return remembered;
     if (liveBoxes[i]) return liveBoxes[i].deviceID;
+    const remembered = i === 0 ? state.stereoLeft : state.stereoRight;
     if (stillThere(remembered)) return remembered;
     return pairCands[i] ? pairCands[i].deviceID : '';
   });
   state.stereoLeft = pairPick[0];
   state.stereoRight = pairPick[1];
-  // The pair the dropdowns describe: match the L/R selection against the live
-  // pairs (stereoPairKey normalizes case+order, so a swapped L/R still matches).
-  // Everything below (status, name, balance, save, dissolve) tracks THIS pair,
-  // so a household with two pairs renames/undoes whichever one is selected.
+  // The pair the dropdowns describe: the live pair whose members match the L/R
+  // selection (stereoPairKey normalizes case+order). null while forming a NEW
+  // pair, so the rename/dissolve controls never act on the wrong existing pair.
   const formingPair = livePairs.find(p =>
-    stereoPairKey(p) === stereoPairKey({ members: [{ deviceID: pairPick[0] }, { deviceID: pairPick[1] }] })) || livePairs[0] || null;
+    stereoPairKey(p) === stereoPairKey({ members: [{ deviceID: pairPick[0] }, { deviceID: pairPick[1] }] })) || null;
   const pairOpts = (sel) => pairCands
     .map(b => `<option value="${escapeAttr(b.deviceID)}"${b.deviceID === pairPick[sel] ? ' selected' : ''}>${escapeHtml(zoneLabel(b))}</option>`)
     .join('') || `<option>${escapeHtml(t('multiroom.noSpeaker'))}</option>`;

--- a/desktop-app/frontend/src/views/settings.js
+++ b/desktop-app/frontend/src/views/settings.js
@@ -35,7 +35,7 @@ import { COUNTRIES, optFlag } from '../localization.js';
 // as one combined error; reconstructing "how many still copied" from that
 // message is a pure decision in copyreport.js (vitest-covered).
 import { summarizePresetCopyError, countValidPresetSlots } from '../copyreport.js';
-import { balanceSourceBox, stereoPairOf } from '../groups.js';
+import { balanceSourceBox, stereoPairsOf, inStereoPair } from '../groups.js';
 import {
   BoxSettings,
   BoxAgentVersion,
@@ -338,7 +338,8 @@ export async function loadBoxSettings() {
       renderBoxSettings(s, state.settingsBox);
       // Read-only, and only present on a stereo pair, so it is filled after the
       // markup exists rather than being part of it.
-      refreshBoxBalanceRow(state.settingsBox, stereoPairOf(state.zoneLive || {}), state.boxes)
+      refreshBoxBalanceRow(state.settingsBox,
+        stereoPairsOf(state.zoneLive || {}).find(p => inStereoPair(state.settingsBox, p)) || null, state.boxes)
         .catch(() => {});
       return;
     } catch (e) {


### PR DESCRIPTION
Completes points 1+2 of Rolf Krause's request for a household with TWO pairs. The stereo UI assumed one pair (stereoPairOf returns the first speaker's group), so a second pair rendered as loose pills and could not be named.

- New `stereoPairsOf(zoneLive)` returns every distinct live pair (deduped on the sorted member key, id fallback for transient records); `stereoPairOf` becomes its first element so every caller/test is unchanged.
- Picker (main.js renderBoxSelect): per-pair `pairHostToKey`/`pairByKey` maps replace the single-pair scalars; `masterOf` routes each paired box to its own frame, and each frame badges under its own stored name via `pairDisplayName(framePair)`.
- Multi-Room (multiroom.js): status/name/save/balance/dissolve track the pair the L/R dropdowns select (order-independent via the pair key); switching selection re-seeds the name field.
- Backend untouched (stereo_names.go already keys per member set).

Designed via an Ultracode understand-workflow; adversarial review to follow. Full frontend suite green (204 tests incl. new stereoPairsOf cases).

Follow-up flagged: a per-pair LIST in the Multi-Room tab (one row per pair) instead of the single dropdown-selected field, for households with several permanent pairs.