### PR TITLE
Preset sync highlight, quick-off re-power, radio + display diagnostics, input feedback

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -562,6 +562,10 @@ func run() error {
 	// instead of the real CDN URL, Bose gets http://127.0.0.1:8888/stream/<slot>
 	// and the stick agent reconnects internally on drops.
 	streamProxySrv := streamproxy.New(store, logger.With("comp", "streamproxy"))
+	// Radio dropout forensics: how often the current station forces a reconnect
+	// and why (eof vs read-fail), so an intermittent-gap report is diagnosed from
+	// the bundle instead of guessed.
+	webui.RegisterDebugSection("radio_stream_health", streamProxySrv.HealthSnapshot)
 
 	// Spotify preset audio plane (#78, P1): the agent supervises
 	// go-librespot and serves its live audio (PCM wrapped as a WAV

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -226,6 +226,7 @@ import {
   noticeDismissed,
   activeSlotFromLocation,
   orionStationPayload,
+  nativeSlotStale,
   clearNoticeDismissal,
   balanceLabel,
   shouldAdoptPresetArt,
@@ -5455,19 +5456,26 @@ function renderPresets() {
   // real stream URL of the source slot. That lets us mark sibling
   // slots with the same station as active too. Otherwise only the
   // single slot named in /stream/<n> would light up.
+  // The station the speaker is ACTUALLY playing, decoded from the native ORION
+  // descriptor (null for Spotify or a bare /stream/<n> proxy). While the box's
+  // own preset list is re-synced under a stale recall, this is the only reliable
+  // identity of the live audio, so a slot whose stored station has since changed
+  // can be told apart from the one still coming out of the speaker (#758).
+  const orionNow = orionStationPayload(state.nowLocation);
+  const playingURL = orionNow && orionNow.streamUrl ? decodeProxyUrl(orionNow.streamUrl) : '';
+  const playingName = orionNow && typeof orionNow.name === 'string' ? orionNow.name : '';
   let activeStreamURL = null;
   if (activeSlot !== null) {
     const ap = state.presets.find(x => x.slot === activeSlot);
     if (ap) activeStreamURL = ap.stream_url;
-  } else {
+  } else if (playingURL) {
     // A native preset whose descriptor carries the RAW proxy form rather than a
     // per-slot one: the slot lookup finds nothing, and the location is the
     // descriptor rather than a URL, so neither of the matches above can fire
     // and no tile lit up while the speaker was plainly playing one of them.
     // The real station URL is inside the descriptor, and that does match what
     // the key holds.
-    const orion = orionStationPayload(state.nowLocation);
-    if (orion && orion.streamUrl) activeStreamURL = decodeProxyUrl(orion.streamUrl);
+    activeStreamURL = playingURL;
   }
   for (let i = 1; i <= 6; i++) {
     const p = state.presets.find(x => x.slot === i);
@@ -5475,7 +5483,7 @@ function renderPresets() {
     // (e.g. a Deezer playlist set on the speaker). Show it so the user sees and
     // can recall it, instead of a misleading "empty" tile.
     const bp = !p ? (state.boxPresets || []).find(x => x.slot === i) : null;
-    const isActive = p && state.nowLocation && (
+    const baseActive = p && state.nowLocation && (
       p.stream_url === state.nowLocation ||
       (activeSlot !== null && p.slot === activeSlot) ||
       (activeStreamURL && p.stream_url === activeStreamURL) ||
@@ -5484,6 +5492,17 @@ function renderPresets() {
       // location. Never match on the preset name (see nowSpotifySlot note above).
       (p.type === 'spotify' && spotifyPlaying && state.nowSpotifySlot != null && p.slot === state.nowSpotifySlot)
     );
+    // While a native descriptor is playing, drop a slot whose stored station no
+    // longer matches the live audio: a preset list re-synced from the box remote
+    // must not leave the freshly-changed tile lit as "playing" (#758). Only bites
+    // when the speaker plays native radio (orionNow set) and the identity is
+    // known and differs; otherwise baseActive stands unchanged.
+    const isActive = baseActive && !(orionNow && nativeSlotStale({
+      presetName: p && p.name,
+      presetUrl: p && p.stream_url,
+      playingName,
+      playingUrl: playingURL,
+    }));
     const hasErr = !!state.presetErrors[i];
     const div = document.createElement('div');
     div.className = 'preset' + (p || bp ? '' : ' empty') + (isActive ? ' playing' : '') + (hasErr ? ' error' : '') + (bp ? ' box-native' : '');

--- a/desktop-app/frontend/src/nativeslot.test.js
+++ b/desktop-app/frontend/src/nativeslot.test.js
@@ -7,7 +7,7 @@
 // (discussion #555, with the speaker reporting LOCAL_INTERNET_RADIO +
 // PLAY_STATE + the station name, i.e. playing perfectly well).
 import { describe, it, expect } from 'vitest';
-import { activeSlotFromLocation, slotFromOrionStation } from './utils.js';
+import { activeSlotFromLocation, slotFromOrionStation, nativeSlotStale } from './utils.js';
 
 // Builds the descriptor exactly as the agent writes it: unpadded base64url.
 function orion(payload) {
@@ -67,5 +67,49 @@ describe('activeSlotFromLocation', () => {
 describe('slotFromOrionStation', () => {
   it('ignores a location that is not a station descriptor', () => {
     expect(slotFromOrionStation('http://127.0.0.1:8888/stream/3')).toBe(null);
+  });
+});
+
+// A native descriptor keeps playing the recalled station even after the box's
+// own preset list is re-synced (edited from the Bose remote / ST Remote), so a
+// slot can come to hold a different station than the audio. The slot number
+// then still points at that slot, and the tile must not stay lit (#758).
+describe('nativeSlotStale', () => {
+  it('keeps a matching slot lit (url matches)', () => {
+    expect(nativeSlotStale({
+      presetName: 'Klove', presetUrl: 'http://cdn/a.mp3',
+      playingName: 'Klove', playingUrl: 'http://cdn/a.mp3',
+    })).toBe(false);
+  });
+
+  it('keeps a matching slot lit when only the name matches', () => {
+    // The stored URL can be normalised differently from the descriptor form;
+    // an identical station name is enough to treat the slot as the live one.
+    expect(nativeSlotStale({
+      presetName: 'Essentially Rush', presetUrl: 'http://cdn/rush',
+      playingName: 'Essentially Rush', playingUrl: 'http://other/rush2',
+    })).toBe(false);
+  });
+
+  it('suppresses a slot whose station changed under the live audio (#758)', () => {
+    // Key 6 was Rush and is still playing; the list re-synced key 6 to Klove.
+    expect(nativeSlotStale({
+      presetName: 'Klove', presetUrl: 'http://cdn/klove',
+      playingName: 'Essentially Rush', playingUrl: 'http://cdn/rush',
+    })).toBe(true);
+  });
+
+  it('does not judge when the descriptor yields no identity (stays lit)', () => {
+    expect(nativeSlotStale({
+      presetName: 'Klove', presetUrl: 'http://cdn/klove',
+      playingName: '', playingUrl: '',
+    })).toBe(false);
+  });
+
+  it('falls back to the url when the playing name is missing', () => {
+    expect(nativeSlotStale({
+      presetName: 'Klove', presetUrl: 'http://cdn/klove',
+      playingName: '', playingUrl: 'http://cdn/rush',
+    })).toBe(true);
   });
 });

--- a/desktop-app/frontend/src/utils.js
+++ b/desktop-app/frontend/src/utils.js
@@ -493,6 +493,28 @@ export function orionStationPayload(loc) {
   }
 }
 
+// nativeSlotStale decides whether a preset tile the active-slot number points
+// at should still light up while the speaker plays a NATIVE radio descriptor.
+// The speaker keeps playing the station it recalled even after the box's own
+// preset list is re-synced (edited from the Bose remote / ST Remote), so a slot
+// can come to hold a DIFFERENT station than the one still coming out of the
+// speaker. Matching by slot number alone then lights the freshly-changed tile
+// even though the audio is another station (#758: "preset key should not stay
+// selected ... when the key's new station no longer matches what is playing").
+//
+// It suppresses ONLY when the playing station's identity is positively known
+// (its name or its stream URL) AND that identity does not match the preset's
+// current content. When the descriptor yields no usable identity we cannot
+// judge and keep the historical behavior (leave the tile lit), so a valid
+// native play never goes dark.
+export function nativeSlotStale({ presetName, presetUrl, playingName, playingUrl }) {
+  const haveIdentity = !!playingUrl || !!playingName;
+  if (!haveIdentity) return false;
+  if (playingUrl && presetUrl && presetUrl === playingUrl) return false;
+  if (playingName && presetName && presetName === playingName) return false;
+  return true;
+}
+
 // balanceLabel renders a stereo-balance reading (-7..+7, 0 = centred) as the
 // localized label the three balance displays share.
 export function balanceLabel(v) {

--- a/internal/streamproxy/health.go
+++ b/internal/streamproxy/health.go
@@ -1,0 +1,50 @@
+package streamproxy
+
+import "time"
+
+// noteReconnect records one upstream disconnect that forces a reconnect, for the
+// radio_stream_health debug section and a single consolidated WARN. reason is a
+// coarse tag (eof|read-fail); connBytes/connDur describe the connection that
+// just ended; gap is how long the box has gone without audio. A station switch
+// (different upstream URL) restarts the tally so the numbers describe the
+// station currently playing, not a lifetime total.
+//
+// This is instrumentation only: it changes no playback behavior. It exists so a
+// reporter's next diagnostic bundle answers "how often, and why" for an
+// intermittent dropout without hand-counting log lines (Erich, ORF Vorarlberg,
+// 2026-08-28): reason=eof at a steady cadence points at CDN token expiry;
+// reason=read-fail with erratic timing points at the box's own uplink.
+func (s *Server) noteReconnect(url, reason string, connBytes int64, connDur, gap time.Duration) {
+	s.healthMu.Lock()
+	if url != s.healthURL { // a station switch restarts the tally
+		s.healthURL = url
+		s.forwardedBytes = 0
+		s.reconnectCount = 0
+	}
+	s.reconnectCount++
+	s.lastDisconnectReason = reason
+	s.lastGapMs = gap.Milliseconds()
+	s.forwardedBytes += connBytes
+	count, total := s.reconnectCount, s.forwardedBytes
+	s.healthMu.Unlock()
+
+	s.logger.Warn("radio upstream disconnect",
+		"url", url, "reason", reason,
+		"connBytes", connBytes, "connectedSec", int(connDur.Seconds()),
+		"gapMs", gap.Milliseconds(), "reconnectCount", count, "forwardedBytesTotal", total)
+}
+
+// HealthSnapshot backs the radio_stream_health debug section registered in
+// cmd/agent. Read lazily at /api/debug/state fetch time, like the other
+// RegisterDebugSection providers.
+func (s *Server) HealthSnapshot() any {
+	s.healthMu.Lock()
+	defer s.healthMu.Unlock()
+	return map[string]any{
+		"reconnectCount":       s.reconnectCount,
+		"lastDisconnectReason": s.lastDisconnectReason,
+		"lastGapMs":            s.lastGapMs,
+		"upstreamURL":          s.healthURL,
+		"forwardedBytes":       s.forwardedBytes,
+	}
+}

--- a/internal/streamproxy/streamproxy.go
+++ b/internal/streamproxy/streamproxy.go
@@ -144,6 +144,20 @@ type Server struct {
 	// backpressure regression test can shrink it; New sets the production
 	// value.
 	upstreamStallAfter time.Duration
+
+	// radio stream health: cross-reconnect counters behind the
+	// radio_stream_health debug section and one consolidated WARN per upstream
+	// disconnect. The per-handler reconnect attempt counter resets on every
+	// fresh box connection, so a reporter chasing intermittent dropouts (a CDN
+	// that expires its token every couple of minutes, or a flaky box uplink)
+	// cannot see the rate from the log alone. These persist across reconnects
+	// and reset only when the station itself changes.
+	healthMu             sync.Mutex
+	reconnectCount       int64
+	lastDisconnectReason string
+	lastGapMs            int64
+	healthURL            string
+	forwardedBytes       int64
 }
 
 // SetOnDisconnect registers a callback invoked whenever the box closes a
@@ -887,6 +901,7 @@ func (s *Server) streamOneDepth(ctx context.Context, w http.ResponseWriter, r *h
 				// how often a station forces a reconnect.
 				s.logger.Info("stream proxy upstream EOF, will reconnect", "url", url,
 					"connectedSec", int(time.Since(connStart).Seconds()), "bytes", connBytes, "delivered", gotData)
+				s.noteReconnect(url, "eof", connBytes, time.Since(connStart), s.audioGap())
 				return true, nil
 			}
 			// Network-level read error mid-stream: this is the dropout cause for
@@ -894,6 +909,7 @@ func (s *Server) streamOneDepth(ctx context.Context, w http.ResponseWriter, r *h
 			// much it delivered, so the bundle pins the drop without a capture.
 			s.logger.Warn("stream proxy upstream read fail, will reconnect", "url", url, "err", readErr,
 				"connectedSec", int(time.Since(connStart).Seconds()), "bytes", connBytes, "delivered", gotData)
+			s.noteReconnect(url, "read-fail", connBytes, time.Since(connStart), s.audioGap())
 			return true, readErr
 		}
 	}

--- a/internal/webui/assets/index.html
+++ b/internal/webui/assets/index.html
@@ -1218,10 +1218,31 @@ async function togglePower() {
 }
 // setSource selects an input and keeps that button highlighted until another is chosen.
 async function setSource(s, btn, account) {
+  var prevActive = document.querySelector('#inputs .btn.active');
   document.querySelectorAll('#inputs .btn').forEach(function(e){ e.classList.remove('active'); });
   if (btn) btn.classList.add('active');
-  await api('/api/box/source','PUT',{source:s, sourceAccount: account || ''});
+  var ok = await api('/api/box/source','PUT',{source:s, sourceAccount: account || ''});
+  if (ok === null) {
+    // The box refused the switch (an input this model does not have, e.g. an
+    // ST20 variant with no Bluetooth answers 409 source_unavailable) or is
+    // unreachable: api() returns null for both. Restore the prior highlight and
+    // say so, rather than leaving a button lit for an input that never engaged.
+    if (btn) btn.classList.remove('active');
+    if (prevActive) prevActive.classList.add('active');
+    flashInputNote(T.musicLibFailed);
+    return;
+  }
   setTimeout(refreshStatus, 1200);
+}
+// flashInputNote briefly shows a short message in the Input label, then restores
+// it. Reuses the existing label so the phone page needs no separate toast layer.
+var inputNoteTimer = null;
+function flashInputNote(msg) {
+  var el = document.getElementById('lblInput');
+  if (!el) return;
+  el.textContent = msg;
+  if (inputNoteTimer) clearTimeout(inputNoteTimer);
+  inputNoteTimer = setTimeout(function(){ el.textContent = T.input; }, 2600);
 }
 
 // STR's own sources and the firmware's bookkeeping entries are not inputs a

--- a/internal/webui/resume_standby.go
+++ b/internal/webui/resume_standby.go
@@ -1090,18 +1090,6 @@ func (s *Server) HandleEnterStandby() {
 	// spontaneous and wake the box right back up. A fresh user-stop always
 	// means deliberate: keep the conservative handling.
 	deliberateStop := s.userStoppedRecently()
-	// A standby right after a NOT_LOGGED_IN rejection is the box giving up on its
-	// own failed source self-activation, not a user power-off (see
-	// loginGiveupStandbyWindow). Latching the deliberate-stop signals and clearing
-	// the transport here stood the recall-verify loop down before the forced
-	// re-login landed, so the first hardware press after a standby-cleared login
-	// played nothing (Portable 2026-07-23). Leave the transport and latches alone
-	// so the verify loop can wake the box and re-push once the re-login completes.
-	// A real user power-off carries no recent 1036, so it is unaffected.
-	if !deliberateStop && s.loginErrorRecentWithin(loginGiveupStandbyWindow) {
-		s.logger.Info("standby bounce: box dropped to standby right after a NOT_LOGGED_IN rejection, treating as a login give-up, not a user power-off (recovery stays armed)")
-		return
-	}
 	recallActive := !playStart.IsZero() && now.Sub(playStart) < userPlayGuardWindow
 	// A key press only reads as "the user powered the box off mid-recall" when
 	// it is BOTH newer than the press that started the recall (outside the
@@ -1112,6 +1100,28 @@ func (s *Server) HandleEnterStandby() {
 	// recovery off mid-recall (#252).
 	newKeySinceRecall := lastKey.After(playStart.Add(userPlayActivityEpsilon))
 	keyAdjacentToFlip := !lastKey.IsZero() && now.Sub(lastKey) <= powerKeyAdjacencyWindow
+	// A standby right after a NOT_LOGGED_IN rejection is the box giving up on its
+	// own failed source self-activation, not a user power-off (see
+	// loginGiveupStandbyWindow). Latching the deliberate-stop signals and clearing
+	// the transport here stood the recall-verify loop down before the forced
+	// re-login landed, so the first hardware press after a standby-cleared login
+	// played nothing (Portable 2026-07-23). Leave the transport and latches alone
+	// so the verify loop can wake the box and re-push once the re-login completes.
+	// A real user power-off carries no recent 1036, so it is unaffected.
+	//
+	// EXCEPT when a user power press accompanies the flip (#517: quick on -> quick
+	// off re-powered the box because this exemption fired before the key was
+	// examined and never armed the stop latches, and the recall-retry wake then
+	// turned the speaker back on). A genuine login give-up drops to STANDBY on its
+	// own with no adjacent key, so gating on the same power-press signal used below
+	// keeps the give-up recovery armed while letting a real power-off fall through
+	// to noteStandbyStop(). On firmware that emits no key press this is vacuously
+	// the old behavior (still exempt), the documented conservative fall-through.
+	userPowerPress := newKeySinceRecall && keyAdjacentToFlip
+	if !deliberateStop && !userPowerPress && s.loginErrorRecentWithin(loginGiveupStandbyWindow) {
+		s.logger.Info("standby bounce: box dropped to standby right after a NOT_LOGGED_IN rejection, treating as a login give-up, not a user power-off (recovery stays armed)")
+		return
+	}
 	// A flip right after STR's OWN transport push, with no key press SINCE that
 	// push, is the firmware rejecting/settling OUR command - not a user
 	// power-off, even when a key press sits just before the push (field case:
@@ -1771,7 +1781,12 @@ func (s *Server) HandleStreamTitle(title string) {
 		s.lastICYTitle = title
 		s.lastPlayMu.Unlock()
 	}
-	if !s.displayTrackEnabled() || s.renderer == nil || title == "" {
+	enabled := s.displayTrackEnabled()
+	if !enabled || s.renderer == nil || title == "" {
+		// Log the silent skip so a "title missing on model X" report shows which
+		// leg was taken (feature off vs no renderer vs empty title) instead of
+		// leaving every skip invisible in the bundle.
+		s.logger.Info("display title not pushed", "enabled", enabled, "haveRenderer", s.renderer != nil, "title", title)
 		return
 	}
 	// Rate-limit: re-buffering the box on every StreamTitle flip (song <-> promo)
@@ -1780,6 +1795,7 @@ func (s *Server) HandleStreamTitle(title string) {
 	throttled := !s.lastDisplayPush.IsZero() && time.Since(s.lastDisplayPush) < minDisplayPushInterval
 	s.lastPlayMu.Unlock()
 	if throttled {
+		s.logger.Debug("display title push throttled", "title", title)
 		return
 	}
 	s.pushDisplayTitle(title)
@@ -1798,12 +1814,14 @@ func (s *Server) setDisplayText(shown string) {
 	lp := s.lastPlay
 	if lp == nil {
 		s.lastPlayMu.Unlock()
+		s.logger.Info("display push skipped: no active stream", "shown", shown)
 		return
 	}
 	boxURL, art, mime := lp.boxURL, lp.art, lp.mime
 	s.lastDisplayPush = time.Now()
 	s.lastPlayMu.Unlock()
 	if boxURL == "" {
+		s.logger.Info("display push skipped: empty box URL", "shown", shown)
 		return
 	}
 	// Serialise against other box commands (re-push, play) so a title update
@@ -1822,7 +1840,10 @@ func (s *Server) setDisplayText(shown string) {
 		s.logger.Warn("display push failed", "err", err, "shown", shown)
 		return
 	}
-	s.logger.Info("display push", "shown", shown)
+	// boxURL + mime prove the exact write reached the box, so a "sent but not
+	// shown" firmware case (title pushed, home-cinema display ignores dc:title)
+	// is distinguishable from "never sent" in the bundle.
+	s.logger.Info("display push", "shown", shown, "boxURL", boxURL, "mime", mime)
 }
 
 // pushDisplayTitle re-issues the now-playing metadata so the configured display
@@ -1831,6 +1852,9 @@ func (s *Server) setDisplayText(shown string) {
 // pushes once immediately.
 func (s *Server) pushDisplayTitle(rawTitle string) {
 	shown := s.displayTrackText(rawTitle)
+	// raw vs shown reveals when the artist/title/both transform emptied a title
+	// the box would otherwise have shown.
+	s.logger.Info("display title computed", "raw", rawTitle, "mode", s.displayTrackMode(), "shown", shown)
 	if shown == "" {
 		return
 	}

--- a/internal/webui/standby_bounce_test.go
+++ b/internal/webui/standby_bounce_test.go
@@ -182,6 +182,53 @@ func TestHandleEnterStandby_StaleKeyDuringRecallDoesNotLatch(t *testing.T) {
 	}
 }
 
+// TestHandleEnterStandby_QuickOffDuringLoginGiveupLatches guards #517: the user
+// powers a box ON via a preset (which the box refuses with 1036 NOT_LOGGED_IN,
+// stamping a recent login error) and powers it straight OFF again. The adjacent
+// power press makes this a real power-off, so the login-give-up exemption must
+// NOT swallow it: both stop latches must arm so the recall-retry wake stands
+// down instead of turning the speaker back on.
+func TestHandleEnterStandby_QuickOffDuringLoginGiveupLatches(t *testing.T) {
+	s, _ := newPlayTestServer(t)
+	s.standbyStopMu.Lock()
+	s.lastUserPlayStart = time.Now().Add(-3 * time.Second) // recall still active
+	s.standbyStopMu.Unlock()
+	s.NoteBoxLoginError()                                        // 1036 just landed
+	s.SetUserActivityFn(func() time.Time { return time.Now() }) // fresh adjacent power press
+
+	s.HandleEnterStandby()
+
+	if !s.standbyStoppedRecently() {
+		t.Fatal("a power press during a login-give-up window must still arm the standby-bounce window (#517)")
+	}
+	if !s.userStoppedRecently() {
+		t.Fatal("a power press during a login-give-up window must still arm the user-stop (#517)")
+	}
+}
+
+// TestHandleEnterStandby_LoginGiveupWithoutKeyStaysExempt is the other half of
+// #517: with a recent 1036 and NO accompanying key press, the drop is the box
+// giving up on its own failed self-activation. The exemption must still fire so
+// the verify loop keeps recovery armed; nothing may latch or clear here.
+func TestHandleEnterStandby_LoginGiveupWithoutKeyStaysExempt(t *testing.T) {
+	s, rec := newPlayTestServer(t)
+	s.standbyStopMu.Lock()
+	s.lastUserPlayStart = time.Now().Add(-3 * time.Second) // recall still active
+	s.standbyStopMu.Unlock()
+	s.NoteBoxLoginError()
+	s.SetUserActivityFn(func() time.Time { return time.Time{} }) // no key signal
+
+	s.HandleEnterStandby()
+
+	if s.standbyStoppedRecently() || s.userStoppedRecently() {
+		t.Fatal("a keyless login give-up must stay exempt and leave the latches unarmed (#517)")
+	}
+	time.Sleep(150 * time.Millisecond)
+	if rec.count() != 0 {
+		t.Fatalf("a keyless login give-up must not clear the transport, got %v", rec.list())
+	}
+}
+
 // TestHandleEnterStandby_NoActivitySignalStaysConservative: firmware that never
 // emits userActivityUpdate gives the discriminator no signal (zero lastKey), so
 // every drop must keep the conservative #197 handling: latch + clear.


### PR DESCRIPTION
Batch of fixes and instrumentation from the 2026-08-28 sweep and mail round. Built and tested (native + ARM cross-compile, frontend vitest 210 green, webui/boxws/agent Go tests green).

## Fixes
- **#758 preset key stays "playing" after external re-sync** (`fix(app)`): a native-radio preset key stayed lit as now-playing after the box's own preset list was re-synced to a different station. The tile now corroborates the slot-number match against the station actually playing (URL or name from the native descriptor); falls back to the old behavior when the descriptor yields no identity. New unit tests in `nativeslot.test.js`.
- **#517 speaker re-powers itself on quick off-after-on** (`fix(agent)`): the login-give-up exemption fired before the power press was examined and left the stop latches unarmed, so the recall retry woke the box. It now yields to a user power press adjacent to the flip; a keyless login give-up still keeps recovery armed. New tests in `standby_bounce_test.go`.

## Feature
- **Phone input feedback** (`feat(phone)`): tapping an input a speaker lacks (or on an unreachable box) now restores the previous input and shows a short localized message instead of leaving a dead button lit.

## Instrumentation (logging only, no behavior change)
- **Radio reconnect health** (Erich / ORF Vorarlberg): `radio_stream_health` debug section + one consolidated WARN per upstream disconnect, so an intermittent-dropout report is root-caused from the next bundle.
- **Display-title path** (Markus / Cinemate 220 missing title): logs each leg of the on-box title push so "never sent" vs "sent but firmware ignored it" is distinguishable in the bundle.

Reporter replies stay draft-gated; these ship for a beta so the two instrumented reports produce a decisive next bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)