### PR TITLE
fix(app): don't offer a stereo pair's speakers individually when adding speakers to play

### DIFF
--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -5480,7 +5480,17 @@ function renderGroupControl() {
   const isMember = !!box && box.host !== sel.host;
   // Chips are every other STR speaker relative to the MASTER (not the selection),
   // so the selected follower itself appears as an in-group chip that can be removed.
-  const others = (state.boxes || []).filter(b => b && b.kind !== 'stock' && b.host && b.host !== box.host);
+  // A live stereo pair's two halves are excluded here: a pair cannot join a group
+  // as a unit yet, so offering its halves only produced a "not groupable" error on
+  // click and left them cluttering the +N row (reported on the music tab,
+  // 2026-08-31). This is the same exclusion the Multi-room grid applies, via the
+  // shared stereoPairsOf helper; the click-time guard in runGroupMemberToggle stays
+  // as a defensive fallback for a pair that forms while the row is stale.
+  const pairMemberIDs = new Set(
+    stereoPairsOf(state.zoneLive || {}).flatMap(pp => (pp.members || []).map(m => String(m.deviceID || '').toUpperCase())));
+  const others = (state.boxes || []).filter(b =>
+    b && b.kind !== 'stock' && b.host && b.host !== box.host
+    && !pairMemberIDs.has(String(b.deviceID || '').toUpperCase()));
   if (others.length === 0) { cont.innerHTML = ''; return; }
   const slaves = currentGroupSlaves();
   // The tick must come from the SAME list the click acts on. It used to be


### PR DESCRIPTION
On the **Listen to music** screen, the add-speakers (`+N`) row still listed the two halves of a live stereo pair as separate add targets. A stereo pair cannot join an ad-hoc playback group as a unit yet, so clicking a half only raised a *"not groupable"* error — the chips were misleading.

This excludes live stereo-pair members from that list, exactly the way the **Multi-room** grid already does (shared `stereoPairsOf(state.zoneLive)` helper, `multiroom.js:176-186`). The click-time guard in `runGroupMemberToggle` stays as a defensive fallback for a pair that forms while the row is stale.

Reported by a user whose kitchen stereo pair still showed both halves in the `+N` section after the v0.9.68 Multi-room group-builder fix.

## Verification
- `vitest run`: 218/218 pass
- `eslint src/main.js`: 0 errors
- `vite build`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)