### PR TITLE
fix: sweep bug batch — preset loss, grouped-volume springback, pair-name focus, contrast

### DIFF
--- a/desktop-app/frontend/src/i18n/bundles/ar.json
+++ b/desktop-app/frontend/src/i18n/bundles/ar.json
@@ -309,6 +309,7 @@
   "preset.noCurrentStation": "لا توجد محطة قيد التشغيل الآن، لذا لا أثر للضغط المطوّل.",
   "preset.copiedToKey": "نُسخ إلى الزر {{n}}: {{name}}",
   "preset.savedToKey": "حُفظ في الزر {{n}}: {{name}}",
+  "preset.alreadyOnKey": "هذه المحطة موجودة بالفعل على الزر {{n}}.",
   "preset.sourceBadge": "من {{source}}",
   "preset.saveFailed": "فشل الحفظ: {{err}}",
   "play.errNoInternet": "لا يوجد إنترنت؟",

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -334,6 +334,7 @@
   "preset.noCurrentStation": "Kein Sender läuft gerade, daher hat Long Press keinen Effekt.",
   "preset.copiedToKey": "Auf Taste {{n}} kopiert: {{name}}",
   "preset.savedToKey": "Auf Taste {{n}} gespeichert: {{name}}",
+  "preset.alreadyOnKey": "Dieser Sender liegt schon auf Taste {{n}}.",
   "preset.sourceBadge": "von {{source}}",
   "preset.onSpeaker": "Auf dem Lautsprecher",
   "preset.boxNativeHint": "antippen zum Abspielen auf dem Lautsprecher",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -334,6 +334,7 @@
   "preset.noCurrentStation": "No station is playing right now, so long press has no effect.",
   "preset.copiedToKey": "Copied to key {{n}}: {{name}}",
   "preset.savedToKey": "Saved to key {{n}}: {{name}}",
+  "preset.alreadyOnKey": "This station is already on key {{n}}.",
   "preset.sourceBadge": "from {{source}}",
   "preset.onSpeaker": "On the speaker",
   "preset.boxNativeHint": "tap to play on the speaker",

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -309,6 +309,7 @@
   "preset.noCurrentStation": "No hay ninguna emisora sonando ahora, así que mantener pulsado no tiene efecto.",
   "preset.copiedToKey": "Copiado a la tecla {{n}}: {{name}}",
   "preset.savedToKey": "Guardado en la tecla {{n}}: {{name}}",
+  "preset.alreadyOnKey": "Esta emisora ya está en la tecla {{n}}.",
   "preset.sourceBadge": "de {{source}}",
   "preset.saveFailed": "Error al guardar: {{err}}",
   "play.errNoInternet": "¿sin internet?",

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -309,6 +309,7 @@
   "preset.noCurrentStation": "Aucune station ne joue actuellement, l'appui long n'a donc aucun effet.",
   "preset.copiedToKey": "Copié sur la touche {{n}} : {{name}}",
   "preset.savedToKey": "Enregistré sur la touche {{n}} : {{name}}",
+  "preset.alreadyOnKey": "Cette station est déjà sur la touche {{n}}.",
   "preset.sourceBadge": "de {{source}}",
   "preset.saveFailed": "Échec de l'enregistrement : {{err}}",
   "play.errNoInternet": "pas d'internet ?",

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -309,6 +309,7 @@
   "preset.noCurrentStation": "現在再生中の放送局がないため、長押しは無効です。",
   "preset.copiedToKey": "キー {{n}} にコピーしました: {{name}}",
   "preset.savedToKey": "キー {{n}} に保存しました: {{name}}",
+  "preset.alreadyOnKey": "この局はすでにキー {{n}} に登録されています。",
   "preset.sourceBadge": "提供元: {{source}}",
   "preset.saveFailed": "保存に失敗しました: {{err}}",
   "play.errNoInternet": "インターネットなし?",

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -309,6 +309,7 @@
   "preset.noCurrentStation": "Šiuo metu negroja jokia stotis, todėl palaikymas neturi poveikio.",
   "preset.copiedToKey": "Nukopijuota į mygtuką {{n}}: {{name}}",
   "preset.savedToKey": "Išsaugota mygtuke {{n}}: {{name}}",
