### PR TITLE
feat(app): back up and restore favorites and presets from the settings

### DIFF
--- a/desktop-app/app_backup.go
+++ b/desktop-app/app_backup.go
@@ -1,0 +1,272 @@
+package main
+
+// Backup and restore of the user's STR configuration (#778): the radio
+// favorites kept by the desktop app and the six preset slots of every
+// speaker, written to one JSON file the user chooses. The point is peace of
+// mind before an update and a way back after a mishap, so the file format is
+// plain JSON a person can read, and restoring is additive: it writes the
+// backed-up slots and touches nothing else.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+// backupKind is the file's self-identification; ImportBackup refuses anything
+// else so a random JSON file cannot be "restored" into the speakers.
+const backupKind = "str-backup"
+
+// backupVersion is bumped only when the format changes incompatibly. Import
+// accepts files up to and including this version.
+const backupVersion = 1
+
+// backupMaxBytes caps the import read. A real backup is a few hundred KB at
+// most (queue presets carry track lists); this is a safety bound, not a limit
+// a legitimate file can hit.
+const backupMaxBytes = 8 << 20
+
+// backupSpeaker is one speaker's share of a backup: enough identity to find
+// the speaker again later (the deviceID is stable, the name is what the user
+// recognizes, the host is informational) and the preset slots verbatim.
+type backupSpeaker struct {
+	Name     string   `json:"name"`
+	Model    string   `json:"model,omitempty"`
+	DeviceID string   `json:"deviceId,omitempty"`
+	Host     string   `json:"host,omitempty"`
+	Presets  []Preset `json:"presets"`
+}
+
+// backupFile is the whole on-disk document. Favorites stay raw JSON on
+// purpose: the frontend owns that schema (its localStorage station list), and
+// the backup must round-trip it verbatim rather than mirror it in Go and
+// silently drop a field the frontend adds later (the queue-preset Items field
+// taught that lesson once already).
+type backupFile struct {
+	Kind       string          `json:"kind"`
+	Version    int             `json:"version"`
+	CreatedAt  string          `json:"createdAt"`
+	AppVersion string          `json:"appVersion"`
+	Favorites  json.RawMessage `json:"favorites,omitempty"`
+	Speakers   []backupSpeaker `json:"speakers"`
+}
+
+// backupBoxes snapshots the discovery cache: the STR speakers a backup can
+// cover, offline ones included (the caller decides what reaching out to them
+// would mean).
+func (a *App) backupBoxes() []BoxInfo {
+	a.discMu.Lock()
+	defer a.discMu.Unlock()
+	var out []BoxInfo
+	for _, e := range a.discCache {
+		if e.box.Kind == "stock" || e.box.Host == "" {
+			continue
+		}
+		out = append(out, e.box)
+	}
+	return out
+}
+
+// ExportBackup gathers the favorites (handed in by the frontend, which owns
+// them) and every reachable speaker's presets, then writes the backup file
+// wherever the user points the save dialog. Speakers that could not be read
+// are reported by name rather than silently left out: a backup whose gaps are
+// invisible is worse than none.
+func (a *App) ExportBackup(favoritesJSON string) (map[string]any, error) {
+	doc := backupFile{
+		Kind:       backupKind,
+		Version:    backupVersion,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		AppVersion: appVersion,
+	}
+	favCount := 0
+	if s := strings.TrimSpace(favoritesJSON); s != "" {
+		var favs []json.RawMessage
+		if err := json.Unmarshal([]byte(s), &favs); err != nil {
+			return nil, fmt.Errorf("favorites payload is not a JSON list: %w", err)
+		}
+		favCount = len(favs)
+		doc.Favorites = json.RawMessage(s)
+	}
+	var skipped []string
+	for _, b := range a.backupBoxes() {
+		label := b.FriendlyName
+		if label == "" {
+			label = b.Name
+		}
+		// An offline speaker cannot be asked for its presets, and waiting for
+		// its transport timeouts would stall the whole export (one unplugged
+		// box, field 2026-08-29). It goes on the skipped list up front.
+		if b.Offline {
+			skipped = append(skipped, label)
+			continue
+		}
+		presets, err := a.GetPresets(b.Host, b.Port)
+		if err != nil {
+			a.logger.Warn("backup: reading presets failed", "host", b.Host, "err", err)
+			skipped = append(skipped, label)
+			continue
+		}
+		doc.Speakers = append(doc.Speakers, backupSpeaker{
+			Name:     label,
+			Model:    b.Model,
+			DeviceID: b.DeviceID,
+			Host:     b.Host,
+			Presets:  presets,
+		})
+	}
+	if favCount == 0 && len(doc.Speakers) == 0 {
+		return nil, fmt.Errorf("nothing to back up: no favorites and no reachable speaker")
+	}
+	path, err := wailsruntime.SaveFileDialog(a.ctx, wailsruntime.SaveDialogOptions{
+		DefaultFilename: "str-backup-" + time.Now().Format("2006-01-02") + ".json",
+		Title:           "Save STR backup",
+		Filters: []wailsruntime.FileFilter{
+			{DisplayName: "STR backup (*.json)", Pattern: "*.json"},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if path == "" {
+		return map[string]any{"canceled": true}, nil
+	}
+	blob, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(path, blob, 0o600); err != nil {
+		return nil, err
+	}
+	presetCount := 0
+	for _, s := range doc.Speakers {
+		presetCount += len(s.Presets)
+	}
+	a.logger.Info("backup: written", "path", path,
+		"favorites", favCount, "speakers", len(doc.Speakers), "presets", presetCount, "skipped", len(skipped))
+	return map[string]any{
+		"path":      path,
+		"favorites": favCount,
+		"speakers":  len(doc.Speakers),
+		"presets":   presetCount,
+		"skipped":   skipped,
+	}, nil
+}
+
+// backupMatchTarget finds the current speaker a backed-up entry belongs to:
+// the stable deviceID decides when it is known, the display name is the
+// fallback (a reinstalled agent can change how the id was recorded, but the
+// user keeps calling the kitchen speaker "Küche").
+func backupMatchTarget(s backupSpeaker, boxes []BoxInfo) *BoxInfo {
+	for i := range boxes {
+		if s.DeviceID != "" && strings.EqualFold(boxes[i].DeviceID, s.DeviceID) {
+			return &boxes[i]
+		}
+	}
+	name := strings.TrimSpace(strings.ToLower(s.Name))
+	if name == "" {
+		return nil
+	}
+	for i := range boxes {
+		label := boxes[i].FriendlyName
+		if label == "" {
+			label = boxes[i].Name
+		}
+		if strings.TrimSpace(strings.ToLower(label)) == name {
+			return &boxes[i]
+		}
+	}
+	return nil
+}
+
+// ImportBackup lets the user pick a backup file, restores each backed-up
+// speaker's presets onto the speaker it matches today, and hands the
+// favorites back to the frontend (which merges them into its own store).
+//
+// Restore semantics are write-only: every backed-up slot is PUT verbatim
+// (the same round-trip the box-to-box copy uses), slots the backup does not
+// name are left as they are, and a speaker that is offline or no longer part
+// of the household is reported, not guessed at.
+func (a *App) ImportBackup() (map[string]any, error) {
+	path, err := wailsruntime.OpenFileDialog(a.ctx, wailsruntime.OpenDialogOptions{
+		Title: "Open STR backup",
+		Filters: []wailsruntime.FileFilter{
+			{DisplayName: "STR backup (*.json)", Pattern: "*.json"},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if path == "" {
+		return map[string]any{"canceled": true}, nil
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if fi.Size() > backupMaxBytes {
+		return nil, fmt.Errorf("this file is too large to be an STR backup")
+	}
+	blob, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var doc backupFile
+	if err := json.Unmarshal(blob, &doc); err != nil || doc.Kind != backupKind {
+		return nil, fmt.Errorf("this is not an STR backup file")
+	}
+	if doc.Version > backupVersion {
+		return nil, fmt.Errorf("this backup was written by a newer STR version; update the app first")
+	}
+	boxes := a.backupBoxes()
+	restored := 0
+	restoredSpeakers := 0
+	var missed []string
+	for _, s := range doc.Speakers {
+		if len(s.Presets) == 0 {
+			continue
+		}
+		target := backupMatchTarget(s, boxes)
+		if target == nil || target.Offline {
+			missed = append(missed, s.Name)
+			continue
+		}
+		wrote := 0
+		var slotErr error
+		for _, p := range s.Presets {
+			if p.Slot < 1 || p.Slot > 6 || p.Name == "" {
+				continue
+			}
+			if err := a.boxPut(target.Host, target.Port, fmt.Sprintf("%s/%d", presetAPIPath, p.Slot), p); err != nil {
+				a.logger.Warn("backup: restoring a preset failed",
+					"host", target.Host, "slot", p.Slot, "err", err)
+				slotErr = err
+				continue
+			}
+			wrote++
+		}
+		if wrote > 0 {
+			restored += wrote
+			restoredSpeakers++
+			// Hardware keys 1-6 must match what was just written, same step as
+			// the box-to-box copy. Best effort: the presets themselves landed.
+			if _, err := a.SyncBoxPresets(target.Host, target.Port); err != nil {
+				a.logger.Warn("backup: hardware key sync failed", "host", target.Host, "err", err)
+			}
+		} else if slotErr != nil {
+			missed = append(missed, s.Name)
+		}
+	}
+	a.logger.Info("backup: restored", "path", path,
+		"speakers", restoredSpeakers, "presets", restored, "missed", len(missed))
+	return map[string]any{
+		"favorites": string(doc.Favorites),
+		"speakers":  restoredSpeakers,
+		"presets":   restored,
+		"missed":    missed,
+	}, nil
+}

--- a/desktop-app/backup_match_test.go
+++ b/desktop-app/backup_match_test.go
@@ -1,0 +1,46 @@
+package main
+
+import "testing"
+
+// The restore has to find "the same speaker" months after the backup was
+// written: the deviceID decides when it matches, and only the display name is
+// left when it does not (agent reinstalled, id recorded differently). A wrong
+// match would write presets onto somebody else's speaker, so the matcher is
+// pinned down here.
+func TestBackupMatchTarget(t *testing.T) {
+	boxes := []BoxInfo{
+		{Host: "192.0.2.10", DeviceID: "AABBCCDDEE01", FriendlyName: "Küche"},
+		{Host: "192.0.2.11", DeviceID: "AABBCCDDEE02", Name: "str-192.0.2.11"},
+		{Host: "192.0.2.12", DeviceID: "AABBCCDDEE03", FriendlyName: "Büro"},
+	}
+
+	t.Run("deviceID wins, case-insensitively", func(t *testing.T) {
+		got := backupMatchTarget(backupSpeaker{Name: "Büro", DeviceID: "aabbccddee01"}, boxes)
+		if got == nil || got.Host != "192.0.2.10" {
+			t.Fatalf("expected the deviceID match to beat the name, got %+v", got)
+		}
+	})
+
+	t.Run("name fallback ignores case and spacing", func(t *testing.T) {
+		got := backupMatchTarget(backupSpeaker{Name: "  küche "}, boxes)
+		if got == nil || got.Host != "192.0.2.10" {
+			t.Fatalf("expected the name fallback to match, got %+v", got)
+		}
+	})
+
+	t.Run("name fallback also reads the bare Name field", func(t *testing.T) {
+		got := backupMatchTarget(backupSpeaker{Name: "str-192.0.2.11"}, boxes)
+		if got == nil || got.Host != "192.0.2.11" {
+			t.Fatalf("expected the Name-field fallback to match, got %+v", got)
+		}
+	})
+
+	t.Run("no identity, no guess", func(t *testing.T) {
+		if got := backupMatchTarget(backupSpeaker{Name: "Wohnzimmer", DeviceID: "FFFFFFFFFFFF"}, boxes); got != nil {
+			t.Fatalf("an unknown speaker must not match anything, got %+v", got)
+		}
+		if got := backupMatchTarget(backupSpeaker{}, boxes); got != nil {
+			t.Fatalf("an empty entry must not match anything, got %+v", got)
+		}
+	})
+}

--- a/desktop-app/frontend/src/api.js
+++ b/desktop-app/frontend/src/api.js
@@ -73,6 +73,8 @@ export {
   DisableBoxMediaServer,
   CurrentWiFi,
   CheckAppUpdate,
+  ExportBackup,
+  ImportBackup,
   ResolveStationLogo,
   BoxSettings,
   SetBoxName,

--- a/desktop-app/frontend/src/i18n/bundles/ar.json
+++ b/desktop-app/frontend/src/i18n/bundles/ar.json
@@ -1340,5 +1340,12 @@
   "updateAll.problemToast": "{{failed}} فشل، {{unconfirmed}} غير مؤكد، {{done}} تم تحديثه، {{deferred}} مؤجل.",
   "speaker.staleVersionTitle": "آخر إصدار مؤكد. مكبر الصوت غير متاح حالياً، وقد تكون هذه القيمة قديمة.",
   "banner.appCheckFailed": "تعذّر إتمام الفحص. لا تزال التنزيلات متاحة على st-reborn.de.",
-  "multiroom.stereoOffline": "تعذّر الوصول: {{names}}. شغّل مكبّر الصوت وحاول مرة أخرى."
+  "multiroom.stereoOffline": "تعذّر الوصول: {{names}}. شغّل مكبّر الصوت وحاول مرة أخرى.",
+  "settingsView.backupHeading": "النسخ الاحتياطي",
+  "settingsView.backupHelp": "يحفظ المفضلة وأزرار الإعدادات المسبقة لكل مكبرات الصوت في ملف واحد. عند الاستعادة تُكتب الإعدادات المسبقة المحفوظة على مكبرات الصوت المطابقة وتُضاف المفضلة؛ وتبقى المفضلة الحالية كما هي.",
+  "settingsView.backupExportBtn": "حفظ النسخة",
+  "settingsView.backupImportBtn": "استعادة النسخة",
+  "settingsView.backupExportDone": "تم الحفظ: {{favs}} من المفضلة و{{presets}} من الإعدادات المسبقة من {{speakers}} من مكبرات الصوت.",
+  "settingsView.backupImportDone": "تمت الاستعادة: {{presets}} من الإعدادات المسبقة على {{speakers}} من مكبرات الصوت، وأُضيف {{favs}} من المفضلة.",
+  "settingsView.backupNotReached": "غير مشمول: {{names}}. شغّل مكبرات الصوت هذه وحاول مرة أخرى."
 }

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -1340,5 +1340,12 @@
   "updateAll.problemToast": "{{failed}} fehlgeschlagen, {{unconfirmed}} unbestätigt, {{done}} aktualisiert, {{deferred}} zurückgestellt.",
   "speaker.staleVersionTitle": "Letzte bestätigte Version. Der Lautsprecher ist gerade nicht erreichbar, der Wert kann veraltet sein.",
   "banner.appCheckFailed": "Die Prüfung hat nicht geklappt. Downloads gibt es weiterhin auf st-reborn.de.",
-  "multiroom.stereoOffline": "Nicht erreichbar: {{names}}. Schalte den Lautsprecher ein und versuch es noch einmal."
+  "multiroom.stereoOffline": "Nicht erreichbar: {{names}}. Schalte den Lautsprecher ein und versuch es noch einmal.",
+  "settingsView.backupHeading": "Sicherung",
+  "settingsView.backupHelp": "Sichert deine Favoriten und die Preset-Tasten aller Lautsprecher in eine Datei, zum Beispiel bevor du etwas umbaust. Beim Wiederherstellen werden die gesicherten Presets auf die passenden Lautsprecher geschrieben und die Favoriten ergänzt, vorhandene Favoriten bleiben erhalten.",
+  "settingsView.backupExportBtn": "Sicherung speichern",
+  "settingsView.backupImportBtn": "Sicherung wiederherstellen",
+  "settingsView.backupExportDone": "Gesichert: {{favs}} Favoriten und {{presets}} Presets von {{speakers}} Lautsprechern.",
+  "settingsView.backupImportDone": "Wiederhergestellt: {{presets}} Presets auf {{speakers}} Lautsprechern, {{favs}} Favoriten ergänzt.",
+  "settingsView.backupNotReached": "Nicht dabei: {{names}}. Schalte diese Lautsprecher ein und versuch es dort noch einmal."
 }

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -1340,5 +1340,12 @@
   "updateAll.problemToast": "{{failed}} failed, {{unconfirmed}} unconfirmed, {{done}} updated, {{deferred}} deferred.",
   "speaker.staleVersionTitle": "Last confirmed version. The speaker is not reachable right now, so this may be out of date.",
   "banner.appCheckFailed": "The check did not go through. Downloads are still available on st-reborn.de.",
-  "multiroom.stereoOffline": "Not reachable: {{names}}. Switch the speaker on and try again."
+  "multiroom.stereoOffline": "Not reachable: {{names}}. Switch the speaker on and try again.",
+  "settingsView.backupHeading": "Backup",
+  "settingsView.backupHelp": "Saves your favorites and the preset keys of every speaker into one file, for example before you change things around. Restoring writes the saved presets back onto the matching speakers and adds the favorites; existing favorites are kept.",
+  "settingsView.backupExportBtn": "Save backup",
+  "settingsView.backupImportBtn": "Restore backup",
+  "settingsView.backupExportDone": "Backed up: {{favs}} favorites and {{presets}} presets from {{speakers}} speakers.",
+  "settingsView.backupImportDone": "Restored: {{presets}} presets on {{speakers}} speakers, {{favs}} favorites added.",
+  "settingsView.backupNotReached": "Not included: {{names}}. Switch these speakers on and try again for them."
 }

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -1340,5 +1340,12 @@
   "updateAll.problemToast": "{{failed}} fallidos, {{unconfirmed}} sin confirmar, {{done}} actualizados, {{deferred}} aplazados.",
   "speaker.staleVersionTitle": "Última versión confirmada. El altavoz no está accesible ahora mismo, este dato puede estar desactualizado.",
   "banner.appCheckFailed": "La comprobación no se pudo completar. Las descargas siguen disponibles en st-reborn.de.",
-  "multiroom.stereoOffline": "No accesible: {{names}}. Enciende el altavoz e inténtalo de nuevo."
+  "multiroom.stereoOffline": "No accesible: {{names}}. Enciende el altavoz e inténtalo de nuevo.",
+  "settingsView.backupHeading": "Copia de seguridad",
+  "settingsView.backupHelp": "Guarda tus favoritos y las teclas de preajuste de cada altavoz en un archivo, por ejemplo antes de hacer cambios. Al restaurar, los preajustes guardados se escriben en los altavoces correspondientes y se añaden los favoritos; los existentes se conservan.",
+  "settingsView.backupExportBtn": "Guardar copia",
+  "settingsView.backupImportBtn": "Restaurar copia",
+  "settingsView.backupExportDone": "Guardado: {{favs}} favoritos y {{presets}} preajustes de {{speakers}} altavoces.",
+  "settingsView.backupImportDone": "Restaurado: {{presets}} preajustes en {{speakers}} altavoces, {{favs}} favoritos añadidos.",
+  "settingsView.backupNotReached": "No incluidos: {{names}}. Enciende estos altavoces y vuelve a intentarlo."
 }

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -1340,5 +1340,12 @@
   "updateAll.problemToast": "{{failed}} en échec, {{unconfirmed}} non confirmés, {{done}} mis à jour, {{deferred}} reportés.",
   "speaker.staleVersionTitle": "Dernière version confirmée. L'enceinte est injoignable pour le moment, cette valeur peut être dépassée.",
   "banner.appCheckFailed": "La vérification a échoué. Les téléchargements restent disponibles sur st-reborn.de.",
-  "multiroom.stereoOffline": "Injoignable : {{names}}. Allumez l’enceinte et réessayez."
+  "multiroom.stereoOffline": "Injoignable : {{names}}. Allumez l’enceinte et réessayez.",
+  "settingsView.backupHeading": "Sauvegarde",
+  "settingsView.backupHelp": "Enregistre vos favoris et les touches de présélection de chaque enceinte dans un fichier, par exemple avant un changement. La restauration réécrit les présélections sur les enceintes correspondantes et ajoute les favoris ; les favoris existants sont conservés.",
+  "settingsView.backupExportBtn": "Enregistrer la sauvegarde",
+  "settingsView.backupImportBtn": "Restaurer la sauvegarde",
+  "settingsView.backupExportDone": "Sauvegardé : {{favs}} favoris et {{presets}} présélections de {{speakers}} enceintes.",
+  "settingsView.backupImportDone": "Restauré : {{presets}} présélections sur {{speakers}} enceintes, {{favs}} favoris ajoutés.",
+  "settingsView.backupNotReached": "Non inclus : {{names}}. Allumez ces enceintes et réessayez pour elles."
 }

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -1340,5 +1340,12 @@
   "updateAll.problemToast": "{{failed}} 件失敗、{{unconfirmed}} 件未確認、{{done}} 件更新、{{deferred}} 件保留。",
   "speaker.staleVersionTitle": "最後に確認できたバージョンです。スピーカーに現在接続できないため、古い可能性があります。",
   "banner.appCheckFailed": "確認できませんでした。st-reborn.de から引き続きダウンロードできます。",
-  "multiroom.stereoOffline": "{{names}} に接続できません。スピーカーの電源を入れて、もう一度お試しください。"
+  "multiroom.stereoOffline": "{{names}} に接続できません。スピーカーの電源を入れて、もう一度お試しください。",
+  "settingsView.backupHeading": "バックアップ",
+  "settingsView.backupHelp": "お気に入りと各スピーカーのプリセットキーを1つのファイルに保存します。復元すると、保存したプリセットが対応するスピーカーに書き戻され、お気に入りが追加されます。既存のお気に入りはそのまま残ります。",
+  "settingsView.backupExportBtn": "バックアップを保存",
+  "settingsView.backupImportBtn": "バックアップを復元",
+  "settingsView.backupExportDone": "{{favs}} 件のお気に入りと {{speakers}} 台のスピーカーの {{presets}} 件のプリセットを保存しました。",
+  "settingsView.backupImportDone": "{{speakers}} 台のスピーカーに {{presets}} 件のプリセットを復元し、{{favs}} 件のお気に入りを追加しました。",
+  "settingsView.backupNotReached": "対象外: {{names}}。これらのスピーカーの電源を入れて、もう一度お試しください。"
 }

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -1340,5 +1340,12 @@
   "updateAll.problemToast": "{{failed}} nepavyko, {{unconfirmed}} nepatvirtinta, {{done}} atnaujinta, {{deferred}} atidėta.",
   "speaker.staleVersionTitle": "Paskutinė patvirtinta versija. Kolonėlė šiuo metu nepasiekiama, reikšmė gali būti pasenusi.",
   "banner.appCheckFailed": "Patikrinti nepavyko. Atsisiuntimai ir toliau pasiekiami st-reborn.de.",
-  "multiroom.stereoOffline": "Nepasiekiama: {{names}}. Įjunkite garsiakalbį ir bandykite dar kartą."
+  "multiroom.stereoOffline": "Nepasiekiama: {{names}}. Įjunkite garsiakalbį ir bandykite dar kartą.",
+  "settingsView.backupHeading": "Atsarginė kopija",
+  "settingsView.backupHelp": "Įrašo jūsų mėgstamiausias stotis ir visų garsiakalbių išankstinių nustatymų mygtukus į vieną failą. Atkuriant įrašyti nustatymai grąžinami į atitinkamus garsiakalbius, o mėgstamiausios papildomos; esamos lieka.",
+  "settingsView.backupExportBtn": "Įrašyti kopiją",
+  "settingsView.backupImportBtn": "Atkurti kopiją",
+  "settingsView.backupExportDone": "Įrašyta: {{favs}} mėgstamiausių ir {{presets}} nustatymų iš {{speakers}} garsiakalbių.",
+  "settingsView.backupImportDone": "Atkurta: {{presets}} nustatymų {{speakers}} garsiakalbiuose, pridėta {{favs}} mėgstamiausių.",
+  "settingsView.backupNotReached": "Neįtraukta: {{names}}. Įjunkite šiuos garsiakalbius ir bandykite dar kartą."
 }

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -1340,5 +1340,12 @@
   "updateAll.problemToast": "{{failed}} neizdevās, {{unconfirmed}} neapstiprināti, {{done}} atjaunināti, {{deferred}} atlikti.",
   "speaker.staleVersionTitle": "Pēdējā apstiprinātā versija. Skaļrunis pašlaik nav sasniedzams, vērtība var būt novecojusi.",
   "banner.appCheckFailed": "Pārbaude neizdevās. Lejupielādes joprojām pieejamas vietnē st-reborn.de.",
-  "multiroom.stereoOffline": "Nav sasniedzams: {{names}}. Ieslēdziet skaļruni un mēģiniet vēlreiz."
+  "multiroom.stereoOffline": "Nav sasniedzams: {{names}}. Ieslēdziet skaļruni un mēģiniet vēlreiz.",
+  "settingsView.backupHeading": "Rezerves kopija",
+  "settingsView.backupHelp": "Saglabā jūsu izlasi un visu skaļruņu iepriekšnoteikto staciju taustiņus vienā failā. Atjaunojot saglabātie iestatījumi tiek ierakstīti atbilstošajos skaļruņos un izlase tiek papildināta; esošā izlase paliek.",
+  "settingsView.backupExportBtn": "Saglabāt kopiju",
+  "settingsView.backupImportBtn": "Atjaunot kopiju",
+  "settingsView.backupExportDone": "Saglabāts: {{favs}} izlases ieraksti un {{presets}} iestatījumi no {{speakers}} skaļruņiem.",
+  "settingsView.backupImportDone": "Atjaunots: {{presets}} iestatījumi {{speakers}} skaļruņos, pievienoti {{favs}} izlases ieraksti.",
+  "settingsView.backupNotReached": "Nav iekļauts: {{names}}. Ieslēdziet šos skaļruņus un mēģiniet vēlreiz."
 }

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -1340,5 +1340,12 @@
   "updateAll.problemToast": "{{failed}} mislukt, {{unconfirmed}} onbevestigd, {{done}} bijgewerkt, {{deferred}} uitgesteld.",
   "speaker.staleVersionTitle": "Laatst bevestigde versie. De speaker is nu niet bereikbaar, dit kan verouderd zijn.",
   "banner.appCheckFailed": "De controle is niet gelukt. Downloads blijven beschikbaar op st-reborn.de.",
