### PR TITLE
fix(app): cap a saved folder preset at 1000 tracks so it can't fill the speaker's storage

### DIFF
--- a/desktop-app/frontend/src/i18n/bundles/ar.json
+++ b/desktop-app/frontend/src/i18n/bundles/ar.json
@@ -191,6 +191,7 @@
   "library.folderQueued": "تشغيل المجلد ({{n}} مقطعًا)",
   "library.assignFolderTitle": "حفظ المجلد على أي زر إعداد مسبق؟",
   "library.folderPresetSaved": "تم حفظ المجلد في الإعداد المسبق {{n}}: {{name}}",
+  "library.folderPresetSavedCapped": "تم حفظ المجلد في الإعداد المسبق {{n}}: {{name}}. كان كبيرًا، لذا تم حفظ أول {{kept}} من {{total}} مقطعًا.",
   "library.addServerManual": "إضافة خادم يدويًا",
   "library.addServerPlaceholder": "عنوان IP أو رابط URL، مثل 192.168.1.20 أو http://192.168.1.20:8200/rootDesc.xml",
   "library.addServerBtn": "إضافة",

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -202,6 +202,7 @@
   "library.folderQueued": "Ordner wird abgespielt ({{n}} Titel)",
   "library.assignFolderTitle": "Auf welche Preset-Taste den Ordner speichern?",
   "library.folderPresetSaved": "Ordner auf Preset {{n}} gespeichert: {{name}}",
+  "library.folderPresetSavedCapped": "Ordner auf Preset {{n}} gespeichert: {{name}}. Er war groß, daher wurden die ersten {{kept}} von {{total}} Titeln gespeichert.",
   "library.addServerManual": "Server manuell hinzufügen",
   "library.addServerPlaceholder": "IP-Adresse oder URL, z. B. 192.168.1.20 oder http://192.168.1.20:8200/rootDesc.xml",
   "library.addServerBtn": "Hinzufügen",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -202,6 +202,7 @@
   "library.folderQueued": "Playing folder ({{n}} tracks)",
   "library.assignFolderTitle": "Save folder to which preset key?",
   "library.folderPresetSaved": "Folder saved to preset {{n}}: {{name}}",
+  "library.folderPresetSavedCapped": "Folder saved to preset {{n}}: {{name}}. It was large, so the first {{kept}} of {{total}} tracks were saved.",
   "library.addServerManual": "Add a server manually",
   "library.addServerPlaceholder": "IP address or URL, e.g. 192.168.1.20 or http://192.168.1.20:8200/rootDesc.xml",
   "library.addServerBtn": "Add",

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -191,6 +191,7 @@
   "library.folderQueued": "Reproduciendo carpeta ({{n}} pistas)",
   "library.assignFolderTitle": "¿En qué tecla de preajuste guardar la carpeta?",
   "library.folderPresetSaved": "Carpeta guardada en el preajuste {{n}}: {{name}}",
+  "library.folderPresetSavedCapped": "Carpeta guardada en el preajuste {{n}}: {{name}}. Era grande, así que se guardaron las primeras {{kept}} de {{total}} pistas.",
   "library.addServerManual": "Añadir un servidor manualmente",
   "library.addServerPlaceholder": "Dirección IP o URL, p. ej. 192.168.1.20 o http://192.168.1.20:8200/rootDesc.xml",
   "library.addServerBtn": "Añadir",

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -191,6 +191,7 @@
   "library.folderQueued": "Lecture du dossier ({{n}} pistes)",
   "library.assignFolderTitle": "Enregistrer le dossier sur quelle touche de préréglage ?",
   "library.folderPresetSaved": "Dossier enregistré dans le préréglage {{n}} : {{name}}",
