### PR TITLE
Media server that changed its UPnP UUID (WD/Twonky) is found again

### DIFF
--- a/internal/webui/librarybrowse.go
+++ b/internal/webui/librarybrowse.go
@@ -136,6 +136,15 @@ func (s *Server) resolveMediaServerFresh(ctx context.Context, udn string) (dlna.
 	if len(found) > 0 {
 		s.logger.Info("library resolve: fresh discovery saw servers but none matched the registered UDN",
 			"want", key, "discovered", len(found))
+		// A registered server whose UDN no longer matches any live one is the
+		// UUID-regeneration case: WD/Twonky servers mint a new UPnP UUID on a
+		// restart or reconfigure, so a strict UDN resolve can never find them
+		// again even though the server is right there and other apps browse it
+		// fine (#733, #726). Recover it by its friendly NAME when exactly one
+		// discovered server carries the registered name.
+		if srv, ok := s.rematchByName(key, found); ok {
+			return srv, true
+		}
 	}
 	// The multicast round came back without this server. On networks whose AP
 	// or router filters multicast between Wi-Fi and wire, the agent's own
@@ -173,8 +182,12 @@ func (s *Server) resolveViaPeers(ctx context.Context, udn string) (dlna.Server, 
 	tryPeer := func(p PeerLink) (dlna.Server, bool) {
 		loc, ip := s.askPeerLocate(ctx, p.URL, udn)
 		if loc != "" {
-			if srv, err := dlna.DescribeServer(ctx, loc); err == nil && srv.CDSControlURL != "" && udnKey(srv.UDN) == key {
-				s.rememberMediaServerLocations([]dlna.Server{srv})
+			// A peer names one specific device-description URL, so a name match is
+			// safe here: it is the address a sibling that CAN see the server just
+			// resolved. serverMatchesKey also accepts a UUID-regenerated server by
+			// its registered name (#733), the same tolerance recall uses.
+			if srv, err := dlna.DescribeServer(ctx, loc); err == nil && srv.CDSControlURL != "" && s.serverMatchesKey(srv, key) {
+				s.rememberMediaServerLocationAs(key, srv.Location)
 				s.logger.Info("library resolve: found via a peer agent's location", "peer", p.Name)
 				return srv, true
 			}
@@ -182,8 +195,8 @@ func (s *Server) resolveViaPeers(ctx context.Context, udn string) (dlna.Server, 
 		if ip != "" {
 			if found, err := dlna.SearchHost(ctx, ip, libraryUnicastProbe); err == nil {
 				for _, srv := range found {
-					if udnKey(srv.UDN) == key {
-						s.rememberMediaServerLocations(found)
+					if s.serverMatchesKey(srv, key) {
+						s.rememberMediaServerLocationAs(key, srv.Location)
 						s.logger.Info("library resolve: found via a peer agent's ip", "peer", p.Name, "ip", ip)
 						return srv, true
 					}

--- a/internal/webui/librarybrowse_test.go
+++ b/internal/webui/librarybrowse_test.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/JRpersonal/streborn/dlna"
 	"github.com/JRpersonal/streborn/internal/mediaservers"
 )
 
@@ -117,5 +118,57 @@ func TestResolveViaPeersAsksDimmedPeers(t *testing.T) {
 	}
 	if atomic.LoadInt32(&asked) == 0 {
 		t.Fatal("a DIMMED peer must still be asked for the server (#726); the reachable-only guard regressed the peer-assist")
+	}
+}
+
+// A server registered under one UDN that later advertises a DIFFERENT UDN (WD and
+// Twonky regenerate their UPnP UUID on a restart/reconfigure) must still be found
+// by its friendly name, or a strict UDN resolve loses it forever even though it
+// is right there (#733). rematchByName recovers it, but only on a UNIQUE name.
+func TestRematchByNameRecoversUUIDRegeneratingServer(t *testing.T) {
+	store, err := mediaservers.Load(filepath.Join(t.TempDir(), "ms.json"))
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	// Registered under the OLD udn, name "Twonky".
+	_ = store.Add(mediaservers.Server{ID: "OLD-UDN-1111", Name: "Twonky"})
+	s := &Server{logger: slog.New(slog.NewTextHandler(io.Discard, nil)), mediaServers: store}
+	key := udnKey("OLD-UDN-1111")
+
+	// Discovery now sees the same server under a NEW udn, plus an unrelated one.
+	found := []dlna.Server{
+		{UDN: "uuid:NEW-UDN-9999", FriendlyName: "Twonky", Location: "http://192.0.2.50:9000/desc.xml", CDSControlURL: "http://192.0.2.50:9000/ctl"},
+		{UDN: "uuid:OTHER-2222", FriendlyName: "Backupserver", Location: "http://192.0.2.51:8200/desc.xml", CDSControlURL: "http://192.0.2.51:8200/ctl"},
+	}
+	got, ok := s.rematchByName(key, found)
+	if !ok || got.CDSControlURL != "http://192.0.2.50:9000/ctl" {
+		t.Fatalf("expected to recover the renamed-UUID server, got ok=%v srv=%+v", ok, got)
+	}
+	// It must remember the address under the ORIGINAL key so recall reaches it.
+	s.mediaLocMu.Lock()
+	loc := s.mediaLoc[key]
+	s.mediaLocMu.Unlock()
+	if loc != "http://192.0.2.50:9000/desc.xml" {
+		t.Fatalf("location not remembered under the original key, got %q", loc)
+	}
+
+	// Ambiguous: two servers share the name -> refuse rather than guess.
+	found2 := []dlna.Server{
+		{UDN: "uuid:A", FriendlyName: "Twonky", Location: "http://a/d", CDSControlURL: "http://a/c"},
+		{UDN: "uuid:B", FriendlyName: "Twonky", Location: "http://b/d", CDSControlURL: "http://b/c"},
+	}
+	if _, ok := s.rematchByName(key, found2); ok {
+		t.Fatal("two servers sharing the name must NOT be matched")
+	}
+
+	// serverMatchesKey: UDN match or registered-name match, nothing else.
+	if !s.serverMatchesKey(dlna.Server{UDN: "uuid:OLD-UDN-1111"}, key) {
+		t.Fatal("exact UDN must match")
+	}
+	if !s.serverMatchesKey(dlna.Server{UDN: "uuid:NEW", FriendlyName: "twonky"}, key) {
+		t.Fatal("registered name (case-insensitive) must match")
+	}
+	if s.serverMatchesKey(dlna.Server{UDN: "uuid:NEW", FriendlyName: "Something else"}, key) {
+		t.Fatal("a different name and UDN must NOT match")
 	}
 }

--- a/internal/webui/librarysearch.go
+++ b/internal/webui/librarysearch.go
@@ -205,6 +205,77 @@ func (s *Server) rememberMediaServerLocations(found []dlna.Server) {
 	}
 }
 
+// rememberMediaServerLocationAs stores a device-description URL under a SPECIFIC
+// key rather than the server's own UDN. Used when a UUID-regenerating server
+// (WD/Twonky) was recovered by name: the registration, the phone and the app all
+// still know it under its ORIGINAL UDN, so recall has to find it under that key
+// even though the live server now advertises a different one (#733).
+func (s *Server) rememberMediaServerLocationAs(key, loc string) {
+	if key == "" || loc == "" {
+		return
+	}
+	s.mediaLocMu.Lock()
+	if s.mediaLoc == nil {
+		s.mediaLoc = make(map[string]string)
+	}
+	s.mediaLoc[key] = loc
+	s.mediaLocMu.Unlock()
+}
+
+// registeredName returns the friendly name the user registered a server under,
+// looked up by its normalised UDN key, or "" when no registered server matches.
+func (s *Server) registeredName(key string) string {
+	if s.mediaServers == nil {
+		return ""
+	}
+	for _, reg := range s.mediaServers.List() {
+		if udnKey(reg.ID) == key {
+			return strings.TrimSpace(reg.Name)
+		}
+	}
+	return ""
+}
+
+// serverMatchesKey reports whether a described server IS the one registered under
+// key: its UDN still matches, or (for a UUID-regenerating server) it carries the
+// registered friendly name. The name path is deliberately used only where the
+// candidate is a SINGLE server at a specific address (recall, a peer-named
+// location), so a name collision cannot silently pick the wrong one; the
+// multi-candidate discovery scan uses rematchByName's stricter unique-match rule.
+func (s *Server) serverMatchesKey(srv dlna.Server, key string) bool {
+	if udnKey(srv.UDN) == key {
+		return true
+	}
+	name := s.registeredName(key)
+	return name != "" && strings.EqualFold(strings.TrimSpace(srv.FriendlyName), name)
+}
+
+// rematchByName recovers a registered server whose UDN CHANGED by finding the one
+// discovered server that carries its registered name, and remembers that server's
+// address under the ORIGINAL key so recall reaches it next time. It requires an
+// EXACT single name match: zero or several servers sharing the name are left
+// unresolved rather than risk hijacking the wrong device.
+func (s *Server) rematchByName(key string, found []dlna.Server) (dlna.Server, bool) {
+	name := s.registeredName(key)
+	if name == "" {
+		return dlna.Server{}, false
+	}
+	var match dlna.Server
+	n := 0
+	for _, srv := range found {
+		if srv.CDSControlURL != "" && strings.EqualFold(strings.TrimSpace(srv.FriendlyName), name) {
+			match, n = srv, n+1
+		}
+	}
+	if n != 1 {
+		return dlna.Server{}, false
+	}
+	s.rememberMediaServerLocationAs(key, match.Location)
+	s.logger.Info("library resolve: matched a registered server by name after its UDN changed",
+		"name", name, "oldKey", key, "newUDN", udnKey(match.UDN))
+	return match, true
+}
+
 // recallMediaServer re-probes the last known address of a registered server
 // that this search's discovery round did not see. The UDN of the answer is
 // checked, because DHCP can have handed that address to something else.
@@ -218,7 +289,14 @@ func (s *Server) recallMediaServer(ctx context.Context, key string) (dlna.Server
 	pctx, cancel := context.WithTimeout(ctx, libraryRecallTimeout)
 	defer cancel()
 	srv, err := dlna.DescribeServer(pctx, loc)
-	if err != nil || srv.CDSControlURL == "" || udnKey(srv.UDN) != key {
+	if err != nil || srv.CDSControlURL == "" {
+		return dlna.Server{}, false
+	}
+	// The UDN check stops a DHCP-reassigned address that now serves a DIFFERENT
+	// device from being accepted. A UUID-regenerating server (WD/Twonky) fails
+	// that check at its OWN unchanged address, so fall back to the registered
+	// name: same address, same name, new UUID is still the same server (#733).
+	if !s.serverMatchesKey(srv, key) {
 		return dlna.Server{}, false
 	}
 	s.logger.Info("library search: discovery missed a registered server, re-probed its last known address",


### PR DESCRIPTION
Root-caused from two v0.9.63 field bundles (#733 UlrichSzy, #726 abschuss) and verified live on real hardware.

## Root cause
Both reporters' media servers were **discovered** but never **browsable**, and v0.9.63's earlier fixes did not help. The v0.9.63 logs show why:
```
library resolve: fresh discovery saw servers but none matched the registered UDN  want=55076F6E-... discovered=4
library resolve: asked peers ... none could locate it  reachAsked=2
```
The registered UPnP UUID no longer matches any live server. WD and Twonky media servers **regenerate their UUID** on a restart/reconfigure, and STR matched strictly by UUID in resolve, recall and the peer-assist, so the server was lost forever even though other apps browse it instantly.

## Fix
When the UUID no longer matches, recover the server by its **friendly name**:
- fresh discovery: accept the one server carrying the registered name (a shared name is left unresolved rather than pick the wrong device);
- recall and the peer-provided address: accept a name match at their single known location.

The registration keeps the server's original UUID so the app and phone stay consistent; only the resolve tolerates the change. New tests: `TestRematchByNameRecoversUUIDRegeneratingServer`.

## Live verification (office fleet, ST10 .58 on this build)
Both of the maintainer's DLNA servers register, browse, and reach real tracks:
- **Synology DS716+** "Backupserver": Musik/Fotos/Video → "One Alpha"
- **FRITZ!Box 6690** "AVM FRITZ!Mediaserver": Musik/Bilder/Filme/Internetradio/Podcasts → "Fly FRITZ! Fly"

Audible playback test pending on the Portable (the sanctioned audio box, currently offline). Built native + ARM, vet + golangci-lint clean, webui tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)