-  "multiroom.stereoOffline": "Niet bereikbaar: {{names}}. Zet de speaker aan en probeer het opnieuw."
+  "multiroom.stereoOffline": "Niet bereikbaar: {{names}}. Zet de speaker aan en probeer het opnieuw.",
+  "settingsView.backupHeading": "Back-up",
+  "settingsView.backupHelp": "Bewaart je favorieten en de presettoetsen van elke speaker in één bestand, bijvoorbeeld voordat je iets verandert. Bij herstellen worden de bewaarde presets naar de juiste speakers geschreven en de favorieten toegevoegd; bestaande favorieten blijven staan.",
+  "settingsView.backupExportBtn": "Back-up opslaan",
+  "settingsView.backupImportBtn": "Back-up herstellen",
+  "settingsView.backupExportDone": "Opgeslagen: {{favs}} favorieten en {{presets}} presets van {{speakers}} speakers.",
+  "settingsView.backupImportDone": "Hersteld: {{presets}} presets op {{speakers}} speakers, {{favs}} favorieten toegevoegd.",
+  "settingsView.backupNotReached": "Niet meegenomen: {{names}}. Zet deze speakers aan en probeer het opnieuw."
 }

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -1340,5 +1340,12 @@
   "updateAll.problemToast": "{{failed}} nieudanych, {{unconfirmed}} niepotwierdzonych, {{done}} zaktualizowanych, {{deferred}} odłożonych.",
   "speaker.staleVersionTitle": "Ostatnia potwierdzona wersja. Głośnik jest teraz nieosiągalny, wartość może być nieaktualna.",
   "banner.appCheckFailed": "Sprawdzanie nie powiodło się. Pliki do pobrania są nadal dostępne na st-reborn.de.",
