### PR TITLE
fix(update): self-heal Wi-Fi lost after a reboot (#853) + refuse a non-softfloat agent binary (#302)

### DIFF
--- a/desktop-app/app_transport.go
+++ b/desktop-app/app_transport.go
@@ -290,7 +290,27 @@ func reachabilityHint(err error) error {
 	if answeredNotSTR(err) {
 		return fmt.Errorf("%w\n\n%s", err, answeredNotSTRAdvice)
 	}
+	// EADDRNOTAVAIL ("can't assign requested address") is the PC failing to open a
+	// LOCAL socket for the connection, not the speaker refusing it, so the
+	// firewall/same-Wi-Fi advice sends the user hunting in the wrong place. It
+	// shows up when a VPN has captured the routing table or the adapter STR is
+	// using has no address on the speaker's network, and it fails identically for
+	// EVERY host (field 2026-09-05: a Mac hit it against the speaker, the router
+	// and a media server alike, while it still received their multicast).
+	if noLocalRoute(err) {
+		return fmt.Errorf("%w\n\n%s", err, noLocalRouteAdvice)
+	}
 	return fmt.Errorf("%w\n\n%s", err, firewallAdvice)
+}
+
+// noLocalRoute reports the EADDRNOTAVAIL family: the OS could not assign a local
+// source address for the outbound connection. macOS/Linux phrase it "can't/cannot
+// assign requested address"; Windows (WSAEADDRNOTAVAIL) as "requested address is
+// not valid in its context".
+func noLocalRoute(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "assign requested address") ||
+		strings.Contains(msg, "address is not valid in its context")
 }
 
 // The two closing paragraphs a user reads under a failed update. They are
@@ -301,6 +321,8 @@ const (
 	firewallAdvice = "The app could not reach the speaker. This is usually a firewall or antivirus blocking ST Reborn, or this PC and the speaker being on different Wi-Fi networks. Allow ST Reborn through your firewall/antivirus (or turn it off briefly to test), and make sure both are on the same Wi-Fi network"
 
 	answeredNotSTRAdvice = "The speaker answered, so this is not your firewall and not a Wi-Fi problem: something on the speaker replied to every request. What answered was not ST Reborn, which is what a speaker looks like while it is still starting up, or when its ST Reborn software did not come up at all. Unplug the speaker for ten seconds, plug it back in, wait about three minutes until it is fully up, and try the update again"
+
+	noLocalRouteAdvice = "This PC could not open a network connection to the speaker's address, and it failed the same way for every device on the network, so this is your PC's own networking, not the speaker and not its firewall. The usual cause is a VPN capturing all your traffic, or the network adapter ST Reborn is using having no address on the speaker's network. Disconnect the VPN (or exclude your local network from it), make sure this PC is on the same Wi-Fi as the speaker with a normal address, then try again"
 )
 
 // The advice paragraphs the install preflight can end on. They used to be

--- a/desktop-app/nolocalroute_test.go
+++ b/desktop-app/nolocalroute_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// EADDRNOTAVAIL ("can't assign requested address") is the PC failing to open a
+// local socket, not the speaker refusing the connection, so it must get the
+// PC-network advice, not the firewall/same-Wi-Fi advice that sends the user
+// hunting in the wrong place (field 2026-09-05: a Mac hit it against the speaker,
+// the router and a media server alike while still receiving their multicast).
+func TestNoLocalRouteAdvice(t *testing.T) {
+	yes := []string{
+		"dial tcp 192.168.1.27:8888: connect: can't assign requested address",
+		"dial tcp 10.0.0.5:8090: connect: cannot assign requested address",
+		"connectex: The requested address is not valid in its context.", // Windows WSAEADDRNOTAVAIL
+	}
+	for _, m := range yes {
+		if !noLocalRoute(errors.New(m)) {
+			t.Errorf("noLocalRoute should match %q", m)
+		}
+		got := reachabilityHint(errors.New(m)).Error()
+		if !strings.Contains(got, noLocalRouteAdvice) {
+			t.Errorf("reachabilityHint(%q) should carry the PC-network advice, got %q", m, got)
+		}
+		if strings.Contains(got, firewallAdvice) {
+			t.Errorf("reachabilityHint(%q) must NOT carry the firewall advice", m)
+		}
+	}
+	no := []string{
+		"dial tcp 192.168.1.27:8888: connect: connection refused",
+		"dial tcp 192.168.1.27:8888: i/o timeout",
+		"no route to host",
+	}
+	for _, m := range no {
+		if noLocalRoute(errors.New(m)) {
+			t.Errorf("noLocalRoute should NOT match %q", m)
+		}
+	}
+}

