### PR TITLE
feat(app): each Playground feature links to a thread for sharing ideas and solutions

### DIFF
--- a/desktop-app/frontend/src/i18n/bundles/ar.json
+++ b/desktop-app/frontend/src/i18n/bundles/ar.json
@@ -719,6 +719,7 @@
   "settingsView.airplayOptConfirmBody": "تغيير تحسين AirPlay يعيد تشغيل السمّاعة لتطبيق الإعداد (تمامًا كتطبيق Bose). ستكون غير متاحة لوهلة. هل تتابع؟",
   "settingsView.airplayOptSavedToast": "تم الحفظ. السمّاعة قيد إعادة التشغيل لتطبيقه.",
   "settingsView.expertBadge": "ساحة تجارب",
+  "settingsView.expertDiscussLink": "شارك أفكارك وحلولك",
   "settingsView.webhookHeading": "أزرار الإعجاب عن بُعد ← Webhook",
   "settingsView.webhookUrlPlaceholder": "https://home.example/api/toggle",
   "settingsView.webhookBodyPlaceholder": "متن الطلب (لـ POST)، اختياري",

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -780,6 +780,7 @@
   "settingsView.airplayOptConfirmBody": "Das Ändern der AirPlay-Optimierung startet den Lautsprecher neu, damit er die Einstellung übernimmt (genau wie die Bose-App). Er ist kurz nicht erreichbar. Fortfahren?",
   "settingsView.airplayOptSavedToast": "Gespeichert. Der Lautsprecher startet neu, um es zu übernehmen.",
   "settingsView.expertBadge": "Spielwiese",
+  "settingsView.expertDiscussLink": "Ideen und Lösungen teilen",
   "settingsView.urlPresetHeading": "Eigene URL über ein Preset abspielen",
   "settingsView.urlPresetHelp": "Lege eine Audio-URL auf eine Preset-Taste: eine Audiodatei (zum Beispiel eine MP3) oder einen fortlaufenden Stream, etwa eine Icecast-Station in deinem eigenen Netzwerk. Beim Drücken, am Lautsprecher oder in der App, wird sie abgespielt. Die URL muss im Netzwerk erreichbar sein; http und https funktionieren beide (STR leitet den Stream an den Lautsprecher weiter). MP3 spielt am zuverlässigsten; manche OGG-Streams eventuell nicht. Beim Drücken wird die aktuelle Wiedergabe ersetzt. Noch besser: trage den Sender stattdessen bei radio-browser.info ein, dann taucht er für alle in der Suche auf, nicht nur auf dieser einen Taste.",
   "settingsView.urlPresetNamePlaceholder": "Name (zum Beispiel Türklingel)",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -780,6 +780,7 @@
   "settingsView.airplayOptConfirmBody": "Changing AirPlay optimization restarts the speaker so it can apply the setting (the same as the Bose app). It will be briefly unavailable. Continue?",
   "settingsView.airplayOptSavedToast": "Saved. The speaker is restarting to apply it.",
   "settingsView.expertBadge": "Playground",
+  "settingsView.expertDiscussLink": "Share your ideas and solutions",
   "settingsView.urlPresetHeading": "Play a custom URL from a preset",
   "settingsView.urlPresetHelp": "Assign an audio URL to a preset key: a sound file (for example an MP3) or a continuous stream, such as an Icecast station on your own network. Pressing the key, on the speaker or in the app, plays it. The URL must be reachable on your network; both http and https work (STR relays the stream to the speaker). MP3 plays most reliably; some OGG streams may not. Pressing it replaces what is currently playing. Even better: add the station to radio-browser.info instead, so it shows up in search for everyone, not just on this one button.",
   "settingsView.urlPresetNamePlaceholder": "Name (for example Doorbell)",

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -719,6 +719,7 @@
   "settingsView.airplayOptConfirmBody": "Cambiar la optimización de AirPlay reinicia el altavoz para que pueda aplicar el ajuste (igual que la app Bose). Estará brevemente no disponible. ¿Continuar?",
   "settingsView.airplayOptSavedToast": "Guardado. El altavoz se está reiniciando para aplicarlo.",
   "settingsView.expertBadge": "Zona de juego",
