### PR TITLE
fix(app): second stereo pair selectable while a pair exists; zone JSON stops leaking speaker names

### DIFF
--- a/desktop-app/frontend/src/groups.js
+++ b/desktop-app/frontend/src/groups.js
@@ -449,3 +449,23 @@ export function balanceSourceBox(selected, pair, boxes) {
     .find(b => b && String(b.deviceID || '').toUpperCase() === String(pair.master || '').toUpperCase());
   return master || selected;
 }
+
+// stereoSelectionPick decides which two speakers the stereo dropdowns show.
+// Priority per slot: a still-valid USER pick wins; the live pair only fills
+// slots the user has not (or no longer validly) chosen; the first candidates
+// are the last resort. The old order put the live pair first, and that
+// reverted every dropdown change on the spot: with any pair live, the
+// UNTOUCHED second select still matched that pair, the whole pair snapped
+// back in, and forming a NEW pair while one existed was impossible (field
+// report 2026-08-29: "haelt an dem alten fest und aendert die Auswahl
+// nicht"). The 2026-08-04 default (controls sit on a real pair, not an
+// unpaired speaker) is preserved: on first paint nothing is remembered and
+// the live slots win.
+export function stereoSelectionPick({ left, right, liveIDs, candIDs }) {
+  const still = (id) => !!id && candIDs.includes(id);
+  return [left, right].map((remembered, i) => {
+    if (still(remembered)) return remembered;
+    if (liveIDs[i]) return liveIDs[i];
+    return candIDs[i] || '';
+  });
+}

--- a/desktop-app/frontend/src/groups.test.js
+++ b/desktop-app/frontend/src/groups.test.js
@@ -23,6 +23,7 @@ import {
   pairMemberBoxes,
   inStereoPair,
   stereoUndoTargets,
+  stereoSelectionPick,
 } from './groups.js';
 
 // Placeholder LAN (192.0.2.0/24, RFC 5737) and deviceIDs only.
@@ -570,5 +571,33 @@ describe('stereoPairOf master field', () => {
   it('still accepts the older master spelling', () => {
     const zoneLive = { A: { stereo: { id: 'x', master: 'cc', members: [] } } };
     expect(stereoPairOf(zoneLive).master).toBe('CC');
+  });
+});
+
+// stereoSelectionPick: a still-valid user pick must beat the live pair, or
+// forming a SECOND pair is impossible (every click reverted, field report
+// 2026-08-29); the live pair stays the default for untouched slots
+// (2026-08-04 behaviour), candidates are the last resort.
+describe('stereoSelectionPick', () => {
+  const candIDs = ['A', 'B', 'C', 'D'];
+  const liveIDs = ['A', 'B']; // the existing pair
+
+  it('first paint without a remembered pick sits on the live pair', () => {
+    expect(stereoSelectionPick({ left: '', right: '', liveIDs, candIDs })).toEqual(['A', 'B']);
+  });
+
+  it('a fresh pick of an unpaired speaker sticks while a pair is live', () => {
+    // She picked C on the left; the right still holds B from the default.
+    expect(stereoSelectionPick({ left: 'C', right: 'B', liveIDs, candIDs })).toEqual(['C', 'B']);
+    // Then D on the right: the new pair C+D survives the repaint.
+    expect(stereoSelectionPick({ left: 'C', right: 'D', liveIDs, candIDs })).toEqual(['C', 'D']);
+  });
+
+  it('a stale pick (speaker gone) falls back to the live pair slot', () => {
+    expect(stereoSelectionPick({ left: 'GONE', right: 'D', liveIDs, candIDs })).toEqual(['A', 'D']);
+  });
+
+  it('no live pair and nothing remembered falls back to the first candidates', () => {
+    expect(stereoSelectionPick({ left: '', right: '', liveIDs: [], candIDs })).toEqual(['A', 'B']);
   });
 });

--- a/desktop-app/frontend/src/views/multiroom.js
+++ b/desktop-app/frontend/src/views/multiroom.js
@@ -11,7 +11,7 @@ import { t } from '../i18n/index.js';
 import { FormZone, DissolveZone, DissolveStereoPair, WakeBox, BrowserOpenURL, readBoxBalance } from '../api.js';
 // Group membership + the shared zoneLive poll live in groups.js: ONE
 // implementation for this tab, the music-tab frames and the group chips.
-import { masterOf as zoneMasterOf, fetchZoneLive, groupMembersOf, stereoPairsOf, stereoPairKey, pairMemberBoxes, stereoUndoTargets } from '../groups.js';
+import { masterOf as zoneMasterOf, fetchZoneLive, groupMembersOf, stereoPairsOf, stereoPairKey, stereoSelectionPick, pairMemberBoxes, stereoUndoTargets } from '../groups.js';
 // App-side pair display name (STR keeps its own, survives updates): see stereoNames.js.
 import { pairDisplayName, setPairName } from '../stereoNames.js';
 