--- a/desktop-app/updatereport.go
+++ b/desktop-app/updatereport.go
@@ -132,6 +132,7 @@ func adviceParagraphs() []string {
 	return []string{
 		firewallAdvice,
 		answeredNotSTRAdvice,
+		noLocalRouteAdvice,
 		notReachableAdvice,
 		installWindowClosedAdvice,
 		controlUnresponsiveAdvice,

--- a/internal/webui/agent_admin.go
+++ b/internal/webui/agent_admin.go
@@ -619,12 +619,41 @@ func (s *Server) readUploadedELF(w http.ResponseWriter, r *http.Request, logger 
 		http.Error(w, "binary too small", http.StatusBadRequest)
 		return nil, false
 	}
-	// ELF magic check.
-	if body[0] != 0x7f || body[1] != 'E' || body[2] != 'L' || body[3] != 'F' {
-		http.Error(w, "not an ELF binary", http.StatusBadRequest)
+	if msg, ok := validSoftfloatARMELF(body); !ok {
+		http.Error(w, msg, http.StatusBadRequest)
 		return nil, false
 	}
 	return body, true
+}
+
+// validSoftfloatARMELF checks that body is a 32-bit little-endian softfloat ARM
+// ELF, the only shape the speakers can run (#302). The magic alone let anything
+// ELF-shaped through: softfloat is pinned at BUILD time (Makefile GOARM=5) but
+// nothing validated it at WRITE time, so a mis-built hard-float or wrong-arch
+// embed would flash, pass the flash verify, reboot, and then SIGILL on every
+// start, crash-looping the agent on a stickless box with no way back. This is
+// the last gate before flash. Real GOARM=5 binaries (the agent AND the
+// go-librespot engine) are EM_ARM, 32-bit LE, with the hard-float ABI flag
+// clear (e_flags 0x05000002), so a correct build always passes. Callers pass a
+// body already length-checked (>= 1024), so the fixed header offsets are safe.
+func validSoftfloatARMELF(body []byte) (msg string, ok bool) {
+	if len(body) < 40 {
+		return "binary too small to be an ELF", false
+	}
+	if body[0] != 0x7f || body[1] != 'E' || body[2] != 'L' || body[3] != 'F' {
+		return "not an ELF binary", false
+	}
+	if body[4] != 1 /*ELFCLASS32*/ || body[5] != 1 /*ELFDATA2LSB*/ {
+		return "not a 32-bit little-endian ARM binary", false
+	}
+	if eMachine := int(body[18]) | int(body[19])<<8; eMachine != 40 /*EM_ARM*/ {
+		return "wrong architecture; STR speakers need an ARM (GOARM=5) build", false
+	}
+	eFlags := uint32(body[36]) | uint32(body[37])<<8 | uint32(body[38])<<16 | uint32(body[39])<<24
+	if eFlags&0x400 != 0 /*EF_ARM_ABI_FLOAT_HARD*/ {
+		return "hard-float ARM binary refused; STR speakers need a softfloat (GOARM=5) build", false
+	}
+	return "", true
 }
 
 // uploadProgressReader logs a large upload's progress every few MB so the

--- a/internal/webui/elfguard_test.go
+++ b/internal/webui/elfguard_test.go
@@ -1,0 +1,42 @@
+package webui
+
+import "testing"
+
+// A mis-built agent embed (hard-float, or wrong arch) used to be accepted by the
+// OTA write path on the ELF magic alone: it would flash, pass the flash verify,
+// reboot, and then SIGILL on every start, crash-looping the agent on a stickless
+// box with no way back (#302). validSoftfloatARMELF is the gate that stops it.
+func TestValidSoftfloatARMELF(t *testing.T) {
+	// A minimal, valid 32-bit LE softfloat ARM ELF header (e_flags 0x05000002,
+	// exactly what our GOARM=5 agent + engine carry), padded past the offsets.
+	base := make([]byte, 64)
+	copy(base, []byte{0x7f, 'E', 'L', 'F'})
+	base[4] = 1 // ELFCLASS32
+	base[5] = 1 // ELFDATA2LSB
+	base[18] = 40
+	base[19] = 0 // e_machine = EM_ARM
+	// e_flags = 0x05000002 at offset 36 (little-endian)
+	base[36], base[37], base[38], base[39] = 0x02, 0x00, 0x00, 0x05
+
+	mut := func(f func([]byte)) []byte { b := append([]byte(nil), base...); f(b); return b }
+
+	cases := []struct {
+		name string
+		body []byte
+		ok   bool
+	}{
+		{"valid softfloat arm", base, true},
+		{"hard-float (e_flags 0x400 set)", mut(func(b []byte) { b[37] = 0x04 }), false}, // 0x05000402 -> HARD bit set
+		{"wrong arch (x86-64)", mut(func(b []byte) { b[18] = 62; b[19] = 0 }), false},
+		{"64-bit class", mut(func(b []byte) { b[4] = 2 }), false},
+		{"big-endian data", mut(func(b []byte) { b[5] = 2 }), false},
+		{"not an ELF", mut(func(b []byte) { b[1] = 'X' }), false},
+		{"too small", []byte{0x7f, 'E', 'L', 'F'}, false},
+	}
+	for _, c := range cases {
+		_, ok := validSoftfloatARMELF(c.body)
+		if ok != c.ok {
+			t.Errorf("%s: ok=%v, want %v", c.name, ok, c.ok)
+		}
+	}
+}

--- a/internal/webui/wlanguard.go
+++ b/internal/webui/wlanguard.go
@@ -143,11 +143,19 @@ func (s *Server) StartWLANBootGuard(ctx context.Context, bootReason string) {
 	}
 
 	cur, assoc := waitAssociationSettled(ctx, iface, wlanGuardSettleBudget)
+	reinited := false
 	if !assoc {
 		if s.recoverUnassociatedRadio(iface) {
+			reinited = true
 			cur, assoc = waitAssociationSettled(ctx, iface, wlanReinitRecheckBudget)
 		}
 	}
+
+	// One line per boot so a bundle shows the guard ran and what it found, even
+	// on the common no-target box where the correction below never fires (#853).
+	s.logger.Info("wlan guard: boot association check",
+		"iface", iface, "assoc", assoc, "gotTag", ssidTag(cur),
+		"hasTarget", hasTarget, "radioReinit", reinited)
 
 	// Everything below is about network SELECTION, which only makes sense with a
 	// target the user chose.

--- a/internal/webui/wlanguard.go
+++ b/internal/webui/wlanguard.go
@@ -22,6 +22,7 @@ package webui
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strconv"
@@ -40,6 +41,10 @@ const (
 	// never associates at all, which is the stand-down case anyway.
 	wlanGuardSettleBudget = 150 * time.Second
 	wlanGuardPoll         = 5 * time.Second
+	// wlanReinitRecheckBudget is how long to wait for association AFTER a chip
+	// re-init, before giving up for this boot (#853). Shorter than the first
+	// settle wait: a chip that just came up clean associates in a few seconds.
+	wlanReinitRecheckBudget = 60 * time.Second
 	// wlanGuardAttempts bounds the correction. Three live switches is already
 	// generous: the runtime switch itself escalates internally (reconfigure,
 	// restart, add_network) before it reports failure.
@@ -119,17 +124,36 @@ func (s *Server) StartWLANBootGuard(ctx context.Context, bootReason string) {
 	if !strings.HasPrefix(bootReason, "box-boot") {
 		return
 	}
-	tgt, ok := readWlanTarget()
-	if !ok {
-		return
-	}
 	iface, mech := detectWlanMechanism()
+	tgt, hasTarget := readWlanTarget()
+
+	// A warm reboot does not power-cycle the TI wl18xx radio, so its firmware
+	// re-download (via the slow deprecated user-helper) can fail and the box
+	// comes up unassociated, blinking white, until the owner pulls the plug
+	// (#853, confirmed on rhino ST10 + Lifestyle; the software recovery was
+	// verified live on hardware 2026-09-05). Recovering a box that booted with
+	// NO association is a different job from moving one off the WRONG network,
+	// and it must run with or without a stored wlan target: a chip that never
+	// came up has no network to be on the wrong one of. So it comes first.
 	if mech != "wpa" {
-		s.wlanGuardWeakVerify(tgt, iface)
+		if hasTarget {
+			s.wlanGuardWeakVerify(tgt, iface)
+		}
 		return
 	}
 
 	cur, assoc := waitAssociationSettled(ctx, iface, wlanGuardSettleBudget)
+	if !assoc {
+		if s.recoverUnassociatedRadio(iface) {
+			cur, assoc = waitAssociationSettled(ctx, iface, wlanReinitRecheckBudget)
+		}
+	}
+
+	// Everything below is about network SELECTION, which only makes sense with a
+	// target the user chose.
+	if !hasTarget {
+		return
+	}
 	visible, surveyOK := s.targetInSurvey(ctx, tgt.SSID)
 	action, reason := guardDecision(assoc, cur, tgt.SSID, visible, tgt.BootsFailed)
 
@@ -310,6 +334,62 @@ func (s *Server) wlanGuardWeakVerify(tgt wlanTarget, iface string) {
 
 // waitAssociationSettled polls until wpa_supplicant reports an association or
 // the budget runs out, and returns the SSID it settled on.
+// wlcoreSDIODriver is the sysfs path of the TI wl18xx SDIO driver on the rhino
+// (sm2) chassis. Powering the chip down and up through its unbind/bind is the
+// software equivalent of a cold power-cycle: the wlcore_sdio probe re-toggles
+// the chip's enable line and re-downloads its firmware.
+const wlcoreSDIODriver = "/sys/bus/sdio/drivers/wl1271_sdio"
+
+// reinitWLANRadio power-cycles the Wi-Fi chip in software by unbinding and
+// rebinding its SDIO device (#853). Returns true if it acted. A no-op on any
+// chassis that does not expose this driver, so it is safe to call blindly. Bound
+// devices look like "mmc0:0001:2"; there is normally exactly one.
+func reinitWLANRadio(logger *slog.Logger) bool {
+	ents, err := os.ReadDir(wlcoreSDIODriver)
+	if err != nil {
+		return false // not this chassis / driver not present
+	}
+	var devs []string
+	for _, e := range ents {
+		n := e.Name()
+		if strings.HasPrefix(n, "mmc") && strings.Count(n, ":") == 2 {
+			devs = append(devs, n)
+		}
+	}
+	if len(devs) == 0 {
+		return false
+	}
+	acted := false
+	for _, d := range devs {
+		if err := os.WriteFile(wlcoreSDIODriver+"/unbind", []byte(d), 0o200); err != nil {
+			logger.Warn("wlan reinit: unbind failed", "dev", d, "err", err)
+			continue
+		}
+		time.Sleep(3 * time.Second) // let the chip fully power down
+		if err := os.WriteFile(wlcoreSDIODriver+"/bind", []byte(d), 0o200); err != nil {
+			logger.Warn("wlan reinit: rebind failed after unbind", "dev", d, "err", err)
+			continue
+		}
+		logger.Info("wlan reinit: power-cycled the Wi-Fi chip via SDIO unbind/rebind", "dev", d)
+		acted = true
+	}
+	return acted
+}
+
+// recoverUnassociatedRadio is the boot recovery for a box that came up with no
+// Wi-Fi association at all (#853): power-cycle the chip in software so it can
+// re-download its firmware and let wpa_supplicant re-associate from its existing
+// config. One-shot per boot, never touched on a healthy (already-associated)
+// boot, so a working box takes no radio churn.
+func (s *Server) recoverUnassociatedRadio(iface string) bool {
+	s.logger.Warn("wlan guard: box booted with no Wi-Fi association, power-cycling the radio to recover it (#853)", "iface", iface)
+	if !reinitWLANRadio(s.logger) {
+		s.logger.Info("wlan guard: no software radio power-cycle available on this chassis; leaving recovery to the boot watchdog", "iface", iface)
+		return false
+	}
+	return true
+}
+
 func waitAssociationSettled(ctx context.Context, iface string, budget time.Duration) (ssid string, associated bool) {
 	deadline := time.Now().Add(budget)
 	for {


### PR DESCRIPTION
Jens' update-safety mandate: Wi-Fi lost after every update must stop happening, and boxes must never boot-loop.

## Wi-Fi lost after update (#853) — root cause found, fix validated live on hardware
A warm/soft reboot (which an STR update ends with) does NOT power-cycle the TI wl18xx radio, so its firmware re-download over the slow deprecated user-helper can fail and the speaker comes up unassociated (fast-blink white) until the owner pulls the plug. Bose's own firmware update never needed a cold boot — the tell that the chip can be re-inited in software.

**Confirmed live on a rhino ST10 (.58) 2026-09-05:** unbinding + rebinding the wl18xx SDIO device (`wl1271_sdio`, `mmc0:0001:2`) re-toggles the chip enable line, re-downloads the firmware, and wpa_supplicant re-associates on its own — no power-cycle.

The boot guard used to stand down on an unassociated box and only run when a wlan target was set, so there was no recovery for a chip that never came up. It now, on every wpa/rhino box boot (an OTA reboot counts — bootReason is box-boot when kernel uptime < 600s), power-cycles the radio in software if wlan0 is still unassociated after the settle window, then re-checks — regardless of any target. Only ever acts when unassociated, so a **healthy boot takes no radio churn (verified on .58: healthy boot, guard left the radio alone)**; a no-op on chassis without this driver. Per-boot forensic log added so a bundle shows the guard's verdict.

Note (bardeen/Lifestyle, Gerhard's field case): same warm-reboot association loss, aggravated by accumulated wpa_supplicant blocks — the single-block rewrite for that chassis is a planned follow-up.

## Boot-loop safety (#302)
STR's OTA can't loop the box (reboot only after sha256 flash-verify), but a mis-built hard-float/wrong-arch embed could SIGILL-loop the agent. Added a float-ABI + arch gate at the OTA write path (agent + engine sidecar); real GOARM=5 builds pass, a build slip cannot flash. Unit-tested.

Builds host + ARM, webui tests + golangci clean. Validated on Jens' .58 (now running this build, self-heals Wi-Fi, engine restored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)