### PR TITLE
fix(app): play a network-library track from Recently played instead of looping forever

### DIFF
--- a/desktop-app/frontend/src/views/recent.js
+++ b/desktop-app/frontend/src/views/recent.js
@@ -16,7 +16,7 @@
 import { state } from '../state.js';
 import { $, escapeHtml, escapeAttr, showError, showToast, confirmWarn, getBoxLabel } from '../utils.js';
 import { t } from '../i18n/index.js';
-import { RecentPlayed, SaveSpotifyPreset, GetPresets, PlaySlot, BrowserOpenURL, ClearRecent, DeleteRecentCard } from '../api.js';
+import { RecentPlayed, SaveSpotifyPreset, GetPresets, PlaySlot, PlayURL, BrowserOpenURL, ClearRecent, DeleteRecentCard } from '../api.js';
 import { logoImgTag, SPOTIFY_LOGO } from '../logos.js';
 
 // Injected main.js helpers (see initRecentView). showSlotPicker is the shared
@@ -111,7 +111,7 @@ function groupRecentCards(entries) {
     cards.push({
       boxKey: e._boxKey, box: e._box, boxName: e._boxName,
       source: e.source, cardKey: e.cardKey, name: e.cardName,
-      art: e.cardArt, url: e.cardURL, account: e.account, ts: e.ts,
+      art: e.cardArt, url: e.cardURL, mime: e.mime, account: e.account, ts: e.ts,
       homepage: e.homepage || '', playSlot,
       tracks: e.track ? [{ track: e.track, ts: e.ts }] : [],
       _seen: seen,
@@ -299,6 +299,15 @@ function wireCard(c, i) {
         if (c.source === 'spotify') {
           // Token present (matched a preset slot): recall it, same as a preset.
           await PlaySlot(c.box.host, c.box.port, c.playSlot);
+          showToast(t('recent.playing', { name: c.name || '' }));
+        } else if (c.source === 'upnp') {
+          // A network-library (NAS) track must replay the DIRECT library way, not
+          // the radio path. The radio path runs the file through the stream proxy
+          // built for endless radio, which loops forever on a finite file (#817);
+          // PlayURL with the stored MIME makes the box play it straight instead.
+          const box = c.box || state.currentBox;
+          const art = (c.art || '').split('|')[0].trim();
+          await PlayURL(box.host, box.port, c.url, c.name || '', art, '', c.mime || '', '', '');
           showToast(t('recent.playing', { name: c.name || '' }));
         } else {
           await deps.playStation(cardStation(c));

--- a/internal/recent/recent.go
+++ b/internal/recent/recent.go
@@ -51,6 +51,7 @@ type Entry struct {
 	CardName string `json:"cardName"`           // station / playlist / folder name
 	CardArt  string `json:"cardArt,omitempty"`  // logo / cover URL
 	CardURL  string `json:"cardURL,omitempty"`  // replay target: stream URL / spotify URI / NAS location
+	Mime     string `json:"mime,omitempty"`     // network-library file MIME, so a replay from history plays direct, not through the radio stream proxy (#817)
 	Track    string `json:"track,omitempty"`    // song / track title; empty for stations without ICY
 	Account  string `json:"account,omitempty"`  // sourceAccount (e.g. which Spotify account)
 	Homepage string `json:"homepage,omitempty"` // station website, for the "website" link (radio)

--- a/internal/webui/playback.go
+++ b/internal/webui/playback.go
@@ -184,7 +184,7 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request) {
 				s.logger.Info("play request: started natively, the speaker fetches the stream itself",
 					"title", req.Title, "url", req.URL)
 				s.setLastPlay(playURL, req.Title, req.Icon, mime)
-				s.recentNoteCard("radio", req.URL, req.Title, req.Icon, req.URL, "", req.Homepage)
+				s.recentNoteCard("radio", req.URL, req.Title, req.Icon, req.URL, "", req.Homepage, "")
 				writeJSON(w, http.StatusOK, map[string]string{"status": "playing", "url": req.URL})
 				return
 			} else {
@@ -210,9 +210,9 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request) {
 	// Recently-played (#135): a network-library file carries a MIME; radio does
 	// not. Record the original URL as the replayable card target, not the proxy.
 	if req.Mime != "" {
-		s.recentNoteCard("upnp", req.URL, req.Title, req.Icon, req.URL, "", "")
+		s.recentNoteCard("upnp", req.URL, req.Title, req.Icon, req.URL, "", "", mime)
 	} else {
-		s.recentNoteCard("radio", req.URL, req.Title, req.Icon, req.URL, "", req.Homepage)
+		s.recentNoteCard("radio", req.URL, req.Title, req.Icon, req.URL, "", req.Homepage, "")
 	}
 	// radio-browser click-tracking moved app-side (the app fires RadioClick
 	// when it starts playback) so the box no longer needs the radiobrowser pkg.
@@ -406,7 +406,7 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		gen := s.setLastPlay(slotURL, p.Name, p.Art, "audio/ogg")
-		s.recentNoteCard("spotify", p.URI, p.Name, p.Art, p.URI, p.Account, "") // #135
+		s.recentNoteCard("spotify", p.URI, p.Name, p.Art, p.URI, p.Account, "", "") // #135
 		// normalizeSpotifyURI on recall heals presets that stored an ephemeral
 		// station context before the save-side unwrap existed.
 		uri, name, art, account, shuffle := normalizeSpotifyURI(p.URI), p.Name, p.Art, p.Account, p.Shuffle
@@ -487,7 +487,7 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			gen := s.setLastPlay(directURL, p.Name, p.Art, mime)
-			s.recentNoteCard("upnp", p.StreamURL, p.Name, p.Art, p.StreamURL, "", "") // #135
+			s.recentNoteCard("upnp", p.StreamURL, p.Name, p.Art, p.StreamURL, "", "", mime) // #135
 			name, art := p.Name, p.Art
 			go s.verifyRecall(gen, recallStart, directURL, func(ctx context.Context, _ bool) {
 				_ = s.renderer.PlayURLMime(ctx, directURL, name, art, mime)
@@ -513,7 +513,7 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 			// and skipping it would silently cost the user their "switch on and
 			// the last station comes back" behaviour.
 			s.setLastPlay(playURL, p.Name, p.Art, upnp.MimeForCodecOrURL(p.Codec, p.StreamURL))
-			s.recentNoteCard("radio", p.StreamURL, p.Name, p.Art, p.StreamURL, "", p.Homepage) // #135
+			s.recentNoteCard("radio", p.StreamURL, p.Name, p.Art, p.StreamURL, "", p.Homepage, "") // #135
 			writeJSON(w, http.StatusOK, map[string]any{"status": "playing", "slot": slot, "name": p.Name})
 			return
 		} else {
@@ -546,7 +546,7 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	gen := s.setLastPlay(playURL, p.Name, p.Art, mime)
-	s.recentNoteCard("radio", p.StreamURL, p.Name, p.Art, p.StreamURL, "", p.Homepage) // #135
+	s.recentNoteCard("radio", p.StreamURL, p.Name, p.Art, p.StreamURL, "", p.Homepage, "") // #135
 	name, art := p.Name, p.Art
 	go s.verifyRecall(gen, recallStart, playURL, func(ctx context.Context, _ bool) {
 		if mime != "" {
@@ -718,11 +718,11 @@ func (s *Server) SetTransportCommandHook(fn func()) {
 // recentNoteCard records a user-chosen source (radio station, Spotify playlist,
 // NAS file) as the start of a Recently-played card. For radio and Spotify it also
 // remembers the card so the live track callbacks can hang tracks under it.
-func (s *Server) recentNoteCard(source, key, name, art, url, account, homepage string) {
+func (s *Server) recentNoteCard(source, key, name, art, url, account, homepage, mime string) {
 	if s.recent == nil || key == "" {
 		return
 	}
-	s.recent.Add(recent.Entry{Source: source, CardKey: key, CardName: name, CardArt: art, CardURL: url, Account: account, Homepage: homepage})
+	s.recent.Add(recent.Entry{Source: source, CardKey: key, CardName: name, CardArt: art, CardURL: url, Account: account, Homepage: homepage, Mime: mime})
 	s.recentMu.Lock()
 	switch source {
 	case "radio":
@@ -747,11 +747,11 @@ func (s *Server) recentNoteCard(source, key, name, art, url, account, homepage s
 // the start of a "library" (upnp) Recently-played card, and remembers it so each
 // track the queue pushes is hung under it (like radio ICY tracks under a station).
 // The replay target is the first track's URL; clicking the card re-plays it.
-func (s *Server) recentNoteQueueCard(key, name, art, url string) {
+func (s *Server) recentNoteQueueCard(key, name, art, url, mime string) {
 	s.recentMu.Lock()
-	s.recentQueueCard = recentCardCtx{key: key, name: name, art: art, url: url}
+	s.recentQueueCard = recentCardCtx{key: key, name: name, art: art, url: url, mime: mime}
 	s.recentMu.Unlock()
-	s.recentNoteCard("upnp", key, name, art, url, "", "")
+	s.recentNoteCard("upnp", key, name, art, url, "", "", mime)
 }
 
 // recentNoteQueueTrack hangs the track the play-queue just started under the
@@ -766,7 +766,7 @@ func (s *Server) recentNoteQueueTrack(track string) {
 	if c.key == "" {
 		return
 	}
-	s.recent.Add(recent.Entry{Source: "upnp", CardKey: c.key, CardName: c.name, CardArt: c.art, CardURL: c.url, Track: track})
+	s.recent.Add(recent.Entry{Source: "upnp", CardKey: c.key, CardName: c.name, CardArt: c.art, CardURL: c.url, Track: track, Mime: c.mime})
 }
 
 // recentClearQueueCard forgets the active folder card so later tracks (a single
@@ -829,10 +829,10 @@ func (s *Server) NoteRecentSpotifyTrack(track, artist string) {
 // the renderer, bypassing the webui play handlers.
 func (s *Server) NoteRecentPreset(p presets.Preset) {
 	if p.Type == "spotify" {
-		s.recentNoteCard("spotify", p.URI, p.Name, p.Art, p.URI, p.Account, "")
+		s.recentNoteCard("spotify", p.URI, p.Name, p.Art, p.URI, p.Account, "", "")
 		return
 	}
-	s.recentNoteCard("radio", p.StreamURL, p.Name, p.Art, p.StreamURL, "", p.Homepage)
+	s.recentNoteCard("radio", p.StreamURL, p.Name, p.Art, p.StreamURL, "", p.Homepage, "")
 }
 
 // handleRecent serves this box's recently-played ring (#135), oldest-first. The

--- a/internal/webui/queueplay.go
+++ b/internal/webui/queueplay.go
@@ -174,7 +174,7 @@ func (s *Server) startQueueLocked(ctx context.Context, items []queueItem, start 
 		if card.art == "" {
 			card.art = it.Art
 		}
-		s.recentNoteQueueCard(card.key, card.name, card.art, card.url)
+		s.recentNoteQueueCard(card.key, card.name, card.art, card.url, it.Mime)
 	} else {
 		s.recentClearQueueCard()
 	}

--- a/internal/webui/recent_queue_test.go
+++ b/internal/webui/recent_queue_test.go
@@ -15,7 +15,7 @@ func TestRecentQueueCardRecordsFolderAndTracks(t *testing.T) {
 
 	// startQueue notes the folder card, then the first push records the first
 	// track (which folds into the card placeholder), then auto-advance records more.
-	s.recentNoteQueueCard("queue:srv:42", "Jazz", "art.png", "http://nas/1.mp3")
+	s.recentNoteQueueCard("queue:srv:42", "Jazz", "art.png", "http://nas/1.mp3", "audio/flac")
 	s.recentNoteQueueTrack("Song A")
 	s.recentNoteQueueTrack("Song B")
 
@@ -34,6 +34,15 @@ func TestRecentQueueCardRecordsFolderAndTracks(t *testing.T) {
 	if all[0].CardURL != "http://nas/1.mp3" {
 		t.Fatalf("replay target lost: %+v", all[0])
 	}
+	// #817: the DLNA MIME must ride along on the card and its tracks, so a replay
+	// from history plays the file directly instead of through the radio stream
+	// proxy, which loops forever on a finite file. Without this a NAS track
+	// replayed from Recently played buffered endlessly.
+	for _, e := range all {
+		if e.Mime != "audio/flac" {
+			t.Fatalf("MIME not carried on the recent entry (a replay would take the radio path and loop): %+v", e)
+		}
+	}
 
 	// After the queue stops (single play / stop / runs out), later tracks must not
 	// attach to the now-dead folder card.
@@ -48,7 +57,7 @@ func TestRecentQueueCardRecordsFolderAndTracks(t *testing.T) {
 // recent store (dev builds), never panicking.
 func TestRecentQueueCardNilStore(t *testing.T) {
 	s := &Server{}
-	s.recentNoteQueueCard("k", "n", "a", "u")
+	s.recentNoteQueueCard("k", "n", "a", "u", "")
 	s.recentNoteQueueTrack("t")
 	s.recentClearQueueCard()
 }

--- a/internal/webui/recent_radio_stale_test.go
+++ b/internal/webui/recent_radio_stale_test.go
@@ -13,11 +13,11 @@ func TestRecentRadioStaleTitleSuppressed(t *testing.T) {
 	s := &Server{recent: recent.New()}
 
 	// Station A plays a song.
-	s.recentNoteCard("radio", "klove", "KLove", "", "http://klove", "", "")
+	s.recentNoteCard("radio", "klove", "KLove", "", "http://klove", "", "", "")
 	s.recentNoteRadioTrack("Phil Wickham - This is Our God")
 
 	// Switch to station B. Its first ICY title is still A's last song (lagged).
-	s.recentNoteCard("radio", "rush", "Exclusively Rush", "", "http://rush", "", "")
+	s.recentNoteCard("radio", "rush", "Exclusively Rush", "", "http://rush", "", "", "")
 	s.recentNoteRadioTrack("Phil Wickham - This is Our God") // stale: must be dropped
 	s.recentNoteRadioTrack("AC/DC - Thunderstruck")          // B's real song
 

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -585,7 +585,7 @@ type BoxPreset struct {
 // track callbacks (radio ICY title, Spotify track change) can hang their tracks
 // under it (#135). homepage is the station website, carried so each ICY-title
 // track entry keeps the "website" link target.
-type recentCardCtx struct{ key, name, art, url, account, homepage string }
+type recentCardCtx struct{ key, name, art, url, account, homepage, mime string }
 
 // lastPlayInfo is the box-facing URL + metadata of the current stream plus the
 // re-push state. rePushes counts consecutive resume attempts on THIS stream and


### PR DESCRIPTION
Reported in #817 (reproduced on Wave and SA-5, screenshots + bundle attached there).

## Cause
Replaying a NAS/library (UPnP) track from Recently played sent it through `playStation` (the radio path, no MIME). Box-side, `playDirect := req.Mime != "" && isPlainHTTPURL(req.URL)` decides whether the file is handed to the speaker directly or wrapped in the stream proxy. With no MIME the file goes through the proxy, which is built for endless radio and can't cope with a finite file: it sits at "stream starting" and reconnects on every EOF, giving the buffer-then-Idle loop the reporter saw. It also records the replayed card as "Radio" instead of "Library".

## Fix
- `recent.Entry` gains a `Mime` field; `recentNoteCard` / `recentNoteQueueCard` / `recentNoteQueueTrack` set it at every library play (single track and folder queue), so the recently-played card and its tracks carry the DLNA MIME.
- `recent.js` replays a `source === 'upnp'` card with `PlayURL(..., mime, ...)` (the direct/library path), the same way the Library tab plays it, instead of `deps.playStation`.

Spotify and radio cards are untouched. Regression test asserts the MIME rides along on the queue card and its tracks. Go build + webui tests pass, cross-compiles linux/arm GOARM=5, frontend builds.

Refs #817 (kept open for the reporter to confirm on the next build).