-  "multiroom.stereoOffline": "Nieosiągalne: {{names}}. Włącz głośnik i spróbuj ponownie."
+  "multiroom.stereoOffline": "Nieosiągalne: {{names}}. Włącz głośnik i spróbuj ponownie.",
+  "settingsView.backupHeading": "Kopia zapasowa",
+  "settingsView.backupHelp": "Zapisuje ulubione oraz przyciski presetów wszystkich głośników do jednego pliku, na przykład przed zmianami. Przy przywracaniu zapisane presety trafiają na odpowiednie głośniki, a ulubione są dodawane; istniejące ulubione zostają.",
+  "settingsView.backupExportBtn": "Zapisz kopię",
+  "settingsView.backupImportBtn": "Przywróć kopię",
+  "settingsView.backupExportDone": "Zapisano: {{favs}} ulubionych i {{presets}} presetów z {{speakers}} głośników.",
+  "settingsView.backupImportDone": "Przywrócono: {{presets}} presetów na {{speakers}} głośnikach, dodano {{favs}} ulubionych.",
+  "settingsView.backupNotReached": "Pominięto: {{names}}. Włącz te głośniki i spróbuj ponownie."
 }

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -1340,5 +1340,12 @@
   "updateAll.problemToast": "{{failed}} başarısız, {{unconfirmed}} doğrulanmadı, {{done}} güncellendi, {{deferred}} ertelendi.",
   "speaker.staleVersionTitle": "Son doğrulanan sürüm. Hoparlöre şu anda ulaşılamıyor, bu değer güncel olmayabilir.",
   "banner.appCheckFailed": "Denetim tamamlanamadı. İndirmeler st-reborn.de üzerinde sunulmaya devam ediyor.",
