### PR TITLE
fix(app): a fresh install no longer triggers the "Spotify component still missing" reminder from an earlier update

### DIFF
--- a/desktop-app/boxbusy.go
+++ b/desktop-app/boxbusy.go
@@ -34,6 +34,14 @@ var writesInFlight = boxBusy{busy: map[string]string{}}
 
 // claim marks the speaker as being written to. The release function must be
 // called when the work finishes; it is a no-op if the claim failed.
+// isBusy reports whether an install or update currently holds host.
+func (b *boxBusy) isBusy(host string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	_, ok := b.busy[host]
+	return ok
+}
+
 func (b *boxBusy) claim(host, what string) (release func(), err error) {
 	if host == "" {
 		return func() {}, nil

--- a/desktop-app/install_str.go
+++ b/desktop-app/install_str.go
@@ -136,6 +136,10 @@ func (a *App) installSTROnBox(host, model string) (InstallResult, error) {
 	// again: lift the "being removed" mark so the post-install engine delivery
 	// is not skipped (see App.uninstalling).
 	a.uninstalling.Delete(host)
+	// A fresh install supersedes any unfinished-update memo for this speaker:
+	// the install delivers the engine itself, and a stale memo from an
+	// earlier update would otherwise nag right after it (Discussion #871).
+	a.ClearUpdateIntent(host, 0)
 	a.installStart = time.Now()
 	a.installPhase = ""
 	defer func() { a.installPhase = ""; a.installMargeHits = nil }()

--- a/desktop-app/updateintent.go
+++ b/desktop-app/updateintent.go
@@ -221,6 +221,14 @@ func (a *App) ClearUpdateIntent(host string, port int) {
 // frontend supervisor. Returns an empty action when there is nothing to do, so
 // the common case costs one file read and no speaker traffic.
 func (a *App) PendingUpdateIntent(host string, port int) map[string]string {
+	// An install or update is writing to this speaker right now: whatever the
+	// memo says is being dealt with by that run, and judging the speaker
+	// mid-run produced "the Spotify component from the last update is still
+	// missing, run the update once more" during a reinstall, eight seconds
+	// before that very install delivered the engine (Discussion #871).
+	if otaRunning.Load() || writesInFlight.isBusy(host) {
+		return map[string]string{"action": "", "reason": "install or update running"}
+	}
 	intentMu.Lock()
 	path, err := updateIntentPath()
 	var list []updateIntent

--- a/desktop-app/updateintent_quiet_test.go
+++ b/desktop-app/updateintent_quiet_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"log/slog"
+	"testing"
+)
+
+// TestPendingIntentIsQuietWhileASpeakerIsBeingWritten: the unfinished-update
+// reminder must not judge a speaker mid-install or mid-update.
+func TestPendingIntentIsQuietWhileASpeakerIsBeingWritten(t *testing.T) {
+	a := &App{logger: slog.Default()}
+	otaRunning.Store(true)
+	defer otaRunning.Store(false)
+	if got := a.PendingUpdateIntent("192.0.2.60", 8888); got["action"] != "" || got["reason"] == "" {
+		t.Fatalf("got %v", got)
+	}
+	otaRunning.Store(false)
+	release, err := writesInFlight.claim("192.0.2.61", "an install")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	if !writesInFlight.isBusy("192.0.2.61") || writesInFlight.isBusy("192.0.2.62") {
+		t.Fatal("isBusy must follow the claim")
+	}
+	if got := a.PendingUpdateIntent("192.0.2.61", 8888); got["action"] != "" {
+		t.Fatalf("busy host: got %v", got)
+	}
+}


### PR DESCRIPTION
Discussion #871: after removing and reinstalling STR, the app toasted "Bose 1 runs the new version, but the Spotify component from the last update is still missing, run the update once more" although the install itself delivered the engine eight seconds later (bundle: install OK 15:47:48, engine delivered 15:47:56). The memo came from the 14:27 update that had deferred the engine; nothing cleared it.

- An install clears the unfinished-update memo for that speaker when it starts.
- The reminder stays quiet while an install or update is writing to a speaker (global OTA flag or the per-host write claim).
- Test: TestPendingIntentIsQuietWhileASpeakerIsBeingWritten.

PR #870 additionally purges the memo on removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrDLQwFNah3qLAHWK5ELGM