+  "library.folderPresetSavedCapped": "Dossier enregistré dans le préréglage {{n}} : {{name}}. Il était volumineux, donc les {{kept}} premières pistes sur {{total}} ont été enregistrées.",
   "library.addServerManual": "Ajouter un serveur manuellement",
   "library.addServerPlaceholder": "Adresse IP ou URL, p. ex. 192.168.1.20 ou http://192.168.1.20:8200/rootDesc.xml",
   "library.addServerBtn": "Ajouter",

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -191,6 +191,7 @@
   "library.folderQueued": "フォルダを再生中（{{n}} 曲）",
   "library.assignFolderTitle": "フォルダをどのプリセットキーに保存しますか?",
   "library.folderPresetSaved": "フォルダをプリセット {{n}} に保存しました: {{name}}",
+  "library.folderPresetSavedCapped": "フォルダをプリセット {{n}} に保存しました: {{name}}。大きかったため、{{total}} 曲のうち最初の {{kept}} 曲を保存しました。",
   "library.addServerManual": "サーバーを手動で追加",
   "library.addServerPlaceholder": "IPアドレスまたはURL（例: 192.168.1.20 または http://192.168.1.20:8200/rootDesc.xml）",
   "library.addServerBtn": "追加",

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -191,6 +191,7 @@
   "library.folderQueued": "Grojamas aplankas ({{n}} kūrinių)",
   "library.assignFolderTitle": "Į kurį mygtuką išsaugoti aplanką?",
   "library.folderPresetSaved": "Aplankas išsaugotas parinktyje {{n}}: {{name}}",
+  "library.folderPresetSavedCapped": "Aplankas išsaugotas parinktyje {{n}}: {{name}}. Jis buvo didelis, todėl išsaugoti pirmi {{kept}} iš {{total}} takelių.",
   "library.addServerManual": "Pridėti serverį rankiniu būdu",
   "library.addServerPlaceholder": "IP adresas arba URL, pvz., 192.168.1.20 arba http://192.168.1.20:8200/rootDesc.xml",
   "library.addServerBtn": "Pridėti",

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -191,6 +191,7 @@
   "library.folderQueued": "Atskaņo mapi ({{n}} ieraksti)",
   "library.assignFolderTitle": "Kurā pogā saglabāt mapi?",
   "library.folderPresetSaved": "Mape saglabāta iestatījumā {{n}}: {{name}}",
+  "library.folderPresetSavedCapped": "Mape saglabāta iestatījumā {{n}}: {{name}}. Tā bija liela, tāpēc tika saglabāti pirmie {{kept}} no {{total}} celiņiem.",
   "library.addServerManual": "Pievienot serveri manuāli",
   "library.addServerPlaceholder": "IP adrese vai URL, piem., 192.168.1.20 vai http://192.168.1.20:8200/rootDesc.xml",
   "library.addServerBtn": "Pievienot",

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -191,6 +191,7 @@
   "library.folderQueued": "Map afspelen ({{n}} nummers)",
   "library.assignFolderTitle": "Op welke voorkeuzetoets de map opslaan?",
   "library.folderPresetSaved": "Map opgeslagen op voorkeuze {{n}}: {{name}}",
+  "library.folderPresetSavedCapped": "Map opgeslagen op voorkeuze {{n}}: {{name}}. De map was groot, dus de eerste {{kept}} van {{total}} nummers zijn opgeslagen.",
   "library.addServerManual": "Server handmatig toevoegen",
   "library.addServerPlaceholder": "IP-adres of URL, bijv. 192.168.1.20 of http://192.168.1.20:8200/rootDesc.xml",
   "library.addServerBtn": "Toevoegen",

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -191,6 +191,7 @@
   "library.folderQueued": "Odtwarzanie folderu ({{n}} utworów)",
   "library.assignFolderTitle": "Na którym przycisku zapisać folder?",
   "library.folderPresetSaved": "Folder zapisany w zaprogramowanym {{n}}: {{name}}",