+  "preset.alreadyOnKey": "Ši stotis jau priskirta klavišui {{n}}.",
   "preset.sourceBadge": "iš {{source}}",
   "preset.saveFailed": "Nepavyko išsaugoti: {{err}}",
   "play.errNoInternet": "nėra interneto?",

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -309,6 +309,7 @@
   "preset.noCurrentStation": "Pašlaik neatskaņo neviena stacija, tāpēc turēšanai nav efekta.",
   "preset.copiedToKey": "Nokopēts pogā {{n}}: {{name}}",
   "preset.savedToKey": "Saglabāts pogā {{n}}: {{name}}",
+  "preset.alreadyOnKey": "Šī stacija jau ir piešķirta taustiņam {{n}}.",
   "preset.sourceBadge": "no {{source}}",
   "preset.saveFailed": "Saglabāt neizdevās: {{err}}",
   "play.errNoInternet": "nav interneta?",

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -309,6 +309,7 @@
   "preset.noCurrentStation": "Er speelt nu geen zender, dus ingedrukt houden heeft geen effect.",
   "preset.copiedToKey": "Gekopieerd naar toets {{n}}: {{name}}",
   "preset.savedToKey": "Opgeslagen op toets {{n}}: {{name}}",
+  "preset.alreadyOnKey": "Deze zender staat al op toets {{n}}.",
   "preset.sourceBadge": "van {{source}}",
   "preset.saveFailed": "Opslaan mislukt: {{err}}",
   "play.errNoInternet": "geen internet?",

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -309,6 +309,7 @@
   "preset.noCurrentStation": "Żadna stacja teraz nie gra, więc przytrzymanie nie ma efektu.",
   "preset.copiedToKey": "Skopiowano do przycisku {{n}}: {{name}}",
   "preset.savedToKey": "Zapisano na przycisku {{n}}: {{name}}",
+  "preset.alreadyOnKey": "Ta stacja jest już przypisana do przycisku {{n}}.",
   "preset.sourceBadge": "z {{source}}",
   "preset.saveFailed": "Zapis nie powiódł się: {{err}}",
   "play.errNoInternet": "brak internetu?",

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -309,6 +309,7 @@
   "preset.noCurrentStation": "Şu anda çalan bir istasyon yok, bu yüzden basılı tutmanın etkisi yok.",
   "preset.copiedToKey": "{{n}} tuşuna kopyalandı: {{name}}",
   "preset.savedToKey": "{{n}} tuşuna kaydedildi: {{name}}",
+  "preset.alreadyOnKey": "Bu istasyon zaten {{n}} tuşunda kayıtlı.",
   "preset.sourceBadge": "kaynak: {{source}}",
   "preset.saveFailed": "Kaydedilemedi: {{err}}",
   "play.errNoInternet": "internet yok mu?",

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -309,6 +309,7 @@
   "preset.noCurrentStation": "Зараз жодна станція не грає, тому утримання не діє.",
   "preset.copiedToKey": "Скопійовано на кнопку {{n}}: {{name}}",
   "preset.savedToKey": "Збережено на кнопку {{n}}: {{name}}",
+  "preset.alreadyOnKey": "Ця станція вже призначена на клавішу {{n}}.",
   "preset.sourceBadge": "з {{source}}",
   "preset.saveFailed": "Не вдалося зберегти: {{err}}",
   "play.errNoInternet": "немає інтернету?",

--- a/desktop-app/frontend/src/i18n/bundles/zh-Hant.json
+++ b/desktop-app/frontend/src/i18n/bundles/zh-Hant.json
@@ -334,6 +334,7 @@
   "preset.noCurrentStation": "現在沒有電台在播放，所以長按沒有作用。",
   "preset.copiedToKey": "已複製到預設鍵 {{n}}：{{name}}",
   "preset.savedToKey": "已存到預設鍵 {{n}}：{{name}}",
