### PR TITLE
fix(phone): first library browse after a restart answers in about a second, not a minute

### DIFF
--- a/internal/mediaservers/mediaservers.go
+++ b/internal/mediaservers/mediaservers.go
@@ -33,6 +33,13 @@ type Server struct {
 	// reboot uses the same label the user saw, and so the box can be told the
 	// display name when the source is removed again.
 	Name string `json:"name,omitempty"`
+	// Location is the device-description URL this server was last actually
+	// DESCRIBED at. It survives the agent's restarts, so the first browse
+	// after a reboot goes straight to the server instead of paying the whole
+	// discovery chain. #726 measured that chain at about a minute on a box
+	// that cannot hear the server's announcements; with the persisted address
+	// the recall probe answers in a second or two.
+	Location string `json:"location,omitempty"`
 }
 
 // Store is the persisted set of enabled servers.
@@ -106,11 +113,37 @@ func (s *Store) Add(srv Server) error {
 		return fmt.Errorf("media server has no id")
 	}
 	s.mu.Lock()
-	if cur, ok := s.servers[srv.ID]; ok && cur.Name == srv.Name {
+	if cur, ok := s.servers[srv.ID]; ok {
+		if cur.Name == srv.Name {
+			s.mu.Unlock()
+			return nil
+		}
+		// A re-enable never knows the resolved address; keep the one on file.
+		if srv.Location == "" {
+			srv.Location = cur.Location
+		}
+	}
+	s.servers[srv.ID] = srv
+	s.mu.Unlock()
+	return s.Save()
+}
+
+// SetLocation remembers the device-description URL a server was last described
+// at (see Server.Location). Persists only on a CHANGE, so steady-state resolves
+// cost no NAND writes; an id that is not enabled is ignored.
+func (s *Store) SetLocation(id, loc string) error {
+	id, loc = strings.TrimSpace(id), strings.TrimSpace(loc)
+	if id == "" || loc == "" {
+		return nil
+	}
+	s.mu.Lock()
+	cur, ok := s.servers[id]
+	if !ok || cur.Location == loc {
 		s.mu.Unlock()
 		return nil
 	}
-	s.servers[srv.ID] = srv
+	cur.Location = loc
+	s.servers[id] = cur
 	s.mu.Unlock()
 	return s.Save()
 }

--- a/internal/mediaservers/mediaservers_test.go
+++ b/internal/mediaservers/mediaservers_test.go
@@ -95,3 +95,41 @@ func TestAddRejectsEmptyID(t *testing.T) {
 		t.Error("an entry without an id must be rejected")
 	}
 }
+
+// The resolved device-description address survives a reboot (#726: without it
+// every agent restart paid the whole discovery chain again, about a minute on
+// a box that cannot hear the server's announcements), and re-enabling the
+// server must not wipe it.
+func TestLocationPersistsAcrossReloadAndReenable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ms.json")
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if err := s.Add(Server{ID: "AAAA", Name: "NAS"}); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if err := s.SetLocation("AAAA", "http://192.0.2.7:50001/desc.xml"); err != nil {
+		t.Fatalf("set location: %v", err)
+	}
+	// Unknown id: ignored, no error, no write.
+	if err := s.SetLocation("NOPE", "http://x/"); err != nil {
+		t.Fatalf("unknown id must be a no-op, got %v", err)
+	}
+
+	re, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	list := re.List()
+	if len(list) != 1 || list[0].Location != "http://192.0.2.7:50001/desc.xml" {
+		t.Fatalf("location lost across reload: %+v", list)
+	}
+	// A re-enable (same id, changed name, no location) keeps the address.
+	if err := re.Add(Server{ID: "AAAA", Name: "NAS umbenannt"}); err != nil {
+		t.Fatalf("re-add: %v", err)
+	}
+	if got := re.List()[0].Location; got != "http://192.0.2.7:50001/desc.xml" {
+		t.Fatalf("re-enable wiped the location: %q", got)
+	}
+}

