### PR TITLE
feat(app): phone remote shows a stereo pair under its own name

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -769,7 +769,7 @@ func run() error {
 			}
 			margeSrv.SetStoredMusicSources(out)
 		}),
-		webui.WithMargeGroups(margeSrv.GroupSnapshot, margeSrv.SetCanonicalGroup, margeSrv.ClearGroup, margeSrv.RenameGroup),
+		webui.WithMargeGroups(margeSrv.GroupSnapshot, margeSrv.SetCanonicalGroup, margeSrv.ClearGroup, margeSrv.RenameGroup, margeSrv.GroupName),
 		webui.WithMargeForward(margeSrv.SetForward),
 		webui.WithRecent(recentStore))
 

--- a/internal/marge/group.go
+++ b/internal/marge/group.go
@@ -182,6 +182,18 @@ func (s *Server) GroupSnapshot() (xmlDoc string, canonical bool, ok bool) {
 	return renderGroupXML(s.group), s.groupCanonical, true
 }
 
+// GroupName returns the stored stereo pair's display name, or "" if no pair is
+// stored. The phone remote reads this (via the agent's zone-volume endpoint) to
+// show a pair under its own name instead of a member box name (#775).
+func (s *Server) GroupName() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.group == nil {
+		return ""
+	}
+	return s.group.Name
+}
+
 // SetCanonicalGroup installs the canonical pair document (from the pairing
 // flow on this box, or relayed from the master's agent via the desktop app for
 // the partner). From now on firmware posts that disagree on the master are

