### PR TITLE
fix(discovery): stop a network broadcast address showing up as a phantom speaker

### DIFF
--- a/desktop-app/app_boxops.go
+++ b/desktop-app/app_boxops.go
@@ -293,6 +293,54 @@ var hostHasLinkLocalIPv4 = func() bool {
 	return false
 }
 
+// isLocalSubnetBroadcast reports whether ip is the IPv4 broadcast address of one
+// of this host's own subnets (e.g. 192.168.0.255 on a /24). A broadcast address
+// is never a real speaker, but it can slip into the candidate list from an
+// announcement or a persisted/seeded entry and then show up as a "phantom
+// speaker": Update All tries to reach it and reports an error even though the
+// real speakers updated fine, and it disappears on the next app restart (field
+// 2026-09-04, ST10 fleet on v0.9.72). Computed per interface against the actual
+// mask, so a legitimate host that happens to end in .255 on a wider subnet
+// (/23 and up) is NOT excluded.
+var isLocalSubnetBroadcast = func(ip net.IP) bool {
+	if ip.To4() == nil {
+		return false
+	}
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return false
+	}
+	for _, a := range addrs {
+		if ipnet, ok := a.(*net.IPNet); ok && ipIsBroadcastOf(ip, ipnet) {
+			return true
+		}
+	}
+	return false
+}
+
+// ipIsBroadcastOf reports whether ip is the IPv4 broadcast address of ipnet
+// (host bits all ones). Pure: the mask math is what decides that .255 is the
+// broadcast of a /24 but an ordinary host on a /23, so it is unit-tested apart
+// from the live-interface lookup.
+func ipIsBroadcastOf(ip net.IP, ipnet *net.IPNet) bool {
+	ip4, n4 := ip.To4(), ipnet.IP.To4()
+	if ip4 == nil || n4 == nil {
+		return false
+	}
+	mask := ipnet.Mask
+	if len(mask) == net.IPv6len { // a 4-in-16 mask: use its last 4 bytes
+		mask = mask[12:]
+	}
+	if len(mask) != net.IPv4len {
+		return false
+	}
+	bcast := make(net.IP, net.IPv4len)
+	for i := 0; i < net.IPv4len; i++ {
+		bcast[i] = n4[i] | ^mask[i]
+	}
+	return bcast.Equal(ip4)
+}
+
 // BoxWifiScan asks the SPEAKER which Wi-Fi networks it can see.
 //
 // This is the list that decides whether a switch can work, and it is not the

--- a/desktop-app/app_discovery.go
+++ b/desktop-app/app_discovery.go
@@ -332,7 +332,7 @@ func (a *App) DiscoverBoxes(timeoutSec int) ([]BoxInfo, error) {
 		var wg sync.WaitGroup
 		for _, h := range hosts {
 			if ip := net.ParseIP(h); ip == nil || ip.IsLoopback() ||
-				(ip.IsLinkLocalUnicast() && !hostHasLinkLocalIPv4()) {
+				(ip.IsLinkLocalUnicast() && !hostHasLinkLocalIPv4()) || isLocalSubnetBroadcast(ip) {
 				continue
 			}
 			host := h

--- a/desktop-app/broadcast_filter_test.go
+++ b/desktop-app/broadcast_filter_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"net"
+	"testing"
+)
+
+// A broadcast address that slipped into the candidate list showed up as a
+// "phantom speaker" and made Update All report an error while the real speakers
+// updated fine (field 2026-09-04). ipIsBroadcastOf is the mask math that decides
+// what to filter, and the point of computing it per mask is that .255 is the
+// broadcast of a /24 but a perfectly ordinary host on a /23.
+func TestIPIsBroadcastOf(t *testing.T) {
+	mustNet := func(cidr string) *net.IPNet {
+		_, n, err := net.ParseCIDR(cidr)
+		if err != nil {
+			t.Fatalf("bad cidr %s: %v", cidr, err)
+		}
+		return n
+	}
+	cases := []struct {
+		ip   string
+		cidr string
+		want bool
+	}{
+		{"192.168.0.255", "192.168.0.10/24", true},  // /24 broadcast -> filtered
+		{"192.168.0.1", "192.168.0.10/24", false},   // ordinary host
+		{"192.168.0.10", "192.168.0.10/24", false},  // the interface itself
+		{"192.168.0.255", "192.168.0.10/23", false}, // /23: .255 is a valid host, keep it
+		{"192.168.1.255", "192.168.0.10/23", true},  // /23 broadcast is .1.255
+		{"10.0.0.255", "10.0.0.5/24", true},
+		{"10.1.2.3", "10.0.0.5/8", false}, // /8 broadcast is 10.255.255.255
+		{"10.255.255.255", "10.0.0.5/8", true},
+	}
+	for _, c := range cases {
+		got := ipIsBroadcastOf(net.ParseIP(c.ip), mustNet(c.cidr))
+		if got != c.want {
+			t.Errorf("ipIsBroadcastOf(%s, %s) = %v, want %v", c.ip, c.cidr, got, c.want)
+		}
+	}
+}

--- a/desktop-app/discovery_coldstart.go
+++ b/desktop-app/discovery_coldstart.go
@@ -237,7 +237,7 @@ func probeKnownSpeakers(ctx context.Context, logger *slog.Logger, hits chan<- Bo
 		// real address anyway, so probing it only produces a second, dead entry
 		// in the list (2026-08-23 report: one speaker listed twice, once on
 		// 169.254, blocking Update All).
-		if ip := net.ParseIP(host); ip != nil && ip.IsLinkLocalUnicast() && !hostHasLinkLocalIPv4() {
+		if ip := net.ParseIP(host); ip != nil && ((ip.IsLinkLocalUnicast() && !hostHasLinkLocalIPv4()) || isLocalSubnetBroadcast(ip)) {
 			continue
 		}
 		wg.Add(1)


### PR DESCRIPTION
Field report 2026-09-04 (Friedrich, ST10 fleet on v0.9.72): an update reported an error and left a transient "phantom speaker" in the app, gone after an app restart, while the two real speakers had updated to v0.9.72 cleanly.

Cause: a subnet broadcast address (x.x.x.255 on a /24) got into the candidate list via an announcement/seed path, never answered a probe, and sat there as a phantom that Update All then tried to OTA and failed on. Same class as the 169.254 phantom already filtered.

Fix: filter broadcast addresses at the SSDP-announce and known-speakers ingest points, computed per interface mask so a legit host ending in .255 on a /23+ is not excluded. Pure mask helper unit-tested (`TestIPIsBroadcastOf`). Bundles into the next release with #847.

🤖 Generated with [Claude Code](https://claude.com/claude-code)