### PR TITLE
chore(relnotes): golangci-lint on main is green again

### DIFF
--- a/cmd/relnotes/main.go
+++ b/cmd/relnotes/main.go
@@ -396,7 +396,7 @@ func significantWords(s string) map[string]bool {
 		"longer": true, "instead": true, "there": true, "that": true, "this": true, "as": true, "at": true, "by": true}
 	out := map[string]bool{}
 	for _, w := range strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
-		return !(r >= 'a' && r <= 'z' || r >= '0' && r <= '9')
+		return (r < 'a' || r > 'z') && (r < '0' || r > '9')
 	}) {
 		if !stop[w] {
 			out[w] = true


### PR DESCRIPTION
Every PR opened today fails the golangci-lint job on a pre-existing staticcheck QF1001 in cmd/relnotes/main.go (the commit a95de4fe on main). One-line rewrite, behaviour unchanged, relnotes tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrDLQwFNah3qLAHWK5ELGM