--- a/internal/webui/assets/index.html
+++ b/internal/webui/assets/index.html
@@ -1436,9 +1436,8 @@ async function loadSettings() {
   // own source list is authoritative; an empty/missing list changes nothing.
   if (Array.isArray(s.sources)) renderInputs(s.sources);
   if (s.info && s.info.name) {
-    var dn = document.getElementById('devName');
-    if (dn && dn.textContent !== s.info.name) { dn.textContent = s.info.name; renderDevMenu(); }
-    document.getElementById('dev').title = s.info.name;
+    lastBoxName = s.info.name;
+    updateTopName();
   }
   if (s.volume && typeof s.volume.actual === 'number') {
     volLast = s.volume.actual;
@@ -2211,7 +2210,21 @@ function dismissCoach() {
    quietly changes meaning cannot say which. It is hidden entirely while the
    speaker plays alone, so a single-speaker home never meets it.
    =========================================================================== */
-var zone = { grouped:false, stereo:false, members:[], master:false, masterName:'' };
+var zone = { grouped:false, stereo:false, pairName:'', members:[], master:false, masterName:'' };
+var lastBoxName = '';
+// updateTopName shows the STEREO PAIR's own name at the top of the page (next to
+// the power button) when this speaker is half of a named pair, instead of its
+// single box name, so the phone reads the pair as one speaker the way the Bose
+// app does (#775). The pair name rides in on the zone poll (stereoName); the box
+// name comes from the status poll. Either poll calls this, so whichever lands
+// first paints and the other only confirms.
+function updateTopName() {
+  var nm = (zone.stereo && zone.pairName) ? zone.pairName : lastBoxName;
+  if (!nm) return;
+  var dn = document.getElementById('devName');
+  if (dn && dn.textContent !== nm) { dn.textContent = nm; renderDevMenu(); }
+  var dev = document.getElementById('dev'); if (dev) dev.title = nm;
+}
 // Which speakers the volume slider moves. Starts on the whole group whenever
 // one exists: somebody who has grouped speakers is listening to the group, so
 // the volume control should move what they are listening to. It only stays on
@@ -2373,14 +2386,17 @@ async function loadZone() {
   var card = document.getElementById('groupCard');
   var tab = document.getElementById('tabSpeakers'), dot = document.getElementById('tabDot');
   if (!z || !z.grouped) {
-    zone = { grouped:false, stereo:false, members:[], master:false, masterName:'' };
+    zone = { grouped:false, stereo:false, pairName:'', members:[], master:false, masterName:'' };
     if (card) card.style.display = 'none';
     if (dot) dot.hidden = true;
+    updateTopName();
     applyScopeUI();
     return;
   }
   zone.grouped = true;
   zone.stereo = !!z.stereo;
+  zone.pairName = z.stereoName || '';
+  updateTopName();
   zone.members = z.members || [];
   var self = zone.members.filter(function(m){ return m.isSelf; })[0];
   zone.master = !!(self && self.isMaster);
@@ -2397,7 +2413,7 @@ async function loadZone() {
   // scope row already makes this distinction, which is why only the card was
   // still saying it.
   var sum = document.getElementById('groupSum');
-  if (sum) sum.textContent = zone.stereo ? T.pairSum : fmt(T.grpSum, { n: zone.members.length });
+  if (sum) sum.textContent = zone.stereo ? (zone.pairName || T.pairSum) : fmt(T.grpSum, { n: zone.members.length });
   var lbl = document.getElementById('lblGroup');
   if (lbl) lbl.textContent = zone.stereo ? T.scPair : T.grp;
   var lblUn = document.getElementById('lblUngroup');

--- a/internal/webui/marge_group_doc_test.go
+++ b/internal/webui/marge_group_doc_test.go
@@ -17,7 +17,7 @@ func newMargeGroupServer() (*Server, *marge.Server) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ms := marge.New(logger)
 	s := &Server{logger: logger}
-	WithMargeGroups(ms.GroupSnapshot, ms.SetCanonicalGroup, ms.ClearGroup, ms.RenameGroup)(s)
+	WithMargeGroups(ms.GroupSnapshot, ms.SetCanonicalGroup, ms.ClearGroup, ms.RenameGroup, ms.GroupName)(s)
 	return s, ms
 }
 

--- a/internal/webui/options.go
+++ b/internal/webui/options.go
@@ -380,12 +380,13 @@ func WithSpotifyCanRecall(f func(ctx context.Context) bool) Option {
 // WithMargeGroups bridges the marge stereo-pair record (get/set/clear) so the
 // pairing and dissolve flows keep BOTH members' marges on one canonical pair
 // document, and /api/marge/group lets the desktop app relay it to the partner.
-func WithMargeGroups(get func() (string, bool, bool), set func(string) error, clear func(string), rename func(string) error) Option {
+func WithMargeGroups(get func() (string, bool, bool), set func(string) error, clear func(string), rename func(string) error, name func() string) Option {
 	return func(s *Server) {
 		s.margeGroupGet = get
 		s.margeGroupSet = set
 		s.margeGroupClear = clear
 		s.margeGroupRename = rename
+		s.margeGroupName = name
 	}
 }
 

--- a/internal/webui/phone_remote_test.go
+++ b/internal/webui/phone_remote_test.go
@@ -127,11 +127,17 @@ func TestPhoneRemoteNamesAStereoPairAsAPair(t *testing.T) {
 	for _, want := range []string{
 		"lbl.textContent = zone.stereo ? T.scPair : T.grp",
 		"lblUn.textContent = zone.stereo ? T.unpair : T.ungroup",
-		"sum.textContent = zone.stereo ? T.pairSum : fmt(T.grpSum",
+		"sum.textContent = zone.stereo ? (zone.pairName || T.pairSum) : fmt(T.grpSum",
 	} {
 		if !strings.Contains(indexHTML, want) {
 			t.Errorf("the Speakers card does not switch to pair wording: missing %q", want)
 		}
+	}
+	// #775: the pair now shows under its OWN name (read from the zone poll's
+	// stereoName) instead of a generic "Stereo pair", both on the card and at the
+	// top of the page next to the power button.
+	if !strings.Contains(indexHTML, "zone.pairName = z.stereoName") {
+		t.Error("the phone does not read the stereo pair's own name (stereoName)")
 	}
 	// The scope hint sits above the slider and described a pair as a group too.
 	if !strings.Contains(indexHTML, "hint.textContent = zone.stereo ? T.pairSum : fmt(T.grpSum") {

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -220,6 +220,9 @@ type Server struct {
 	margeGroupSet    func(xmlDoc string) error
 	margeGroupClear  func(reason string)
 	margeGroupRename func(name string) error
+	// margeGroupName returns the stored pair's display name so the phone remote
+	// can show a pair under its own name instead of a member box name (#775).
+	margeGroupName func() string
 	// margeForward registers (or clears) a developer machine the box's cloud
 	// conversation is relayed to. nil disables the endpoint. See margelab.go.
 	margeForward func(target string) error

--- a/internal/webui/zonevolume.go
+++ b/internal/webui/zonevolume.go
@@ -242,10 +242,19 @@ func (s *Server) zoneVolumeGet(w http.ResponseWriter, r *http.Request) {
 	// actually is, which is what a group slider should read when the speakers
 	// are deliberately at different levels. A slider showing the average of 40
 	// and 10 reads 25, and nothing in the room is playing at 25.
-	writeJSON(w, http.StatusOK, map[string]any{
+	resp := map[string]any{
 		"grouped": true, "stereo": stereo, "members": members,
 		"average": avg, "loudest": loudest,
-	})
+	}
+	// A stereo pair carries its own display name in the marge group record (shared
+	// with the Bose app). Hand it to the phone remote so it can show the pair
+	// under that name instead of one member's box name (#775).
+	if stereo && s.margeGroupName != nil {
+		if nm := s.margeGroupName(); nm != "" {
+			resp["stereoName"] = nm
+		}
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // groupView is the ONE answer to "which speakers is this one grouped with".


### PR DESCRIPTION
Part of #775 (shorty310): on the phone remote a stereo pair should read as one speaker under its own name, the way the Bose app treats it, instead of showing a member's box name.

## What was already there
The pair name is stored in the marge group record (shared with the Bose app), the desktop app pushes it to both members (`/api/box/zone/stereo-name` -> `marge.RenameGroup`), and `/api/box/zone` already returns it. The infrastructure existed; only the phone did not use it, because the phone reads `/api/box/zone/volume`, which reported `stereo: true` with no name.

## Change
- **Box:** `marge.GroupName()` accessor + wired through `WithMargeGroups`; `zoneVolumeGet` now includes `stereoName` when the group is a stereo pair.
- **Phone (index.html):** reads `stereoName` into `zone.pairName`; a shared `updateTopName()` shows the pair name at the top of the page (next to the power button) from whichever of the two polls (status / zone) lands first, and the Speakers card heads the pair with its name instead of a generic "Stereo pair". Falls back to the generic wording when a pair has no custom name.

Box + marge tests pass (the phone-remote pair-wording guard updated + a #775 assertion added), agent cross-compiles linux/arm GOARM=5, the phone script passes a JS syntax check.

**Not live-tested end to end** (no stereo pair powered on here) — the name-flow is unit-covered, but the on-phone display wants a real pair before it is called done. The picker "collapse the two halves into one entity" half of #775 is a separate, larger follow-up.

Refs #775.