+  "settingsView.expertDiscussLink": "Comparte tus ideas y soluciones",
   "settingsView.webhookHeading": "Pulgares del mando → webhook",
   "settingsView.webhookUrlPlaceholder": "https://home.example/api/toggle",
   "settingsView.webhookBodyPlaceholder": "Cuerpo de la petición (para POST), opcional",

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -719,6 +719,7 @@
   "settingsView.airplayOptConfirmBody": "Modifier l'optimisation AirPlay redémarre l'enceinte pour appliquer le réglage (comme l'application Bose). Elle sera brièvement indisponible. Continuer ?",
   "settingsView.airplayOptSavedToast": "Enregistré. L'enceinte redémarre pour l'appliquer.",
   "settingsView.expertBadge": "Bac à sable",
+  "settingsView.expertDiscussLink": "Partagez vos idées et solutions",
   "settingsView.webhookHeading": "Pouces à distance → webhook",
   "settingsView.webhookUrlPlaceholder": "https://home.example/api/toggle",
   "settingsView.webhookBodyPlaceholder": "Corps de la requête (pour POST), facultatif",

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -719,6 +719,7 @@
   "settingsView.airplayOptConfirmBody": "AirPlay最適化を変更すると、設定を適用するためスピーカーが再起動します (Boseアプリと同じです)。短時間利用できなくなります。続行しますか?",
   "settingsView.airplayOptSavedToast": "保存しました。適用のためスピーカーを再起動しています。",
   "settingsView.expertBadge": "遊び場",
+  "settingsView.expertDiscussLink": "アイデアや解決策を共有",
   "settingsView.webhookHeading": "リモコンの評価ボタン → Webhook",
   "settingsView.webhookUrlPlaceholder": "https://home.example/api/toggle",
   "settingsView.webhookBodyPlaceholder": "リクエストボディ（POST 用）、任意",

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -719,6 +719,7 @@
   "settingsView.airplayOptConfirmBody": "AirPlay optimizavimo keitimas paleidžia garsiakalbį iš naujo, kad pritaikytų nustatymą (kaip ir Bose programa). Jis trumpam bus nepasiekiamas. Tęsti?",
   "settingsView.airplayOptSavedToast": "Išsaugota. Garsiakalbis paleidžiamas iš naujo, kad pritaikytų.",
   "settingsView.expertBadge": "Eksperimentai",
+  "settingsView.expertDiscussLink": "Pasidalykite idėjomis ir sprendimais",
   "settingsView.webhookHeading": "Nuotolinio valdymo nykščiai → tinklo nuoroda (webhook)",
   "settingsView.webhookUrlPlaceholder": "https://home.example/api/toggle",
   "settingsView.webhookBodyPlaceholder": "Užklausos turinys (POST atveju), nebūtina",

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -719,6 +719,7 @@
   "settingsView.airplayOptConfirmBody": "AirPlay optimizācijas maiņa restartē skaļruni, lai pielietotu iestatījumu (tāpat kā Bose lietotne). Tas uz brīdi nebūs pieejams. Turpināt?",
   "settingsView.airplayOptSavedToast": "Saglabāts. Skaļrunis tiek restartēts, lai pielietotu.",
   "settingsView.expertBadge": "Smilšu kaste",
+  "settingsView.expertDiscussLink": "Dalieties ar idejām un risinājumiem",
   "settingsView.webhookHeading": "Tālvadības īkšķi → tīmekļa āķis",
   "settingsView.webhookUrlPlaceholder": "https://home.example/api/toggle",
   "settingsView.webhookBodyPlaceholder": "Pieprasījuma saturs (priekš POST), neobligāti",

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -719,6 +719,7 @@
   "settingsView.airplayOptConfirmBody": "Het wijzigen van de AirPlay-optimalisatie herstart de speaker zodat de instelling kan worden toegepast (net als de Bose-app). Hij is kort niet beschikbaar. Doorgaan?",
   "settingsView.airplayOptSavedToast": "Opgeslagen. De speaker herstart om het toe te passen.",
   "settingsView.expertBadge": "Speeltuin",
+  "settingsView.expertDiscussLink": "Deel je ideeën en oplossingen",
   "settingsView.webhookHeading": "Duim op afstandsbediening → webhook",
   "settingsView.webhookUrlPlaceholder": "https://home.example/api/toggle",
   "settingsView.webhookBodyPlaceholder": "Aanvraaginhoud (voor POST), optioneel",

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -719,6 +719,7 @@
   "settingsView.airplayOptConfirmBody": "Zmiana optymalizacji AirPlay uruchamia głośnik ponownie, aby zastosować ustawienie (tak jak aplikacja Bose). Będzie chwilowo niedostępny. Kontynuować?",
   "settingsView.airplayOptSavedToast": "Zapisano. Głośnik się restartuje, aby to zastosować.",
   "settingsView.expertBadge": "Piaskownica",
