### PR TITLE
fix(setup): Continue on an already-installed speaker leads to the update, not into a dead wait

### DIFF
--- a/desktop-app/frontend/src/views/setup.js
+++ b/desktop-app/frontend/src/views/setup.js
@@ -1595,11 +1595,21 @@ async function watchForSpeakerReady({ ssid, pass, html }) {
       await sleep(3000); continue;
     }
 
-    // Already runs STR.
+    // Already runs STR. Continue must NOT re-enter the stick wait: the
+    // message promises "you'll be offered an update", and the wait loop it
+    // used to hand off into ignores STR speakers by design, so the button
+    // greyed out and the screen sat unchanged through a silent five-minute
+    // poll (field report + log, 2026-08-30). Hand over to the speaker view,
+    // where the update offer actually lives.
     if (cand && cand.kind === 'str') {
       lastSeenState = 'str';
       setStatus('setup-ok', t('setup.awaitAlreadyStr'));
-      arm(t('setup.awaitContinueBtn'), handoff);
+      arm(t('setup.awaitContinueBtn'), () => {
+        aborted = true;
+        stopTicker();
+        state.currentBox = cand;
+        deps.switchView('box');
+      });
       ready = true; break;
     }
 


### PR DESCRIPTION
From today's #775 follow-up (screenshot + diagnostic): on the stick-await panel, the already-has-STR state's Continue button disabled itself and nothing changed; the log shows only the post-setup wait loop polling discovery, which ignores STR speakers by design, so the promised "you'll be offered an update" could never arrive. Continue now selects the found speaker and switches to the speaker view where the update banner/button lives. The reporter's third point (dark warning box in light theme on the Prepare step) is the `.format-warn` element already fixed in #784, unreleased in his v0.9.67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFzcAvQkHKWn7hMwxAqfae