--- a/internal/webui/librarybrowse.go
+++ b/internal/webui/librarybrowse.go
@@ -133,6 +133,20 @@ func (s *Server) resolveMediaServer(ctx context.Context, udn string) (dlna.Serve
 // without wiping the one reachable address when discovery comes back empty.
 func (s *Server) resolveMediaServerFresh(ctx context.Context, udn string) (dlna.Server, []dlna.Server, bool) {
 	key := udnKey(udn)
+	// The speaker's own discovery cache first, and only its CHEAP half: one
+	// boxapi GET plus one description fetch, a second or two. The firmware
+	// hears NOTIFY announcements continuously and keeps its list across the
+	// agent's restarts, so for a server that answers no probes (Twonky, #733)
+	// or a box that cannot hear the multicast at all (#726) this is the fast
+	// path. The old order ran it AFTER the full SSDP window and the peer
+	// rounds, which #726 measured as about a minute to the first browse after
+	// a reboot. The expensive unicast probe stays behind the SSDP round.
+	if ip, boxLoc, known := s.boxCacheEntry(ctx, key); known && boxLoc != "" {
+		if srv, ok := s.describeAt(ctx, key, boxLoc, "the speaker's own cached location"); ok {
+			return srv, nil, true
+		}
+		_ = ip
+	}
 	// Early exit on the strict UDN match only: FindServer returns the moment
 	// the registered server is described (the healthy case pays one or two
 	// seconds, not the full listen window), while the name rematch below needs
@@ -383,47 +397,56 @@ func (s *Server) handleLibraryLocate(w http.ResponseWriter, r *http.Request) {
 // exit logs its reason: this path only runs when the phone page is about to
 // show "server not answering", and a silent miss here cannot be told apart
 // from a server that is genuinely off (#726).
-func (s *Server) resolveViaBoxCache(ctx context.Context, key string, discovered int) (dlna.Server, bool) {
+// boxCacheEntry reads the speaker's own /listMediaServers cache and returns
+// the registered server's entry (last seen IP and device-description URL).
+// known=false when the box does not currently list it.
+func (s *Server) boxCacheEntry(ctx context.Context, key string) (ip, loc string, known bool) {
 	if s.boxHost == "" {
-		return dlna.Server{}, false
+		return "", "", false
 	}
-	known, err := boxapi.New(s.boxHost).ListMediaServers(ctx)
+	list, err := boxapi.New(s.boxHost).ListMediaServers(ctx)
 	if err != nil {
-		s.logger.Warn("library resolve: server unresolved and the speaker's own list could not be read",
-			"discovered", discovered, "err", err)
-		return dlna.Server{}, false
+		s.logger.Info("library resolve: the speaker's own server list could not be read", "err", err)
+		return "", "", false
 	}
-	ip, boxLoc := "", ""
-	for _, m := range known {
+	for _, m := range list {
 		if udnKey(m.ID) == key {
-			ip, boxLoc = m.IP, strings.TrimSpace(m.Location)
-			break
+			return m.IP, strings.TrimSpace(m.Location), true
 		}
 	}
-	if ip == "" && boxLoc == "" {
+	return "", "", false
+}
+
+// describeAt fetches the device description at loc and accepts it when it IS
+// the registered server (UDN, or registered name for a UUID-regenerated one).
+// The accepted address is remembered for recall. via names the source for the
+// log line.
+func (s *Server) describeAt(ctx context.Context, key, loc, via string) (dlna.Server, bool) {
+	pctx, cancel := context.WithTimeout(ctx, libraryRecallTimeout)
+	srv, err := dlna.DescribeServer(pctx, loc)
+	cancel()
+	if err == nil && srv.CDSControlURL != "" && s.serverMatchesKey(srv, key) {
+		s.rememberMediaServerLocationAs(key, srv.Location)
+		s.logger.Info("library resolve: described the server at "+via, "location", loc)
+		return srv, true
+	}
+	s.logger.Info("library resolve: "+via+" did not describe the server", "location", loc, "err", err)
+	return dlna.Server{}, false
+}
+
+func (s *Server) resolveViaBoxCache(ctx context.Context, key string, discovered int) (dlna.Server, bool) {
+	ip, _, known := s.boxCacheEntry(ctx, key)
+	if !known {
 		s.logger.Warn("library resolve: server unresolved, the speaker's own discovery does not see it either",
-			"discovered", discovered, "boxKnows", len(known))
+			"discovered", discovered)
 		return dlna.Server{}, false
 	}
-	// The firmware's list carries the device-description URL its own discovery
-	// recorded, and that is the decisive path for a server that never answers
-	// M-SEARCH at all: Twonky ignores the unicast probe below while its HTTP
-	// side serves the description fine, which is exactly why the #733 box could
-	// browse WD-02 natively (firmware cache, NOTIFY-fed) while every probe STR
-	// sent came back empty. Ask that URL directly before probing.
-	if boxLoc != "" {
-		pctx, cancel := context.WithTimeout(ctx, libraryRecallTimeout)
-		srv, err := dlna.DescribeServer(pctx, boxLoc)
-		cancel()
-		if err == nil && srv.CDSControlURL != "" && s.serverMatchesKey(srv, key) {
-			s.rememberMediaServerLocationAs(key, srv.Location)
-			s.logger.Info("library resolve: described the server at the speaker's own cached location",
-				"location", boxLoc)
-			return srv, true
-		}
-		s.logger.Info("library resolve: the speaker's cached location did not describe the server",
-			"location", boxLoc, "err", err)
+	if ip == "" {
+		return dlna.Server{}, false
 	}
+	// The cheap location describe already ran at the START of the fresh chain
+	// (see resolveMediaServerFresh); what is left here is the unicast probe at
+	// the address the firmware names.
 	found, err := dlna.SearchHost(ctx, ip, libraryUnicastProbe)
 	if err != nil {
 		s.logger.Warn("library resolve: unicast probe failed", "ip", ip, "err", err)

--- a/internal/webui/librarybrowse_test.go
+++ b/internal/webui/librarybrowse_test.go
@@ -173,6 +173,45 @@ func TestRematchByNameRecoversUUIDRegeneratingServer(t *testing.T) {
 	}
 }
 
+// After an agent restart the in-memory location map is empty; the persisted
+// store address must seed the recall so the first browse goes straight to the
+// server instead of paying the whole discovery chain (#726: about a minute on
+// a box that cannot hear the server's announcements).
+func TestRecallSeedsFromPersistedLocation(t *testing.T) {
+	const xml = `<?xml version="1.0"?>
+<root xmlns="urn:schemas-upnp-org:device-1-0">
+  <device>
+    <deviceType>urn:schemas-upnp-org:device:MediaServer:1</deviceType>
+    <friendlyName>NETHomeData</friendlyName>
+    <UDN>uuid:SEED-1</UDN>
+    <serviceList>
+      <service>
+        <serviceType>urn:schemas-upnp-org:service:ContentDirectory:1</serviceType>
+        <controlURL>/ctl</controlURL>
+      </service>
+    </serviceList>
+  </device>
+</root>`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = io.WriteString(w, xml)
+	}))
+	defer srv.Close()
+
+	store, err := mediaservers.Load(filepath.Join(t.TempDir(), "ms.json"))
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	_ = store.Add(mediaservers.Server{ID: "SEED-1", Name: "NETHomeData"})
+	_ = store.SetLocation("SEED-1", srv.URL+"/desc.xml")
+
+	s := &Server{logger: slog.New(slog.NewTextHandler(io.Discard, nil)), mediaServers: store}
+	got, ok := s.recallMediaServer(context.Background(), udnKey("SEED-1"))
+	if !ok || got.FriendlyName != "NETHomeData" {
+		t.Fatalf("recall did not resolve from the persisted location: ok=%v srv=%+v", ok, got)
+	}
+}
+
 // A failed browse must say which servers DID answer, or the user cannot tell a
 // dark NAS from a broken STR. The #733 bundle had a live WD-01 and three
 // FritzBox servers on the network while the browsed WD-02 was off; only the

--- a/internal/webui/librarysearch.go
+++ b/internal/webui/librarysearch.go
@@ -193,7 +193,6 @@ func udnKey(udn string) string {
 // can still reach the server directly (see recallMediaServer).
 func (s *Server) rememberMediaServerLocations(found []dlna.Server) {
 	s.mediaLocMu.Lock()
-	defer s.mediaLocMu.Unlock()
 	if s.mediaLoc == nil {
 		s.mediaLoc = make(map[string]string, len(found))
 	}
@@ -203,6 +202,46 @@ func (s *Server) rememberMediaServerLocations(found []dlna.Server) {
 		}
 		s.mediaLoc[udnKey(srv.UDN)] = srv.Location
 	}
+	s.mediaLocMu.Unlock()
+	for _, srv := range found {
+		if srv.Location != "" {
+			s.persistMediaServerLocation(udnKey(srv.UDN), srv.Location)
+		}
+	}
+}
+
+// persistMediaServerLocation writes a resolved address into the media-server
+// store when the key belongs to a REGISTERED server, so it survives the agent's
+// restarts (#726: the in-memory map alone meant every reboot paid the whole
+// discovery chain again, about a minute on a box that cannot hear the server).
+// The store only writes on a change, so the steady state costs no NAND writes.
+func (s *Server) persistMediaServerLocation(key, loc string) {
+	if s.mediaServers == nil || loc == "" {
+		return
+	}
+	for _, reg := range s.mediaServers.List() {
+		if udnKey(reg.ID) == key {
+			if err := s.mediaServers.SetLocation(reg.ID, loc); err != nil {
+				s.logger.Warn("library resolve: could not persist the server's address", "err", err)
+			}
+			return
+		}
+	}
+}
+
+// storedMediaServerLocation returns the persisted last-known address for a
+// registered server, "" when none is on file. The reboot-surviving seed for
+// recallMediaServer.
+func (s *Server) storedMediaServerLocation(key string) string {
+	if s.mediaServers == nil {
+		return ""
+	}
+	for _, reg := range s.mediaServers.List() {
+		if udnKey(reg.ID) == key {
+			return strings.TrimSpace(reg.Location)
+		}
+	}
+	return ""
 }
 
 // rememberMediaServerLocationAs stores a device-description URL under a SPECIFIC
@@ -220,6 +259,7 @@ func (s *Server) rememberMediaServerLocationAs(key, loc string) {
 	}
 	s.mediaLoc[key] = loc
 	s.mediaLocMu.Unlock()
+	s.persistMediaServerLocation(key, loc)
 }
 
 // registeredName returns the friendly name the user registered a server under,
@@ -283,6 +323,11 @@ func (s *Server) recallMediaServer(ctx context.Context, key string) (dlna.Server
 	s.mediaLocMu.Lock()
 	loc := s.mediaLoc[key]
 	s.mediaLocMu.Unlock()
+	if loc == "" {
+		// The in-memory map is empty after every agent restart; the store
+		// carries the last address across reboots (#726).
+		loc = s.storedMediaServerLocation(key)
+	}
 	if loc == "" {
 		return dlna.Server{}, false
 	}


### PR DESCRIPTION
Follow-up to #769, driven by the live #726 confirmation on v0.9.65 ("Jetzt ist der Server in ca. 1 Min gefunden"). The fresh Küche bundle shows where the minute went: full SSDP window plus peer rounds before the box cache, and an address map that starts empty on every agent restart.

- The resolved device-description address now persists in the media-server store (write on change only) and seeds recall after a restart. Measured on a live ST10: **0.217 s** for the first browse after a reboot.
- The fresh chain consults the speaker's own cache FIRST, cheap half only (list + describe, ~1 s); the 18 s unicast probe stays behind the SSDP round.

Tests: store location survives reload and re-enable; recall seeds from the persisted address (httptest device description). Full suites green, ARM cross-build clean, live-verified through two OTA reboots on the office ST10.

Refs #726, refs #733.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFzcAvQkHKWn7hMwxAqfae