+  "settingsView.expertDiscussLink": "Podziel się pomysłami i rozwiązaniami",
   "settingsView.webhookHeading": "Zdalne kciuki → webhook",
   "settingsView.webhookUrlPlaceholder": "https://home.example/api/toggle",
   "settingsView.webhookBodyPlaceholder": "Treść żądania (dla POST), opcjonalnie",

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -719,6 +719,7 @@
   "settingsView.airplayOptConfirmBody": "AirPlay optimizasyonunu değiştirmek ayarı uygulamak için hoparlörü yeniden başlatır (Bose uygulaması gibi). Kısa süre erişilemez olur. Devam edilsin mi?",
   "settingsView.airplayOptSavedToast": "Kaydedildi. Hoparlör uygulamak için yeniden başlatılıyor.",
   "settingsView.expertBadge": "Oyun alanı",
+  "settingsView.expertDiscussLink": "Fikirlerinizi ve çözümlerinizi paylaşın",
   "settingsView.webhookHeading": "Uzaktan kumanda beğeni tuşları → webhook",
   "settingsView.webhookUrlPlaceholder": "https://home.example/api/toggle",
   "settingsView.webhookBodyPlaceholder": "İstek gövdesi (POST için), isteğe bağlı",

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -719,6 +719,7 @@
   "settingsView.airplayOptConfirmBody": "Зміна оптимізації AirPlay перезапускає колонку, щоб застосувати налаштування (так само, як застосунок Bose). Вона ненадовго стане недоступною. Продовжити?",
   "settingsView.airplayOptSavedToast": "Збережено. Колонка перезапускається, щоб застосувати це.",
   "settingsView.expertBadge": "Пісочниця",
+  "settingsView.expertDiscussLink": "Поділіться своїми ідеями та рішеннями",
   "settingsView.webhookHeading": "Кнопки лайків на пульті → вебхук",
   "settingsView.webhookUrlPlaceholder": "https://home.example/api/toggle",
   "settingsView.webhookBodyPlaceholder": "Тіло запиту (для POST), необов'язково",

--- a/desktop-app/frontend/src/i18n/bundles/zh-Hant.json
+++ b/desktop-app/frontend/src/i18n/bundles/zh-Hant.json
@@ -780,6 +780,7 @@
   "settingsView.airplayOptConfirmBody": "變更 AirPlay 最佳化後，喇叭要重新啟動才能套用這個設定（和 Bose 應用程式一樣），期間會短暫無法使用。要繼續嗎？",
   "settingsView.airplayOptSavedToast": "已儲存。喇叭正在重新啟動來套用設定。",
   "settingsView.expertBadge": "實驗場",
+  "settingsView.expertDiscussLink": "分享你的想法和解決方案",
   "settingsView.urlPresetHeading": "用預設鍵播放自訂網址",
   "settingsView.urlPresetHelp": "把一段音訊網址指派到預設鍵：可以是音效檔（例如 MP3），也可以是持續的串流，例如你自己網路上的 Icecast 電台。不管是在喇叭上還是在應用程式裡按下這個鍵，都會播放它。網址必須在你的網路上連得到；http 和 https 都可以（STR 會把串流轉送給喇叭）。MP3 播放最穩定，有些 OGG 串流可能不行。按下之後會取代目前正在播放的內容。更好的做法：把這個電台加到 radio-browser.info，這樣所有人搜尋時都找得到，而不是只在這一個按鍵上。",
   "settingsView.urlPresetNamePlaceholder": "名稱（例如門鈴）",