+  "library.folderPresetSavedCapped": "Folder zapisany w zaprogramowanym {{n}}: {{name}}. Był duży, więc zapisano pierwsze {{kept}} z {{total}} utworów.",
   "library.addServerManual": "Dodaj serwer ręcznie",
   "library.addServerPlaceholder": "Adres IP lub URL, np. 192.168.1.20 lub http://192.168.1.20:8200/rootDesc.xml",
   "library.addServerBtn": "Dodaj",

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -191,6 +191,7 @@
   "library.folderQueued": "Klasör çalınıyor ({{n}} parça)",
   "library.assignFolderTitle": "Klasör hangi ön ayar tuşuna kaydedilsin?",
   "library.folderPresetSaved": "Klasör ön ayar {{n}} olarak kaydedildi: {{name}}",
+  "library.folderPresetSavedCapped": "Klasör ön ayar {{n}} olarak kaydedildi: {{name}}. Büyük olduğundan {{total}} parçanın ilk {{kept}} tanesi kaydedildi.",
   "library.addServerManual": "Sunucuyu elle ekle",
   "library.addServerPlaceholder": "IP adresi veya URL, örn. 192.168.1.20 veya http://192.168.1.20:8200/rootDesc.xml",
   "library.addServerBtn": "Ekle",

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -191,6 +191,7 @@
   "library.folderQueued": "Відтворення теки ({{n}} треків)",
   "library.assignFolderTitle": "На яку кнопку пресета зберегти теку?",
   "library.folderPresetSaved": "Теку збережено в пресет {{n}}: {{name}}",
+  "library.folderPresetSavedCapped": "Теку збережено в пресет {{n}}: {{name}}. Вона була велика, тож збережено перші {{kept}} із {{total}} треків.",
   "library.addServerManual": "Додати сервер вручну",
   "library.addServerPlaceholder": "IP-адреса або URL, напр. 192.168.1.20 або http://192.168.1.20:8200/rootDesc.xml",
   "library.addServerBtn": "Додати",

--- a/desktop-app/frontend/src/i18n/bundles/zh-Hant.json
+++ b/desktop-app/frontend/src/i18n/bundles/zh-Hant.json
@@ -202,6 +202,7 @@
   "library.folderQueued": "正在播放資料夾（{{n}} 首曲目）",
   "library.assignFolderTitle": "要把這個資料夾存到哪個預設鍵？",
   "library.folderPresetSaved": "資料夾已存到預設 {{n}}：{{name}}",
+  "library.folderPresetSavedCapped": "資料夾已存到預設 {{n}}：{{name}}。因為很大，已存 {{total}} 首中的前 {{kept}} 首。",
   "library.addServerManual": "手動新增伺服器",
   "library.addServerPlaceholder": "IP 位址或網址，例如 192.168.1.20 或 http://192.168.1.20:8200/rootDesc.xml",
   "library.addServerBtn": "新增",

