### PR TITLE
fix: five field bugs (permanent-group wipe, reinstall status, multi-update pipelining, post-update auto-resume, folder preset on source switch)

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -817,6 +817,12 @@ func run() error {
 	// /api/stream-status, so the app can name the real cause instead of
 	// blaming the station and cycling radio-browser alternates.
 	streamProxySrv.SetBoxStateFn(webuiSrv.BoxStateHint)
+	// Queue presets register on the box as a native /stream/<slot> station but
+	// carry no single stored StreamURL. When the box self-activates that station
+	// (a hardware source switch), this lets the proxy resolve the play queue's
+	// current track and briefly hold for it, instead of 404-ing into the old
+	// station (the ST20 folder-preset race).
+	streamProxySrv.SetQueueLiveURLFn(webuiSrv.QueueLiveURL)
 
 	// ICY radio text: the proxy parses the live StreamTitle out of the
 	// stream; push it to the box display by re-issuing the current stream URI

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -3511,8 +3511,49 @@ async function runBoxUpdate(box, onPhase, attempt = 1, gate = null) {
     if (pv) { preBuild = pv.build || ''; preVersion = pv.version || ''; }
   } catch { /* pre-OTA version unknown: fall back to the appBuild match */ }
   phase('uploading');
+  // Serialize only the BYTE push, not the box's whole reboot. UpdateBoxAgent
+  // does not return when the bytes land: the box replies, then reboots ~1.5 s
+  // later, and that reboot usually eats the reply, so the call then sits on a
+  // dead connection for up to ~107 s before its reply window times out (#466).
+  // Holding the upload gate for all of that keeps the next box from starting its
+  // push long after this box's bytes were delivered and it is already rebooting
+  // on its own, the serial-restart stall makeUploadGate exists to kill. So
+  // release the gate the moment the upload bytes are on the wire
+  // (box:update:progress pct>=100, the same signal the overlay uses to flip a
+  // row to "restarting") and await the real UpdateBoxAgent result OUTSIDE the
+  // gate. A box that never streams pct>=100 (a fast failure, or a chassis that
+  // does not emit progress) falls back to releasing when the call settles,
+  // exactly the old behavior, never worse. The single-box path (gate=null) has
+  // nothing to queue behind, so it runs the call directly.
+  let updatePromise;
+  if (gate) {
+    await new Promise((begun) => {
+      gate.run(() => new Promise((release) => {
+        let done = false, offProg = null;
+        const free = () => {
+          if (done) return;
+          done = true;
+          if (offProg) { try { offProg(); } catch {} }
+          release();
+        };
+        offProg = EventsOn('box:update:progress', (p) => {
+          if (p && p.host === box.host && p.pct != null && p.pct >= 100) free();
+        });
+        // try/catch so a (near-impossible) synchronous throw from the binding
+        // still lets begun() fire and the gate release, never stranding the run.
+        try { updatePromise = UpdateBoxAgent(box.host, box.port); }
+        catch (e) { updatePromise = Promise.reject(e); }
+        begun();
+        // Fallback: release on settle if pct>=100 never arrives, and give
+        // updatePromise a handler so no unhandledrejection can fire.
+        updatePromise.then(free, free);
+      })).catch(() => {});
+    });
+  } else {
+    updatePromise = UpdateBoxAgent(box.host, box.port);
+  }
   try {
-    await gated(() => UpdateBoxAgent(box.host, box.port));
+    await updatePromise;
   } catch (e) {
     // A timeout-class rejection ("deadline exceeded ... while reading body",
     // common on a slow link or with an HTTP-inspecting suite like Norton) does

--- a/desktop-app/install_str.go
+++ b/desktop-app/install_str.go
@@ -90,6 +90,20 @@ func (a *App) InstallSTROnBox(host, model string) (InstallResult, error) {
 		a.recordOTA(host, "install: FAILED step="+res.Step+" code="+res.Code)
 	default:
 		a.recordOTA(host, "install: OK (step="+res.Step+")")
+		// Pin the box as STR through its post-install reboot, exactly as the OTA
+		// path does (notePostOTA). Install ends by rebooting the box, and its
+		// stock Bose :8090 answers before the STR agent binds its port, so the
+		// first discovery cycle after a reinstall would classify it "stock /
+		// Ready for STR"; with an earlier uninstall having cleared the deviceID
+		// identity memory, nothing corrects it until an mDNS or probeSTR sighting
+		// eventually lands, so a freshly reinstalled box was offered for reinstall
+		// for 30+ minutes (#825). This case is reached ONLY when installSTROnBox
+		// returned err==nil AND res.OK==true, which every success path sets only
+		// after waitForAgent confirmed the agent is up, so the pin never fires on
+		// a failed or agent-not-up install. The pin is IP-keyed and bounded to
+		// otaRebootGrace (4 min), so a box that genuinely cannot be reached as STR
+		// self-corrects rather than being masked durably.
+		a.notePostOTA(host)
 	}
 	return res, err
 }

--- a/internal/streamproxy/queuehold_test.go
+++ b/internal/streamproxy/queuehold_test.go
@@ -1,0 +1,141 @@
+package streamproxy
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/JRpersonal/streborn/internal/presets"
+)
+
+// finiteFileServer serves a small, cleanly-terminating file so handle() ends
+// with the file-complete path (200 + body) instead of reconnecting forever.
+func finiteFileServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	payload := bytes.Repeat([]byte{0x5A}, 8192)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "audio/mp4")
+		w.Header().Set("Accept-Ranges", "bytes")
+		w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(payload)
+	}))
+}
+
+func queuePreset(store *presets.Store, slot int) {
+	// SetSlot returns "Store has no path" for a pathless test store, but the
+	// in-memory slot is populated before Save runs, so Get sees it. Ignore the err.
+	_ = store.SetSlot(presets.Preset{Slot: slot, Name: "Folder", Type: "queue"})
+}
+
+// TestQueuePresetHoldsForLiveTrack: a queue preset (empty StreamURL) whose live
+// URL is not ready yet must be HELD, not 404'd, until the recall lands the first
+// track - the ST20 source-switch race. Once the resolver returns a URL, the box
+// gets that track's bytes.
+func TestQueuePresetHoldsForLiveTrack(t *testing.T) {
+	up := finiteFileServer(t)
+	defer up.Close()
+
+	s := New(presets.New(), silentLogger())
+	s.client = &http.Client{} // allow the loopback dial past the SSRF guard
+	queuePreset(s.store, 6)
+
+	var polls atomic.Int32
+	s.SetQueueLiveURLFn(func(slot int) (string, bool) {
+		if slot != 6 {
+			return "", false
+		}
+		// Empty (still recalling) for the first few polls, then the live track.
+		if polls.Add(1) < 3 {
+			return "", true
+		}
+		return up.URL, true
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/stream/6", nil)
+	rw := httptest.NewRecorder()
+	s.handle(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("queue preset must be served once the track lands, got %d", rw.Code)
+	}
+	if rw.Body.Len() == 0 {
+		t.Fatal("the held-for track produced no bytes")
+	}
+	if polls.Load() < 3 {
+		t.Fatalf("handler did not hold for the track (only %d polls)", polls.Load())
+	}
+}
+
+// TestQueuePresetIdleBailsFast: a queue slot whose resolver never reports a
+// recall in flight must 404 quickly (after queueRecallGrace), never burn the
+// full queueRecallHold. Guards against a spurious native fetch hanging the box.
+func TestQueuePresetIdleBailsFast(t *testing.T) {
+	s := New(presets.New(), silentLogger())
+	queuePreset(s.store, 6)
+	s.SetQueueLiveURLFn(func(slot int) (string, bool) { return "", false })
+
+	req := httptest.NewRequest(http.MethodGet, "/stream/6", nil)
+	rw := httptest.NewRecorder()
+	start := time.Now()
+	s.handle(rw, req)
+	elapsed := time.Since(start)
+
+	if rw.Code != http.StatusNotFound {
+		t.Fatalf("an idle queue slot must 404, got %d", rw.Code)
+	}
+	if elapsed >= 2*time.Second {
+		t.Fatalf("idle bail took %s; it must return near queueRecallGrace, not queueRecallHold", elapsed)
+	}
+}
+
+// TestNonQueuePresetImmediate404: a non-queue preset with an empty StreamURL
+// keeps the instant 404 and never consults the queue resolver - the queue hold
+// is strictly scoped to Type=="queue".
+func TestNonQueuePresetImmediate404(t *testing.T) {
+	s := New(presets.New(), silentLogger())
+	// A radio-type preset saved with no URL (the genuinely-dead slot, #252).
+	_ = s.store.SetSlot(presets.Preset{Slot: 4, Name: "Dead", Type: "radio"})
+
+	var called atomic.Bool
+	s.SetQueueLiveURLFn(func(slot int) (string, bool) { called.Store(true); return "", false })
+
+	req := httptest.NewRequest(http.MethodGet, "/stream/4", nil)
+	rw := httptest.NewRecorder()
+	start := time.Now()
+	s.handle(rw, req)
+
+	if rw.Code != http.StatusNotFound {
+		t.Fatalf("a non-queue empty preset must 404, got %d", rw.Code)
+	}
+	if time.Since(start) >= 500*time.Millisecond {
+		t.Fatal("a non-queue 404 must be immediate, no hold")
+	}
+	if called.Load() {
+		t.Fatal("the queue resolver must not be consulted for a non-queue preset")
+	}
+}
+
+// TestQueuePresetNilResolver: with no resolver wired (nil fn), a queue preset
+// falls back to the same instant 404 - a partially-wired build never hangs.
+func TestQueuePresetNilResolver(t *testing.T) {
+	s := New(presets.New(), silentLogger())
+	queuePreset(s.store, 6)
+	// no SetQueueLiveURLFn
+
+	req := httptest.NewRequest(http.MethodGet, "/stream/6", nil)
+	rw := httptest.NewRecorder()
+	start := time.Now()
+	s.handle(rw, req)
+
+	if rw.Code != http.StatusNotFound {
+		t.Fatalf("queue preset with nil resolver must 404, got %d", rw.Code)
+	}
+	if time.Since(start) >= 500*time.Millisecond {
+		t.Fatal("a nil-resolver 404 must be immediate")
+	}
+}

--- a/internal/streamproxy/streamproxy.go
+++ b/internal/streamproxy/streamproxy.go
@@ -88,6 +88,11 @@ type Server struct {
 	// from a station problem. nil-safe.
 	boxStateFn func() string
 
+	// queueLiveURLFn resolves the CURRENT track URL for a queue preset the box
+	// natively activated as /stream/<slot>, plus whether a queue (re)call for
+	// that slot is still landing. Wired to webui.QueueLiveURL. nil-safe.
+	queueLiveURLFn func(slot int) (url string, recalling bool)
+
 	// netMu guards a briefly-cached verdict on whether the SPEAKER itself can
 	// reach the public internet. It lets /api/stream-status tell "this one
 	// station is unreachable" apart from "the speaker has no internet at all"
@@ -163,6 +168,44 @@ type Server struct {
 // SetOnDisconnect registers a callback invoked whenever the box closes a
 // proxied stream (raw or slot). Set once at wiring time.
 func (s *Server) SetOnDisconnect(fn func(upstreamErr error)) { s.onDisconnect = fn }
+
+// SetQueueLiveURLFn wires the queue-preset live-track resolver (see queueLiveURLFn).
+func (s *Server) SetQueueLiveURLFn(fn func(slot int) (string, bool)) { s.queueLiveURLFn = fn }
+
+const (
+	queueRecallHold  = 3 * time.Second        // max hold while a queue recall is in flight
+	queueRecallGrace = 750 * time.Millisecond // idle/spurious fetch bails after this
+	queueRecallPoll  = 100 * time.Millisecond
+)
+
+// awaitQueueLiveURL resolves a queue preset's current track for slot, holding up
+// to queueRecallHold while a (re)call is in flight. Returns "" fast for an idle
+// slot (after queueRecallGrace) so a spurious native fetch never hangs the full
+// budget, and immediately on ctx cancel (the box dropped the connection).
+func (s *Server) awaitQueueLiveURL(ctx context.Context, slot int) string {
+	if s.queueLiveURLFn == nil {
+		return ""
+	}
+	start := time.Now()
+	deadline := start.Add(queueRecallHold)
+	for {
+		url, recalling := s.queueLiveURLFn(slot)
+		if url != "" {
+			return url
+		}
+		if recalling && time.Now().After(deadline) {
+			return ""
+		}
+		if !recalling && time.Since(start) >= queueRecallGrace {
+			return ""
+		}
+		select {
+		case <-time.After(queueRecallPoll):
+		case <-ctx.Done():
+			return ""
+		}
+	}
+}
 
 func New(store *presets.Store, logger *slog.Logger) *Server {
 	// The SSRF guard (loopback/link-local/metadata blocked after DNS
@@ -400,16 +443,28 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	p, ok := s.store.Get(slot)
-	if !ok || p.StreamURL == "" {
+	streamURL := p.StreamURL
+	if ok && streamURL == "" && p.Type == "queue" {
+		// A queue preset carries no single StreamURL: its tracks live in the play
+		// queue the webui owns, and its box-native /stream/<slot> station must
+		// serve the CURRENT track. The box self-activates that station and can
+		// pull /stream/<slot> BEFORE RecallSlot has loaded the first track (a
+		// fresh boot wins; a radio->folder source switch loses, the ST20). Hold
+		// BRIEFLY for the live track instead of 404-ing into silence, which
+		// strands the box on the old station. Only for a queue preset; a
+		// non-queue empty slot still 404s at once.
+		streamURL = s.awaitQueueLiveURL(r.Context(), slot)
+	}
+	if !ok || streamURL == "" {
 		// Log before 404ing: the box fetching a slot the store cannot serve is
 		// exactly the "preset button does nothing" symptom, and this used to be
 		// the only branch in the recall chain with no trace at all (#252).
 		s.logger.Warn("stream proxy: box fetched a slot with no playable preset",
-			"slot", slot, "found", ok)
+			"slot", slot, "found", ok, "queue", ok && p.Type == "queue")
 		http.Error(w, "no preset", http.StatusNotFound)
 		return
 	}
-	p.StreamURL = s.resolvePresetURL(slot, p.StreamURL)
+	p.StreamURL = s.resolvePresetURL(slot, streamURL)
 	s.noteSlotFetch(slot)
 	defer s.noteSlotFetchDone(slot)
 	s.logger.Info("stream proxy start", append([]any{"slot", slot, "name", p.Name}, requestFacts(r)...)...)
@@ -464,10 +519,19 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		// Fetch the current URL — the user might have changed the preset in
 		// the meantime.
 		cur, ok := s.store.Get(slot)
-		if !ok || cur.StreamURL == "" {
+		if !ok {
 			return
 		}
-		curURL := s.resolvePresetURL(slot, cur.StreamURL)
+		curStream := cur.StreamURL
+		if curStream == "" && cur.Type == "queue" {
+			// A queue preset has no per-track URL in the store; keep serving the
+			// track this fetch resolved above rather than 404-ing on reconnect.
+			curStream = streamURL
+		}
+		if curStream == "" {
+			return
+		}
+		curURL := s.resolvePresetURL(slot, curStream)
 		boseAlive, err := s.streamOne(r.Context(), w, r, curURL, !headersSent)
 		lastErr = err
 		if errors.Is(err, errPlaylistIsHLS) && !headersSent {

--- a/internal/webui/agent_admin.go
+++ b/internal/webui/agent_admin.go
@@ -418,6 +418,16 @@ func (s *Server) handleAgentUpdate(w http.ResponseWriter, r *http.Request) {
 				// sync cannot revert this update (#381). Delaying our exit is
 				// safe: the swap helper waits for this PID.
 				refreshStickAgentBinary(body, s.logger)
+				// Same OTA-reboot marker as the normal reboot path, but fsync'd:
+				// os.Exit skips buffered flushes and the swap helper reboots the
+				// box right after us, so the marker must be on NAND before we go.
+				if f, werr := os.OpenFile(otaRebootMarkerPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644); werr == nil {
+					_, _ = f.WriteString(time.Now().UTC().Format(time.RFC3339) + "\n")
+					_ = f.Sync()
+					_ = f.Close()
+				} else {
+					s.logger.Warn("could not write OTA-reboot marker (ram-staged); post-OTA resume may fire", "err", werr)
+				}
 				s.logger.Info("exiting for the RAM-staged binary swap; the helper reboots the box")
 				os.Exit(0)
 			}()
@@ -478,6 +488,14 @@ func (s *Server) handleAgentUpdate(w http.ResponseWriter, r *http.Request) {
 		// desktop app's SSH stick refresh covers this only when SSH is open;
 		// this on-box write needs nothing. The reboot waits for it.
 		refreshStickAgentBinary(body, s.logger)
+		// Mark this reboot as OUR maintenance OTA so the agent that comes back up
+		// does not immediately blast the room with the automatic power-on resume
+		// (consumed once at the next start, resume_standby.go). A genuine power
+		// outage leaves no marker and resumes as before. Written before the sync
+		// below so it is flushed to NAND with everything else.
+		if werr := os.WriteFile(otaRebootMarkerPath, []byte(time.Now().UTC().Format(time.RFC3339)+"\n"), 0o644); werr != nil {
+			s.logger.Warn("could not write OTA-reboot marker; post-OTA resume may fire", "err", werr)
+		}
 		// Unconditional flush before the reboot. refreshStickAgentBinary syncs
 		// only when a stick is mounted; on a stickless box (the #381 field
 		// case) nothing else flushed this path before v0.9.7. Every other

--- a/internal/webui/playback.go
+++ b/internal/webui/playback.go
@@ -271,6 +271,10 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.logger.Info("preset slot recall (app): queue", "slot", slot, "tracks", len(items), "shuffle", p.Shuffle)
+		// Bind the slot before the queue starts so a box-native /stream/<slot>
+		// fetch racing this app-initiated recall can hold for the first track
+		// (mirrors the hardware RecallSlot path).
+		s.armQueueRecall(slot)
 		card := recentCardCtx{key: fmt.Sprintf("queue:slot:%d", slot), name: p.Name, art: p.Art}
 		if err := s.startQueueLocked(playCtx, items, 0, p.Shuffle, repeatOff, card); err != nil {
 			if isGroupedRejection(err) {

--- a/internal/webui/queuelive_test.go
+++ b/internal/webui/queuelive_test.go
@@ -1,0 +1,45 @@
+package webui
+
+import (
+	"testing"
+	"time"
+)
+
+// TestQueueLiveURL pins the streamproxy-facing resolver for a box-native
+// /stream/<slot> fetch of a queue preset: it must (1) return nothing for an
+// unarmed slot, (2) signal "hold" (recalling=true) once armed while the first
+// track is still loading, (3) never let one slot's fetch borrow another slot's
+// queue, (4) resolve the current track once the queue loads, and (5) stop
+// signalling "hold" after the in-flight window while still serving the track.
+func TestQueueLiveURL(t *testing.T) {
+	s := &Server{queue: newPlayQueue()}
+
+	if url, rec := s.QueueLiveURL(6); url != "" || rec {
+		t.Fatalf("unarmed slot must return empty/false, got %q/%v", url, rec)
+	}
+
+	// Armed, but the queue has not loaded a track yet: hold.
+	s.armQueueRecall(6)
+	if url, rec := s.QueueLiveURL(6); url != "" || !rec {
+		t.Fatalf("armed slot with empty queue must return empty/true, got %q/%v", url, rec)
+	}
+	// A fetch for a different slot must never borrow slot 6's recall.
+	if url, rec := s.QueueLiveURL(3); url != "" || rec {
+		t.Fatalf("other slot must return empty/false, got %q/%v", url, rec)
+	}
+
+	// Queue loads its first track: resolve to it, still within the hold window.
+	s.queue.load([]queueItem{{URL: "http://nas/track0.flac"}}, 0, false, repeatOff)
+	if url, rec := s.QueueLiveURL(6); url != "http://nas/track0.flac" || !rec {
+		t.Fatalf("loaded queue must return track0/true, got %q/%v", url, rec)
+	}
+
+	// Past the in-flight window: the track still resolves (a steady source
+	// switch is still served) but the proxy is no longer told to hold.
+	s.queueMu.Lock()
+	s.queueRecallAt = time.Now().Add(-2 * queueRecallInFlight)
+	s.queueMu.Unlock()
+	if url, rec := s.QueueLiveURL(6); url != "http://nas/track0.flac" || rec {
+		t.Fatalf("after the in-flight window: track0/false expected, got %q/%v", url, rec)
+	}
+}

--- a/internal/webui/queueplay.go
+++ b/internal/webui/queueplay.go
@@ -36,6 +36,42 @@ func presetItemsToQueue(in []presets.PresetItem) []queueItem {
 	return out
 }
 
+// queueRecallInFlight bounds how long after a recall was armed the streamproxy
+// may hold a box-native /stream/<slot> fetch waiting for the first track. It
+// covers the gap between arming and the queue's first push; a queue that plays
+// on keeps serving via queue.current() with recalling=false afterwards.
+const queueRecallInFlight = 5 * time.Second
+
+// armQueueRecall binds the play queue that is about to start to the preset slot
+// it was recalled from, so a racing box-native /stream/<slot> fetch of a queue
+// preset (whose stored StreamURL is empty) can hold for the first track instead
+// of 404-ing into the previous station. See QueueLiveURL.
+func (s *Server) armQueueRecall(slot int) {
+	s.queueMu.Lock()
+	s.queueRecallSlot = slot
+	s.queueRecallAt = time.Now()
+	s.queueMu.Unlock()
+}
+
+// QueueLiveURL resolves the current track URL for a queue preset the box has
+// natively activated as /stream/<slot> (empty stored StreamURL). recalling=true
+// tells the streamproxy it may keep holding: a recall for this slot is still in
+// its landing window. Returns ("", false) for a slot that is not the active
+// queue's, so a fetch for one slot never serves another slot's queue.
+func (s *Server) QueueLiveURL(slot int) (url string, recalling bool) {
+	s.queueMu.Lock()
+	bound := s.queueRecallSlot
+	inFlight := bound == slot && !s.queueRecallAt.IsZero() && time.Since(s.queueRecallAt) < queueRecallInFlight
+	s.queueMu.Unlock()
+	if bound != slot {
+		return "", false
+	}
+	if it, ok := s.queue.current(); ok {
+		return it.URL, inFlight
+	}
+	return "", inFlight
+}
+
 // RecallSlot handles a hardware preset-button press for a queue preset: if the
 // slot holds a saved DLNA folder it starts the play-queue and returns true.
 // Otherwise it returns false and the caller falls back to the existing
@@ -53,6 +89,10 @@ func (s *Server) RecallSlot(ctx context.Context, slot int) (handled bool) {
 	if len(items) == 0 {
 		return false
 	}
+	// Bind this slot as the in-flight queue recall BEFORE the queue starts, so a
+	// box-native /stream/<slot> fetch that races ahead of the first track load can
+	// hold for it (the ST20 source-switch race) instead of 404-ing into silence.
+	s.armQueueRecall(slot)
 	// Supersede any still-running hardware verify at claim time: startQueue's
 	// own setLastPlay only bumps the generation once the first push SUCCEEDS,
 	// and until then a stale verify loop from an earlier press would keep

--- a/internal/webui/resume_standby.go
+++ b/internal/webui/resume_standby.go
@@ -54,6 +54,10 @@ func (s *Server) ResumeLastPlay() {
 		s.logger.Warn("wake resume: standing down, the last automatic resumes each ended in a reboot before playback stabilised (crash-loop guard, #381); press a preset key or start playback from the app to re-enable")
 		return
 	}
+	if s.resumeSuppressedPostOTA() {
+		s.logger.Info("wake resume: box was just rebooted for an agent update, not resuming (post-OTA suppression)")
+		return
+	}
 	s.lastPlayMu.Lock()
 	lp := s.lastPlay
 	// Split the two no-resume reasons so a diagnostic shows which one hit, and
@@ -254,6 +258,10 @@ func (s *Server) RecoverAfterReconnect() {
 		s.logger.Warn("reconnect recovery: standing down, the last automatic resumes each ended in a reboot before playback stabilised (crash-loop guard, #381); press a preset key or start playback from the app to re-enable")
 		return
 	}
+	if s.resumeSuppressedPostOTA() {
+		s.logger.Info("reconnect recovery: box was just rebooted for an agent update, not resuming (post-OTA suppression)")
+		return
+	}
 	// A deliberate user stop must survive a WS reconnect: without this guard a
 	// reconnect resumed the last stream the user had stopped.
 	if s.userStoppedRecently() {
@@ -435,6 +443,42 @@ func reconnectResumeWindow(stuckSelectionLocation string) time.Duration {
 // defaultResumeOnPowerOnPath is the NAND flag file for the per-box power-on
 // resume opt-out. Absent or "1" means on (the default), "0" means off.
 const defaultResumeOnPowerOnPath = "/mnt/nv/streborn/resume-on-power-on"
+
+// otaRebootMarkerPath is written by the agent-update handler right before it
+// reboots the box for an update, and consumed once at the next agent start. Its
+// presence means the reboot that just happened was OUR maintenance OTA, not a
+// genuine power outage, so the automatic power-on resume stands down briefly:
+// blasting the room right after the user pressed Update is surprising. A power
+// outage cannot write the marker, so the legitimate post-outage resume is
+// untouched. var (not const) so a test can point it at a temp path.
+var otaRebootMarkerPath = "/mnt/nv/streborn/ota-reboot"
+
+// postOTAResumeSuppressWindow is how long after an OTA reboot the automatic
+// resume stays down. It only has to outlast the post-boot RecoverAfterReconnect
+// (which fires within seconds of the gabbo WS connecting); a real user power
+// press later still resumes.
+const postOTAResumeSuppressWindow = 5 * time.Minute
+
+// consumeOTARebootMarker runs once at agent start. If the last reboot was our
+// OTA it arms a short suppression window and DELETES the marker, so it only ever
+// affects the boot right after the update. The window is measured from now
+// (agent start), never the marker's stored wall-clock time: these boxes have no
+// battery RTC and boot in 2015 until NTP corrects them.
+func (s *Server) consumeOTARebootMarker() {
+	if _, err := os.Stat(otaRebootMarkerPath); err != nil {
+		return
+	}
+	_ = os.Remove(otaRebootMarkerPath)
+	s.postOTAResumeSuppressUntil = time.Now().Add(postOTAResumeSuppressWindow)
+	s.logger.Info("power-on resume: last reboot was a maintenance OTA, standing down the automatic resume briefly",
+		"forSec", int(postOTAResumeSuppressWindow.Seconds()))
+}
+
+// resumeSuppressedPostOTA reports whether we are still inside the post-OTA
+// suppression window. Read-only after New(), so no lock is needed.
+func (s *Server) resumeSuppressedPostOTA() bool {
+	return !s.postOTAResumeSuppressUntil.IsZero() && time.Now().Before(s.postOTAResumeSuppressUntil)
+}
 
 // defaultDisplayTrackPath is the NAND flag file for the per-box "show the live
 // radio track on the speaker display" opt-in. Absent or "0" means off (the
@@ -1501,6 +1545,10 @@ func (s *Server) RunDeferredResume() {
 	}
 	if !spontaneousResumeEnabled() || s.autoResumeBlocked() {
 		s.logger.Info("deferred resume: auto-resume disabled or blocked, standing down")
+		return
+	}
+	if s.resumeSuppressedPostOTA() {
+		s.logger.Info("deferred resume: box was just rebooted for an agent update, not resuming (post-OTA suppression)")
 		return
 	}
 	if s.userStoppedRecently() || s.standbyStoppedRecently() || s.boxInZone() {

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -348,6 +348,10 @@ type Server struct {
 	// standby (in-RAM only lost the station and the box fell back to its native
 	// "Preset not assigned", #119 Klaus). Empty disables persistence (tests).
 	lastPlayPath string
+	// postOTAResumeSuppressUntil arms the post-OTA resume suppression: set once
+	// in New() by consumeOTARebootMarker() when the last reboot was our own
+	// maintenance OTA, read-only afterwards (no lock). See resume_standby.go.
+	postOTAResumeSuppressUntil time.Time
 
 	// mirrorSkips remembers, per zone member, why the last mirror reconcile
 	// tick skipped it, so the skip is logged at INFO only on a state change
@@ -710,6 +714,10 @@ func New(addr string, logger *slog.Logger, opts ...Option) *Server {
 		o(s)
 	}
 	s.loadLastPlay()
+	// If STR itself rebooted the box for an update, stand the automatic power-on
+	// resume down briefly so it does not blast the room right after the update
+	// (a genuine power outage leaves no marker and resumes as before).
+	s.consumeOTARebootMarker()
 	return s
 }
 

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -565,6 +565,13 @@ type Server struct {
 	queueGen        int
 	queueTrackStart time.Time
 	queueTrackDur   time.Duration
+	// queueRecallSlot binds the active play queue to the preset slot it was
+	// recalled from; queueRecallAt marks when. QueueLiveURL uses them so the
+	// box-native /stream/<slot> fetch of a queue preset serves the right queue's
+	// current track, and only holds while a recall is genuinely in flight.
+	// Guarded by queueMu.
+	queueRecallSlot int
+	queueRecallAt   time.Time
 	// baseCtx is the server-lifetime context (set in Run), the parent for the
 	// long-lived queue watcher so it outlives the request that started the queue.
 	baseCtx context.Context

--- a/internal/webui/zonemirror.go
+++ b/internal/webui/zonemirror.go
@@ -190,12 +190,28 @@ func (s *Server) handleZonePurge(w http.ResponseWriter, r *http.Request) {
 	cleared := false
 	if s.zones != nil {
 		if z, ok := s.zones.Get(); ok && zoneReferences(z, req.DeviceID, req.IP) {
-			if err := s.zones.Clear(); err != nil {
-				s.logger.Warn("zone purge: clear store failed", "err", err)
-			} else {
-				cleared = true
-				s.logger.Info("zone purge: cleared persisted zone on request of a dissolving peer",
+			switch {
+			case z.Permanent:
+				// A PERMANENT group is the user's explicit, durable choice, and its
+				// document is the only thing the play-reform (formDefaultGroupOnPlay)
+				// rebuilds from. A near-simultaneous fleet OTA reboots every member at
+				// once, so a peer that is merely between boots (or a #342
+				// dissolve/retry storm) can POST a purge that references this master
+				// while nothing was actually torn down. Clearing here would wipe the
+				// group with nothing to re-assert it, exactly the loss boxInZone's
+				// permanent exemption prevents on the standby path (577301b). The
+				// user's own dissolve on the master still clears it directly
+				// (handleZoneDissolve), so the opt-out is unaffected.
+				s.logger.Info("zone purge: keeping the permanent group; a peer's dissolve must not drop the user's durable choice",
 					"peerDeviceID", req.DeviceID, "peerIP", req.IP)
+			default:
+				if err := s.zones.Clear(); err != nil {
+					s.logger.Warn("zone purge: clear store failed", "err", err)
+				} else {
+					cleared = true
+					s.logger.Info("zone purge: cleared persisted zone on request of a dissolving peer",
+						"peerDeviceID", req.DeviceID, "peerIP", req.IP)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Five independent field bugs found during the 2026-09-03 sweep. Each is a self-contained commit so they can be split if needed.

## 1. Permanent group lost after a firmware/STR update (`95d94b0`)
A fleet update reboots every group member at once. A member that comes back between the others' reboots posts a zone purge referencing the master, and `handleZonePurge` cleared `zones.json` unconditionally, so a **permanent** group's stored membership was wiped and the group vanished from the app. The purge now leaves a permanent group's document intact; only a non-permanent (ad-hoc) group is cleared. This is what wiped the groups on my own fleet after an update.

## 2. A reinstalled speaker shows "Ready for STR" instead of STR (`292ce62`)
The OTA path pins a box as STR through its reboot; the fresh-install path did not, so right after a successful install the box briefly read as "Ready for STR" and offered to install again. The install success path now marks the box the same way, bounded to the reboot-grace window and only on a confirmed install. (workflow #825 reclassify)

## 3. Second speaker's update upload starts far too late (`9c9b1fc`)
In a multi-speaker update the app held the serialising gate across the whole of each box's `UpdateBoxAgent` call, so the next box could not begin its upload until the previous box had fully rebooted and re-answered (~1.5 min of dead wait). The gate is now released once the upload completes; the reboot/settle wait for one box overlaps the next box's upload. Hardened so the gate still releases if the call throws synchronously.

## 4. A speaker starts playing by itself after an update, at its old volume (`d56656e`)
The post-update reboot went through the normal power-on resume, so a box that had been playing before the update resumed on its own (the Portable did this at volume 30). The agent now drops a marker before an OTA reboot and suppresses auto-resume for a short window after it, so an update reboot no longer restarts playback.

## 5. A saved folder preset does nothing on a hardware source switch, box stays on the old station (`cd4e1d4`)
A saved DLNA folder preset (a play queue) is registered on the box as a native station served from `/stream/<slot>`, but unlike a radio preset it carries no single stream URL, so the proxy answered "no preset" and the speaker kept playing the previous station while only the folder name changed. Some models (the ST20) hit this every time; others won a timing race. The proxy now recognises a queue preset and briefly waits for the queue's current track before serving it. Tightly bounded and scoped to queue presets only; every other preset keeps its exact current behaviour.

**Needs fleet validation before it ships in a release:** the hold closes the ST20 race, but on a model that already worked (my ST10s .58/.59) the `/stream/<slot>` station now serves audio where it used to 404 harmlessly, so I want to confirm no double-start there. Validate on Volker's ST20 and my ST10s + Portable (.79) before releasing.

## Verification
- `GOOS=linux GOARCH=arm GOARM=5 go build ./...` clean (agent cross-compiles for the box)
- desktop-app + frontend build clean; 219 vitest pass
- `go test ./internal/streamproxy/... ./internal/webui/...` pass, including new tests for the queue hold (`queuehold_test.go`) and the live-URL resolver (`queuelive_test.go`)
- gofmt clean

Fixes 1-4 are ready. Fix 5 (ST20) is ready but flagged above for a fleet pass before it goes in a release.