--- a/desktop-app/frontend/src/views/settings.js
+++ b/desktop-app/frontend/src/views/settings.js
@@ -794,6 +794,26 @@ function helpBlock(text, tag = 'small', cls = 'muted small expert-intro') {
       </details>`;
 }
 
+// Each Playground (Spielwiese) section links to its own "Show and tell" thread
+// so owners can swap setups and ideas for that one feature, building a small
+// community around the experimental features (2026-09-02). data-url is opened by
+// the .expert-disc-link handler in renderBoxSettings, the same BrowserOpenURL
+// pattern the firmware-banner links use.
+const EXPERT_DISCUSS = {
+  announce: 'https://github.com/JRpersonal/streborn/discussions/826',
+  webhook: 'https://github.com/JRpersonal/streborn/discussions/827',
+  voice: 'https://github.com/JRpersonal/streborn/discussions/828',
+  copyPresets: 'https://github.com/JRpersonal/streborn/discussions/829',
+  urlPreset: 'https://github.com/JRpersonal/streborn/discussions/830',
+};
+function discussLink(key) {
+  const url = EXPERT_DISCUSS[key];
+  if (!url) return '';
+  return `<div class="expert-disc-row" style="margin-top:10px">`
+    + `<a href="#" class="expert-disc-link" data-url="${escapeAttr(url)}" style="font-size:0.9em">`
+    + `&#128172; ${escapeHtml(t('settingsView.expertDiscussLink'))}</a></div>`;
+}
+
 function renderBoxSettings(s, box) {
   const info = s.info || {};
   const vol = s.volume || {};
@@ -1029,6 +1049,7 @@ function renderBoxSettings(s, box) {
           <button class="btn btn-mini" id="announceCopy">${escapeHtml(t('settingsView.announceCopy'))}</button>
         </div>
       </details>
+      ${discussLink('announce')}
     </details>
 
     <details class="settings-section settings-expert">
@@ -1091,6 +1112,7 @@ function renderBoxSettings(s, box) {
         <button class="btn btn-mini" id="webhookTestBtn">${escapeHtml(t('settingsView.webhookTestBtn'))}</button>
         <button class="btn btn-mini btn-primary" id="webhookSaveBtn">${escapeHtml(t('common.save'))}</button>
       </div>
+      ${discussLink('webhook')}
     </details>
 
     <details class="settings-section settings-expert">
@@ -1099,6 +1121,7 @@ function renderBoxSettings(s, box) {
       <div class="setting-row">
         <button class="btn btn-mini" id="voiceGuideBtn">${escapeHtml(t('settingsView.voiceGuideBtn'))}</button>
       </div>
+      ${discussLink('voice')}
     </details>
 
     ${(() => {
@@ -1125,6 +1148,7 @@ function renderBoxSettings(s, box) {
         <select id="copyPresetTarget" style="flex:1;">${allOpt}${opts}</select>
         <button class="btn btn-mini btn-warning" id="copyPresetBtn">${escapeHtml(t('settingsView.copyPresetsBtn'))}</button>
       </div>
+      ${discussLink('copyPresets')}
     </details>`;
     })()}
 
@@ -1141,6 +1165,7 @@ function renderBoxSettings(s, box) {
         <input type="text" id="urlPresetUrl" autocomplete="off" placeholder="${escapeAttr(t('settingsView.urlPresetUrlPlaceholder'))}" />
         <button class="btn btn-mini btn-primary" id="urlPresetSaveBtn">${escapeHtml(t('common.save'))}</button>
       </div>
+      ${discussLink('urlPreset')}
     </details>
 
     <div class="settings-section">
@@ -1340,6 +1365,11 @@ function renderBoxSettings(s, box) {
   {
     const vg = $('voiceGuideBtn');
     if (vg) vg.onclick = () => { try { BrowserOpenURL(VOICE_GUIDE_URL); } catch {} };
+  }
+  // Playground discussion links: every expert section links to its own
+  // "Show and tell" thread. One handler for all of them, driven by data-url.
+  for (const el of document.querySelectorAll('.expert-disc-link')) {
+    el.onclick = (e) => { e.preventDefault(); try { BrowserOpenURL(el.dataset.url); } catch {} };
   }
 
   // Status block: software version + USB stick mount.


### PR DESCRIPTION
Builds a small community around the experimental "Playground" (Spielwiese) features: each one in the speaker settings now carries a **"Share your ideas and solutions"** link that opens a GitHub *Show and tell* thread dedicated to that single feature. Owners can post what they built and what they'd like to see, so setups and ideas circulate per feature instead of scattering.

The five sections and their threads:
- Announcements / spoken messages -> #826
- Remote-thumb webhook automation -> #827
- Voice control via a home hub -> #828
- Copy presets between speakers -> #829
- Custom URL / audio-stream presets -> #830

Implementation: a small `discussLink()` helper renders each link with a `data-url`, wired through the existing `BrowserOpenURL` handler (same pattern as the firmware-banner links). The `settingsView.expertDiscussLink` label is added to all 13 i18n bundles so the key-parity test stays green.

Build + all 219 vitest tests green; eslint clean (0 errors).