--- a/desktop-app/frontend/src/views/library.js
+++ b/desktop-app/frontend/src/views/library.js
@@ -75,6 +75,11 @@ const libState = {
 // or choke the DOM. Past the cap the folder search narrows what is shown.
 const LIB_PAGE = 200;
 const LIB_MAX = 2500;
+// Max tracks a queue preset stores. The full list is serialized into presets.json
+// on the box, so a whole-library folder can leave it too tight on flash for the
+// next agent update (juelo, 2026-08-31). Keep in sync with presets.MaxQueueItems
+// (internal/presets/presets.go), which enforces the same cap box-side.
+const MAX_QUEUE_PRESET_ITEMS = 1000;
 
 // The media server the user last browsed. Stored in the app rather than on a
 // speaker: it is a preference of this person at this computer, and the
@@ -502,6 +507,15 @@ function librarySaveFolderAsPreset() {
     showError(t('library.errorNoURL'));
     return;
   }
+  // Cap how many tracks a queue preset stores: the whole list is serialized into
+  // presets.json on the box, and a whole-library folder (2600 tracks was ~1.5 MB
+  // with the backup) can leave the box too tight on flash for its next agent
+  // update. The box store enforces the same MAX_QUEUE_PRESET_ITEMS as a safety
+  // net; capping here lets us tell the user their large folder was trimmed.
+  const totalItems = items.length;
+  const queueItems = totalItems > MAX_QUEUE_PRESET_ITEMS
+    ? items.slice(0, MAX_QUEUE_PRESET_ITEMS)
+    : items;
   // Name the preset after the open folder (last breadcrumb), falling back to the
   // media server name, so the tile and the box display show something meaningful.
   const stack = libState.stack || [];
@@ -520,11 +534,15 @@ function librarySaveFolderAsPreset() {
         type: 'queue',
         shuffle: !!libState.shuffle,
         source,
-        items,
+        items: queueItems,
       };
       try {
         await SaveFolderPreset(state.currentBox.host, state.currentBox.port, i, JSON.stringify(payload));
-        showToast(t('library.folderPresetSaved', { n: i, name }));
+        if (queueItems.length < totalItems) {
+          showToast(t('library.folderPresetSavedCapped', { n: i, name, kept: queueItems.length, total: totalItems }));
+        } else {
+          showToast(t('library.folderPresetSaved', { n: i, name }));
+        }
       } catch (e) {
         showError(`SaveFolderPreset: ${e}`);
       }

--- a/internal/presets/presets.go
+++ b/internal/presets/presets.go
@@ -81,6 +81,25 @@ type PresetItem struct {
 	DurationSec int    `json:"duration_sec,omitempty"`
 }
 
+// MaxQueueItems bounds how many tracks a queue preset (Type=="queue") stores on
+// the speaker. Saving a whole media-server library as a single preset (a 2600-
+// track queue was ~777 KB in presets.json plus its .bak, ~1.5 MB together) left
+// the box so tight on flash that the next agent OTA could not fit its atomic
+// write and the speaker came up without the agent (2026-08-31). 1000 tracks keep
+// the store well under ~300 KB while still giving a large shuffle pool; recall
+// plays whatever subset is stored (presetItemsToQueue accepts any length).
+const MaxQueueItems = 1000
+
+// capQueueItems trims a preset's Items to MaxQueueItems and reports whether it
+// changed anything. Only queue presets carry Items; every other type is a no-op.
+func capQueueItems(p *Preset) bool {
+	if len(p.Items) > MaxQueueItems {
+		p.Items = p.Items[:MaxQueueItems]
+		return true
+	}
+	return false
+}
+
 // rawPreset is the disk format helper. Accepts multiple alias fields.
 type rawPreset struct {
 	Slot      int          `json:"slot"`
@@ -135,6 +154,7 @@ func Load(path string) (*Store, error) {
 	if len(b) > 0 {
 		if data, perr := parse(b); perr == nil {
 			s.data = data
+			s.healOverCap()
 			return s, nil
 		}
 		// Primary present but corrupt: fall through to the backup.
@@ -144,8 +164,11 @@ func Load(path string) (*Store, error) {
 		if data, perr := parse(bb); perr == nil && len(data) > 0 {
 			s.data = data
 			// Restore the primary durably so the box is whole again and
-			// GET /api/presets stops returning empty. Best-effort.
-			_ = atomicfile.WriteFile(path, bb, 0o644)
+			// GET /api/presets stops returning empty. healOverCap's re-save
+			// (below) does the write when it trims; otherwise restore here.
+			if !s.healOverCap() {
+				_ = atomicfile.WriteFile(path, bb, 0o644)
+			}
 			return s, nil
 		}
 	}
@@ -215,6 +238,26 @@ func normalize(in []rawPreset) []Preset {
 	return out
 }
 
+// healOverCap trims any queue preset that exceeds MaxQueueItems (a store written
+// before the cap existed, e.g. a whole-library queue preset) and, when it trimmed
+// anything, rewrites presets.json + .bak so the speaker reclaims the flash on the
+// next agent start. Returns whether it actually wrote. Called from Load before the
+// Store is shared, so it needs no lock; pathless-safe (a Store with no path keeps
+// the trimmed data in memory and reports false).
+func (s *Store) healOverCap() bool {
+	changed := false
+	for i := range s.data {
+		if capQueueItems(&s.data[i]) {
+			changed = true
+		}
+	}
+	if changed && s.path != "" {
+		_ = s.Save()
+		return true
+	}
+	return false
+}
+
 // All returns a copy of all presets.
 func (s *Store) All() []Preset {
 	s.mu.RLock()
@@ -237,8 +280,11 @@ func (s *Store) Get(slot int) (Preset, bool) {
 }
 
 // SetSlot adds a preset or replaces the existing one for the same slot.
-// Persists immediately.
+// Persists immediately. A queue preset is trimmed to MaxQueueItems here so the
+// cap is enforced on every write path (the HTTP save, the copy-presets flow, any
+// future client), not only in the frontend.
 func (s *Store) SetSlot(p Preset) error {
+	capQueueItems(&p)
 	s.mu.Lock()
 	replaced := false
 	for i, existing := range s.data {

--- a/internal/presets/presets_test.go
+++ b/internal/presets/presets_test.go
@@ -1,9 +1,11 @@
 package presets
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"testing"
 )
 
@@ -105,6 +107,84 @@ func TestSaveLoadSpotifyRoundtrip(t *testing.T) {
 	}
 	if got.Type != "spotify" || got.URI != want.URI || got.Account != want.Account || got.Name != want.Name {
 		t.Errorf("round trip lost fields: %+v", got)
+	}
+}
+
+// makeItems builds n distinct queue items for the cap tests.
+func makeItems(n int) []PresetItem {
+	out := make([]PresetItem, n)
+	for i := range out {
+		out[i] = PresetItem{URL: "http://nas/" + strconv.Itoa(i) + ".mp3"}
+	}
+	return out
+}
+
+// A queue preset larger than MaxQueueItems must be trimmed on save, so one saved
+// library folder cannot fill the box's flash and strand the next OTA. The kept
+// slice must be the FIRST MaxQueueItems items, and other preset types untouched.
+func TestSetSlotCapsQueueItems(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "presets.json")
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	items := makeItems(MaxQueueItems + 600)
+	if err := s.SetSlot(Preset{Slot: 3, Name: "Whole Library", Type: "queue", Items: items}); err != nil {
+		t.Fatalf("SetSlot: %v", err)
+	}
+	got, _ := s.Get(3)
+	if len(got.Items) != MaxQueueItems {
+		t.Fatalf("queue not capped: kept %d, want %d", len(got.Items), MaxQueueItems)
+	}
+	if got.Items[0].URL != "http://nas/0.mp3" || got.Items[MaxQueueItems-1].URL != "http://nas/"+strconv.Itoa(MaxQueueItems-1)+".mp3" {
+		t.Errorf("cap dropped the wrong end: first=%s last=%s", got.Items[0].URL, got.Items[MaxQueueItems-1].URL)
+	}
+	// A radio preset carries no Items and must be unaffected.
+	if err := s.SetSlot(Preset{Slot: 1, Name: "NDR2", Type: "radio", StreamURL: "http://x/ndr2.mp3"}); err != nil {
+		t.Fatalf("SetSlot radio: %v", err)
+	}
+	if r, _ := s.Get(1); len(r.Items) != 0 {
+		t.Errorf("radio preset gained items: %+v", r.Items)
+	}
+}
+
+// A presets.json written before the cap existed (a whole-library queue preset)
+// must be trimmed on Load and the smaller file rewritten, so the box reclaims the
+// flash on the next agent start without the user re-saving anything.
+func TestLoadHealsOverCapQueue(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "presets.json")
+	// Seed an over-cap store directly on disk via a first Store that skips the cap
+	// (write the raw JSON so the fixture mirrors a pre-cap file).
+	big := struct {
+		Presets []Preset `json:"presets"`
+	}{Presets: []Preset{{Slot: 3, Name: "All Music", Type: "queue", Items: makeItems(MaxQueueItems + 1600)}}}
+	raw, _ := json.MarshalIndent(big, "", "  ")
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sizeBefore := len(raw)
+
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got, ok := s.Get(3)
+	if !ok || len(got.Items) != MaxQueueItems {
+		t.Fatalf("over-cap queue not healed on load: kept %d, want %d (ok=%v)", len(got.Items), MaxQueueItems, ok)
+	}
+	// The on-disk file must have shrunk (the heal re-saved the trimmed store).
+	b, _ := os.ReadFile(path)
+	if len(b) >= sizeBefore {
+		t.Errorf("healed file not rewritten smaller: before=%d after=%d", sizeBefore, len(b))
+	}
+	// A fresh Load must now be a no-op heal (already at the cap).
+	s2, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load(reload): %v", err)
+	}
+	if g2, _ := s2.Get(3); len(g2.Items) != MaxQueueItems {
+		t.Errorf("second load changed the count: %d", len(g2.Items))
 	}
 }
 

--- a/internal/webui/presets_http.go
+++ b/internal/webui/presets_http.go
@@ -109,6 +109,13 @@ func (s *Server) handlePresetSlot(w http.ResponseWriter, r *http.Request) {
 				})
 				return
 			}
