### PR TITLE
chore: network-reachability forensics for the plays-but-unreachable fault

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -503,6 +503,10 @@ func run() error {
 		}()
 	}
 	webui.RegisterDebugSection("clock_status", clockStatusSnapshot)
+	// net_reachability captures the "plays radio but unreachable" fault: the
+	// cheap carrier/IP/gateway-ARP snapshot the health tick watches, plus the
+	// on-demand INPUT chain, routes, ARP table and listeners for a bundle.
+	webui.RegisterDebugSection("net_reachability", netReachabilityDebugSection)
 	// dns_status makes the #487 fault class visible in one glance: a bundle
 	// with an empty nameserver list explains dead radio, a stuck clock, an
 	// unpaired box and a crash-looping Spotify engine all at once.
@@ -1168,6 +1172,7 @@ func run() error {
 	go func() {
 		defer wg.Done()
 		logResourceHealth(logger)
+		checkNetworkReachability(logger)
 		health := time.NewTicker(5 * time.Minute)
 		defer health.Stop()
 		// The guard polls far more often than the heartbeat log: a runaway can
@@ -1180,6 +1185,7 @@ func run() error {
 				return
 			case <-health.C:
 				logResourceHealth(logger)
+				checkNetworkReachability(logger)
 			case <-guard.C:
 				memoryGuardCheck(logger, spotifyMgr, *boxHost)
 			}

--- a/cmd/agent/netforensics.go
+++ b/cmd/agent/netforensics.go
@@ -1,0 +1,269 @@
+package main
+
+// Network reachability forensics for the "plays radio but unreachable" hunt.
+//
+// A box in that state keeps its outbound radio stream (an ESTABLISHED
+// connection) while every inbound packet is dropped, so it is invisible over the
+// network exactly when we most want to look at it (confirmed on a mojo ST30 and
+// reported on an ST10; see project_st30_blackhole_usb_stick). The box cannot
+// test its own EXTERNAL inbound reachability from the inside, that needs an
+// outside prober, but it CAN watch the two things that fail underneath it:
+//
+//   1. the LAN interface losing carrier while it stays administratively up (the
+//      USB-bridged eth0 coprocessor degrading on scm/BCO chassis), and
+//   2. the default gateway falling out of the ARP table (an L2 breakdown that
+//      would strand both chassis, wlan0 and the USB bridge alike).
+//
+// Both are read from /proc and the net package, cost nothing, and ride the
+// existing 5-minute resource-health tick, so there is NO new timer and NO
+// per-tick exec (keeping the box hardware spared). A degradation is logged at
+// INFO so it lands in the 32 KB NAND ring that survives the reboot the user does
+// to recover; the full picture (the INPUT chain, routes, the whole ARP table,
+// the listeners) is exposed only on demand as the net_reachability debug
+// section, where the exec cost is paid once per diagnostic bundle, not on a tick.
+
+import (
+	"bufio"
+	"encoding/binary"
+	"log/slog"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+type netForensicsSnapshot struct {
+	IfaceName    string   `json:"ifaceName"`
+	IfaceUp      bool     `json:"ifaceUp"`      // administratively up
+	IfaceCarrier bool     `json:"ifaceCarrier"` // IFF_RUNNING: the link is actually up
+	HasLANIP     bool     `json:"hasLANIP"`
+	LANAddrs     []string `json:"lanAddrs"`
+	GatewayIP    string   `json:"gatewayIP"`
+	GatewayARP   string   `json:"gatewayARP"` // reachable | incomplete | absent | unknown
+}
+
+var (
+	netForensicsMu   sync.Mutex
+	netForensicsLast netForensicsSnapshot
+	netForensicsHave bool
+)
+
+// defaultRouteV4 reads /proc/net/route and returns the IPv4 default route's
+// (gatewayIP, ifaceName), or ("","") if there is none. The gateway is stored
+// little-endian hex in the file.
+func defaultRouteV4() (string, string) {
+	f, err := os.Open("/proc/net/route")
+	if err != nil {
+		return "", ""
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	sc.Scan() // header
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) < 3 || fields[1] != "00000000" { // Destination 0 = default
+			continue
+		}
+		v, err := strconv.ParseUint(fields[2], 16, 32)
+		if err != nil {
+			continue
+		}
+		var b [4]byte
+		binary.LittleEndian.PutUint32(b[:], uint32(v))
+		return net.IP(b[:]).String(), fields[0]
+	}
+	return "", ""
+}
+
+// gatewayARPState reads /proc/net/arp and reports the gateway's entry state:
+// "reachable" (flags 0x2 = ATF_COM, a completed MAC), "incomplete", "absent"
+// (no entry at all), or "unknown" (no gateway / file unreadable).
+func gatewayARPState(gw string) string {
+	if gw == "" {
+		return "unknown"
+	}
+	f, err := os.Open("/proc/net/arp")
+	if err != nil {
+		return "unknown"
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	sc.Scan() // header
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) < 4 || fields[0] != gw {
+			continue
+		}
+		if fields[2] == "0x2" {
+			return "reachable"
+		}
+		return "incomplete"
+	}
+	return "absent"
+}
+
+// isRFC1918 reports whether s is a private-range IPv4, so the fallback interface
+// pick skips the usb0 203.0.113.x internal link and any link-local address.
+func isRFC1918(s string) bool {
+	ip := net.ParseIP(s).To4()
+	if ip == nil {
+		return false
+	}
+	switch {
+	case ip[0] == 10:
+		return true
+	case ip[0] == 172 && ip[1] >= 16 && ip[1] <= 31:
+		return true
+	case ip[0] == 192 && ip[1] == 168:
+		return true
+	}
+	return false
+}
+
+// readNetForensics builds the cheap snapshot from /proc + the net package. No
+// exec, so it is safe to call on every health tick.
+func readNetForensics() netForensicsSnapshot {
+	var s netForensicsSnapshot
+	gwIP, gwIface := defaultRouteV4()
+	s.GatewayIP = gwIP
+	s.GatewayARP = gatewayARPState(gwIP)
+
+	ifaces, _ := net.Interfaces()
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		var v4s []string
+		addrs, _ := iface.Addrs()
+		for _, a := range addrs {
+			if ipn, ok := a.(*net.IPNet); ok {
+				if ip := ipn.IP.To4(); ip != nil {
+					v4s = append(v4s, ip.String())
+				}
+			}
+		}
+		// Prefer the interface that owns the default route (the real LAN path);
+		// otherwise the first non-loopback carrying a private-range address, so
+		// the usb0 203.0.113.x internal bridge link is never mistaken for the LAN.
+		isGwIface := gwIface != "" && iface.Name == gwIface
+		fallback := s.IfaceName == "" && anyRFC1918(v4s)
+		if isGwIface || fallback {
+			s.IfaceName = iface.Name
+			s.IfaceUp = iface.Flags&net.FlagUp != 0
+			s.IfaceCarrier = iface.Flags&net.FlagRunning != 0
+			s.LANAddrs = v4s
+			s.HasLANIP = anyRFC1918(v4s)
+			if isGwIface {
+				break // exact match wins over the fallback
+			}
+		}
+	}
+	return s
+}
+
+func anyRFC1918(v4s []string) bool {
+	for _, s := range v4s {
+		if isRFC1918(s) {
+			return true
+		}
+	}
+	return false
+}
+
+// netDegradations returns the human-readable list of ways cur is worse than
+// last for inbound reachability. Pure, so the decision is unit-testable without
+// touching /proc.
+func netDegradations(last, cur netForensicsSnapshot) []string {
+	var d []string
+	if last.IfaceCarrier && !cur.IfaceCarrier {
+		d = append(d, "interface lost carrier (link down while the box stays up)")
+	}
+	if last.HasLANIP && !cur.HasLANIP {
+		d = append(d, "LAN IP disappeared")
+	}
+	if last.GatewayARP == "reachable" && cur.GatewayARP != "reachable" {
+		d = append(d, "default gateway fell out of the ARP table ("+cur.GatewayARP+")")
+	}
+	return d
+}
+
+// netRecovered reports whether cur is healthy again after last was degraded, so
+// a bundle shows the box came back on its own instead of needing the reboot.
+func netRecovered(last, cur netForensicsSnapshot) bool {
+	return (!last.IfaceCarrier && cur.IfaceCarrier) ||
+		(!last.HasLANIP && cur.HasLANIP) ||
+		(last.GatewayARP != "reachable" && cur.GatewayARP == "reachable")
+}
+
+// checkNetworkReachability rides the resource-health tick. It logs the first
+// reading and any degradation or recovery at INFO so the evidence lands in the
+// NAND log that survives the recovery reboot; a quiet reading costs nothing
+// (Debug only, no NAND write), matching the resource-health philosophy.
+func checkNetworkReachability(logger *slog.Logger) {
+	cur := readNetForensics()
+	netForensicsMu.Lock()
+	last, have := netForensicsLast, netForensicsHave
+	netForensicsLast, netForensicsHave = cur, true
+	netForensicsMu.Unlock()
+
+	attrs := []any{
+		"iface", cur.IfaceName, "up", cur.IfaceUp, "carrier", cur.IfaceCarrier,
+		"lanAddrs", strings.Join(cur.LANAddrs, ","),
+		"gateway", cur.GatewayIP, "gatewayARP", cur.GatewayARP,
+	}
+	if !have {
+		logger.Info("network forensics: baseline", attrs...)
+		return
+	}
+	if deg := netDegradations(last, cur); len(deg) > 0 {
+		logger.Info("network forensics: reachability DEGRADED - "+strings.Join(deg, "; ")+
+			" (the 'plays but unreachable' signature; kept in the NAND log across the reboot)",
+			append(attrs, "prevCarrier", last.IfaceCarrier, "prevHasLANIP", last.HasLANIP,
+				"prevGatewayARP", last.GatewayARP)...)
+		return
+	}
+	if netRecovered(last, cur) {
+		logger.Info("network forensics: reachability recovered on its own", attrs...)
+		return
+	}
+	logger.Debug("network forensics", attrs...)
+}
+
+// netReachabilityDebugSection is the on-demand full picture for a diagnostic
+// bundle: the cheap snapshot plus the state that needs a command. Exec is fine
+// here because it runs only when someone fetches /api/debug/state, never on the
+// tick.
+func netReachabilityDebugSection() any {
+	run := func(name string, args ...string) string {
+		out, err := exec.Command(name, args...).CombinedOutput()
+		if err != nil && len(out) == 0 {
+			return "(" + name + ": " + err.Error() + ")"
+		}
+		return strings.TrimRight(string(out), "\n")
+	}
+	readFile := func(p string) string {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			return "(" + err.Error() + ")"
+		}
+		return strings.TrimRight(string(b), "\n")
+	}
+	listeners := run("netstat", "-ltn")
+	if strings.HasPrefix(listeners, "(") {
+		listeners = run("ss", "-ltn")
+	}
+	return map[string]any{
+		"snapshot":                snapshotOrEmpty(),
+		"iptables_input":          run("iptables", "-w", "-S", "INPUT"),
+		"iptables_nat_prerouting": run("iptables", "-w", "-t", "nat", "-S", "PREROUTING"),
+		"ip_route":                run("ip", "route"),
+		"arp_table":               readFile("/proc/net/arp"),
+		"listeners":               listeners,
+	}
+}
+
+func snapshotOrEmpty() netForensicsSnapshot {
+	return readNetForensics()
+}

