### PR TITLE
fix(app): stereo-pair picker never shows the same speaker in both channels

### DIFF
--- a/desktop-app/frontend/src/groups.js
+++ b/desktop-app/frontend/src/groups.js
@@ -463,11 +463,21 @@ export function balanceSourceBox(selected, pair, boxes) {
 // the live slots win.
 export function stereoSelectionPick({ left, right, liveIDs, candIDs }) {
   const still = (id) => !!id && candIDs.includes(id);
-  return [left, right].map((remembered, i) => {
-    if (still(remembered)) return remembered;
-    if (liveIDs[i]) return liveIDs[i];
-    return candIDs[i] || '';
+  const picks = [];
+  [left, right].forEach((remembered, i) => {
+    // The two channels must never resolve to the SAME speaker (#775). A stale
+    // remembered pick for one channel would otherwise collide with the live pair
+    // member filling the other, showing "Grace right / Grace right" in the L and
+    // R slots and a bottom card that reads "no stereo pair" while the real pair
+    // sits up top. So each channel skips whatever the first one already took.
+    const taken = picks[0];
+    let pick = '';
+    if (still(remembered) && remembered !== taken) pick = remembered;
+    else if (liveIDs[i] && liveIDs[i] !== taken) pick = liveIDs[i];
+    else pick = candIDs.find((c) => c && c !== taken) || '';
+    picks.push(pick);
   });
+  return picks;
 }
 
 // zoneOrPairMaster returns the master KEY (uppercase deviceID) a box currently

--- a/desktop-app/frontend/src/groups.test.js
+++ b/desktop-app/frontend/src/groups.test.js
@@ -600,4 +600,14 @@ describe('stereoSelectionPick', () => {
   it('no live pair and nothing remembered falls back to the first candidates', () => {
     expect(stereoSelectionPick({ left: '', right: '', liveIDs: [], candIDs })).toEqual(['A', 'B']);
   });
+
+  it('never resolves both channels to the SAME speaker (#775)', () => {
+    // The remembered left is the live pair's RIGHT member, and the right channel
+    // would otherwise fall back to that same live member, showing "B / B" in the
+    // L and R slots and a bottom card that reads "no pair" while the real pair
+    // sits up top. The two channels must stay distinct.
+    const got = stereoSelectionPick({ left: 'B', right: '', liveIDs, candIDs });
+    expect(got[0]).not.toEqual(got[1]);
+    expect(got).toEqual(['B', 'A']);
+  });
 });


### PR DESCRIPTION
Reported in #775: the multi-room stereo picker showed "Bose (Grace right)" in both the left and right channel slots, and the top of the screen showed a live stereo pair while the bottom read "No stereo pair on these speakers right now".

## Cause
`stereoSelectionPick` resolved the left and right channel independently (remembered pick, else the live pair's member at that slot, else a candidate). A stale remembered pick for one channel could equal the live pair member that fills the other, so both channels landed on the same speaker. A speaker paired with itself matches no real pair, so `formingPair` came back empty and the bottom card said "no pair" while the live pair sat up top.

## Fix
Each channel now skips whatever the first channel already took, so the two can never resolve to the same speaker. The impossible combination cannot appear, and the bottom card lines up with the live pair again. All existing `stereoSelectionPick` tests still pass; a regression test covers the collision case.

Refs #775 (the "pair as one entity in the phone remote" feature from the same thread is separate and larger; tracked for a follow-up).