### PR TITLE
fix(multiroom): a permanent group survives standby so it re-forms on the next play

### DIFF
--- a/internal/webui/resume_standby.go
+++ b/internal/webui/resume_standby.go
@@ -644,6 +644,19 @@ func (s *Server) boxInZone() bool {
 	if hasDoc && (doc.Stereo || doc.Mirror()) {
 		return true
 	}
+	// A PERMANENT group is a firmware zone, unlike the two above, but the user
+	// opted it in to outlive the standby/reboot that dissolves that zone, so it can
+	// re-form on the master's next play (#70). An empty /getZone is therefore the
+	// EXPECTED resting state of a permanent group, not evidence to forget it by.
+	// Dropping the document here would delete the only thing the play-reform
+	// (kickMirrorAfterPlay -> formDefaultGroupOnPlay) has to rebuild from, so the
+	// group would never come back. Live: Portable master, standby then radio,
+	// played alone because the standby had already cleared the document
+	// (2026-08-30). A non-permanent native group still falls through to the clear
+	// below, so power-on resume for the ordinary case is unchanged.
+	if hasDoc && doc.Permanent {
+		return true
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
 	defer cancel()
 	z, err := fetchZone(ctx, s.boxHost)

--- a/internal/webui/zonestaledoc_test.go
+++ b/internal/webui/zonestaledoc_test.go
@@ -189,6 +189,49 @@ func TestAMirrorGroupSurvivesAnEmptyZoneRead(t *testing.T) {
 	}
 }
 
+// A PERMANENT (native default) group must survive the empty /getZone that
+// standby and reboot always produce. The whole point of the opt-in is that the
+// group re-forms on the master's next play (#70), and the play-reform reads this
+// document; if standby drops it, the reform has nothing to act on and the master
+// plays alone. Live regression: Portable master, put into standby, then a radio
+// started on it, played solo because the document had already been cleared
+// (2026-08-30). Even the ordinary two denials must not drop a permanent group.
+func TestAPermanentGroupSurvivesAnEmptyZoneRead(t *testing.T) {
+	doc := nativeDoc()
+	doc.Permanent = true
+	s, st := staleDocServer(t, "192.0.2.10", doc, true)
+	withSpeakers(t, map[string]boxapi.Zone{"192.0.2.10": {}}, map[string]string{"192.0.2.10": "DEV-MASTER"})
+
+	for i := 0; i < 3; i++ {
+		if !s.boxInZone() {
+			t.Fatal("a permanent group must keep its document across the standby that dissolves the firmware zone")
+		}
+	}
+	if !storedGroup(t, st) {
+		t.Fatal("the permanent group document was dropped, so the play-triggered re-form has nothing to rebuild from")
+	}
+}
+
+// The regression boundary: a NON-permanent native group is still dropped after
+// two denials, so power-on resume for the ordinary case is unchanged. This is
+// the exact case TestSecondEmptyZoneReadDropsTheStaleGroupDocument covers, made
+// explicit next to the permanent case so the boundary is not accidentally moved.
+func TestANonPermanentNativeGroupIsStillDropped(t *testing.T) {
+	doc := nativeDoc() // Permanent defaults to false
+	s, st := staleDocServer(t, "192.0.2.10", doc, true)
+	withSpeakers(t, map[string]boxapi.Zone{"192.0.2.10": {}}, map[string]string{"192.0.2.10": "DEV-MASTER"})
+
+	if !s.boxInZone() || !storedGroup(t, st) {
+		t.Fatal("the first empty read must change nothing")
+	}
+	if s.boxInZone() {
+		t.Fatal("an ordinary native group must stand down after the speaker denies it twice, or power-on resume never runs")
+	}
+	if storedGroup(t, st) {
+		t.Fatal("an ordinary native group must be dropped after two denials, so other readers stop believing in it")
+	}
+}
+
 // Unchanged: no document, the speaker says no zone, the speaker resumes.
 func TestAStandaloneSpeakerStillResumes(t *testing.T) {
 	s, _ := staleDocServer(t, "192.0.2.10", zones.Zone{}, false)


### PR DESCRIPTION
**Live-found (2026-08-30):** a Portable set as a permanent group's master was put into standby, then a radio was started on it, and it played **alone** instead of re-forming the group.

**Root cause.** The permanent (default) group re-forms when its master starts music (#70), via `kickMirrorAfterPlay` -> `reconcileZoneOnce` -> `formDefaultGroupOnPlay`, all of which read the persisted zone document (`s.zones.Get()`). But `boxInZone` in `resume_standby.go` clears that document whenever the speaker reports no firmware zone twice, which standby and reboot always cause. The clear ran during standby, so by the time the master played again the document was gone and the re-form had nothing to rebuild from. The agent log showed `dropped the document so power-on resume works again` at 22:15:38, well before the wake+play at 22:16:34.

This also explains the earlier "permanent groups lost after update" report: an OTA reboots the box, the box then reports no zone, and the same path cleared the document.

**Fix.** Gate the drop on the `Permanent` flag. A permanent group is a firmware zone (unlike a stereo pair or a mirror group), but the user opted it in to outlive the standby/reboot that dissolves that zone, so an empty `/getZone` is its expected resting state, not evidence to forget it by. Stereo pairs and mirror groups were already persisted-first at this spot; permanent native groups now join them. A non-permanent native group still gets dropped, so ordinary power-on resume is unchanged.

**Tests** (both in `zonestaledoc_test.go`, the file that already covers this clearing): `TestAPermanentGroupSurvivesAnEmptyZoneRead` (permanent group survives two denials) and `TestANonPermanentNativeGroupIsStillDropped` (the regression boundary, made explicit). Full `internal/webui` suite green, agent cross-compiles (GOARM=5), vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFzcAvQkHKWn7hMwxAqfae