### PR TITLE
fix(app): settings dropdown switch no longer shows the previous speaker's values

### DIFF
--- a/desktop-app/frontend/src/views/settings.js
+++ b/desktop-app/frontend/src/views/settings.js
@@ -137,6 +137,13 @@ function mountSettingsShell() {
     const box = state.boxes.find(b => b.deviceID === id);
     if (box) {
       state.settingsBox = box;
+      // A switch starts the new speaker's story from zero: the previous
+      // speaker's reconnect countdown (and its pending retry timer) must not
+      // keep running against the one just picked.
+      if (state.settingsReconnect && state.settingsReconnect.timer) {
+        clearTimeout(state.settingsReconnect.timer);
+      }
+      state.settingsReconnect = null;
       loadBoxSettings();
       // Lock-step with the music tab (and the Setup target picker).
       if (deps.speakerPicked) deps.speakerPicked(box);
@@ -307,8 +314,19 @@ export async function loadBoxSettings() {
     if (go) go.onclick = () => deps.switchView('setup');
     return;
   }
-  // If content is already rendered, do not overwrite it. The user
-  // should keep seeing the previous values while we fetch fresh data.
+  // The pane may still show ANOTHER speaker's settings: the user just
+  // switched in the dropdown. Keeping those visible while the new fetch runs
+  // made an unreachable or slow speaker look fully configured, every value
+  // on screen belonged to the previous box and nothing said so (field,
+  // 2026-08-29). A switch therefore blanks the pane down to the loading hint
+  // until the new speaker has actually answered; only a re-fetch of the SAME
+  // speaker keeps its current values on screen.
+  if (body.dataset.renderedBoxId && body.dataset.renderedBoxId !== state.settingsBox.deviceID) {
+    delete body.dataset.renderedBoxId;
+    body.innerHTML = '';
+  }
+  // If this speaker's content is already rendered, do not overwrite it. The
+  // user should keep seeing the previous values while we fetch fresh data.
   // Otherwise show a hint.
   const hasContent = body.querySelector('.settings-section');
   if (!hasContent) {
@@ -338,6 +356,9 @@ export async function loadBoxSettings() {
       }
       state.settingsReconnect = null;
       renderBoxSettings(s, state.settingsBox);
+      // Stamp whose settings the pane now shows, so the next dropdown
+      // switch can tell "this speaker's values" from "the previous one's".
+      body.dataset.renderedBoxId = state.settingsBox.deviceID;
       // Read-only, and only present on a stereo pair, so it is filled after the
       // markup exists rather than being part of it.
       refreshBoxBalanceRow(state.settingsBox,


### PR DESCRIPTION
Live report: switching the settings dropdown to a speaker that is unreachable (or slow on weak Wi-Fi) kept the previous speaker's settings fully visible below, so it was impossible to tell whose values were on screen.

The settings body now carries a `renderedBoxId` stamp: a dropdown switch to a different speaker blanks the pane to the loading hint until that speaker has answered (unreachable ones then get the existing reconnect banner on an empty pane instead of on top of foreign values). A re-fetch of the same speaker keeps its values, as before. The reconnect countdown and its retry timer are reset on every switch so a previous speaker's failed attempts cannot leak into the new one's banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFzcAvQkHKWn7hMwxAqfae