-  "multiroom.stereoOffline": "Ulaşılamıyor: {{names}}. Hoparlörü açıp yeniden deneyin."
+  "multiroom.stereoOffline": "Ulaşılamıyor: {{names}}. Hoparlörü açıp yeniden deneyin.",
+  "settingsView.backupHeading": "Yedekleme",
+  "settingsView.backupHelp": "Favorilerinizi ve tüm hoparlörlerin ön ayar tuşlarını tek bir dosyaya kaydeder. Geri yüklerken kayıtlı ön ayarlar eşleşen hoparlörlere yazılır ve favoriler eklenir; mevcut favoriler korunur.",
+  "settingsView.backupExportBtn": "Yedeği kaydet",
+  "settingsView.backupImportBtn": "Yedeği geri yükle",
+  "settingsView.backupExportDone": "Kaydedildi: {{favs}} favori ve {{speakers}} hoparlörden {{presets}} ön ayar.",
+  "settingsView.backupImportDone": "Geri yüklendi: {{speakers}} hoparlörde {{presets}} ön ayar, {{favs}} favori eklendi.",
+  "settingsView.backupNotReached": "Dahil edilmedi: {{names}}. Bu hoparlörleri açıp yeniden deneyin."
 }

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -1340,5 +1340,12 @@
   "updateAll.problemToast": "{{failed}} невдало, {{unconfirmed}} не підтверджено, {{done}} оновлено, {{deferred}} відкладено.",
   "speaker.staleVersionTitle": "Остання підтверджена версія. Колонка зараз недоступна, значення може бути застарілим.",
   "banner.appCheckFailed": "Перевірка не вдалася. Завантаження, як і раніше, доступні на st-reborn.de.",
