### PR TITLE
feat(multiroom): the stereo pair's name shows in the Bose app too

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -769,7 +769,7 @@ func run() error {
 			}
 			margeSrv.SetStoredMusicSources(out)
 		}),
-		webui.WithMargeGroups(margeSrv.GroupSnapshot, margeSrv.SetCanonicalGroup, margeSrv.ClearGroup),
+		webui.WithMargeGroups(margeSrv.GroupSnapshot, margeSrv.SetCanonicalGroup, margeSrv.ClearGroup, margeSrv.RenameGroup),
 		webui.WithMargeForward(margeSrv.SetForward),
 		webui.WithRecent(recentStore))
 

--- a/desktop-app/app_zone.go
+++ b/desktop-app/app_zone.go
@@ -326,6 +326,25 @@ func (a *App) relayStereoPairClear(out map[string]any) {
 // to the firmware's /getGroup teardown when the caller explicitly asked for a
 // pair to be undone (?stereo=1), so a plain multiroom dissolve can never
 // destroy a stereo pair as a side effect.
+// SetStereoPairName writes the pair's display name onto one member's agent,
+// which stores it in the marge group record: the very record the Bose app
+// reads and edits, so one rename shows the same name in STR and in the Bose
+// app instead of a bare "Stereo pair (L+R)" (field report, 2026-08-30). The
+// frontend calls this for BOTH members, because each member's marge holds its
+// own copy of the pair document.
+func (a *App) PushStereoPairNameToBox(host string, port int, name string) error {
+	body, _ := json.Marshal(map[string]string{"name": name})
+	resp, err := a.boxDo(host, port, http.MethodPost, "/api/box/zone/stereo-name", "application/json", string(body))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return readHTTPError(resp)
+	}
+	return nil
+}
+
 func (a *App) DissolveStereoPair(host string, port int) error {
 	resp, err := a.boxDoTimeout(host, port, http.MethodDelete, "/api/box/zone?stereo=1", "", "", zoneCallTimeout)
 	if err != nil {

--- a/desktop-app/frontend/src/api.js
+++ b/desktop-app/frontend/src/api.js
@@ -32,6 +32,7 @@ export {
   RemoveConflictingMod,
   WakeBox,
   SyncBoxPresets,
+  PushStereoPairNameToBox,
   BoxPresets,
   BoxSnapshot,
   RestoreBoxSnapshot,

--- a/desktop-app/frontend/src/views/multiroom.js
+++ b/desktop-app/frontend/src/views/multiroom.js
@@ -8,7 +8,7 @@
 import { state } from '../state.js';
 import { $, escapeHtml, escapeAttr, getBoxLabel, showToast, balanceLabel } from '../utils.js';
 import { t } from '../i18n/index.js';
-import { FormZone, DissolveZone, DissolveStereoPair, WakeBox, BrowserOpenURL, readBoxBalance } from '../api.js';
+import { FormZone, DissolveZone, DissolveStereoPair, PushStereoPairNameToBox, WakeBox, BrowserOpenURL, readBoxBalance } from '../api.js';
 // Group membership + the shared zoneLive poll live in groups.js: ONE
 // implementation for this tab, the music-tab frames and the group chips.
 import { masterOf as zoneMasterOf, fetchZoneLive, groupMembersOf, stereoPairsOf, stereoPairKey, stereoSelectionPick, pairMemberBoxes, stereoUndoTargets } from '../groups.js';
@@ -393,7 +393,16 @@ export function renderMultiroom(fetchLive) {
     // the freshly stored name.
     const ns = $('stereoNameSave');
     if (ns) ns.onclick = async () => {
-      try { await setPairName(formingPair, $('stereoName').value); } catch {}
+      const newName = $('stereoName').value;
+      try { await setPairName(formingPair, newName); } catch {}
+      // Push the name into BOTH members' firmware pair records too: that is
+      // the record the Bose app reads and edits, so the rename shows up there
+      // as well (field report, 2026-08-30). Best effort per member; the
+      // app-side store above already carries the STR display.
+      try {
+        const members = pairMemberBoxes(formingPair, strBoxes).map(x => x.box).filter(Boolean);
+        await Promise.allSettled(members.map(b => PushStereoPairNameToBox(b.host, b.port, newName.trim())));
+      } catch {}
       delete state.stereoName;
       renderMultiroom(false);
     };
@@ -443,7 +452,9 @@ async function doFormStereo(pairCands) {
     const res = await FormZone(left.host, left.port, {
       master: { deviceID: left.deviceID, ip: left.host },
       slaves: [{ deviceID: right.deviceID, ip: right.host }],
-      name: '', stereo: true,
+      // The typed name goes into the firmware pair document from the start,
+      // so the Bose app shows it too instead of "Stereo pair (L+R)".
+      name: wantName.trim(), stereo: true,
     });
     // The agent answers 200 with ok:false when the firmware silently dropped a
     // member (incomplete pair) - and FormZone answers ok:false with notReady

--- a/desktop-app/frontend/wailsjs/go/main/App.d.ts
+++ b/desktop-app/frontend/wailsjs/go/main/App.d.ts
@@ -137,6 +137,8 @@ export function Prev(arg1:string,arg2:number):Promise<void>;
 
 export function ProbeSetupAP():Promise<main.BoxInfo|boolean>;
 
+export function PushStereoPairNameToBox(arg1:string,arg2:number,arg3:string):Promise<void>;
+
 export function PushWLANToBox(arg1:string,arg2:string,arg3:string,arg4:string):Promise<main.SetupAPPushResult>;
 
 export function QueueNext(arg1:string,arg2:number):Promise<void>;

--- a/desktop-app/frontend/wailsjs/go/main/App.js
+++ b/desktop-app/frontend/wailsjs/go/main/App.js
@@ -266,6 +266,10 @@ export function ProbeSetupAP() {
   return window['go']['main']['App']['ProbeSetupAP']();
 }
 
+export function PushStereoPairNameToBox(arg1, arg2, arg3) {
+  return window['go']['main']['App']['PushStereoPairNameToBox'](arg1, arg2, arg3);
+}
+
 export function PushWLANToBox(arg1, arg2, arg3, arg4) {
   return window['go']['main']['App']['PushWLANToBox'](arg1, arg2, arg3, arg4);
 }

--- a/internal/marge/group.go
+++ b/internal/marge/group.go
@@ -151,6 +151,26 @@ func (s *Server) persistGroupLocked() {
 	}
 }
 
+// RenameGroup updates the stored stereo pair's display name and persists it.
+// The Bose app shows and edits exactly this record (its own rename arrives
+// here through the firmware), so writing STR's pair name here is what makes
+// one name appear in both apps instead of a bare "Stereo pair (L+R)"
+// (field report, 2026-08-30). The canonical flag is untouched: a rename does
+// not change who authored the pair document.
+func (s *Server) RenameGroup(name string) error {
+	name = strings.TrimSpace(name)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.group == nil {
+		return fmt.Errorf("no stereo pair stored")
+	}
+	s.group.Name = name
+	s.persistGroupLocked()
+	s.logger.Info("marge group: renamed", slog.String("comp", "marge"),
+		slog.String("groupId", s.group.ID), slog.String("name", name))
+	return nil
+}
+
 // GroupSnapshot returns the current group document and whether it is the
 // canonical (STR-installed) record. ok is false when no pair is stored.
 func (s *Server) GroupSnapshot() (xmlDoc string, canonical bool, ok bool) {

--- a/internal/marge/group_rename_test.go
+++ b/internal/marge/group_rename_test.go
@@ -1,0 +1,36 @@
+package marge
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A rename must land in the stored pair document (that is what the Bose app
+// reads) and survive persistence; without a stored pair it must refuse.
+func TestRenameGroup(t *testing.T) {
+	dir := t.TempDir()
+	s := &Server{logger: slog.New(slog.NewTextHandler(io.Discard, nil)), groupPath: filepath.Join(dir, "group.json")}
+
+	if err := s.RenameGroup("Wohnzimmer"); err == nil {
+		t.Fatal("renaming with no stored pair must refuse")
+	}
+
+	if err := s.SetCanonicalGroup(CanonicalGroupXML("", "AAA", "192.0.2.1", "BBB", "192.0.2.2")); err != nil {
+		t.Fatalf("seed pair: %v", err)
+	}
+	if err := s.RenameGroup("  Wohnzimmer  "); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	doc, _, ok := s.GroupSnapshot()
+	if !ok || !strings.Contains(doc, "<name>Wohnzimmer</name>") {
+		t.Fatalf("renamed name missing from the document: %q", doc)
+	}
+	b, err := os.ReadFile(s.groupPath)
+	if err != nil || !strings.Contains(string(b), "Wohnzimmer") {
+		t.Fatalf("rename did not persist: %v %q", err, string(b))
+	}
+}

--- a/internal/webui/marge_group_doc_test.go
+++ b/internal/webui/marge_group_doc_test.go
@@ -17,7 +17,7 @@ func newMargeGroupServer() (*Server, *marge.Server) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ms := marge.New(logger)
 	s := &Server{logger: logger}
-	WithMargeGroups(ms.GroupSnapshot, ms.SetCanonicalGroup, ms.ClearGroup)(s)
+	WithMargeGroups(ms.GroupSnapshot, ms.SetCanonicalGroup, ms.ClearGroup, ms.RenameGroup)(s)
 	return s, ms
 }
 

--- a/internal/webui/options.go
+++ b/internal/webui/options.go
@@ -380,11 +380,12 @@ func WithSpotifyCanRecall(f func(ctx context.Context) bool) Option {
 // WithMargeGroups bridges the marge stereo-pair record (get/set/clear) so the
 // pairing and dissolve flows keep BOTH members' marges on one canonical pair
 // document, and /api/marge/group lets the desktop app relay it to the partner.
-func WithMargeGroups(get func() (string, bool, bool), set func(string) error, clear func(string)) Option {
+func WithMargeGroups(get func() (string, bool, bool), set func(string) error, clear func(string), rename func(string) error) Option {
 	return func(s *Server) {
 		s.margeGroupGet = get
 		s.margeGroupSet = set
 		s.margeGroupClear = clear
+		s.margeGroupRename = rename
 	}
 }
 

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -216,9 +216,10 @@ type Server struct {
 	// from its own point of view and the RIGHT box stores itself as master).
 	// The desktop app relays the document to the partner because agent-to-
 	// agent HTTP is blocked between series-I boxes. nil until wired.
-	margeGroupGet   func() (xmlDoc string, canonical bool, ok bool)
-	margeGroupSet   func(xmlDoc string) error
-	margeGroupClear func(reason string)
+	margeGroupGet    func() (xmlDoc string, canonical bool, ok bool)
+	margeGroupSet    func(xmlDoc string) error
+	margeGroupClear  func(reason string)
+	margeGroupRename func(name string) error
 	// margeForward registers (or clears) a developer machine the box's cloud
 	// conversation is relayed to. nil disables the endpoint. See margelab.go.
 	margeForward func(target string) error
@@ -800,6 +801,7 @@ func (s *Server) Run(ctx context.Context) error {
 	mux.HandleFunc("/api/box/zone/volume", s.handleZoneVolume)
 	mux.HandleFunc("/api/box/sleep", s.handleSleep)
 	mux.HandleFunc("/api/box/zone/purge", s.handleZonePurge)
+	mux.HandleFunc("/api/box/zone/stereo-name", s.handleStereoName)
 	mux.HandleFunc("/api/box/group", s.handleBoxGroup)
 	mux.HandleFunc("/api/marge/group", s.handleMargeGroupDoc)
 	mux.HandleFunc("/api/webhooks", s.handleWebhooks)

--- a/internal/webui/zones_stereo.go
+++ b/internal/webui/zones_stereo.go
@@ -49,6 +49,33 @@ func (s *Server) handleBoxZone(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// handleStereoName renames the stored stereo pair (POST {"name": "..."}). The
+// name lives in the marge group record, which is the same place the Bose app
+// reads and edits, so one rename shows up in STR and the Bose app alike. The
+// desktop app calls this on BOTH members (their marges each hold the pair
+// document; agent-to-agent HTTP is blocked between series-I boxes).
+func (s *Server) handleStereoName(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	if s.margeGroupRename == nil {
+		http.Error(w, "stereo rename not wired", http.StatusNotImplemented)
+		return
+	}
+	var req struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4*1024)).Decode(&req); err != nil {
+		http.Error(w, "bad json: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := s.margeGroupRename(req.Name); err != nil {
+		writeJSON(w, http.StatusConflict, map[string]any{"ok": false, "error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
 func (s *Server) handleZoneGet(w http.ResponseWriter, r *http.Request) {
 	c := boxapi.New(s.boxHost)
 	ctx, cancel := context.WithTimeout(r.Context(), 6*time.Second)


### PR DESCRIPTION
Field report (Gabriele, 2026-08-30): both pairs show as "Stereo pair (L+R)" in the Bose app, and a rename made there persists. It persists because the Bose app edits the pair name in the agent's marge group record; STR itself always created pairs with `name: ''` and kept its own name only app-side, never telling the firmware record.

- The stereo create now carries the typed name into the firmware pair document (frontend sends it; the agent's canonical-doc path already supported it).
- New agent endpoint `POST /api/box/zone/stereo-name` renames the stored marge group (marge.RenameGroup, canonical flag untouched); the desktop rename pushes it to BOTH members, since each member's marge holds its own copy of the pair document. App-side name store stays as the fast display path.
- Test: marge rename lands in the document and persists, refuses with no stored pair; WithMargeGroups gained the rename hook (call sites updated); bindings regenerated (PushStereoPairNameToBox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFzcAvQkHKWn7hMwxAqfae