### PR TITLE
fix(spotify): a track skipped in the Spotify app is heard within seconds

### DIFF
--- a/internal/spotify/appskip_test.go
+++ b/internal/spotify/appskip_test.go
@@ -1,0 +1,112 @@
+package spotify
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newAppSkipTestManager() *Manager {
+	return &Manager{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+}
+
+func TestParseLoadedTrackDurMs(t *testing.T) {
+	line := strings.ToLower(`time="2026-08-29T14:19:00+02:00" level=info msg="loaded track \"Rain\" (paused: false, position: 9ms, duration: 236400ms, prefetched: true)" uri="spotify:track:x"`)
+	if got := parseLoadedTrackDurMs(line); got != 236400 {
+		t.Fatalf("duration = %d, want 236400", got)
+	}
+	if got := parseLoadedTrackDurMs("no duration here"); got != 0 {
+		t.Fatalf("lines without a duration must parse to 0, got %d", got)
+	}
+}
+
+func TestCutShortOfDuration(t *testing.T) {
+	full := int64(236400) // ms
+	fullGran := full * vorbisRate / 1000
+	cases := []struct {
+		name string
+		gran, body, dur int64
+		want bool
+	}{
+		// A natural end's granule matches the duration within fractions of a
+		// second (live 2026-08-29: 11855256 samples vs 268826 ms).
+		{"natural end", fullGran + 1176, 4096, full, false},
+		// The observed app skip: La Grange cut at 207.5 s of 230.5 s.
+		{"mid-track cut", 9150400, 4096, 230480, true},
+		{"cut in the final seconds is natural", fullGran - 4*vorbisRate, 4096, full, false},
+		{"unknown duration never fires", 100000, 4096, 0, false},
+		{"empty previous track never fires", 100000, 0, full, false},
+	}
+	for _, c := range cases {
+		if got := cutShortOfDuration(c.gran, c.body, c.dur); got != c.want {
+			t.Errorf("%s: cutShortOfDuration(%d, %d, %d) = %v, want %v", c.name, c.gran, c.body, c.dur, got, c.want)
+		}
+	}
+}
+
+// The full detector path: durations queue up from engine log lines, each
+// boundary shifts the queue, and only a mid-track cut with no STR cut armed
+// re-points an attached box.
+func TestNoteTrackBoundaryCutFiresOnForeignSkip(t *testing.T) {
+	m := newAppSkipTestManager()
+	fired := make(chan struct{}, 2)
+	m.SetOnActivate(func(context.Context) { fired <- struct{}{} })
+	m.sink = io.Discard // a box is attached
+
+	// Track A loads (269 s), its BOS arrives: the queue shifts, but the
+	// PREVIOUS stream track has no known duration (agent saw no load for
+	// it), so nothing may fire.
+	m.noteLibrespotLine(`level=info msg="loaded track \"a\" (position: 0ms, duration: 268826ms, prefetched: true)"`)
+	m.noteTrackBoundaryCut(0, 0)
+	select {
+	case <-fired:
+		t.Fatal("boundary with unknown previous duration must not re-point")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Track B loads, and A's boundary arrives 23 s early: an app skip.
+	m.noteLibrespotLine(`level=info msg="loaded track \"b\" (position: 0ms, duration: 230480ms, prefetched: true)"`)
+	m.noteTrackBoundaryCut((268826-23000)*vorbisRate/1000, 4096)
+	select {
+	case <-fired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("mid-track cut with no STR cut armed must re-point the box")
+	}
+	if m.LastSkipBoundary().IsZero() {
+		t.Fatal("a foreign cut must stamp the skip boundary")
+	}
+}
+
+func TestNoteTrackBoundaryCutStandsDown(t *testing.T) {
+	t.Run("STR skip armed the cut", func(t *testing.T) {
+		m := newAppSkipTestManager()
+		fired := make(chan struct{}, 1)
+		m.SetOnActivate(func(context.Context) { fired <- struct{}{} })
+		m.sink = io.Discard
+		m.noteLibrespotLine(`level=info msg="loaded track \"a\" (duration: 268826ms)"`)
+		m.noteTrackBoundaryCut(0, 0) // seed streamTrackDurMs
+		m.NoteSkip()
+		m.noteTrackBoundaryCut(100*vorbisRate, 4096) // cut at 100 s of 269 s
+		select {
+		case <-fired:
+			t.Fatal("an armed STR cut must keep the detector silent")
+		case <-time.After(50 * time.Millisecond):
+		}
+	})
+	t.Run("no box attached", func(t *testing.T) {
+		m := newAppSkipTestManager()
+		fired := make(chan struct{}, 1)
+		m.SetOnActivate(func(context.Context) { fired <- struct{}{} })
+		m.noteLibrespotLine(`level=info msg="loaded track \"a\" (duration: 268826ms)"`)
+		m.noteTrackBoundaryCut(0, 0)
+		m.noteTrackBoundaryCut(100*vorbisRate, 4096)
+		select {
+		case <-fired:
+			t.Fatal("a detached or paused box must not be forced back into playing")
+		case <-time.After(50 * time.Millisecond):
+		}
+	})
+}

--- a/internal/spotify/engine.go
+++ b/internal/spotify/engine.go
@@ -455,6 +455,11 @@ func (m *Manager) runOnce(ctx context.Context) error {
 			m.logger.Info("spotify: track boundary (BOS)",
 				"track", trackNum+1, "prevTrackKB", trackBody/1024,
 				"prevMaxGran", maxGran, "forwardedKB", forwarded/1024)
+			// App-skip detector: a boundary that cuts the previous track
+			// clearly short, with no STR skip or recall cut armed, came from
+			// the Spotify app itself; re-point the box so it drops the old
+			// track's buffered tail (see durQueueMs in Manager).
+			m.noteTrackBoundaryCut(maxGran, trackBody)
 			// A fresh logical stream means the engine is demonstrably
 			// delivering audio: that is the recovery signal the delayed
 			// auto-advance checks before skipping (see handleEnginePlaybackEnd).
@@ -631,8 +636,41 @@ const (
 	keyRefusalRunTrips = 5
 )
 
+// parseLoadedTrackDurMs pulls the millisecond duration out of a lowercased
+// go-librespot "loaded track" line (`... duration: 236400ms, ...`). Zero when
+// the line carries none.
+func parseLoadedTrackDurMs(lc string) int64 {
+	i := strings.Index(lc, "duration: ")
+	if i < 0 {
+		return 0
+	}
+	var ms int64
+	for _, r := range lc[i+len("duration: "):] {
+		if r < '0' || r > '9' {
+			break
+		}
+		ms = ms*10 + int64(r-'0')
+	}
+	return ms
+}
+
 func (m *Manager) noteLibrespotLine(line string) {
 	lc := strings.ToLower(line)
+	// "loaded track" carries the duration the app-skip detector needs (see
+	// durQueueMs). The prefetch line names a duration too, but describes a
+	// track that may never play, so it must not enter the queue.
+	if strings.Contains(lc, `msg="loaded track`) {
+		if ms := parseLoadedTrackDurMs(lc); ms > 0 {
+			m.mu.Lock()
+			m.durQueueMs = append(m.durQueueMs, ms)
+			// Bounded: a load that never produces a boundary (aborted play)
+			// must not let the queue drift away from the stream for good.
+			if len(m.durQueueMs) > 4 {
+				m.durQueueMs = m.durQueueMs[len(m.durQueueMs)-4:]
+			}
+			m.mu.Unlock()
+		}
+	}
 	if strings.Contains(lc, "free") && (strings.Contains(lc, "not support") || strings.Contains(lc, "premium")) {
 		m.mu.Lock()
 		already := m.sawFreeAccountLog

--- a/internal/spotify/manager.go
+++ b/internal/spotify/manager.go
@@ -277,6 +277,17 @@ type Manager struct {
 	// playlist) the box is re-pointed at the stream so it drops its buffer and
 	// plays the new playlist promptly instead of finishing the old buffer.
 	lastContext string
+	// durQueueMs / streamTrackDurMs feed the app-skip detector: every engine
+	// "loaded track" line queues that track's duration, and each BOS shifts
+	// the queue so streamTrackDurMs names the duration of the track whose
+	// pages are currently being forwarded. A BOS arriving while the forwarded
+	// granule is clearly short of that duration is a mid-track cut the agent
+	// did not issue (the Spotify app's own Next/Prev), and the box must drop
+	// its buffered tail like the STR skip paths do; without that, an app skip
+	// only became audible once the box had drained its whole pacing buffer,
+	// which a listener clocked at over 20 seconds (field, 2026-08-29).
+	durQueueMs       []int64
+	streamTrackDurMs int64
 	// pendingRepointFrom/To hold a context change announced by will_play that
 	// has not been acted on yet.
 	//

--- a/internal/spotify/ogg.go
+++ b/internal/spotify/ogg.go
@@ -276,6 +276,47 @@ func (m *Manager) ArmRecallCut() {
 	m.mu.Unlock()
 }
 
+// cutShortOfDuration reports whether a track whose pages ended at prevGran
+// samples was cut clearly short of its known duration. The 5 s slack covers
+// the fraction-of-a-second disagreement between the final granule and the
+// advertised duration on a natural end, and a skip within the last seconds of
+// a song is heard as the natural transition anyway.
+func cutShortOfDuration(prevGran, prevBody, durMs int64) bool {
+	if prevBody == 0 || prevGran <= 0 || durMs <= 0 {
+		return false
+	}
+	return prevGran*1000/vorbisRate < durMs-5000
+}
+
+// noteTrackBoundaryCut runs the app-skip detector at a track boundary: it
+// shifts the duration queue (see durQueueMs in Manager) and, when the ended
+// track was cut mid-play while NO STR-issued cut was armed, stamps the skip
+// boundary and re-points the box so its buffered tail of the old track is
+// dropped. STR's own skip and recall paths arm the cut first, so they never
+// trip this; a boundary with no known duration (agent restarted mid-play) is
+// conservatively treated as natural.
+func (m *Manager) noteTrackBoundaryCut(prevGran, prevBody int64) {
+	m.mu.Lock()
+	endedMs := m.streamTrackDurMs
+	if len(m.durQueueMs) > 0 {
+		m.streamTrackDurMs = m.durQueueMs[0]
+		m.durQueueMs = m.durQueueMs[1:]
+	} else {
+		m.streamTrackDurMs = 0
+	}
+	armed := time.Now().Before(m.skipCutUntil)
+	m.mu.Unlock()
+	if armed || !cutShortOfDuration(prevGran, prevBody, endedMs) {
+		return
+	}
+	m.logger.Info("spotify: mid-track boundary without an STR skip (Spotify-app skip), re-pointing the box to drop its buffered tail",
+		"playedSec", prevGran/vorbisRate, "durationSec", endedMs/1000)
+	// Stamp the boundary like an STR skip would, so the webui's soft-skip
+	// bookkeeping (LastSkipBoundary consumers) sees a consistent timeline.
+	m.noteSkipBoundary()
+	m.repointForForeignSkip()
+}
+
 // skipCutArmed reports whether an armed user skip is awaiting its track
 // boundary; clearSkipCut disarms it the moment that boundary arrives, so the
 // new track's pages are never mistaken for stale ones.

--- a/internal/spotify/recall.go
+++ b/internal/spotify/recall.go
@@ -631,33 +631,62 @@ func (m *Manager) maybeActivate() {
 	go cb(context.Background())
 }
 
+// armRepoint applies the shared re-point debounces (activate callback wired,
+// not within maybeActivate's window, not suppressed) and, when the re-point
+// may fire, stamps them and returns the callback to run. Nil means stand down.
+//
+// It also keeps the engine playing across the re-point, exactly as
+// SetRecalling does for a preset recall. The UPnP push the callback performs
+// makes the box tear its current Ogg fetch down and open a new one; for the
+// ~1 s in between there is no sink, and without this the drain takes its "no
+// consumer" branch and PAUSES go-librespot. The box then re-attaches to a
+// paused engine, gets the previous track's headers and no audio, and the Bose
+// transport gives up 30 s later with AUDIO_ERROR_BAD_URL. That is the
+// "Spotify stops after about half an hour" report: half an hour is simply how
+// long an album runs before Spotify moves to the next context and triggers
+// this path (field bundle 2026-07-27, seven boxes, every occurrence). PR #454
+// closed the identical hole for hardware presets and missed this one.
+func (m *Manager) armRepoint() func(context.Context) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cb := m.onActivate
+	if cb == nil || time.Since(m.lastActivate) < 5*time.Second ||
+		time.Now().Before(m.suppressActivateUntil) {
+		return nil
+	}
+	m.lastActivate = time.Now()
+	if t := m.lastActivate.Add(30 * time.Second); t.After(m.engineHotUntil) {
+		m.engineHotUntil = t
+	}
+	return cb
+}
+
+// repointForForeignSkip drops the box's buffered tail after a skip that came
+// from the Spotify app itself (noteTrackBoundaryCut). It requires an attached
+// sink on top of the shared debounces: a paused or detached box must not be
+// forced back into playing by the push this triggers.
+func (m *Manager) repointForForeignSkip() {
+	m.mu.Lock()
+	attached := m.sink != nil
+	m.mu.Unlock()
+	if !attached {
+		return
+	}
+	cb := m.armRepoint()
+	if cb == nil {
+		return
+	}
+	go cb(context.Background())
+}
+
 // repointBox re-points the box at the Spotify stream even if it is already
 // attached, so a playlist switch from the app flushes the box buffer and plays
 // the new stream promptly. Debounced and shares lastActivate with maybeActivate.
 func (m *Manager) repointBox(from, to string) {
-	m.mu.Lock()
-	cb := m.onActivate
-	if cb == nil || time.Since(m.lastActivate) < 5*time.Second ||
-		time.Now().Before(m.suppressActivateUntil) {
-		m.mu.Unlock()
+	cb := m.armRepoint()
+	if cb == nil {
 		return
 	}
-	m.lastActivate = time.Now()
-	// Keep the engine playing across the re-point, exactly as SetRecalling does
-	// for a preset recall. The UPnP push below makes the box tear its current
-	// Ogg fetch down and open a new one; for the ~1 s in between there is no
-	// sink, and without this the drain takes its "no consumer" branch and
-	// PAUSES go-librespot. The box then re-attaches to a paused engine, gets
-	// the previous track's headers and no audio, and the Bose transport gives
-	// up 30 s later with AUDIO_ERROR_BAD_URL. That is the "Spotify stops after
-	// about half an hour" report: half an hour is simply how long an album
-	// runs before Spotify moves to the next context and triggers this path
-	// (field bundle 2026-07-27, seven boxes, every occurrence). PR #454 closed
-	// the identical hole for hardware presets and missed this one.
-	if t := m.lastActivate.Add(30 * time.Second); t.After(m.engineHotUntil) {
-		m.engineHotUntil = t
-	}
-	m.mu.Unlock()
 	// Name both contexts. This re-point tears the box's Ogg fetch down and
 	// opens a new one, which the listener hears as the next song arriving
 	// abruptly, so the first question about it is always "switched from what


### PR DESCRIPTION
Live report today: skipping a track in the Spotify app took 20+ seconds to become audible on a playing ST30 group. The engine switched tracks in ~4 s (log: skip at 14:33:44, BOS at 14:33:49), but the agent appends the new track to the same HTTP stream, and the box first drained its paced buffer of the old track. STR-initiated skips already re-point the box (`reattachAfterSoftSkip` / hardware flow); an app-side skip bypassed all of it because the press never touches the agent.

Detection is granule-vs-duration at the track boundary: the agent queues each engine `loaded track` duration, and a BOS whose previous track ended clearly short of its known duration (5 s slack), with no STR cut armed, is an app skip. Verified against today's log: the observed skip cut La Grange at 207.5 s of 230.5 s (fires), while natural ends match within fractions of a second (stands down). The re-point reuses the playlist-switch path (shared debounces, engine kept hot across the detach, requires an attached sink so a paused box is never forced back into playing).

Unit tests cover the parser, the discriminator against today's real numbers, the queue shift, and the stand-down cases (STR cut armed, no sink).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFzcAvQkHKWn7hMwxAqfae