### PR TITLE
fix: single library track replay (#817) + phone volume slider jump-back (#726)

### DIFF
--- a/desktop-app/frontend/src/views/library.js
+++ b/desktop-app/frontend/src/views/library.js
@@ -362,6 +362,26 @@ async function libraryGoTo(depth) {
   await libraryBrowseCurrent();
 }
 
+// Some DLNA servers omit the MIME on a browse result. Without one, a single
+// track was played with an empty MIME, and the box-side /play handler then filed
+// it under "radio" instead of "upnp" (its only discriminator is a non-empty
+// MIME). On replay from Recently played a radio-typed card takes the streaming
+// route and loops forever on a finite file (#817: folders were fixed in #818,
+// single tracks still looped). Inferring the MIME from the file extension keeps
+// the track typed as a library file, so it plays direct and replays cleanly.
+// Only known audio extensions map; an unknown one stays empty rather than risk a
+// wrong label the box would reject (#139).
+const AUDIO_MIME_BY_EXT = {
+  mp3: 'audio/mpeg', m4a: 'audio/mp4', mp4: 'audio/mp4', aac: 'audio/aac',
+  flac: 'audio/flac', wav: 'audio/wav', wave: 'audio/wav', ogg: 'audio/ogg',
+  oga: 'audio/ogg', opus: 'audio/opus', wma: 'audio/x-ms-wma',
+  aif: 'audio/aiff', aiff: 'audio/aiff', alac: 'audio/mp4',
+};
+function guessAudioMime(url) {
+  const m = String(url || '').toLowerCase().match(/\.([a-z0-9]+)(?:[?#]|$)/);
+  return (m && AUDIO_MIME_BY_EXT[m[1]]) || '';
+}
+
 async function libraryPlay(item) {
   if (!state.currentBox) {
     showToast(t('library.toastNoBox') || t('common.pickBox'));
@@ -378,7 +398,8 @@ async function libraryPlay(item) {
     // Pass the track's real codec MIME so the box decodes FLAC/ALAC/M4A
     // correctly instead of being told audio/mpeg and rejecting it (#139).
     await PlayURL(target.host, target.port,
-      item.streamURL, item.title || '', item.albumArtURL || '', '', item.mimeType || '', '', '');
+      item.streamURL, item.title || '', item.albumArtURL || '', '',
+      item.mimeType || guessAudioMime(item.streamURL), '', '');
     // A library play supersedes any ad-hoc radio station the app started, so
     // a later long-press save must not resurrect that station (#252).
     state.lastAppPlay = null;

--- a/internal/webui/assets/index.html
+++ b/internal/webui/assets/index.html
@@ -1440,9 +1440,17 @@ async function loadSettings() {
     updateTopName();
   }
   if (s.volume && typeof s.volume.actual === 'number') {
-    volLast = s.volume.actual;
-    var el = document.getElementById('vol'); el.value = s.volume.actual;
-    document.getElementById('volval').textContent = s.volume.actual;
+    // Do not let a status poll snap the slider back to a stale reading in the
+    // moment right after the user changed it. The box may not have applied the
+    // new level yet, so overwriting here made a tap appear to jump back to the
+    // old value (#726). Hold off until the send has settled (the same window the
+    // group path uses), then trust the box again; a change made on the box
+    // itself is picked up on the next poll after the window.
+    if (Date.now() - volSentAt >= GRP_VOL_SETTLE_MS) {
+      volLast = s.volume.actual;
+      var el = document.getElementById('vol'); el.value = s.volume.actual;
+      document.getElementById('volval').textContent = s.volume.actual;
+    }
   }
   if (s.bass && s.bass.available && typeof s.bass.actual === 'number') {
     var b = document.getElementById('bass');


### PR DESCRIPTION
Two sweep fixes found after v0.9.70.

**#817 — a single library track loops on replay.** #818 fixed folders, but a single track whose DLNA server sent no MIME still buffering-looped. The box-side `/play` handler files a track under `radio` unless the request carries a MIME, and a radio-typed card replays through the streaming route (which loops on a finite file). The track's MIME is now inferred from its file extension when the server omits it, so it stays typed as a library file and replays cleanly. Unknown extensions stay empty rather than risk a wrong label the box would reject (#139).

*Note for existing entries:* a track that was already misfiled needs to be played once more from the library to be re-recorded correctly.

**#726 — the phone volume slider jumps back after a step.** A status poll overwrote the slider with the box's reported level on every refresh, with no settling window, so a poll landing right after a tap (before the box applied the change) snapped it back to the old value. The single-box path now holds off the overwrite for the same short window (`GRP_VOL_SETTLE_MS`) the group path already uses.

Go build + all webui tests green; frontend build green; eslint clean.