+  "preset.alreadyOnKey": "此電台已設定在按鍵 {{n}}。",
   "preset.sourceBadge": "來自 {{source}}",
   "preset.onSpeaker": "喇叭上的預設",
   "preset.boxNativeHint": "點一下就在喇叭上播放",

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -5948,6 +5948,17 @@ function attachPresetHandlers(el, slot, preset, opts = {}) {
 // what the user hears, so the box report wins again.
 const APP_PLAY_FRESH_MS = 2 * 60 * 1000;
 
+// showPresetSaveError turns a failed preset save into the right message. The
+// agent refuses (409 already-on-slot) a save whose station already sits on
+// another key rather than silently deleting that key (#836); that is a friendly
+// "already on key N" note, not an error.
+function showPresetSaveError(err) {
+  const s = String(err);
+  const m = /already-on-slot/.test(s) && s.match(/"slot":\s*(\d+)/);
+  if (m) { showToast(t('preset.alreadyOnKey', { n: m[1] })); return; }
+  showError(t('preset.saveFailed', { err: s }));
+}
+
 // saveCurrentToSlot saves the currently playing station onto the
 // given slot (overwrites whatever was there before). Uses the
 // now_playing data state.nowLocation + state.nowName plus the last
@@ -5966,19 +5977,10 @@ async function saveCurrentToSlot(slot) {
   // Which save path applies is a pure decision (savePresetCase in utils.js,
   // unit-tested): spotify / app-play / copy-slot / direct.
   const sourceSlot = activeSlotFromLocation(state.nowLocation);
-  // What the box report actually resolves to: a NATIVE ad-hoc play reports
-  // the ORION descriptor (no slot in it, so sourceSlot is null) and a
-  // non-native one the /stream/raw wrapper; both unwrap to the exact URL the
-  // app handed to PlayURL. Passing it lets savePresetCase tell "the box is
-  // playing what the app just started" (save the app's own record, with the
-  // station's real logo chain) from "someone started something else". Without
-  // it every hold-save of an app-started native play fell to 'direct' and
-  // persisted the descriptor's box-loopback art-proxy URL as the key's
-  // artwork, dead from this machine, so the tile ended on the grey chevron
-  // (#696).
-  const nowOrion = orionStationPayload(state.nowLocation);
-  const nowStreamUrl = decodeProxyUrl((nowOrion && nowOrion.streamUrl) || state.nowLocation);
-  const saveCase = savePresetCase(state.nowLocation, sourceSlot, state.lastAppPlay, Date.now(), APP_PLAY_FRESH_MS, nowStreamUrl);
+  // A fresh app play is authoritative regardless of what the box reports right
+  // now (native-switch lag / wake-resume race, #836). savePresetCase decides;
+  // the 'app-play' branch below saves state.lastAppPlay with its real logo chain.
+  const saveCase = savePresetCase(state.nowLocation, sourceSlot, state.lastAppPlay, Date.now(), APP_PLAY_FRESH_MS);
 
   // Case Spotify: the speaker is playing a Spotify playlist. Save a REAL
   // Spotify preset (type=spotify with the playlist URI), not a radio link to
@@ -6040,7 +6042,7 @@ async function saveCurrentToSlot(slot) {
       if (/spotify-uri-unplayable|replayable playlist/i.test(msg)) {
         showError(t('preset.spotifyNotSaveable'));
       } else {
-        showError(t('preset.saveFailed', { err: msg }));
+        showPresetSaveError(err);
       }
       return;
     }
@@ -6079,7 +6081,7 @@ async function saveCurrentToSlot(slot) {
           VoteStation(state.currentBox.host, state.currentBox.port, app.uuid).catch(() => {});
         }
       } catch (err) {
-        showError(t('preset.saveFailed', { err: String(err) }));
+        showPresetSaveError(err);
       }
       return;
     }