-  "multiroom.stereoOffline": "Недоступно: {{names}}. Увімкніть колонку та спробуйте ще раз."
+  "multiroom.stereoOffline": "Недоступно: {{names}}. Увімкніть колонку та спробуйте ще раз.",
+  "settingsView.backupHeading": "Резервна копія",
+  "settingsView.backupHelp": "Зберігає ваші улюблені станції та кнопки пресетів усіх колонок в один файл, наприклад перед змінами. Під час відновлення збережені пресети записуються на відповідні колонки, а улюблені додаються; наявні улюблені зберігаються.",
+  "settingsView.backupExportBtn": "Зберегти копію",
+  "settingsView.backupImportBtn": "Відновити копію",
+  "settingsView.backupExportDone": "Збережено: {{favs}} улюблених і {{presets}} пресетів із {{speakers}} колонок.",
+  "settingsView.backupImportDone": "Відновлено: {{presets}} пресетів на {{speakers}} колонках, додано {{favs}} улюблених.",
+  "settingsView.backupNotReached": "Не включено: {{names}}. Увімкніть ці колонки та спробуйте ще раз."
 }

--- a/desktop-app/frontend/src/i18n/bundles/zh-Hant.json
+++ b/desktop-app/frontend/src/i18n/bundles/zh-Hant.json
@@ -1340,5 +1340,12 @@
   "updateAll.problemToast": "{{failed}} 個失敗、{{unconfirmed}} 個未確認、{{done}} 個已更新、{{deferred}} 個延後。",
   "speaker.staleVersionTitle": "最後確認的版本。目前無法連線到喇叭，此數值可能已過時。",
   "banner.appCheckFailed": "檢查未能完成。st-reborn.de 上仍可下載。",