@@ -214,25 +214,22 @@ export function renderMultiroom(fetchLive) {
   // ones and every repaint put them back there ("die Lautsprecherauswahl
   // springt immer auf den nicht gepaarten Lautsprecher", field 2026-08-04).
   const livePairs = stereoPairsOf(state.zoneLive);
-  // The controls act on the live pair that CONTAINS whichever speaker is
-  // selected, so a household with two pairs can reach the second one: picking
-  // one of its members snaps the whole pair in. Default is the first live pair,
-  // which keeps the controls on a real pair rather than an unpaired speaker
-  // (the 2026-08-04 fix), and forming a NEW pair (no live match) leaves the raw
-  // selection alone via pairPick below.
-  const selUp = (id) => String(id || '').toUpperCase();
-  const pairHasSel = (p) => (p.members || []).some(m => {
-    const id = selUp(m && m.deviceID);
-    return id && (id === selUp(state.stereoLeft) || id === selUp(state.stereoRight));
-  });
-  const livePair = livePairs.find(pairHasSel) || livePairs[0] || null;
-  const liveBoxes = pairMemberBoxes(livePair, strBoxes).map(x => x.box).filter(Boolean);
-  const stillThere = (id) => id && pairCands.some(b => b.deviceID === id);
-  const pairPick = [0, 1].map(i => {
-    if (liveBoxes[i]) return liveBoxes[i].deviceID;
-    const remembered = i === 0 ? state.stereoLeft : state.stereoRight;
-    if (stillThere(remembered)) return remembered;
-    return pairCands[i] ? pairCands[i].deviceID : '';
+  // Which two speakers the dropdowns show: a still-valid USER pick wins per
+  // slot, the first live pair only fills what the user has not chosen (the
+  // 2026-08-04 "sit on a real pair by default" behaviour, first paint has no
+  // remembered pick), and the first candidates are the last resort. The old
+  // order put the live pair FIRST, which reverted every dropdown change on
+  // the spot: the untouched second select still matched the existing pair,
+  // the whole pair snapped back in, and forming a NEW pair while any pair
+  // existed was impossible (field report 2026-08-29). Reaching a second
+  // existing pair by picking one of its members (the 1e0eb40 intent) now
+  // lives in the onchange handlers below, keyed on the FRESH pick alone.
+  const liveBoxes = pairMemberBoxes(livePairs[0] || null, strBoxes).map(x => x.box).filter(Boolean);
+  const pairPick = stereoSelectionPick({
+    left: state.stereoLeft,
+    right: state.stereoRight,
+    liveIDs: liveBoxes.map(b => b.deviceID),
+    candIDs: pairCands.map(b => b.deviceID),
   });
   state.stereoLeft = pairPick[0];
   state.stereoRight = pairPick[1];
@@ -367,8 +364,24 @@ export function renderMultiroom(fetchLive) {
     // Dropping the in-progress name on a selection change re-seeds the single
     // Name field from the newly selected pair's stored name, so typing for one
     // pair never leaks onto another.
-    if (left) left.onchange = () => { state.stereoLeft = left.value; delete state.stereoName; renderMultiroom(false); };
-    if (right) right.onchange = () => { state.stereoRight = right.value; delete state.stereoName; renderMultiroom(false); };
+    //
+    // snapPair keys ONLY on the freshly picked id: picking a member of an
+    // existing pair loads both of its members (so rename/dissolve reach a
+    // second pair, the 1e0eb40 intent), while picking an unpaired speaker
+    // sticks and lets a NEW pair be formed next to the existing one (field
+    // report 2026-08-29). The old render-time snap matched against BOTH
+    // selects, so the untouched side re-attached the old pair on every click.
+    const selUpper = (id) => String(id || '').toUpperCase();
+    const snapPair = (pickedId) => {
+      const p = livePairs.find(pr => (pr.members || []).some(m => selUpper(m && m.deviceID) === selUpper(pickedId)));
+      const mb = p ? pairMemberBoxes(p, strBoxes).map(x => x.box).filter(Boolean) : [];
+      if (mb.length === 2) {
+        state.stereoLeft = mb[0].deviceID;
+        state.stereoRight = mb[1].deviceID;
+      }
+    };
+    if (left) left.onchange = () => { state.stereoLeft = left.value; snapPair(left.value); delete state.stereoName; renderMultiroom(false); };
+    if (right) right.onchange = () => { state.stereoRight = right.value; snapPair(right.value); delete state.stereoName; renderMultiroom(false); };
     $('stereoCreate').onclick = () => doFormStereo(pairCands);
     // Keep the typed name across the automatic live-poll repaints (which rebuild
     // this markup wholesale), the same way the L/R selects persist to state.

--- a/desktop-app/logexport.go
+++ b/desktop-app/logexport.go
@@ -782,8 +782,10 @@ func anonymizeSnapshot(s boxSnapshot) boxSnapshot {
 	// JSON rather than XML, so it needs the equivalent pass.
 	s.BoxSnapshot = anonymizeBoxSnapshotJSON(s.BoxSnapshot)
 	s.STRStatus = anonymizeText(s.STRStatus)
-	// The zone JSON carries member IPs and device IDs.
-	s.STRZone = anonymizeText(s.STRZone)
+	// The zone JSON carries member IPs and device IDs, and speaker/pair names
+	// under plain "name" keys that the friendlyName-keyed scrub deliberately
+	// skips; those need the structured pass or they ship in the clear.
+	s.STRZone = anonymizeZoneJSON(s.STRZone)
 	// /api/agent/version carries the user-chosen friendlyName ("Bose Wit"), which
 	// was previously copied into the bundle verbatim. Round-trip the parsed map
 	// through scrubPII so friendlyName (and any device ID it grows) is hashed like
@@ -892,6 +894,49 @@ func hashAccountFields(v any) any {
 // from a text blob using the same shared pass (scrubPII) as the app log. Used
 // for box-side logs we pull over SSH and the /api/debug state so the user can
 // safely attach them to a public GitHub issue.
+// anonymizeZoneJSON hashes the speaker and pair names in the zone JSON. The
+// zone's name fields live under plain "name" keys (remembered[].name,
+// stereo.name), which the friendlyName-keyed scrub deliberately skips so it
+// does not over-scrub radio or preset names, and so a household's speaker
+// names shipped in the clear (found in a 2026-08-29 bundle: a real practice
+// name in remembered[].name). In the ZONE document every "name" IS a speaker
+// or pair name, so hashing them all over-scrubs nothing. Falls back to the
+// plain text pass when the JSON does not parse.
+func anonymizeZoneJSON(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return s
+	}
+	var v any
+	if err := json.Unmarshal([]byte(s), &v); err == nil {
+		hashZoneNames(v)
+		if b, err := json.Marshal(v); err == nil {
+			s = string(b)
+		}
+	}
+	return anonymizeText(s)
+}
+
+// hashZoneNames walks a decoded zone document and replaces every non-empty
+// string under a "name" key with its NAME# hash, in place.
+func hashZoneNames(v any) {
+	switch t := v.(type) {
+	case map[string]any:
+		for k, val := range t {
+			if k == "name" {
+				if str, ok := val.(string); ok && str != "" {
+					t[k] = "NAME#" + hashShort(str)
+				}
+				continue
+			}
+			hashZoneNames(val)
+		}
+	case []any:
+		for _, item := range t {
+			hashZoneNames(item)
+		}
+	}
+}
+
 func anonymizeText(s string) string {
 	return scrubPII(s)
 }

--- a/desktop-app/logexport_zone_test.go
+++ b/desktop-app/logexport_zone_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The zone JSON stores speaker and pair names under plain "name" keys, which
+// the friendlyName-keyed scrub skips by design; a real household speaker name
+// shipped in the clear that way (bundle 2026-08-29, remembered[].name). The
+// structured pass must hash every zone name and keep the rest intact.
+func TestAnonymizeZoneJSONHashesSpeakerNames(t *testing.T) {
+	in := `{"grouped":false,"stereo":{"name":"Praxis Paar","master":"AABBCCDDEEFF"},` +
+		`"remembered":[{"deviceID":"112233445566","ip":"192.168.178.56","name":"Bose Praxis Rechts"}]}`
+	out := anonymizeZoneJSON(in)
+	for _, leak := range []string{"Praxis Paar", "Bose Praxis Rechts", "192.168.178.56"} {
+		if strings.Contains(out, leak) {
+			t.Errorf("zone anonymizer leaked %q in %s", leak, out)
+		}
+	}
+	if !strings.Contains(out, "NAME#") {
+		t.Errorf("zone names not hashed: %s", out)
+	}
+	if !strings.Contains(out, "grouped") {
+		t.Errorf("structure lost: %s", out)
+	}
+	// Broken JSON must still get the text pass, never panic.
+	if got := anonymizeZoneJSON("{not json"); got == "" {
+		t.Error("fallback for unparseable zone JSON returned empty")
+	}
+}


### PR DESCRIPTION
Driven by today's mail report (v0.9.65, six ST10s + ST300, one pair live): every dropdown change in the stereo section reverted instantly, so a second pair could never be formed. The bundle proves it is a pure UI defect: not one FormZone call reached any speaker across all attempts.

- The render-time pair snap matched the live pair against BOTH selects; the untouched select always re-matched the old pair and the selection sprang back each repaint. New pure helper `stereoSelectionPick` inverts the priority (valid user pick > live-pair default > candidates), and the snap-whole-pair-in feature moves into the onchange handlers keyed on the fresh pick only, restoring the 1e0eb40 intent for second pairs as well. Four new vitest cases cover the priority matrix.
- Side finding from the same bundle: `strZoneJson` shipped a real speaker name in the clear (`remembered[].name` is a plain "name" key the friendlyName scrub skips by design). New structured zone pass hashes those names; test included.

Refs the mail thread (reporter gets the workaround: dissolve the existing pair, form the new one, re-form the old one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFzcAvQkHKWn7hMwxAqfae