### PR TITLE
fix(multiroom): honest group form/dissolve confirmations (#843, #775)

### DIFF
--- a/desktop-app/app_zone.go
+++ b/desktop-app/app_zone.go
@@ -327,19 +327,25 @@ func (a *App) relayStereoGroupDoc(out map[string]any) {
 // DissolveZone tears down the multiroom zone led by masterHost (#70 beta).
 // Logged with the outcome: group bugs reported from the field were previously
 // undiagnosable because the app log never said which zone operations ran.
-func (a *App) DissolveZone(masterHost string, masterPort int) error {
+// DissolveZone returns the agent's own verdict so the UI can tell the three
+// outcomes apart instead of treating every HTTP 200 as success: a real dissolve
+// (ok:true), an incomplete one (ok:false, remaining), and a no-op where there
+// was nothing to dissolve (nothing:true). The last is why pressing Ungroup with
+// no group used to show a green "Group dissolved" (#843): the app discarded this
+// body and assumed success.
+func (a *App) DissolveZone(masterHost string, masterPort int) (map[string]any, error) {
 	// Same budget as forming: dissolving also wakes the members first, and a
 	// timeout here is what leaves a half-dissolved group behind (#442).
 	resp, err := a.boxDoTimeout(masterHost, masterPort, http.MethodDelete, "/api/box/zone", "", "", zoneCallTimeout)
 	if err != nil {
 		a.logger.Info("zone: dissolve failed", "master", masterHost, "err", err)
-		return err
+		return nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		herr := readHTTPError(resp)
 		a.logger.Info("zone: dissolve rejected", "master", masterHost, "err", herr)
-		return herr
+		return nil, herr
 	}
 	// A dissolved stereo pair must also drop the partner's marge pair record;
 	// the agent tries directly and reports whether the app needs to relay the
@@ -347,8 +353,8 @@ func (a *App) DissolveZone(masterHost string, masterPort int) error {
 	var out map[string]any
 	_ = json.NewDecoder(resp.Body).Decode(&out)
 	a.relayStereoPairClear(out)
-	a.logger.Info("zone: dissolved", "master", masterHost)
-	return nil
+	a.logger.Info("zone: dissolved", "master", masterHost, "nothing", out["nothing"], "ok", out["ok"])
+	return out, nil
 }
 
 // relayStereoPairClear relays the pair-record DELETE to the partner's agent

--- a/desktop-app/frontend/src/views/multiroom.js
+++ b/desktop-app/frontend/src/views/multiroom.js
@@ -736,7 +736,18 @@ async function doFormZone(strBoxes) {
     });
     // Real feedback: mirror reports back {ok,mode}; native returns the live
     // zone, so verify the firmware actually took the members.
-    if (mode === 'mirror') {
+    if (res && res.ok === false) {
+      // The agent refused the form outright (it answers ok:false with a reason),
+      // e.g. the master or a member is half of a stereo pair, which cannot join a
+      // group (#792). This must NOT fall through to the count below: with no
+      // verified/missing fields the fallback assumed slaves.length joined and
+      // showed a green "Group active" for a group that was never formed (#775).
+      const inPair = Array.isArray(res.inPair) && res.inPair.length;
+      const msg = inPair
+        ? t('multiroom.pairNotGroupable')
+        : ((res.error && String(res.error)) || t('multiroom.formedNone'));
+      state.zoneMsg = `<div class="setup-err">${escapeHtml(msg)}</div>`;
+    } else if (mode === 'mirror') {
       state.zoneMsg = `<div class="setup-ok">${escapeHtml(t('multiroom.formedMirror', { n: slaves.length }))}</div>`;
     } else {
       // Trust the followers' own zone self-report, not the master's optimistic

--- a/desktop-app/frontend/src/views/multiroom.js
+++ b/desktop-app/frontend/src/views/multiroom.js
@@ -904,8 +904,18 @@ async function doDissolveZone(strBoxes) {
 async function doDissolveZoneAt(master) {
   if (!master) return;
   try {
-    await DissolveZone(master.host, master.port);
-    flashZoneMsg(`<div class="setup-ok">${escapeHtml(t('multiroom.zoneDissolved'))}</div>`);
+    // Trust the speaker's verdict, do not treat every 200 as success. nothing:
+    // there was no group to take apart (Ungroup on a groupless box used to show
+    // a green "Group dissolved", #843); ok:false: the firmware did not empty the
+    // group; otherwise it is really gone.
+    const res = await DissolveZone(master.host, master.port);
+    if (res && res.nothing) {
+      flashZoneMsg(`<div class="setup-warn">${escapeHtml(t('multiroom.nothingToUngroup'))}</div>`);
+    } else if (res && res.ok === false) {
+      state.zoneMsg = `<div class="setup-err">${escapeHtml(t('multiroom.dissolveIncomplete'))}</div>`;
+    } else {
+      flashZoneMsg(`<div class="setup-ok">${escapeHtml(t('multiroom.zoneDissolved'))}</div>`);
+    }
   } catch (e) {
     state.zoneMsg = `<div class="setup-err">${escapeHtml(t('multiroom.formFailed', { err: String(e) }))}</div>`;
   }

--- a/desktop-app/frontend/wailsjs/go/main/App.d.ts
+++ b/desktop-app/frontend/wailsjs/go/main/App.d.ts
@@ -59,7 +59,7 @@ export function DiscoverBoxes(arg1:number):Promise<Array<main.BoxInfo>>;
 
 export function DissolveStereoPair(arg1:string,arg2:number):Promise<void>;
 
-export function DissolveZone(arg1:string,arg2:number):Promise<void>;
+export function DissolveZone(arg1:string,arg2:number):Promise<Record<string, any>>;
 
 export function DownloadUpdate(arg1:string):Promise<string>;
 

--- a/desktop-app/stereo_live_test.go
+++ b/desktop-app/stereo_live_test.go
@@ -131,7 +131,7 @@ func TestLiveStereoPairRoundTrip(t *testing.T) {
 		// undo-pair button uses (also covers the ?stereo=1 escalation wiring).
 		var derr error
 		if round == 1 {
-			derr = a.DissolveZone(left, 8888)
+			_, derr = a.DissolveZone(left, 8888)
 		} else {
 			derr = a.DissolveStereoPair(left, 8888)
 		}


### PR DESCRIPTION
shorty310's v0.9.72 testing surfaced two confirmation-honesty bugs, both the same root: the app assumed an HTTP 200 meant success instead of reading the agent's own verdict.

- **#843** Ungroup with no group showed a green "Group dissolved". `DissolveZone` now returns the agent's {ok, nothing, remaining} (bindings regenerated); the UI shows "nothing to ungroup" / incomplete / dissolved accordingly.
- **#775** Grouping a speaker whose master is half of a stereo pair is refused by the agent (ok:false, #792), but the form showed a green "Group active" because the native branch's fallback assumed slaves.length joined. Now ok:false is honoured first and shows the reason (the stereo-pair-not-groupable note when the agent flags `inPair`).

Live stereo harness adapted to the new DissolveZone return. Bundles into the next release with #847/#848.

🤖 Generated with [Claude Code](https://claude.com/claude-code)