--- a/cmd/agent/netforensics_test.go
+++ b/cmd/agent/netforensics_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func nfSnap(carrier, hasIP bool, arp string) netForensicsSnapshot {
+	return netForensicsSnapshot{IfaceCarrier: carrier, HasLANIP: hasIP, GatewayARP: arp}
+}
+
+func TestNetDegradationsCatchesTheBlackholeSignatures(t *testing.T) {
+	healthy := nfSnap(true, true, "reachable")
+	cases := []struct {
+		name string
+		cur  netForensicsSnapshot
+		want string // substring expected in a degradation line; "" = none
+	}{
+		{"carrier lost", nfSnap(false, true, "reachable"), "lost carrier"},
+		{"lan ip gone", nfSnap(true, false, "reachable"), "LAN IP disappeared"},
+		{"gateway arp incomplete", nfSnap(true, true, "incomplete"), "ARP table"},
+		{"gateway arp absent", nfSnap(true, true, "absent"), "ARP table"},
+		{"all healthy", healthy, ""},
+	}
+	for _, c := range cases {
+		got := netDegradations(healthy, c.cur)
+		if c.want == "" {
+			if len(got) != 0 {
+				t.Errorf("%s: expected no degradation, got %v", c.name, got)
+			}
+			continue
+		}
+		found := false
+		for _, g := range got {
+			if strings.Contains(g, c.want) {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%s: expected a degradation containing %q, got %v", c.name, c.want, got)
+		}
+	}
+}
+
+// A box coming back UP must never read as a degradation, and must read as a
+// recovery.
+func TestNetRecoveryIsNotADegradation(t *testing.T) {
+	down := nfSnap(false, false, "absent")
+	up := nfSnap(true, true, "reachable")
+	if d := netDegradations(down, up); len(d) != 0 {
+		t.Errorf("recovery misread as degradation: %v", d)
+	}
+	if !netRecovered(down, up) {
+		t.Error("netRecovered should be true when the box came back")
+	}
+	if netRecovered(up, up) {
+		t.Error("a steady healthy box is not a recovery event")
+	}
+}
+
+func TestIsRFC1918(t *testing.T) {
+	for _, ip := range []string{"192.168.178.21", "10.10.50.5", "172.16.0.1", "172.31.255.1"} {
+		if !isRFC1918(ip) {
+			t.Errorf("%s should be RFC1918", ip)
+		}
+	}
+	// 203.0.113.x is the usb0 internal bridge link, must never count as the LAN.
+	for _, ip := range []string{"203.0.113.1", "8.8.8.8", "169.254.1.1", "172.32.0.1"} {
+		if isRFC1918(ip) {
+			t.Errorf("%s should NOT be RFC1918", ip)
+		}
+	}
+}

--- a/usb-stick/run.sh
+++ b/usb-stick/run.sh
@@ -3413,6 +3413,24 @@ fi
 INPUT_ACCEPT_PORTS="8888 9080 8081 8443"
 iptables_install_streborn_fw() {
     rc_total=0
+    healed=0
+    # ICMP first: a healthy STR box must always answer ping, even behind Bose's
+    # port-whitelist firewall. This is also the diagnostic tell for the "plays
+    # radio but is unreachable" failure (#... field reports on ST10 and ST30):
+    # in that state the box keeps streaming (an ESTABLISHED outbound connection)
+    # while EVERY inbound packet is dropped, ping and Bose's own :8090 included,
+    # which is a whole-INPUT blackhole, not a closed port. Keeping ICMP up here
+    # means a box that has gone silent to ping is one whose watchdog itself has
+    # stopped, which tells that failure apart from a mere port flush.
+    if iptables -w -C INPUT -p icmp \
+        -m comment --comment "streborn-fw" -j ACCEPT 2>/dev/null; then
+        : # already present
+    elif iptables -w -I INPUT 1 -p icmp \
+        -m comment --comment "streborn-fw" -j ACCEPT 2>/dev/null; then
+        healed=$((healed + 1))
+    else
+        rc_total=$((rc_total + 1))
+    fi
     for port in $INPUT_ACCEPT_PORTS; do
         if iptables -w -C INPUT -p tcp --dport "$port" \
             -m comment --comment "streborn-fw" -j ACCEPT 2>/dev/null; then
@@ -3421,10 +3439,20 @@ iptables_install_streborn_fw() {
         if iptables -w -I INPUT 1 -p tcp --dport "$port" \
             -m comment --comment "streborn-fw" -j ACCEPT 2>/dev/null; then
             setup_log "iptables INPUT ACCEPT tcp/$port installed at uptime=$(uptime_s)s"
+            healed=$((healed + 1))
         else
             rc_total=$((rc_total + 1))
         fi
     done
+    # A (re)install AFTER the first pass means our rules were flushed out from
+    # under us since the last check. Log it as a distinct, grep-able self-heal
+    # event so the NAND log shows how often and when the flush happens (the
+    # root-cause evidence for the unreachable-while-playing reports); the
+    # reinstall above is already the recovery for the next 30 s window.
+    if [ "$healed" -gt 0 ] && [ "${STR_FW_PRIMED:-0}" = "1" ]; then
+        setup_log "iptables INPUT self-heal: reinstalled $healed streborn-fw rule(s) after a chain flush at uptime=$(uptime_s)s"
+    fi
+    STR_FW_PRIMED=1
     return $rc_total
 }
 (


### PR DESCRIPTION
Instrumentation so the "plays radio but the app cannot reach it" fault (confirmed on a mojo ST30, reported on an ST10) finally leaves evidence, instead of us guessing. This is the instrument, not the fix: the fix follows once a real bundle or NAND log captures the fault.

## agent: net_reachability forensics
A box in that state keeps its outbound radio stream (an ESTABLISHED connection) while every inbound packet is dropped, so it is invisible over the network exactly when it fails. The agent cannot test its own external inbound reachability from the inside, but it watches the two things that fail underneath it:
- the LAN interface losing carrier while it stays administratively up (the USB-bridged eth0 coprocessor degrading on scm/BCO chassis), and
- the default gateway falling out of the ARP table (an L2 breakdown that would strand wlan0 and the USB bridge alike).

Both are read from /proc on the EXISTING 5-minute resource-health tick, so there is no new timer and no per-tick exec (box hardware spared). A degradation or a self-recovery is logged at INFO so it lands in the 32KB NAND ring that survives the reboot the user does to recover. The full picture (INPUT chain, routes, the whole ARP table, listeners) is exposed on demand as the `net_reachability` debug section, so a diagnostic bundle carries it.

Files: cmd/agent/netforensics.go (+ test), cmd/agent/main.go (two tick hooks + one debug-section registration). Cross-compiles linux/arm GOARM=5; pure-logic unit tests pass.

## box: run.sh diagnostic hardening
The 30s INPUT-ACCEPT watchdog now also inserts an ICMP ACCEPT, so a healthy STR box always answers ping even behind Bose's port-whitelist firewall. That is the tell: a box that keeps streaming yet stops answering ping has had its whole INPUT chain flushed, which is distinct from a single closed port. Any reinstall after the first pass is logged as a grep-able `iptables INPUT self-heal` line, so the NAND log shows how often the chain is flushed. Relevant to Series-I / rhino boxes that carry a real Bose INPUT DROP chain (see #815); the mojo ST30 has an open INPUT and is a separate, interface-level fault.