+			// A whole-library folder can carry thousands of tracks; the store caps
+			// the persisted list at presets.MaxQueueItems so one preset cannot fill
+			// the box's flash and strand the next OTA (juelo's 2600-track preset,
+			// 2026-08-31). Log the trim; SetSlot below does the actual capping.
+			if n := len(p.Items); n > presets.MaxQueueItems {
+				s.logger.Info("queue preset capped to fit NAND", "slot", slot, "requested", n, "kept", presets.MaxQueueItems)
+			}
 			if err := s.presets.SetSlot(p); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return


### PR DESCRIPTION
## What & why
Saving a whole media-server library as one **queue preset** serialized every track into `presets.json` on the speaker. A user's 2600-track "save folder as preset" produced a ~777 KB store plus its 777 KB backup (~1.5 MB), which left one box so tight on flash that its **next agent update could not fit the atomic write**: the speaker rebooted into the Bose firmware *without* the STR agent, so the hardware buttons went dead until a power cycle. (Found in juelo's fleet on 2026-08-31; the other ten boxes updated fine — this was the one box carrying the huge preset.)

## Fix — cap a queue preset at 1000 tracks
- **`internal/presets`** (authoritative): `SetSlot` trims to `MaxQueueItems` on *every* write path (HTTP save, copy-presets, any client). `Load` **self-heals** a store written before the cap and rewrites the smaller `presets.json` + `.bak`, so an affected box reclaims the space on its next agent start with no user action.
- **`internal/webui`**: the queue-save handler logs when it trims a large folder.
- **Frontend**: `library.js` "save folder as preset" caps the list and tells the user their large folder was saved as *the first 1000 of N tracks* (new `library.folderPresetSavedCapped`, all 13 locales).

1000 tracks keep the store well under ~300 KB while still giving a large shuffle pool; recall plays whatever subset is stored (`presetItemsToQueue` accepts any length), so truncation never breaks playback. The only reason 2600 slipped through before was the browse cap `LIB_MAX=2500` rounding up to the next 200-track page — there was no real preset cap.

## Tests
- `internal/presets`: `TestSetSlotCapsQueueItems` (cap keeps the first N, radio presets untouched), `TestLoadHealsOverCapQueue` (pre-cap store trimmed + rewritten smaller on load).
- Full `go test ./internal/presets/... ./internal/webui/...` green; `go vet` clean; ARM cross-compile OK.
- Frontend `vitest` 218/218 (incl. locale key-parity), `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)