@@ -6094,7 +6096,7 @@ async function saveCurrentToSlot(slot) {
         await loadPresets();
         return;
       } catch (err) {
-        showError(t('preset.saveFailed', { err: String(err) }));
+        showPresetSaveError(err);
         return;
       }
     }
@@ -6145,7 +6147,7 @@ async function saveCurrentToSlot(slot) {
       showToast(t('preset.savedToKey', { n: slot, name: oname }));
       await loadPresets();
     } catch (err) {
-      showError(t('preset.saveFailed', { err: String(err) }));
+      showPresetSaveError(err);
     }
     return;
   }
@@ -6171,7 +6173,7 @@ async function saveCurrentToSlot(slot) {
       VoteStation(state.currentBox.host, state.currentBox.port, state.nowUUID).catch(() => {});
     }
   } catch (err) {
-    showError(t('preset.saveFailed', { err: String(err) }));
+    showPresetSaveError(err);
   }
 }
 

--- a/desktop-app/frontend/src/style.css
+++ b/desktop-app/frontend/src/style.css
@@ -672,8 +672,10 @@ body {
 }
 .box-edit:hover { color: var(--brand); background: rgba(102, 187, 221, 0.12); }
 .box-ver { background: var(--c-surface-3); color: var(--c-muted); font-size: 10px; padding: 1px 5px; border-radius: 8px; margin-left: 6px; }
-/* Offline: die Version ist der letzte bestaetigte Stand, kein Live-Wert (#775). */
-.box-ver-stale { opacity: 0.55; font-style: italic; }
+/* Offline: die Version ist der letzte bestaetigte Stand, kein Live-Wert (#775).
+   0.55 faded the greyed version almost to nothing on a light theme (#833); 0.82
+   keeps the "not a live value" cue while staying readable. */
+.box-ver-stale { opacity: 0.82; font-style: italic; }
 .box-model { color: var(--c-muted); font-size: 11px; font-weight: 500; margin-left: 8px; }
 /* Multiroom group frame (#70): speakers sharing a live zone are clustered and
    wrapped in a colored border so the group reads as one block on the music tab.
@@ -797,7 +799,10 @@ html.a11y-contrast .speaker-update-card .suc-ver { color: #fff; }
   margin-left: 8px;
   padding: 1px 6px;
   border-radius: 8px;
-  background: rgba(204, 0, 0, 0.18);
+  /* A red tint behind red-ish text was too low-contrast, worst on the muted
+     default palette (#833). A neutral surface chip keeps the red "needs
+     install" cue legible in every theme (light, dark, high-contrast). */
+  background: var(--c-surface-3);
   color: var(--signal-red);
   font-size: 10px;
   font-weight: 600;