-  "multiroom.stereoOffline": "無法連線：{{names}}。請開啟喇叭後再試一次。"
+  "multiroom.stereoOffline": "無法連線：{{names}}。請開啟喇叭後再試一次。",
+  "settingsView.backupHeading": "備份",
+  "settingsView.backupHelp": "將你的最愛與所有喇叭的預設按鍵儲存到一個檔案，例如在變更設定之前。還原時會把儲存的預設寫回對應的喇叭並加入最愛；現有的最愛會保留。",
+  "settingsView.backupExportBtn": "儲存備份",
+  "settingsView.backupImportBtn": "還原備份",
+  "settingsView.backupExportDone": "已備份：{{favs}} 個最愛，以及 {{speakers}} 台喇叭的 {{presets}} 個預設。",
+  "settingsView.backupImportDone": "已還原：{{speakers}} 台喇叭上的 {{presets}} 個預設，並加入 {{favs}} 個最愛。",
+  "settingsView.backupNotReached": "未包含：{{names}}。請開啟這些喇叭後再試一次。"
 }

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -398,7 +398,7 @@ initSpotifyView({
     .filter(b => b && b.kind !== 'stock' && b.deviceID && b.host)
     .map(b => ({ host: b.host, port: b.port, name: getBoxLabel(b) })),
 });
