### PR TITLE
fix(agent): decode Latin-1 ICY track titles so umlauts are not garbled

### DIFF
--- a/internal/streamproxy/icy.go
+++ b/internal/streamproxy/icy.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // SetOnTitle registers a callback invoked when the live ICY StreamTitle of
@@ -34,6 +35,7 @@ func (s *Server) CurrentTitle() string {
 func (s *Server) setTitle(url, title string) {
 	title = strings.TrimRight(title, "\x00")
 	title = strings.TrimSpace(title)
+	title = titleToUTF8(title)
 	s.titleMu.Lock()
 	changed := title != s.curTitle || url != s.curTitleURL
 	s.curTitle = title
@@ -47,6 +49,27 @@ func (s *Server) setTitle(url, title string) {
 	if fire {
 		cb(title)
 	}
+}
+
+// titleToUTF8 normalises an ICY StreamTitle to valid UTF-8. Shoutcast/Icecast
+// stations often send the title in Latin-1 (ISO-8859-1), not UTF-8, so an umlaut
+// in a track or artist ("Fürstenfeld", "Böhse Onkelz") arrives as a lone high
+// byte. Left as-is it is invalid UTF-8, and json.Marshal to the app then replaces
+// it with U+FFFD, so the song shows up garbled as "F�rstenfeld". This is the same
+// fix the box names get in boxapi.ensureUTF8: a title that is already valid UTF-8
+// is returned unchanged, otherwise the bytes are read as Latin-1 (a 1:1 map to the
+// first 256 code points, so ASCII is untouched and only high bytes are widened)
+// and re-encoded as UTF-8.
+func titleToUTF8(s string) string {
+	if utf8.ValidString(s) {
+		return s
+	}
+	b := []byte(s)
+	out := make([]byte, 0, len(b)+8)
+	for _, c := range b {
+		out = utf8.AppendRune(out, rune(c))
+	}
+	return string(out)
 }
 
 // clearTitleForNewURL drops a stale title when the proxied stream changes, so

--- a/internal/streamproxy/icy_charset_test.go
+++ b/internal/streamproxy/icy_charset_test.go
@@ -1,0 +1,32 @@
+package streamproxy
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+// A Shoutcast/Icecast StreamTitle with a Latin-1 umlaut byte (ü = 0xFC) must be
+// decoded to valid UTF-8, otherwise json.Marshal to the app replaces the byte
+// with U+FFFD and the song shows up garbled.
+func TestTitleToUTF8DecodesLatin1Umlauts(t *testing.T) {
+	latin1 := string([]byte{'F', 0xFC, 'r', 's', 't', 'e', 'n', 'f', 'e', 'l', 'd'})
+	if utf8.ValidString(latin1) {
+		t.Fatal("test input should be invalid UTF-8 Latin-1 bytes")
+	}
+	got := titleToUTF8(latin1)
+	if got != "Fürstenfeld" {
+		t.Fatalf("latin1 title not decoded: got %q want %q", got, "Fürstenfeld")
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("result is not valid UTF-8: %q", got)
+	}
+}
+
+// A title that is already valid UTF-8 (a modern station) must pass through byte
+// for byte, so a correct umlaut is never double-encoded.
+func TestTitleToUTF8LeavesValidUTF8Unchanged(t *testing.T) {
+	in := "Über den Wolken (Reinhard Mey)"
+	if got := titleToUTF8(in); got != in {
+		t.Fatalf("valid UTF-8 title was altered: got %q want %q", got, in)
+	}
+}


### PR DESCRIPTION
Jens noticed umlaut characters were garbled somewhere in STR or the phone page. Root cause found in the ICY (Shoutcast/Icecast) live-title path.

## Cause
setTitle in internal/streamproxy/icy.go trims NUL and whitespace but never normalises the character encoding. ICY StreamTitle is frequently Latin-1, not UTF-8, so an umlaut in a song or artist arrives as a lone high byte (ue = 0xFC). Left as invalid UTF-8, json.Marshal to the app replaces it with U+FFFD, so the track shows up as "F<?>rstenfeld".

Box names already get this fix via boxapi.ensureUTF8 (#70); the ICY title path was the gap.

## Fix
A small titleToUTF8 helper mirrors the proven ensureUTF8 logic: a title that is already valid UTF-8 is returned unchanged (never double-encoded), one that is not is read as Latin-1 and re-encoded as UTF-8. Applied at the source in setTitle, so every consumer (recent-played ring, the on-display push, the desktop app and the phone page) gets clean text.

Covered by two tests (a Latin-1 umlaut title decodes, a valid UTF-8 title is untouched). Agent-side, ships via OTA.