### PR TITLE
fix(app): three sweep fixes (recent-played mark, already-removed notice, stereo pair name in history)

### DIFF
--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -334,7 +334,7 @@ import {
 // pulls state/utils/i18n/api from the shared modules; only the slot-picker modal
 // is main.js-local, injected below. New views should follow this pattern so this
 // file stops growing.
-import { renderRecent, initRecentView } from './views/recent.js';
+import { renderRecent, initRecentView, refreshRecentList } from './views/recent.js';
 import { shareModalHTML, shareTriggerHTML, wireShareModal, openShareModal } from './share.js';
 import { renderMultiroom, initMultiroomView } from './views/multiroom.js';
 import { renderSpotifyAlpha, initSpotifyView } from './views/spotify.js';
@@ -6812,9 +6812,16 @@ async function refreshStatus() {
     // its reading so the bar does not stutter on an unrelated status change.
     const trackKey = newLoc + '|' + newName;
     if (trackKey !== trackPos.key) resetTrackProgress(trackKey);
+    // #810: the Recently played list marks the current source from
+    // state.nowName / nowLocation, but only repaints on its own 30 s timer or on
+    // re-entry, so a station change made from another controller (the phone ST
+    // Remote) left the "now playing" badge on the old card until then. Repaint it
+    // here on an actual source change so the mark tracks the speaker at once.
+    const recentSourceChanged = state.nowLocation !== newLoc || state.nowName !== newName;
     state.nowPlayState = ps;
     state.nowLocation = newLoc;
     state.nowName = newName;
+    if (recentSourceChanged && state.view === 'recent') refreshRecentList();
     // Live Spotify track metadata for the now-playing line: poll the agent's
     // /spotify/info (throttled) while a Spotify stream is active so the desktop
     // shows the current song + artist, not just the playlist/preset name.

--- a/desktop-app/frontend/src/views/recent.js
+++ b/desktop-app/frontend/src/views/recent.js
@@ -359,7 +359,10 @@ function stopRecentAutoRefresh() {
 // refreshRecentList re-fetches and repaints only the card list (not the header /
 // scope chips), so the auto-refresh does not disturb the controls. /api/recent
 // is a cheap in-RAM read on the box; this only runs while the tab is visible.
-async function refreshRecentList() {
+// Exported so main.js's status poll can repaint it the instant the speaker's
+// source changes from another controller, instead of waiting for the 30 s timer
+// (#810).
+export async function refreshRecentList() {
   if (state.view !== 'recent') { stopRecentAutoRefresh(); return; }
   const cards = await loadRecentCards();
   const listEl = $('recentList');

--- a/desktop-app/frontend/src/views/recent.js
+++ b/desktop-app/frontend/src/views/recent.js
@@ -18,6 +18,8 @@ import { $, escapeHtml, escapeAttr, showError, showToast, confirmWarn, getBoxLab
 import { t } from '../i18n/index.js';
 import { RecentPlayed, SaveSpotifyPreset, GetPresets, PlaySlot, BrowserOpenURL, ClearRecent, DeleteRecentCard } from '../api.js';
 import { logoImgTag, SPOTIFY_LOGO } from '../logos.js';
+import { stereoPairsOf } from '../groups.js';
+import { pairDisplayName } from '../stereoNames.js';
 
 // Injected main.js helpers (see initRecentView). showSlotPicker is the shared
 // modal; playStation/openPick/toggleFav/isFav are the exact radio-search-row
@@ -57,6 +59,26 @@ function recentSelectedBoxes() {
   }
   if (state.currentBox) return [state.currentBox];
   return all.length ? [all[0]] : [];
+}
+
+// recentBoxDisplayLabel is the speaker name shown on a played card. When the
+// speaker is half of a live firmware stereo pair, the pair's own STR name is
+// shown instead of the single box name (#775), so the history reads as one
+// speaker exactly like the multi-room view names it. The name is kept app-side
+// (stereoNames.js); its first lookup is async, so pairDisplayName repaints the
+// list once the name lands. Falls back to the plain box label when the box is
+// not paired or the pair has no stored name.
+function recentBoxDisplayLabel(b) {
+  const dev = String(b.deviceID || '').toUpperCase();
+  if (dev) {
+    const pair = stereoPairsOf(state.zoneLive || {}).find((p) =>
+      (p.members || []).some((m) => String(m.deviceID || '').toUpperCase() === dev));
+    if (pair) {
+      const nm = pairDisplayName(pair, () => refreshRecentList());
+      if (nm) return nm;
+    }
+  }
+  return getBoxLabel(b);
 }
 
 // cardStation projects a recent card into the radio-station shape the search-row
@@ -131,7 +153,8 @@ async function loadRecentCards() {
     const boxKey = recentBoxKey(b);
     // friendlyName first: the backend always fills Name with a "str-<IP>" fallback,
     // so b.name is never empty. This matches the box switcher and the rest of the app.
-    const boxName = getBoxLabel(b);
+    // A stereo pair shows its own STR name here instead of the single box (#775).
+    const boxName = recentBoxDisplayLabel(b);
     let list = [];
     try { list = await RecentPlayed(b.host, b.port) || []; } catch { list = []; }
     // Map Spotify playlist URI -> preset slot on this box. A match means the box

--- a/desktop-app/uninstall_str.go
+++ b/desktop-app/uninstall_str.go
@@ -139,6 +139,26 @@ func (a *App) UninstallSTR(host string) UninstallSTRResult {
 		}
 	}
 	if helloErr != nil || !strings.Contains(hello, "STR_SSH_OK") {
+		// #683: a box that STR already fully removed has rebooted back to stock, so
+		// there is no STR agent left to open SSH and a stock box keeps :22 closed.
+		// Pressing Remove a second time then failed HERE with the raw "exit status
+		// 255" SSH error, when the honest answer is that STR is already gone. Tell
+		// that case apart from a genuinely unreachable or wedged box: a live stock
+		// speaker still answers the Bose API on :8090 while NEITHER STR agent port
+		// (:8888 sm2, :17008 BCO) is open. A wedged STR box keeps its agent port
+		// open, so it never reaches this branch; a powered-off box answers nothing,
+		// so it keeps the reachability error rather than a false "already removed".
+		boseUp := tcpReachable(host, 8090, 2*time.Second)
+		strAgentUp := tcpReachable(host, 8888, 1500*time.Millisecond) || tcpReachable(host, 17008, 1500*time.Millisecond)
+		if boseUp && !strAgentUp {
+			a.forgetSTRDeviceByHost(host)
+			res.Step = "already-stock"
+			res.OK = true
+			res.Message = "STR is already removed from this speaker. It is back to a stock Bose speaker, " +
+				"so there was nothing to remove and nothing else is needed."
+			a.logger.Info("uninstall_str: speaker is already stock, nothing to remove", "host", host)
+			return res
+		}
 		res.Log = hello
 		res.Message = "Could not open install access (SSH) to the speaker to remove STR: " + classifySSHError(hello, helloErr)
 		return res


### PR DESCRIPTION
Three fixes surfaced in the GitHub sweep, all diagnosed from shorty310 diagnostic bundles / reports.

## #810 Recently played mark lagged on an external station change
The Recently played screen marks the current source from the speaker now-playing state, but only repainted on its own 30s timer or on re-entry. Changing the station from another controller (the phone remote) while that screen was open left the mark on the old card until then. The desktop status poll now repaints the list the instant the source changes, so the mark follows the speaker at once. Cosmetic only, the speaker was on the right station the whole time.

Files: desktop-app/frontend/src/main.js, desktop-app/frontend/src/views/recent.js

## #683 raw SSH error when removing STR from a speaker twice
Removing STR a second time from an already-removed speaker showed "could not open install access (SSH): exit status 255", because the box had rebooted back to stock and a stock speaker keeps SSH closed. When no STR agent answers but the box is a live stock speaker (Bose API up on :8090, neither agent port open), the app now reports that STR is already gone and nothing is needed. A wedged box keeps its agent port open and a powered-off box answers nothing, so neither is misread as already removed.

Files: desktop-app/uninstall_str.go

## #775 (partial) stereo pair name in the Recently played history
A speaker that is half of a stereo pair listed its single box name in Recently played instead of the pair name. The card now shows the pair STR name (the same app-side name the multi-room view uses) when a live pair member played it. The other half of #775, the same name in the phone web UI speaker list, needs the app-side pair name to reach the box first and is tracked separately; the reporter is also being asked which surface he means by "ST Remote".

Files: desktop-app/frontend/src/views/recent.js

All three reporters still need to confirm on the next build, so the issues stay open (Refs #810, Refs #683, Refs #775).