### PR TITLE
fix: pre-release bug batch (permanent-group music, failure-report false blame, uninstall re-run, multi-room jitter)

### DIFF
--- a/desktop-app/app_transport.go
+++ b/desktop-app/app_transport.go
@@ -323,6 +323,14 @@ const (
 	// or client/AP isolation in the router). Leading with the firewall sent
 	// users chasing the wrong thing (Jens, #763).
 	isolationAdvice = "The speaker shows up in the list because it announces itself, but it answers on no port and your PC cannot even reach it with a ping while both are on the same network. That is the fingerprint of a Wi-Fi that keeps devices apart from each other, not a firewall on your PC: usually a guest network, or client isolation (sometimes called AP isolation) switched on in the router. Put the PC and the speaker on the same normal Wi-Fi, not a guest network, turn off client/AP isolation in the router, then refresh the speaker list and try again."
+	// agentNotUpAdvice replaces the network-blame advice when the app's own log
+	// proves it reached the speaker this run (an SSH login, a staged install):
+	// none of that survives a firewall, a wrong subnet or client isolation, so
+	// the network is fine and blaming it sends the user chasing a problem that is
+	// not theirs (Klaus, 2026-09-03: the app SSH'd in and ran the installer, then
+	// the report told him to change his Wi-Fi). What went wrong is the speaker not
+	// coming back after the install rebooted it.
+	agentNotUpAdvice = "ST Reborn reached your speaker and ran the install over the network, so your Wi-Fi, firewall and network are fine. The speaker just did not come back on the network after the install rebooted it. First pull any USB stick out of the speaker: a stick left in can keep an ST30 or Portable off the network even while it still plays. Then power-cycle the speaker, unplug it for about 30 seconds, plug it back in, and wait about 3 minutes before you refresh the speaker list. If it still does not appear, use \"Save diagnostic logs\" and send the file in."
 
 	installWindowClosedAdvice = "Bose only opens the install access while the speaker boots with the STR stick plugged in. Power the speaker off, insert the STR stick, power it back on, then install."
 

--- a/desktop-app/frontend/src/views/multiroom.js
+++ b/desktop-app/frontend/src/views/multiroom.js
@@ -647,8 +647,16 @@ async function doFormZone(strBoxes) {
     // Wake the master and every selected member before enrolling them (#70): a box
     // switched off at the speaker still answers STR but would join the zone silent.
     // Waking an already-awake box is a fast no-op.
+    //
+    // NOT for a permanent group, though: waking a standby speaker resumes its
+    // last station, so waking to create a permanent group started music on the
+    // speakers. A permanent group is not formed now anyway, it is stored and the
+    // box forms it (waking the members) the next time the master plays, so the
+    // boxes are left exactly as they are.
     const slaveBoxes = strBoxes.filter(b => b.deviceID !== state.zoneMaster && sel[b.deviceID]);
-    await Promise.allSettled([master, ...slaveBoxes].map(b => WakeBox(b.host, b.port)));
+    if (!state.zonePermanent) {
+      await Promise.allSettled([master, ...slaveBoxes].map(b => WakeBox(b.host, b.port)));
+    }
     const res = await FormZone(master.host, master.port, {
       master: { deviceID: master.deviceID, ip: master.host },
       slaves, stereo: false, mode,

--- a/desktop-app/frontend/src/views/multiroom.js
+++ b/desktop-app/frontend/src/views/multiroom.js
@@ -70,6 +70,14 @@ function liveZoneMaster(strBoxes) {
 // errors and warnings stay until the next action, since the user still has to
 // act on them. The token guards a newer message from being wiped by an older
 // timer, and the identity check makes sure we only clear the message we set.
+// Cached stereo-pair balance readout. Without it the balance div was rendered
+// `hidden` on every one of the 5s live repaints and revealed async after a box
+// read, so the Multi-Room panel jumped a line each time (#821). Cache the text
+// keyed on the pair master and render it in place, so the div keeps its height
+// across repaints; a different pair does not show the previous one's value.
+let pairBalanceText = '';
+let pairBalanceMaster = '';
+
 let stereoMsgToken = 0;
 function flashStereoMsg(html) {
   state.stereoMsg = html;
@@ -381,8 +389,10 @@ export function renderMultiroom(fetchLive) {
   // the speaker was woken), so shown beside a slider it reads as a control that
   // is broken. An owner said exactly that: "steht neben dem Lautstaerkeregler
   // und hat auch keinen Effekt" (2026-08-09), and #70 asked twice where it was.
+  const fpMaster = formingPair ? String(formingPair.master || '').toUpperCase() : '';
+  const showBal = !!(formingPair && pairBalanceText && fpMaster === pairBalanceMaster);
   const pairBalance = formingPair
-    ? `<div class="muted small" id="pairBalance" hidden></div>`
+    ? `<div class="muted small" id="pairBalance"${showBal ? '' : ' hidden'}>${showBal ? escapeHtml(pairBalanceText) : ''}</div>`
     : '';
 
   root.innerHTML = intro + liveFramesHtml + topbar + previewNote + updateWarn +
@@ -845,6 +855,8 @@ async function fillPairBalance(pair, boxes) {
   if (!src || src.kind === 'stock') return;
   const v = await readBoxBalance(src);
   if (v === null) return;
-  el.textContent = balanceLabel(v) + '. ' + t('controls.balanceTitle');
+  pairBalanceText = balanceLabel(v) + '. ' + t('controls.balanceTitle');
+  pairBalanceMaster = String(pair.master || '').toUpperCase();
+  el.textContent = pairBalanceText;
   el.hidden = false;
 }

--- a/desktop-app/uninstall_str.go
+++ b/desktop-app/uninstall_str.go
@@ -118,6 +118,23 @@ func (a *App) UninstallSTR(host string) UninstallSTRResult {
 		}
 	}
 	if helloErr != nil || !strings.Contains(hello, "STR_SSH_OK") {
+		// Fast path (#683 follow-up): a box STR already removed is back to stock and
+		// answers the Bose API on :8090 with NEITHER STR agent port open (:8888 sm2,
+		// :17008 BCO). Recognise that here, BEFORE the :17000 stick-free unlock
+		// below, so pressing Remove again on an already-stock speaker returns at
+		// once. Without this the second Remove ran the whole unlock-then-SSH dance
+		// first and took as long as a real removal (shorty310, 2026-09-03).
+		if tcpReachable(host, 8090, 2*time.Second) &&
+			!tcpReachable(host, 8888, 1500*time.Millisecond) &&
+			!tcpReachable(host, 17008, 1500*time.Millisecond) {
+			a.forgetSTRDeviceByHost(host)
+			res.Step = "already-stock"
+			res.OK = true
+			res.Message = "STR is already removed from this speaker. It is back to a stock Bose speaker, " +
+				"so there was nothing to remove and nothing else is needed."
+			a.logger.Info("uninstall_str: speaker is already stock, nothing to remove (fast path)", "host", host)
+			return res
+		}
 		// FALLBACK: the STR agent was not reachable (e.g. a wedged box). Try the
 		// stick-free :17000 unlock like the installer, and restore stock cloud URLs
 		// on EVERY exit so a failed attempt never leaves the box dialing the unlock

--- a/desktop-app/updatereport.go
+++ b/desktop-app/updatereport.go
@@ -259,6 +259,7 @@ func formatFailureReport(r failureReport) string {
 	}
 
 	advice = dropContradictedBlame(advice)
+	advice = applyReachedThisSession(advice, r)
 	advice = applyIsolationDiagnosis(advice, r)
 	if len(advice) > 0 {
 		section(&b, "what to try")
@@ -301,10 +302,47 @@ func formatFailureReport(r failureReport) string {
 // its clients apart, not a firewall, and pointing at the firewall sent users
 // chasing the wrong thing (Jens, #763). Only fires on the not-reachable phase,
 // i.e. when :22, :8090 and :8091 were all silent.
+// reachedThisSession reports whether the app's own log proves it reached the
+// speaker earlier in the SAME run: an SSH login or a staged install. A firewall,
+// a wrong subnet or client isolation would all have blocked that, so any of
+// these markers makes the "not reachable / firewall / guest Wi-Fi / isolation"
+// advice a false lead. Only strong SSH-install evidence counts: a bare
+// "agent-not-up" can also mean the install never reached the box at all (wrong
+// subnet), which IS a network problem and must keep the network advice.
+func reachedThisSession(r failureReport) bool {
+	blob := r.History + "\n" + r.Facts.LogTail
+	for _, s := range []string{"ssh ok", "repair_ssh", "SSH-staged install ran", "install_str: ssh"} {
+		if strings.Contains(blob, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// applyReachedThisSession swaps the network-blame advice for the agent-did-not-
+// come-back advice when the app provably reached the speaker this run (see
+// reachedThisSession). It drops the firewall, not-reachable and isolation
+// paragraphs so the report cannot both tell the user their network ran the
+// install and that their network is the problem.
+func applyReachedThisSession(advice []string, r failureReport) []string {
+	if !reachedThisSession(r) {
+		return advice
+	}
+	out := []string{agentNotUpAdvice}
+	for _, p := range advice {
+		if strings.HasPrefix(p, firewallAdvice) || strings.HasPrefix(p, notReachableAdvice) || strings.HasPrefix(p, isolationAdvice) {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
 func applyIsolationDiagnosis(advice []string, r failureReport) []string {
 	f := r.Facts
 	isolated := strings.Contains(r.Phase, "not-reachable") &&
-		f.SubnetKnown && f.SameSubnet && f.PingRan && !f.PingAlive
+		f.SubnetKnown && f.SameSubnet && f.PingRan && !f.PingAlive &&
+		!reachedThisSession(r)
 	if !isolated {
 		return advice
 	}

--- a/desktop-app/updatereport_test.go
+++ b/desktop-app/updatereport_test.go
@@ -1,0 +1,55 @@
+package main
+
+import "testing"
+
+// TestReachedThisSessionSuppressesNetworkBlame pins the #03 fix (Klaus,
+// 2026-09-03): the app SSH'd into the speaker and ran the installer, then the
+// box did not come back on the network. The report must NOT then blame the
+// network (client isolation / firewall / guest Wi-Fi), because none of that
+// would have let the SSH install run. It must lead with the agent-not-up advice.
+func TestReachedThisSessionSuppressesNetworkBlame(t *testing.T) {
+	r := failureReport{
+		Phase:   "install:agent-not-up",
+		History: "install_str: ssh ok\nrepair_ssh: install ran (outBytes=671)\nstep=reboot code=agent-not-up",
+		Facts:   installFacts{SubnetKnown: true, SameSubnet: true, PingRan: true, PingAlive: false},
+	}
+	if !reachedThisSession(r) {
+		t.Fatal("SSH-install evidence must count as reached-this-session")
+	}
+	got := applyReachedThisSession([]string{notReachableAdvice, firewallAdvice, "keep me"}, r)
+	if len(got) == 0 || got[0] != agentNotUpAdvice {
+		t.Fatalf("must lead with agentNotUpAdvice, got %v", got)
+	}
+	for _, p := range got {
+		if p == notReachableAdvice || p == firewallAdvice || p == isolationAdvice {
+			t.Error("network-blame advice must be dropped once the app reached the box")
+		}
+	}
+	// A non-blame paragraph is kept.
+	if got[len(got)-1] != "keep me" {
+		t.Error("unrelated advice must be preserved")
+	}
+	// applyIsolationDiagnosis must now be a no-op: isolation is suppressed.
+	if iso := applyIsolationDiagnosis(got, r); iso[0] != agentNotUpAdvice {
+		t.Error("applyIsolationDiagnosis must not re-add isolation once the app reached the box")
+	}
+}
+
+// TestReachedThisSessionFalseForDifferentSubnet pins the other side (Walter,
+// 2026-09-03): the SoundTouch was on a different subnet (192.168.1.1), no SSH
+// ran, so the network advice is correct and must stay. A bare "agent-not-up"
+// with no SSH evidence must not be mistaken for a reached-this-session install.
+func TestReachedThisSessionFalseForDifferentSubnet(t *testing.T) {
+	r := failureReport{
+		Phase:   "install:agent-not-up",
+		History: "network install started\nthe agent did not come up in time",
+		Facts:   installFacts{SubnetKnown: true, SameSubnet: false, PingRan: true, PingAlive: false},
+	}
+	if reachedThisSession(r) {
+		t.Fatal("a network install with no SSH evidence must not count as reached (wrong subnet)")
+	}
+	got := applyReachedThisSession([]string{notReachableAdvice}, r)
+	if len(got) != 1 || got[0] != notReachableAdvice {
+		t.Fatalf("network advice must be kept for a different-subnet box, got %v", got)
+	}
+}

--- a/internal/webui/zones_stereo.go
+++ b/internal/webui/zones_stereo.go
@@ -502,6 +502,22 @@ func (s *Server) handleZoneForm(w http.ResponseWriter, r *http.Request) {
 		s.forgetZoneDocDoubt()
 	}
 
+	// A PERMANENT group whose master is idle must not be woken and formed now.
+	// Waking a standby speaker (sys power) resumes its last station, so creating
+	// a permanent group started music on the speakers (reported live 2026-09-03).
+	// The document is persisted above; formDefaultGroupOnPlay wires the firmware
+	// zone, waking the members, the next time the master actually plays. A master
+	// that is already playing falls through and forms live so the group hears the
+	// current stream at once.
+	if req.Permanent {
+		if standby, busy := s.boxPlayState(); standby || !busy {
+			s.logger.Info("zone: permanent group stored, forming deferred to the next play (master idle, not waking it)",
+				"master", master.DeviceID, "slaves", len(slaves), "mode", mode)
+			writeJSON(w, http.StatusOK, map[string]any{"ok": true, "mode": mode, "deferred": true})
+			return
+		}
+	}
+
 	if mode == "mirror" {
 		// Deliberate user action: push unconditionally (reconcile=false), the
 		// user just asked for exactly this group.


### PR DESCRIPTION
Four field bugs from the 2026-09-03 mail batch + a live report. Independent commits.

## Permanent group creation starts music (`9177d4a2`)
Creating a permanent group woke every selected speaker, and waking from standby resumes the last station. A permanent group re-forms on the next play anyway, so creating one now just stores it and leaves idle speakers untouched. Validated on hardware (.79): forming from standby returns `deferred:true`, speaker stays silent.

## Failure report blames the network when the install actually reached the speaker (`487c5322`)
Klaus's ST30: the app SSH'd in, ran the installer, the box rebooted and did not return — and the report told him to change his Wi-Fi / turn off client isolation. The SSH install running proves the network is fine. The report now recognises in-session SSH-install evidence and leads with the real step (install ran, box didn't return, pull any stick + power-cycle). A different-subnet/unreachable box keeps the network advice. Unit-tested both ways.

## Re-removing STR from an already-stock speaker returns at once (`dc4bc2c3`)
shorty310: pressing Remove again ran the whole unlock+SSH dance before noticing there was nothing to remove. Now it detects an already-stock speaker (Bose API up, no STR agent port) up front.

## Multi-Room panel jumps while a stereo pair is selected (`fef0e61b`)
The pair balance readout was hidden and refilled on every live refresh; it's now cached and kept in place.

## Verification
- `go build ./...` + ARM cross-compile clean; `go vet` + tests pass; `GOOS=linux golangci-lint run` = 0 issues; gofmt clean.
- Frontend builds; 215 vitest; eslint 0 errors.
- New test `updatereport_test.go` (reached-this-session both directions). Permanent-group fix hardware-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)