-initSettingsView({ switchView, updateFilterIndicators, discoverBoxes, renderBoxSelect, localizeLanguageName, doBoxUpdate, updateAllBoxes, boxNeedsUpdate, loadPresets, getRoomNames, speakerPicked: speakerPickedInTab });
+initSettingsView({ switchView, updateFilterIndicators, discoverBoxes, renderBoxSelect, localizeLanguageName, doBoxUpdate, updateAllBoxes, boxNeedsUpdate, loadPresets, getRoomNames, speakerPicked: speakerPickedInTab, favStationsJSON, mergeFavStations });
 initLibraryView({ showSlotPicker, formatDuration, effectivePlayTarget, speakerPicked: speakerPickedInTab });
 initSetupView({ switchView, discoverBoxes, doBoxUpdate, getRoomNames, celebrateProvision: inviteWorldMapAfterProvision, speakerPicked: speakerPickedInTab });
 initPodcastsView();
@@ -7196,6 +7196,32 @@ function favMinimal(s) {
   };
 }
 function favId(s) { return s && (s.stationuuid || (s.name + '|' + (s.url || ''))); }
+// favStationsJSON / mergeFavStations are the backup hooks (#778): export hands
+// the raw store to the backup file, import merges the file's list back in.
+// Merging (not replacing) is deliberate: restoring onto a damaged install adds
+// everything back, and restoring an old file onto a healthy one cannot delete
+// the stars added since.
+function favStationsJSON() {
+  try { return localStorage.getItem(FAV_KEY) || '[]'; } catch { return '[]'; }
+}
+function mergeFavStations(json) {
+  let incoming = [];
+  try { incoming = JSON.parse(json) || []; } catch { /* not a list: nothing to merge */ }
+  if (!Array.isArray(incoming)) incoming = [];
+  const arr = loadFavStore();
+  const have = new Set(arr.map(favId));
+  let added = 0;
+  for (const s of incoming) {
+    const id = favId(s);
+    if (!id || have.has(id)) continue;
+    arr.push(favMinimal(s));
+    have.add(id);
+    added++;
+  }
+  if (added) saveFavStore(arr);
+  updateFavModeBtn();
+  return { added, total: arr.length };
+}
 function isFav(s) {
   const id = favId(s);
   return !!id && loadFavStore().some(x => favId(x) === id);

--- a/desktop-app/frontend/src/views/settings.js
+++ b/desktop-app/frontend/src/views/settings.js
@@ -43,6 +43,8 @@ import {
   RebootBox,
   SetPreset,
   SyncBoxPresets,
+  ExportBackup,
+  ImportBackup,
   RestoreBoxSnapshot,
   SaveDiagnosticBundle,
   BrowserOpenURL,
@@ -485,6 +487,7 @@ function groupSettingsSections() {
     [t('settingsView.regionHeading')]: 'network',
     [t('settingsView.sourcesHeading')]: 'info',
     [t('settingsView.actionsHeading')]: 'actions',
+    [t('settingsView.backupHeading')]: 'actions',
     [t('settingsView.speakerInfoHeading')]: 'info',
   };
   const buckets = {};
@@ -1165,6 +1168,15 @@ function renderBoxSettings(s, box) {
         <p class="muted small">${escapeHtml(t('settingsView.removeSTRHelp'))}</p>
       </div>
     </div>
+    <div class="settings-section" id="backupSection">
+      <h3>${escapeHtml(t('settingsView.backupHeading'))}</h3>
+      ${helpBlock(t('settingsView.backupHelp'), 'p', 'muted small')}
+      <div class="setting-row">
+        <button class="btn btn-mini" id="backupExportBtn">${escapeHtml(t('settingsView.backupExportBtn'))}</button>
+        <button class="btn btn-mini" id="backupImportBtn">${escapeHtml(t('settingsView.backupImportBtn'))}</button>
+      </div>
+      <div id="backupResult" class="muted small" style="margin-top:8px"></div>
+    </div>
     <details class="settings-section settings-expert">
       <summary class="settings-expert-summary">${escapeHtml(t('settingsView.restoreHeading'))} <span class="exp-badge">${escapeHtml(t('settingsView.experimentalBadge'))}</span></summary>
       ${helpBlock(t('settingsView.restoreHelp'), 'p', 'muted small')}
@@ -1507,6 +1519,62 @@ function renderBoxSettings(s, box) {
       } catch (e) { showError(e); }
     };
   })();