--- a/desktop-app/frontend/src/utils.js
+++ b/desktop-app/frontend/src/utils.js
@@ -116,35 +116,31 @@ export function sleep(ms) {
 // savePresetCase is the pure decision behind saveCurrentToSlot: which save
 // path applies to the currently playing location.
 //   'spotify'   playing via the Spotify engine — save a real Spotify preset.
-//   'app-play'  a proxy slot is playing but the app itself started an ad-hoc
-//               station within freshMs — trust the app's own record (an
-//               agent-side wake resume racing the play can leave the box
-//               briefly reporting the PREVIOUS preset, #252).
-//   'copy-slot' a proxy slot is playing (hardware key / other soft slot) —
-//               copy the source preset one to one.
-//   'direct'    a non-proxy stream — save the box-reported now-playing.
+//   'app-play'  the app itself started a station within freshMs — trust the
+//               app's own record of WHICH station that was.
+//   'copy-slot' a proxy slot is playing (hardware key / other soft slot) with
+//               no fresh app record — copy that source preset one to one.
+//   'direct'    a non-proxy stream with no fresh app record — save the
+//               box-reported now-playing.
 // sourceSlot is activeSlotFromLocation(nowLocation), passed in so the caller
 // computes it once; null means "not a proxy location".
-// nowStreamUrl is the real upstream URL the box report resolves to (the
-// caller unwraps the ORION descriptor and the /stream/raw proxy; '' when
-// unknown). It exists because a NATIVE ad-hoc play has no slot: the box
-// reports the descriptor, sourceSlot is null, and this function used to fall
-// through to 'direct' even when the app itself had started the station
-// seconds earlier. 'direct' then persisted the descriptor's box-loopback
-// art-proxy URL as the key's artwork, which is dead from the user's machine,
-// so every hold-saved key lost its logo to the grey-chevron fallback (#696,
-// six ST10 keys, MacBook). Unlike the proxy branch above, the app record is
-// trusted here ONLY when it matches what the box actually plays: there is no
-// wake-resume race to excuse a mismatch (#252's reason does not apply), so a
-// station someone started elsewhere still saves from the box report.
-export function savePresetCase(nowLocation, sourceSlot, lastAppPlay, nowMs, freshMs, nowStreamUrl) {
+//
+// A fresh app play wins outright, for EVERY location shape. The app knows
+// exactly which station the user just picked, and the box's now-playing cannot
+// be trusted to agree at save time: a native preset switch (#530) reports the
+// PREVIOUS station for a moment, and a wake-resume can race the play (#252).
+// The old rule only trusted the app record when the box already echoed the same
+// URL, so on that lag it fell to 'direct'/'copy-slot' and saved the previously
+// playing station instead. That station was usually already on another key, the
+// agent dedup then removed it from there, and the user's presets vanished one
+// after another (#836). The trade-off Jens chose: if you app-play a station and
+// manually switch to a different one within freshMs before hold-saving, the
+// save takes the app's station, not the manual one.
+export function savePresetCase(nowLocation, sourceSlot, lastAppPlay, nowMs, freshMs) {
   if (/\/spotify\/stream|\/playback\/container/.test(nowLocation || '')) return 'spotify';
   const fresh = !!(lastAppPlay && lastAppPlay.url && nowMs - lastAppPlay.at < freshMs);
-  if (sourceSlot !== null && sourceSlot !== undefined) {
-    if (fresh) return 'app-play';
-    return 'copy-slot';
-  }
-  if (fresh && nowStreamUrl && lastAppPlay.url === nowStreamUrl) return 'app-play';
+  if (fresh) return 'app-play';
+  if (sourceSlot !== null && sourceSlot !== undefined) return 'copy-slot';
   return 'direct';
 }
 

--- a/desktop-app/frontend/src/utils.test.js
+++ b/desktop-app/frontend/src/utils.test.js
@@ -9,49 +9,34 @@ const freshPlay = { url: 'http://radio.example.com/stream', at: NOW - 5_000 };
 const stalePlay = { url: 'http://radio.example.com/stream', at: NOW - FRESH_MS - 1 };
 
 describe('savePresetCase', () => {
-  it('classifies Spotify locations first, whatever the slot says', () => {
+  const orionLoc = '/station?data=native-descriptor-caller-decodes-it';
+
+  it('classifies Spotify locations first, whatever the slot or app record says', () => {
     expect(savePresetCase('http://192.0.2.1:8888/spotify/stream-3.ogg', 3, freshPlay, NOW, FRESH_MS)).toBe('spotify');
     expect(savePresetCase('/playback/container/c3BvdGlmeQ==', null, null, NOW, FRESH_MS)).toBe('spotify');
   });
-  it('prefers the app`s own fresh play record over a proxy-slot copy (#252)', () => {
-    expect(savePresetCase('http://192.0.2.1:8888/stream/2', 2, freshPlay, NOW, FRESH_MS)).toBe('app-play');
+
+  // A fresh app play is authoritative for EVERY location shape (#836): the app
+  // knows which station the user just picked, even when the box's now-playing
+  // still lags on it (native preset switch #530, wake-resume race #252). Saving
+  // the box's stale report captured an already-saved station and the dedup then
+  // wiped the key it was on, so presets vanished one after another.
+  it('prefers the app`s own fresh play record, whatever the box reports', () => {
+    expect(savePresetCase('http://192.0.2.1:8888/stream/2', 2, freshPlay, NOW, FRESH_MS)).toBe('app-play'); // proxy slot
+    expect(savePresetCase('http://radio.example.com/live.mp3', null, freshPlay, NOW, FRESH_MS)).toBe('app-play'); // non-proxy
+    expect(savePresetCase(orionLoc, null, freshPlay, NOW, FRESH_MS)).toBe('app-play'); // native, no slot in location
   });
-  it('copies the source preset when the app record is stale or absent', () => {
+
+  it('copies the source preset when a proxy slot plays and the app record is stale or absent', () => {
     expect(savePresetCase('http://192.0.2.1:8888/stream/2', 2, stalePlay, NOW, FRESH_MS)).toBe('copy-slot');
     expect(savePresetCase('http://192.0.2.1:8888/stream/2', 2, null, NOW, FRESH_MS)).toBe('copy-slot');
     expect(savePresetCase('http://192.0.2.1:8888/stream/2', 2, { at: NOW }, NOW, FRESH_MS)).toBe('copy-slot'); // no url
   });
-  it('saves the box-reported now-playing for non-proxy streams', () => {
-    expect(savePresetCase('http://radio.example.com/live.mp3', null, freshPlay, NOW, FRESH_MS)).toBe('direct');
-    expect(savePresetCase('', null, null, NOW, FRESH_MS)).toBe('direct');
-  });
 
-  // #696: a NATIVE ad-hoc play reports the ORION descriptor, which carries no
-  // slot, so sourceSlot is null and the old decision fell to 'direct'. That
-  // path saved the descriptor's box-loopback art-proxy URL as the key's
-  // artwork (dead from the user's machine, so the tile ended on the grey
-  // chevron), even though the app had started the station seconds earlier
-  // and holds its full logo chain. When the box report resolves to the SAME
-  // URL the app played (the caller passes it as nowStreamUrl), the app's
-  // record must win.
-  describe('native ad-hoc play, no slot in the location (#696)', () => {
-    const orionLoc = '/station?data=irrelevant-here-the-caller-decodes-it';
-    it('prefers the fresh app record when the box plays exactly that URL', () => {
-      expect(savePresetCase(orionLoc, null, freshPlay, NOW, FRESH_MS, freshPlay.url)).toBe('app-play');
-    });
-    it('still trusts the box report when it plays something else', () => {
-      // No wake-resume race to excuse a mismatch here (unlike #252's proxy
-      // branch): a station started from a hardware key or another client
-      // must be saved as the box reports it.
-      expect(savePresetCase(orionLoc, null, freshPlay, NOW, FRESH_MS, 'http://other.example.com/live')).toBe('direct');
-    });
-    it('still trusts the box report when the app record has gone stale', () => {
-      expect(savePresetCase(orionLoc, null, stalePlay, NOW, FRESH_MS, stalePlay.url)).toBe('direct');
-    });
-    it('falls back to direct when the caller cannot resolve the box URL', () => {
-      expect(savePresetCase(orionLoc, null, freshPlay, NOW, FRESH_MS, '')).toBe('direct');
-      expect(savePresetCase(orionLoc, null, freshPlay, NOW, FRESH_MS)).toBe('direct');
-    });
+  it('saves the box-reported now-playing when there is no fresh app record and no slot', () => {
+    expect(savePresetCase('http://radio.example.com/live.mp3', null, stalePlay, NOW, FRESH_MS)).toBe('direct');
+    expect(savePresetCase(orionLoc, null, stalePlay, NOW, FRESH_MS)).toBe('direct');
+    expect(savePresetCase('', null, null, NOW, FRESH_MS)).toBe('direct');
   });
 });
 

--- a/desktop-app/frontend/src/views/multiroom.js
+++ b/desktop-app/frontend/src/views/multiroom.js
@@ -554,7 +554,16 @@ export function renderMultiroom(fetchLive) {
 // repaint (which used to leave stale badges).
 async function refreshZoneLive() {
   const ran = await fetchZoneLive(state.boxes, { maxAgeMs: 0, minBoxes: 1 });
-  if (ran) renderMultiroom(false);
+  if (!ran) return;
+  // Do not repaint while the user is typing the pair name. The repaint rebuilds
+  // the input, which drops focus mid-word and swallows the keystrokes, so the
+  // box beeps and nothing lands in the field (#775). The live poll waits a
+  // cycle; the value is already mirrored into state.stereoName by its oninput,
+  // so nothing is lost, and the next poll after they click away still picks up
+  // any change made elsewhere.
+  const active = document.activeElement;
+  if (active && active.id === 'stereoName') return;
+  renderMultiroom(false);
 }
 
 // doFormStereo creates a real left/right stereo pair on two SoundTouch 10s

--- a/internal/webui/assets/index.html
+++ b/internal/webui/assets/index.html
@@ -1439,13 +1439,21 @@ async function loadSettings() {
     lastBoxName = s.info.name;
     updateTopName();
   }
-  if (s.volume && typeof s.volume.actual === 'number') {
+  if (s.volume && typeof s.volume.actual === 'number' && (volScope === 'one' || !zone.grouped)) {
     // Do not let a status poll snap the slider back to a stale reading in the
     // moment right after the user changed it. The box may not have applied the
     // new level yet, so overwriting here made a tap appear to jump back to the
     // old value (#726). Hold off until the send has settled (the same window the
     // group path uses), then trust the box again; a change made on the box
     // itself is picked up on the next poll after the window.
+    //
+    // s.volume.actual is THIS speaker's own level. When the group slider drives
+    // the whole zone (grouped and not scoped to one speaker), this poll must not
+    // touch it: the master's own report lags the members' ramp, worst on an
+    // scm/BCO box whose getGroup hangs, so it sprang the group slider back a
+    // second after each step even with the group-adopt fix (#726, abschuss's
+    // Kueche). The group slider is owned by the zone-volume adopt in loadZone,
+    // which is gated on the members confirming the sent levels.
     if (Date.now() - volSentAt >= GRP_VOL_SETTLE_MS) {
       volLast = s.volume.actual;
       var el = document.getElementById('vol'); el.value = s.volume.actual;

--- a/internal/webui/phone_remote_test.go
+++ b/internal/webui/phone_remote_test.go
@@ -193,6 +193,19 @@ func TestPhoneRemoteGroupVolumeHoldsSentValue(t *testing.T) {
 	}
 }
 
+// The v0.9.71 group-adopt gate fixed only ONE of the two slider-adopt paths.
+// The status poll adopts this speaker's OWN s.volume.actual, and when the group
+// slider drives a whole zone that master-only reading lags the members' ramp
+// (worst on an scm/BCO box whose getGroup hangs), so it sprang the group slider
+// back a second after each step even after the fix (#726, abschuss's Kueche).
+// The status-poll adopt must be scoped like volSend: only when controlling one
+// speaker (volScope === 'one') or when not grouped.
+func TestPhoneRemoteStatusPollDoesNotSpringTheGroupSlider(t *testing.T) {
+	if !strings.Contains(indexHTML, "typeof s.volume.actual === 'number' && (volScope === 'one' || !zone.grouped)") {
+		t.Error("the status-poll volume adopt is not scoped away from the group slider; it will spring a grouped speaker's slider back (#726)")
+	}
+}
+
 // TestPhoneRemoteSleepArmingIsNotSelfCancelling guards the defect that made the
 // sleep timer unusable from the day it shipped: press() adds .active as a
 // 600 ms tap flash, and the click handler read .active as "this choice is

--- a/internal/webui/presets_http.go
+++ b/internal/webui/presets_http.go
@@ -305,10 +305,16 @@ func (s *Server) handlePresetSlot(w http.ResponseWriter, r *http.Request) {
 			}
 			cancel()
 		}
-		// Dedup: a given playlist/station lives on at most ONE preset. Saving it
-		// here removes it from any other slot first (matched by Spotify URI, or
-		// by stream URL for radio), so the same content cannot occupy two
-		// buttons (user request; also avoids two Spotify presets colliding).
+		// A given playlist/station lives on at most ONE key. If the station being
+		// saved is already on ANOTHER slot, REFUSE rather than deleting that slot.
+		// The old behaviour silently removed the other slot, and that is what wiped
+		// a user's keys one after another (#836): a hold-save that captured an
+		// already-saved station (the box's now-playing lagged the native switch,
+		// so the app saved the previously playing station) deleted the key that
+		// station was on. Refusing is loss-free; the frontend turns this 409 into a
+		// "Sender liegt schon auf Taste N" note. A same-slot re-save (metadata
+		// self-heal, or overwriting the key with itself) is skipped, so it is never
+		// blocked.
 		for _, other := range s.presets.All() {
 			if other.Slot == slot {
 				continue
@@ -318,13 +324,15 @@ func (s *Server) handlePresetSlot(w http.ResponseWriter, r *http.Request) {
 			if !dup {
 				continue
 			}
-			_ = s.presets.RemoveSlot(other.Slot)
-			s.logger.Info("preset dedup: removed duplicate from other slot", "kept", slot, "removed", other.Slot)
-			if s.boxHost != "" {
-				rmCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				_ = boxcli.RemovePreset(rmCtx, s.boxHost, other.Slot)
-				cancel()
-			}
+			s.logger.Info("preset save refused: this station is already on another slot",
+				"slot", slot, "existingSlot", other.Slot, "name", other.Name,
+				"from", r.RemoteAddr, "ua", r.Header.Get("User-Agent"))
+			writeJSON(w, http.StatusConflict, map[string]any{
+				"code": "already-on-slot",
+				"slot": other.Slot,
+				"name": other.Name,
+			})
+			return
 		}
 		// Every accepted write is logged with WHO wrote it. The #758 bundle
 		// showed a slot rewritten six times in twenty minutes (a phone save


### PR DESCRIPTION
Four field bugs from the 2026-09-03 sweep. Independent commits.

## #836 — saved stations disappear when you save preset keys (`823995f`)
Long-press "save to key" saved whatever was *playing at that instant*, and the speaker's now-playing lags the station you just picked (native preset switch #530). So a save grabbed an already-saved station, and the agent then **silently removed** it from the other key. Three saves in a row could collapse onto one key.
Fix (both halves): the save takes the app's own fresh record, not the box's lagging report; and a save whose station already sits on another key is **refused** (`409 already-on-slot`, a "already on key N" note) instead of deleting that key. No preset is ever removed by saving another one. New i18n key in all 13 bundles; `savePresetCase` tests updated.

## #726 — phone volume slider springs back on a grouped speaker (`40cbafc`)
The v0.9.71 fix held only one of the page's two volume refreshes. The plain status poll adopted the speaker's **own** level, which lags the members' ramp when the group slider drives a whole zone (worst on an scm/BCO box whose `getGroup` hangs — abschuss's Küche). The status poll now leaves the slider alone while the group owns it, adopting the speaker's own level only when controlling a single speaker.

## #775 — stereo pair name box loses focus while typing (`813d812`)
The Multi-Room screen re-polls and repaints every few seconds, rebuilding the name field mid-word: focus jumped out, keystrokes were lost, the machine beeped. The repaint now waits a cycle while the name box is focused. Value is kept throughout.

## #833 — low contrast (`bcd35dc`)
Offline-speaker version 0.55→0.82 opacity; "first install" badge → neutral chip so the red label reads in every theme.

## Verification
- `GOOS=linux GOARCH=arm GOARM=5 go build ./...` clean; `go vet` + full `internal/webui` + `internal/streamproxy` tests pass; gofmt clean.
- Frontend builds; 215 vitest pass; eslint 0 errors; i18n coverage 100%.
- New regression tests: `savePresetCase` (preset save), `TestPhoneRemoteStatusPollDoesNotSpringTheGroupSlider` (#726).

All four are phone/app UI + preset-store fixes from one sweep; bundling to keep OTA/release churn down. Good to fleet-check alongside the next roll.