### PR TITLE
fix(app): stop telling users a speaker only supports 2.4 GHz Wi-Fi

### DIFF
--- a/desktop-app/app_boxops.go
+++ b/desktop-app/app_boxops.go
@@ -298,7 +298,7 @@ var hostHasLinkLocalIPv4 = func() bool {
 // This is the list that decides whether a switch can work, and it is not the
 // list the computer sees. The app used to offer the computer's own known
 // networks and only find out afterwards that the speaker could not see the
-// chosen one, which is how users met the "SoundTouch only supports 2.4 GHz"
+// chosen one, which is how users met the "the speaker can't see that network"
 // refusal at the worst possible moment: after committing.
 //
 // Best effort by design. A speaker that cannot survey returns an empty list

--- a/desktop-app/frontend/src/i18n/bundles/ar.json
+++ b/desktop-app/frontend/src/i18n/bundles/ar.json
@@ -764,7 +764,7 @@
   "settingsView.wlanHiddenToggle": "شبكة مخفية (لا تبثّ اسمها)",
   "settingsView.wlanHiddenHint": "حدّد هذا الخيار إذا كانت الشبكة لا تظهر في البحث. تبحث السمّاعة عنها عندئذ بالاسم.",
   "settingsView.wlanNotVisibleTitle": "السمّاعة لا ترى هذه الشبكة",
-  "settingsView.wlanNotVisibleBody": "لا تجد السمّاعة <b>{{ssid}}</b> أثناء البحث. سمّاعات SoundTouch تدعم فقط شبكات Wi-Fi بتردد 2.4 GHz. الشبكات التي تراها السمّاعة: {{visible}}. هل تريد التبديل رغم ذلك؟",
+  "settingsView.wlanNotVisibleBody": "لا تجد السمّاعة <b>{{ssid}}</b> في بحثها الخاص، لذا قد لا تتمكن من الاتصال بها. الشبكات التي تراها السمّاعة: {{visible}}. هل تريد التبديل رغم ذلك؟",
   "settingsView.wlanForceBtn": "التبديل رغم ذلك",
   "settingsView.wlanSsidEmpty": "يجب ألّا يكون SSID فارغًا",
   "settingsView.wlanSwitchedToast": "تم تغيير Wi-Fi. تحصل السمّاعة على IP جديد، أعد البحث في القائمة بعد لحظة.",

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -830,7 +830,7 @@
   "settingsView.wlanHiddenToggle": "Verstecktes Netzwerk (Name wird nicht ausgestrahlt)",
   "settingsView.wlanHiddenHint": "Ankreuzen, wenn das WLAN in Scans nicht auftaucht. Der Lautsprecher sucht es dann gezielt über den Namen.",
   "settingsView.wlanNotVisibleTitle": "Lautsprecher sieht dieses Netzwerk nicht",
-  "settingsView.wlanNotVisibleBody": "Der Lautsprecher findet <b>{{ssid}}</b> bei der Suche nicht. SoundTouch-Lautsprecher unterstützen nur 2,4-GHz-WLAN. Netzwerke, die der Lautsprecher sieht: {{visible}}. Trotzdem wechseln?",
+  "settingsView.wlanNotVisibleBody": "Der Lautsprecher findet <b>{{ssid}}</b> bei seiner eigenen Suche nicht, er kann sich also möglicherweise nicht damit verbinden. Netzwerke, die der Lautsprecher sieht: {{visible}}. Trotzdem wechseln?",
   "settingsView.wlanForceBtn": "Trotzdem wechseln",
   "settingsView.wlanSsidEmpty": "SSID darf nicht leer sein",
   "settingsView.wlanSwitchedToast": "WLAN umgeschaltet. Lautsprecher bekommt eine neue IP, gleich Liste neu suchen.",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -830,7 +830,7 @@
   "settingsView.wlanHiddenToggle": "Hidden network (does not broadcast its name)",
   "settingsView.wlanHiddenHint": "Check this if the network does not show up in scans. The speaker then searches for it by name.",
   "settingsView.wlanNotVisibleTitle": "Speaker cannot see this network",
-  "settingsView.wlanNotVisibleBody": "The speaker cannot find <b>{{ssid}}</b> in its scan. SoundTouch speakers only support 2.4 GHz Wi-Fi. Networks the speaker can see: {{visible}}. Switch anyway?",
+  "settingsView.wlanNotVisibleBody": "The speaker cannot find <b>{{ssid}}</b> in its own scan, so it may not be able to join it. Networks the speaker can see: {{visible}}. Switch anyway?",
   "settingsView.wlanForceBtn": "Switch anyway",
   "settingsView.wlanSsidEmpty": "SSID must not be empty",
   "settingsView.wlanSwitchedToast": "Wi-Fi switched. The speaker is getting a new IP, search the list again in a moment.",

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -764,7 +764,7 @@
   "settingsView.wlanHiddenToggle": "Red oculta (no difunde su nombre)",
   "settingsView.wlanHiddenHint": "Marca esta casilla si la red no aparece en las búsquedas. El altavoz la buscará por su nombre.",
   "settingsView.wlanNotVisibleTitle": "El altavoz no ve esta red",
-  "settingsView.wlanNotVisibleBody": "El altavoz no encuentra <b>{{ssid}}</b> en su búsqueda. Los altavoces SoundTouch solo admiten Wi-Fi de 2,4 GHz. Redes que el altavoz ve: {{visible}}. ¿Cambiar de todos modos?",
+  "settingsView.wlanNotVisibleBody": "El altavoz no encuentra <b>{{ssid}}</b> en su propia búsqueda, por lo que quizá no pueda conectarse. Redes que el altavoz ve: {{visible}}. ¿Cambiar de todos modos?",
   "settingsView.wlanForceBtn": "Cambiar de todos modos",
   "settingsView.wlanSsidEmpty": "El SSID no puede estar vacío",
   "settingsView.wlanSwitchedToast": "Wi-Fi cambiado. El altavoz está obteniendo una nueva IP, busca la lista de nuevo en un momento.",

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -764,7 +764,7 @@
   "settingsView.wlanHiddenToggle": "Réseau masqué (le nom n'est pas diffusé)",
   "settingsView.wlanHiddenHint": "Cochez cette case si le réseau n'apparaît pas dans les recherches. L'enceinte le cherchera alors par son nom.",
   "settingsView.wlanNotVisibleTitle": "L'enceinte ne voit pas ce réseau",
-  "settingsView.wlanNotVisibleBody": "L'enceinte ne trouve pas <b>{{ssid}}</b> lors de sa recherche. Les enceintes SoundTouch ne prennent en charge que le Wi-Fi 2,4 GHz. Réseaux visibles par l'enceinte : {{visible}}. Basculer quand même ?",
+  "settingsView.wlanNotVisibleBody": "L'enceinte ne trouve pas <b>{{ssid}}</b> dans sa propre recherche, elle ne pourra donc peut-être pas s'y connecter. Réseaux visibles par l'enceinte : {{visible}}. Basculer quand même ?",
   "settingsView.wlanForceBtn": "Basculer quand même",
   "settingsView.wlanSsidEmpty": "Le SSID ne doit pas être vide",
   "settingsView.wlanSwitchedToast": "Wi-Fi changé. L'enceinte reçoit une nouvelle IP, recherchez la liste à nouveau dans un instant.",

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -764,7 +764,7 @@
   "settingsView.wlanHiddenToggle": "非公開ネットワーク（SSIDステルス）",
   "settingsView.wlanHiddenHint": "検索に表示されないネットワークの場合はチェックしてください。スピーカーが名前を指定して検索します。",
   "settingsView.wlanNotVisibleTitle": "スピーカーがこのネットワークを見つけられません",
-  "settingsView.wlanNotVisibleBody": "スピーカーのスキャンで <b>{{ssid}}</b> が見つかりません。SoundTouch スピーカーは 2.4 GHz の Wi-Fi のみ対応です。スピーカーが確認できるネットワーク: {{visible}}。それでも切り替えますか？",
+  "settingsView.wlanNotVisibleBody": "スピーカーは自身のスキャンで <b>{{ssid}}</b> を見つけられないため、接続できない可能性があります。スピーカーが確認できるネットワーク: {{visible}}。それでも切り替えますか？",
   "settingsView.wlanForceBtn": "それでも切り替える",
   "settingsView.wlanSsidEmpty": "SSIDは空にできません",
   "settingsView.wlanSwitchedToast": "Wi-Fiを切り替えました。スピーカーは新しいIPを取得中です。少し待ってから一覧を再検索してください。",

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -764,7 +764,7 @@
   "settingsView.wlanHiddenToggle": "Paslėptas tinklas (netransliuoja savo pavadinimo)",
   "settingsView.wlanHiddenHint": "Pažymėkite, jei tinklas nerodomas paieškoje. Kolonėlė jo ieškos pagal pavadinimą.",
   "settingsView.wlanNotVisibleTitle": "Kolonėlė nemato šio tinklo",
-  "settingsView.wlanNotVisibleBody": "Kolonėlė skenuodama neranda <b>{{ssid}}</b>. SoundTouch kolonėlės palaiko tik 2,4 GHz Wi-Fi. Tinklai, kuriuos kolonėlė mato: {{visible}}. Vis tiek perjungti?",
+  "settingsView.wlanNotVisibleBody": "Kolonėlė savo pačios skenavime neranda <b>{{ssid}}</b>, todėl gali nepavykti prie jo prisijungti. Tinklai, kuriuos kolonėlė mato: {{visible}}. Vis tiek perjungti?",
   "settingsView.wlanForceBtn": "Vis tiek perjungti",
   "settingsView.wlanSsidEmpty": "SSID negali būti tuščias",
   "settingsView.wlanSwitchedToast": "Wi-Fi pakeistas. Garsiakalbis gaus naują IP, netrukus iš naujo nuskaitykite sąrašą.",

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -764,7 +764,7 @@
   "settingsView.wlanHiddenToggle": "Slēpts tīkls (neizplata savu nosaukumu)",
   "settingsView.wlanHiddenHint": "Atzīmējiet, ja tīkls neparādās meklēšanā. Skaļrunis to meklēs pēc nosaukuma.",
   "settingsView.wlanNotVisibleTitle": "Skaļrunis neredz šo tīklu",
-  "settingsView.wlanNotVisibleBody": "Skaļrunis skenējot neatrod <b>{{ssid}}</b>. SoundTouch skaļruņi atbalsta tikai 2,4 GHz Wi-Fi. Tīkli, ko skaļrunis redz: {{visible}}. Tomēr pārslēgt?",
+  "settingsView.wlanNotVisibleBody": "Skaļrunis savā skenēšanā neatrod <b>{{ssid}}</b>, tāpēc, iespējams, nevarēs tam pievienoties. Tīkli, ko skaļrunis redz: {{visible}}. Tomēr pārslēgt?",
   "settingsView.wlanForceBtn": "Tomēr pārslēgt",
   "settingsView.wlanSsidEmpty": "SSID nevar būt tukšs",
   "settingsView.wlanSwitchedToast": "Wi-Fi mainīts. Skaļrunis saņems jaunu IP, drīz skenējiet sarakstu vēlreiz.",

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -764,7 +764,7 @@
   "settingsView.wlanHiddenToggle": "Verborgen netwerk (zendt zijn naam niet uit)",
   "settingsView.wlanHiddenHint": "Vink dit aan als het netwerk niet in scans verschijnt. De speaker zoekt het dan gericht op naam.",
   "settingsView.wlanNotVisibleTitle": "Speaker ziet dit netwerk niet",
-  "settingsView.wlanNotVisibleBody": "De speaker vindt <b>{{ssid}}</b> niet bij het zoeken. SoundTouch-speakers ondersteunen alleen 2,4GHz-wifi. Netwerken die de speaker ziet: {{visible}}. Toch overschakelen?",
+  "settingsView.wlanNotVisibleBody": "De speaker vindt <b>{{ssid}}</b> niet in zijn eigen zoekopdracht en kan er mogelijk geen verbinding mee maken. Netwerken die de speaker ziet: {{visible}}. Toch overschakelen?",
   "settingsView.wlanForceBtn": "Toch overschakelen",
   "settingsView.wlanSsidEmpty": "SSID mag niet leeg zijn",
   "settingsView.wlanSwitchedToast": "Wifi gewisseld. De speaker krijgt een nieuw IP, doorzoek de lijst zo opnieuw.",

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -764,7 +764,7 @@
   "settingsView.wlanHiddenToggle": "Sieć ukryta (nie rozgłasza swojej nazwy)",
   "settingsView.wlanHiddenHint": "Zaznacz, jeśli sieć nie pojawia się w wynikach wyszukiwania. Głośnik będzie jej szukał po nazwie.",
   "settingsView.wlanNotVisibleTitle": "Głośnik nie widzi tej sieci",
-  "settingsView.wlanNotVisibleBody": "Głośnik nie znajduje sieci <b>{{ssid}}</b> podczas skanowania. Głośniki SoundTouch obsługują tylko Wi-Fi 2,4 GHz. Sieci widoczne dla głośnika: {{visible}}. Przełączyć mimo to?",
+  "settingsView.wlanNotVisibleBody": "Głośnik nie znajduje sieci <b>{{ssid}}</b> we własnym skanowaniu, więc może nie być w stanie się z nią połączyć. Sieci widoczne dla głośnika: {{visible}}. Przełączyć mimo to?",
   "settingsView.wlanForceBtn": "Przełącz mimo to",
   "settingsView.wlanSsidEmpty": "SSID nie może być puste",
   "settingsView.wlanSwitchedToast": "Wi-Fi zmienione. Głośnik dostanie nowy adres IP, przeszukaj listę za chwilę.",

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -764,7 +764,7 @@
   "settingsView.wlanHiddenToggle": "Gizli ağ (adını yayınlamaz)",
   "settingsView.wlanHiddenHint": "Ağ taramalarda görünmüyorsa bunu işaretleyin. Hoparlör ağı adıyla arar.",
   "settingsView.wlanNotVisibleTitle": "Hoparlör bu ağı görmüyor",
-  "settingsView.wlanNotVisibleBody": "Hoparlör taramada <b>{{ssid}}</b> ağını bulamıyor. SoundTouch hoparlörler yalnızca 2,4 GHz Wi-Fi destekler. Hoparlörün gördüğü ağlar: {{visible}}. Yine de geçilsin mi?",
+  "settingsView.wlanNotVisibleBody": "Hoparlör kendi taramasında <b>{{ssid}}</b> ağını bulamıyor, bu yüzden bağlanamayabilir. Hoparlörün gördüğü ağlar: {{visible}}. Yine de geçilsin mi?",
   "settingsView.wlanForceBtn": "Yine de geç",
   "settingsView.wlanSsidEmpty": "SSID boş olamaz",
   "settingsView.wlanSwitchedToast": "Wi-Fi değiştirildi. Hoparlör yeni bir IP alacak, listeyi yakında yeniden tarayın.",

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -764,7 +764,7 @@
   "settingsView.wlanHiddenToggle": "Прихована мережа (не транслює свою назву)",
   "settingsView.wlanHiddenHint": "Позначте, якщо мережа не з'являється під час сканування. Колонка шукатиме її за назвою.",
   "settingsView.wlanNotVisibleTitle": "Колонка не бачить цю мережу",
-  "settingsView.wlanNotVisibleBody": "Колонка не знаходить <b>{{ssid}}</b> під час сканування. Колонки SoundTouch підтримують лише Wi-Fi 2,4 ГГц. Мережі, які бачить колонка: {{visible}}. Все одно перемкнути?",
+  "settingsView.wlanNotVisibleBody": "Колонка не знаходить <b>{{ssid}}</b> у власному скануванні, тож, можливо, не зможе до неї підключитися. Мережі, які бачить колонка: {{visible}}. Все одно перемкнути?",
   "settingsView.wlanForceBtn": "Все одно перемкнути",
   "settingsView.wlanSsidEmpty": "SSID не може бути порожнім",
   "settingsView.wlanSwitchedToast": "Wi-Fi змінено. Колонка отримує нову IP, повторіть пошук списку за мить.",

--- a/desktop-app/frontend/src/i18n/bundles/zh-Hant.json
+++ b/desktop-app/frontend/src/i18n/bundles/zh-Hant.json
@@ -830,7 +830,7 @@
   "settingsView.wlanHiddenToggle": "隱藏網路（不廣播名稱）",
   "settingsView.wlanHiddenHint": "如果這個網路在掃描中沒出現，請勾選這裡。喇叭就會直接用名稱去找它。",
   "settingsView.wlanNotVisibleTitle": "喇叭看不到這個網路",
-  "settingsView.wlanNotVisibleBody": "喇叭掃描時找不到 <b>{{ssid}}</b>。SoundTouch 喇叭只支援 2.4 GHz 的 Wi-Fi。喇叭看得到的網路：{{visible}}。還是要切換嗎？",
+  "settingsView.wlanNotVisibleBody": "喇叭在自己的掃描中找不到 <b>{{ssid}}</b>，因此可能無法連上。喇叭看得到的網路：{{visible}}。還是要切換嗎？",
   "settingsView.wlanForceBtn": "還是要切換",
   "settingsView.wlanSsidEmpty": "SSID 不能空白",
   "settingsView.wlanSwitchedToast": "Wi-Fi 已切換。喇叭正在取得新的 IP，過一會兒再重新搜尋清單。",

--- a/desktop-app/frontend/src/views/settings.js
+++ b/desktop-app/frontend/src/views/settings.js
@@ -2560,10 +2560,9 @@ function wireWlanSwitch(box) {
   //
   // These are different lists, and only the speaker's decides whether a switch
   // can work. Offering the computer's known networks meant a user picked one,
-  // committed, and only then learned the speaker could not see it, which is
-  // where the "SoundTouch only supports 2.4 GHz" explanation came from. A
-  // 5 GHz network is simply not in the speaker's list, so the rule does not
-  // have to be taught at all.
+  // committed, and only then learned the speaker could not see it. A network
+  // the speaker's own radio cannot pick up is simply not in its list, so the
+  // switch is refused on that fact alone, with no claim about why.
   //
   // The computer's list stays as the fallback for a speaker that cannot
   // survey, and typing a name by hand still works for a hidden network.
@@ -2636,9 +2635,8 @@ function wireWlanSwitch(box) {
       if (!r.ok) {
         const body = await r.text();
         // The agent's visibility preflight (422 ssid-not-visible) refused the
-        // switch because the speaker's own scan cannot see the target SSID
-        // (typically a 5 GHz-only network; the speakers are 2.4 GHz only).
-        // Explain it and offer a localized "switch anyway" that re-PUTs with
+        // switch because the speaker's own scan cannot see the target SSID.
+        // Surface it and offer a localized "switch anyway" that re-PUTs with
         // force:true instead of surfacing the raw JSON error.
         let refuse = null;
         if (r.status === 422) { try { refuse = JSON.parse(body); } catch {} }

--- a/internal/boxapi/boxapi.go
+++ b/internal/boxapi/boxapi.go
@@ -842,8 +842,8 @@ func (c *Client) url(path string) string {
 }
 
 // SiteSurvey kicks the box radio into a ~5 s scan via /performWirelessSiteSurvey
-// and returns the SSIDs the box can actually SEE. SoundTouch speakers are 2.4 GHz
-// only, so a 5 GHz-only network never appears here. STR uses this as a pre-flight
+// and returns the SSIDs the box can actually SEE. A network the box's own radio
+// cannot pick up never appears here. STR uses this as a pre-flight
 // before a Wi-Fi change so it never strands the box on a network it cannot join
 // (the box would otherwise leave its current network and fail to join the new
 // one, forcing a Bose-app re-pair).

--- a/internal/webui/wlan.go
+++ b/internal/webui/wlan.go
@@ -59,9 +59,8 @@ var (
 // had typed a network in: the app offered the computer's own known networks,
 // the user picked one, and the speaker then said it could not see it. That is
 // the wrong way round. Asking the speaker first means the user only ever sees
-// what is actually reachable, and the "SoundTouch only supports 2.4 GHz"
-// explanation stops being something they have to know: a 5 GHz network simply
-// is not in the list.
+// what is actually reachable, so a network the speaker's radio cannot pick up
+// never gets offered in the first place.
 //
 // Only on request. The survey puts the radio into a scan for about five
 // seconds, so it must stay tied to the user pressing refresh rather than
@@ -140,10 +139,10 @@ func (s *Server) handleBoxWLAN(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Pre-flight: confirm the box can actually SEE the target network before the
-	// switch. SoundTouch speakers are 2.4 GHz only, so pointing one at a 5 GHz-only
-	// network strands it (it leaves the current network, cannot join the new one,
-	// and then needs a Bose-app re-pair). The box's own site survey only lists the
-	// bands it supports, so an invisible SSID is the clean signal to refuse; the
+	// switch. Pointing a box at a network its own scan cannot see risks stranding
+	// it (it leaves the current network, cannot join the new one, and then needs a
+	// Bose-app re-pair). The box's own site survey is the clean signal, so an
+	// invisible SSID is the reason to refuse; the
 	// `force` flag lets the user override a momentarily-missed but real network,
 	// and `hidden` implies the same skip: a hidden SSID is invisible to the
 	// survey BY DESIGN, so refusing on invisibility would refuse every hidden
@@ -160,9 +159,8 @@ func (s *Server) handleBoxWLAN(w http.ResponseWriter, r *http.Request) {
 			// the absence of evidence, and refusing on it told a user the
 			// opposite of the truth. A speaker on ethernet with no Wi-Fi
 			// configured scans and finds nothing at all, and the refusal then
-			// said "the speaker cannot see Vodafone-0674, SoundTouch only
-			// supports 2.4 GHz. Networks the speaker sees: -" while listing
-			// nothing. He was trying to correct a mistyped password on a
+			// wrongly claimed the target network was unreachable while listing
+			// nothing at all. He was trying to correct a mistyped password on a
 			// cabled ST20, which is exactly when this has to work (mail,
 			// 2026-08-15).
 			s.logger.Info("WLAN switch preflight: the speaker reported no networks at all, cannot verify, proceeding")
@@ -177,7 +175,7 @@ func (s *Server) handleBoxWLAN(w http.ResponseWriter, r *http.Request) {
 			if !visible {
 				s.logger.Info("WLAN switch refused: target SSID not visible to the speaker", "ssid", req.SSID, "visible", ssids)
 				writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
-					"error":   "The speaker can't see that network. SoundTouch speakers only support 2.4 GHz Wi-Fi, so a 5 GHz network will not work. Pick a network the speaker can see, or switch anyway.",
+					"error":   "The speaker can't see that network in its own scan, so it may not be able to join it. Pick a network the speaker can see, or switch anyway.",
 					"code":    "ssid-not-visible",
 					"ssid":    req.SSID,
 					"visible": ssids,


### PR DESCRIPTION
The Wi-Fi switch preflight, when the speaker's own site survey does not list the target SSID, told the user **"SoundTouch speakers only support 2.4 GHz Wi-Fi"**. That claim is false: SoundTouch speakers do join 5 GHz networks (confirmed live on a fleet of ST10s associated at 5 GHz). It also attributed a refusal to the band when the only real evidence is that the SSID is absent from the speaker's own scan.

What changes:
- `settingsView.wlanNotVisibleBody` reworded in all 13 locales: drops the 2.4 GHz claim, keeps "the speaker cannot find it in its own scan, here is what it can see, switch anyway".
- The agent's `ssid-not-visible` (422) error string reworded the same band-agnostic way.
- Developer comments in `wlan.go`, `boxapi.go`, `app_boxops.go`, `settings.js` that asserted the false "2.4 GHz only" premise are corrected. The preflight logic itself (refuse-when-not-in-scan, with a force override) is unchanged.

Agent cross-compiles (GOARM=5), go vet clean, frontend tests green (218/218).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFzcAvQkHKWn7hMwxAqfae