### PR TITLE
Phone media-server browse regression (v0.9.62) + Recently-played parity

### DIFF
--- a/internal/webui/assets/index.html
+++ b/internal/webui/assets/index.html
@@ -2890,11 +2890,13 @@ async function loadRecent() {
     sub.textContent = [e.track, e.account].filter(Boolean).join(' \u00b7 ');
     nm.appendChild(sub);
     row.appendChild(nm);
-    /* Replay only what this page can honestly start: a radio card carries a
-       stream URL the /api/play path accepts. Spotify needs the engine recall
-       (a preset), and a NAS track without its mime would fall into the radio
-       proxy and loop, so those rows are history, not buttons. */
-    if (e.source === 'radio' && e.cardURL && e.cardURL.indexOf('http') === 0) {
+    /* Replay what this page can honestly start: a radio card carries a stream
+       URL the /api/play path accepts, and a media-server (upnp) card carries its
+       NAS HTTP location, which replays through the very same mime-less path the
+       desktop app already uses for these cards (true parity, so no new server
+       behaviour). Spotify needs the engine recall (a preset), so those rows stay
+       history, not buttons. */
+    if ((e.source === 'radio' || e.source === 'upnp') && e.cardURL && e.cardURL.indexOf('http') === 0) {
       var b = document.createElement('button');
       b.className = 'btn'; b.type = 'button';
       b.setAttribute('aria-label', T.play + ': ' + (e.cardName || ''));

--- a/internal/webui/librarybrowse.go
+++ b/internal/webui/librarybrowse.go
@@ -108,12 +108,16 @@ func (s *Server) resolveMediaServer(ctx context.Context, udn string) (dlna.Serve
 }
 
 // resolveMediaServerFresh resolves a server WITHOUT the recall shortcut: a fresh
-// SSDP round, then the box's own discovery cache. It also drops any stored
-// last-known location for the key first, so a stale address that a failed
-// Browse just exposed cannot be recalled again on the retry or the next tap.
+// SSDP round, then the box's own discovery cache, then the fleet. It does NOT
+// drop the stored last-known location first: on a subnet where the box cannot
+// self-discover the server (multicast filtered, firmware cache empty, #726) that
+// stored address is the ONLY one the box can reach, and a transient Browse error
+// must not destroy it. rememberMediaServerLocations below OVERWRITES the stored
+// location when the fresh round actually finds the server at a NEW address (the
+// genuinely-moved-server case #749 targeted), so a real move is still corrected
+// without wiping the one reachable address when discovery comes back empty.
 func (s *Server) resolveMediaServerFresh(ctx context.Context, udn string) (dlna.Server, bool) {
 	key := udnKey(udn)
-	s.forgetMediaServerLocation(key)
 	found, err := dlna.DiscoverServers(ctx, libraryBrowseDiscovery)
 	if err != nil {
 		s.logger.Info("library resolve: discovery failed", "err", err)
@@ -162,15 +166,11 @@ func (s *Server) resolveViaPeers(ctx context.Context, udn string) (dlna.Server, 
 		return dlna.Server{}, false
 	}
 	key := udnKey(udn)
-	tried := 0
-	for _, p := range s.peersFn(ctx) {
-		if !p.Reachable || p.URL == "" {
-			continue
-		}
-		if tried >= 3 { // a small fleet answers on the first reachable sibling
-			break
-		}
-		tried++
+	peers := s.peersFn(ctx)
+
+	// tryPeer asks one peer where the server is and reaches it directly. ok is
+	// true only when it actually described the registered server.
+	tryPeer := func(p PeerLink) (dlna.Server, bool) {
 		loc, ip := s.askPeerLocate(ctx, p.URL, udn)
 		if loc != "" {
 			if srv, err := dlna.DescribeServer(ctx, loc); err == nil && srv.CDSControlURL != "" && udnKey(srv.UDN) == key {
@@ -190,6 +190,50 @@ func (s *Server) resolveViaPeers(ctx context.Context, udn string) (dlna.Server, 
 				}
 			}
 		}
+		return dlna.Server{}, false
+	}
+
+	// Ask reachable peers first, then dimmed ones, with SEPARATE budgets. A
+	// dimmed peer is still worth asking: the box reaches a sibling on another
+	// segment by routed unicast, and /api/library/locate is exactly that unicast
+	// GET; the roster dims a sibling only because its mDNS sightings went stale
+	// (peerDimAfter), not because it is unreachable. #726: the ST-10 that CAN see
+	// the server sat dimmed on the ST-20's roster and the old reachable-only
+	// guard skipped it, so the peer-assist never fired. Peers are name-sorted, so
+	// one shared cap would let earlier-sorted useless peers starve the one useful
+	// dimmed sibling; a per-class cap guarantees the dimmed set its own turn.
+	reachTried, dimTried := 0, 0
+	for _, p := range peers {
+		if p.URL == "" || !p.Reachable {
+			continue
+		}
+		if reachTried >= 3 { // a small fleet answers on the first reachable sibling
+			break
+		}
+		reachTried++
+		if srv, ok := tryPeer(p); ok {
+			return srv, true
+		}
+	}
+	for _, p := range peers {
+		if p.URL == "" || p.Reachable {
+			continue
+		}
+		if dimTried >= 3 {
+			break
+		}
+		dimTried++
+		if srv, ok := tryPeer(p); ok {
+			return srv, true
+		}
+	}
+	// Silent before (#726: the bundle showed zero peer lines even though this
+	// ran, because every peer was dimmed and skipped). Log which branch we hit so
+	// the next bundle proves the path taken.
+	if reachTried == 0 && dimTried == 0 {
+		s.logger.Info("library resolve: no peer agents available to ask for the server", "peers", len(peers))
+	} else {
+		s.logger.Info("library resolve: asked peers for the server but none could locate it", "reachAsked", reachTried, "dimAsked", dimTried)
 	}
 	return dlna.Server{}, false
 }
@@ -372,8 +416,10 @@ func (s *Server) handleLibraryBrowse(w http.ResponseWriter, r *http.Request) {
 		// that still answers its device.xml with a matching UDN but whose
 		// control URL is dead (a moved server, #733/#726). A Browse failure is
 		// the signal that the address is wrong, so re-resolve FRESH (recall
-		// skipped, stored location dropped) and retry once at the current
-		// address before giving up.
+		// skipped) and retry once at the current address before giving up. The
+		// fresh round only REPLACES the stored address when it positively finds
+		// the server elsewhere, so a fresh miss leaves the reachable address
+		// intact (#749 no longer wipes it).
 		if fresh, ok2 := s.resolveMediaServerFresh(ctx, udn); ok2 && fresh.CDSControlURL != srv.CDSControlURL {
 			s.logger.Info("library browse: retrying at a freshly resolved address",
 				"server", fresh.FriendlyName, "wasControl", srv.CDSControlURL, "nowControl", fresh.CDSControlURL)

--- a/internal/webui/librarybrowse_test.go
+++ b/internal/webui/librarybrowse_test.go
@@ -1,12 +1,15 @@
 package webui
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
+	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/JRpersonal/streborn/internal/mediaservers"
@@ -81,5 +84,38 @@ func TestPhoneRemoteRecentBrowseAndRememberedGroup(t *testing.T) {
 		if !strings.Contains(indexHTML, want) {
 			t.Errorf("phone page is missing %q", want)
 		}
+	}
+}
+
+// A box on a segment where it cannot self-discover the media server borrows the
+// address from a sibling. The sibling that CAN see the server is often DIMMED on
+// the roster (its mDNS sightings went stale), not unreachable, and the old
+// reachable-only guard skipped it, so the peer-assist never fired and the phone
+// browse got no answer (#726, v0.9.62 regression). resolveViaPeers must ask a
+// dimmed peer too.
+func TestResolveViaPeersAsksDimmedPeers(t *testing.T) {
+	var asked int32
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/library/locate") {
+			atomic.AddInt32(&asked, 1)
+		}
+		// Empty location: resolveViaPeers then finds nothing and returns false.
+		// The point of the test is that the dimmed peer was ASKED at all.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"udn":"","location":"","ip":""}`)
+	}))
+	defer peer.Close()
+
+	s := &Server{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		peersFn: func(context.Context) []PeerLink {
+			return []PeerLink{{Name: "sibling", URL: peer.URL, Reachable: false}} // DIMMED
+		},
+	}
+	if _, ok := s.resolveViaPeers(context.Background(), "uuid:AAAA-BBBB"); ok {
+		t.Fatal("an empty locate reply must not resolve a server")
+	}
+	if atomic.LoadInt32(&asked) == 0 {
+		t.Fatal("a DIMMED peer must still be asked for the server (#726); the reachable-only guard regressed the peer-assist")
 	}
 }

--- a/internal/webui/librarysearch.go
+++ b/internal/webui/librarysearch.go
@@ -205,18 +205,6 @@ func (s *Server) rememberMediaServerLocations(found []dlna.Server) {
 	}
 }
 
-// forgetMediaServerLocation drops the stored last-known address for a server so
-// recallMediaServer stops handing it back. Used when a Browse against the
-// recalled address failed, i.e. the address is stale even though it still
-// described with a matching UDN (#733/#726: a moved server keeps answering its
-// old device.xml). The next resolve then goes fresh and re-learns the current
-// address.
-func (s *Server) forgetMediaServerLocation(key string) {
-	s.mediaLocMu.Lock()
-	defer s.mediaLocMu.Unlock()
-	delete(s.mediaLoc, key)
-}
-
 // recallMediaServer re-probes the last known address of a registered server
 // that this search's discovery round did not see. The UDN of the answer is
 // checked, because DHCP can have handed that address to something else.


### PR DESCRIPTION
First regression report on v0.9.62 (abschuss, #726) plus a long-standing phone/desktop parity gap. Root-caused from the v0.9.62 bundle and designed + adversarially verified via a multi-agent workflow; corrections from the verify pass are applied.

## The regression (#726)
On a segmented LAN the ST20 could not self-discover the media server (`WARN library resolve: server unresolved, discovered=0 boxKnows=0`) and produced **zero** peer-locate attempts, while the desktop app browsed the same server fine and the "start from the desktop first" workaround stopped working in v0.9.62. Two v0.9.62 changes were responsible:
- **#749** unconditionally forgot the box's one reachable, warmed server address before a fresh round; an empty fresh discovery never put it back, so a transient Browse error permanently wiped it. **Fix:** the fresh resolve keeps the stored address and only *replaces* it when it positively finds the server at a new address (the moved-server case #749 targeted is preserved).
- **#753** peer-assist asked only fully-reachable siblings, but the sibling that can see the server is usually *dimmed* on the roster (stale mDNS, not unreachable), so it was skipped and the assist never fired. **Fix:** dimmed peers are asked too, with a separate budget so a useful dimmed sibling is never crowded out by earlier-sorted ones. New test `TestResolveViaPeersAsksDimmedPeers`.

The resolve path now logs which branch it took, so the next bundle proves it.

## Recently-played parity
The phone offered a Play button only on radio cards, so media-server tracks appeared on the desktop but not the phone. Media-server cards now replay through the same mime-less path the desktop already uses (true parity, no new server behaviour).

Built native + ARM, `go vet` + golangci-lint clean, webui tests green (library tests race-clean; the pre-existing `TestVerifyFollowersJoined` race is unrelated and present on main).

Note: a further app-first durable seed (box borrows the server address from the desktop even when no sibling can see it) is designed and verified but held as a follow-up; abschuss's case is covered because his ST-10 siblings can see the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)