+
+  // Backup and restore (#778): favorites + every speaker's presets into one
+  // JSON file, and back. The heavy lifting is Go-side (ExportBackup /
+  // ImportBackup own the dialogs, the preset reads and the restore writes);
+  // this wiring only contributes the favorites, which live in the frontend's
+  // localStorage, and renders the outcome.
+  const bkExport = $('backupExportBtn');
+  if (bkExport) {
+    bkExport.onclick = async () => {
+      const out = $('backupResult');
+      bkExport.disabled = true;
+      if (out) out.innerHTML = `<div class="muted small">${escapeHtml(t('common.loading'))}</div>`;
+      try {
+        const favs = deps.favStationsJSON ? deps.favStationsJSON() : '[]';
+        const r = await ExportBackup(favs);
+        if (out) {
+          if (r && r.canceled) { out.innerHTML = ''; }
+          else {
+            out.innerHTML = `<div class="setup-ok">${escapeHtml(t('settingsView.backupExportDone', {
+              favs: (r && r.favorites) || 0, speakers: (r && r.speakers) || 0, presets: (r && r.presets) || 0,
+            }))}</div>` + ((r && r.skipped && r.skipped.length)
+              ? `<div class="setup-warn">${escapeHtml(t('settingsView.backupNotReached', { names: r.skipped.join(', ') }))}</div>` : '');
+          }
+        }
+      } catch (e) {
+        if (out) out.innerHTML = `<div class="setup-err">${escapeHtml(String(e))}</div>`;
+      }
+      bkExport.disabled = false;
+    };
+  }
+  const bkImport = $('backupImportBtn');
+  if (bkImport) {
+    bkImport.onclick = async () => {
+      const out = $('backupResult');
+      bkImport.disabled = true;
+      if (out) out.innerHTML = `<div class="muted small">${escapeHtml(t('common.loading'))}</div>`;
+      try {
+        const r = await ImportBackup();
+        if (r && r.canceled) { if (out) out.innerHTML = ''; }
+        else {
+          const merged = (deps.mergeFavStations && r && typeof r.favorites === 'string' && r.favorites)
+            ? deps.mergeFavStations(r.favorites) : { added: 0 };
+          if (out) {
+            out.innerHTML = `<div class="setup-ok">${escapeHtml(t('settingsView.backupImportDone', {
+              favs: merged.added || 0, presets: (r && r.presets) || 0, speakers: (r && r.speakers) || 0,
+            }))}</div>` + ((r && r.missed && r.missed.length)
+              ? `<div class="setup-warn">${escapeHtml(t('settingsView.backupNotReached', { names: r.missed.join(', ') }))}</div>` : '');
+          }
+          deps.loadPresets && deps.loadPresets();
+        }
+      } catch (e) {
+        if (out) out.innerHTML = `<div class="setup-err">${escapeHtml(String(e))}</div>`;
+      }
+      bkImport.disabled = false;
+    };
+  }
 
   // Hardware key sync handler.
   const syncBtn = $('boxSyncPresetsBtn');

--- a/desktop-app/frontend/wailsjs/go/main/App.d.ts
+++ b/desktop-app/frontend/wailsjs/go/main/App.d.ts
@@ -69,6 +69,8 @@ export function EnableBoxMediaServer(arg1:string,arg2:number,arg3:string,arg4:st
 
 export function EnsureSpotifyEngine(arg1:string,arg2:number):Promise<string>;
 
+export function ExportBackup(arg1:string):Promise<Record<string, any>>;
+
 export function ExportDiagnosticLogs(arg1:main.LogExportRequest):Promise<main.LogExportResult>;
 
 export function FormZone(arg1:string,arg2:number,arg3:main.ZoneSpec):Promise<Record<string, any>>;
@@ -102,6 +104,8 @@ export function GetStereoPairName(arg1:string):Promise<string>;
 export function GetWebhooks(arg1:string,arg2:number):Promise<Record<string, any>>;
 
 export function GetZoneState(arg1:string,arg2:number):Promise<Record<string, any>>;
+
+export function ImportBackup():Promise<Record<string, any>>;
 
 export function InstallSTROnBox(arg1:string,arg2:string):Promise<main.InstallResult>;
 

--- a/desktop-app/frontend/wailsjs/go/main/App.js
+++ b/desktop-app/frontend/wailsjs/go/main/App.js
@@ -130,6 +130,10 @@ export function EnsureSpotifyEngine(arg1, arg2) {
   return window['go']['main']['App']['EnsureSpotifyEngine'](arg1, arg2);
 }
 
+export function ExportBackup(arg1) {
+  return window['go']['main']['App']['ExportBackup'](arg1);
+}
+
 export function ExportDiagnosticLogs(arg1) {
   return window['go']['main']['App']['ExportDiagnosticLogs'](arg1);
 }
@@ -196,6 +200,10 @@ export function GetWebhooks(arg1, arg2) {
 
 export function GetZoneState(arg1, arg2) {
   return window['go']['main']['App']['GetZoneState'](arg1, arg2);
+}
+
+export function ImportBackup() {
+  return window['go']['main']['App']['ImportBackup']();
 }
 
 export function InstallSTROnBox(arg1, arg2) {


### PR DESCRIPTION
Implements #778: a Backup card in the speaker settings (Actions group).

- **Save backup**: favorites (frontend store, embedded verbatim) + presets of every reachable STR speaker into one readable JSON file (`str-backup-YYYY-MM-DD.json`, kind/version-stamped). Offline speakers are listed as not included instead of stalling the export.
- **Restore backup**: refuses non-STR files, matches each backed-up speaker by deviceID first and display name second (pure matcher covered by a Go test), PUTs the saved slots verbatim (same round-trip as the box-to-box copy), re-syncs hardware keys, and hands the favorites back to the frontend for an additive merge (existing stars survive). Unmatched or offline speakers are named in the result.
- 6 new i18n keys in 13 languages; bindings regenerated for the two new App methods.

The i18n bundles overlap with PR #779; I will rebase whichever merges second.

Refs #778.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFzcAvQkHKWn7hMwxAqfae