### PR TITLE
fix(agent): creating a group with a sleeping main speaker no longer starts its last station in every room

### DIFF
--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -691,61 +691,77 @@ func (s *Server) handleBoxWake(w http.ResponseWriter, r *http.Request) {
 	// firmware resumed, answer. The level comes back the moment the speaker
 	// joins a zone (NoteBoxZoneState) or after a bounded wait.
 	quiet := r.URL.Query().Get("quiet") == "1"
-	var prevVol = -1
-	var muteDone chan struct{}
+	var err error
 	if quiet {
-		if v, err := boxapi.New(s.boxHost).GetVolume(ctx); err == nil {
-			prevVol = v.Actual
-		}
-		// The mute has to land AFTER the power-on, not before it: a level
-		// written while the speaker sleeps is accepted by its API and then
-		// overwritten by the firmware's own remembered level the moment it
-		// powers on (measured 2026-09-06: set to 0 in standby, woke at 30).
-		// So a watcher polls for the first sign of life and mutes right then,
-		// a few hundred milliseconds into the resume instead of seconds.
-		muteDone = make(chan struct{})
-		go func() {
-			defer close(muteDone)
-			c := boxapi.New(s.boxHost)
-			for ctx.Err() == nil {
-				if np := fetchNowPlaying(ctx, s.boxHost); np.Source != "" && np.Source != "STANDBY" {
-					_ = c.SetVolume(ctx, 0)
-					return
-				}
-				select {
-				case <-ctx.Done():
-					return
-				case <-time.After(150 * time.Millisecond):
-				}
+		err = s.quietWake(ctx)
+	} else {
+		err = boxcli.WakeAndWait(ctx, s.boxHost, 8*time.Second, s.logger)
+	}
+	if err != nil {
+		http.Error(w, "wake failed: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"awake": true})
+}
+
+// quietWake wakes the speaker for a group operation, not for listening to
+// it: the firmware's power-on resumes the speaker's own last station at its
+// own level, so the speaker is muted the moment it shows life, whatever the
+// firmware resumed is stopped, and the level comes back when it joins a zone
+// or after a bounded wait (armQuietWakeRestore). Used by the app's group-join
+// wake (/api/box/wake?quiet=1) and by the zone form for a sleeping master,
+// which otherwise started its last station in every room the moment the
+// group was created (Jens, 2026-09-06).
+func (s *Server) quietWake(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+	var prevVol = -1
+	if v, err := boxapi.New(s.boxHost).GetVolume(ctx); err == nil {
+		prevVol = v.Actual
+	}
+	// The mute has to land AFTER the power-on, not before it: a level
+	// written while the speaker sleeps is accepted by its API and then
+	// overwritten by the firmware's own remembered level the moment it
+	// powers on (measured 2026-09-06: set to 0 in standby, woke at 30).
+	// So a watcher polls for the first sign of life and mutes right then,
+	// a few hundred milliseconds into the resume instead of seconds.
+	muteDone := make(chan struct{})
+	go func() {
+		defer close(muteDone)
+		c := boxapi.New(s.boxHost)
+		for ctx.Err() == nil {
+			if np := fetchNowPlaying(ctx, s.boxHost); np.Source != "" && np.Source != "STANDBY" {
+				_ = c.SetVolume(ctx, 0)
+				return
 			}
-		}()
-	}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(150 * time.Millisecond):
+			}
+		}
+	}()
 	err := boxcli.WakeAndWait(ctx, s.boxHost, 8*time.Second, s.logger)
-	if muteDone != nil {
-		<-muteDone
-	}
+	<-muteDone
 	if err != nil {
 		if prevVol >= 0 {
 			_ = boxapi.New(s.boxHost).SetVolume(ctx, prevVol)
 		}
-		http.Error(w, "wake failed: "+err.Error(), http.StatusBadGateway)
-		return
+		return err
 	}
-	if quiet {
-		// Belt and braces: the watcher may have raced the firmware's level
-		// restore, so the mute is written once more now that the box is up.
-		_ = boxapi.New(s.boxHost).SetVolume(ctx, 0)
-		// Whatever the firmware resumed on power-on is stopped, so the zone
-		// join meets an idle speaker instead of a station still spinning up.
-		if np := fetchNowPlaying(ctx, s.boxHost); np.PlayStatus != "" && np.PlayStatus != "STOP_STATE" && np.Source != "STANDBY" {
-			_ = boxapi.New(s.boxHost).Key(ctx, "STOP")
-		}
-		if prevVol >= 0 {
-			s.armQuietWakeRestore(prevVol)
-		}
-		s.logger.Info("wake: quiet wake for a group join", "mutedFrom", prevVol)
+	// Belt and braces: the watcher may have raced the firmware's level
+	// restore, so the mute is written once more now that the box is up.
+	_ = boxapi.New(s.boxHost).SetVolume(ctx, 0)
+	// Whatever the firmware resumed on power-on is stopped, so the zone
+	// join meets an idle speaker instead of a station still spinning up.
+	if np := fetchNowPlaying(ctx, s.boxHost); np.PlayStatus != "" && np.PlayStatus != "STOP_STATE" && np.Source != "STANDBY" {
+		_ = boxapi.New(s.boxHost).Key(ctx, "STOP")
 	}
-	writeJSON(w, http.StatusOK, map[string]bool{"awake": true})
+	if prevVol >= 0 {
+		s.armQuietWakeRestore(prevVol)
+	}
+	s.logger.Info("wake: quiet wake for a group operation", "mutedFrom", prevVol)
+	return nil
 }
 
 // quietWakeRestoreAfter bounds how long a member stays muted after a quiet

--- a/internal/webui/zones_stereo.go
+++ b/internal/webui/zones_stereo.go
@@ -621,6 +621,20 @@ func (s *Server) handleZoneForm(w http.ResponseWriter, r *http.Request) {
 	// which is what the field log showed: two reads of /now_playing timed out,
 	// the wake had no source to report, and everything after that was doomed.
 	// So the wake failing is only the prompt to ask one cheap question.
+	// A master asleep at form time is woken QUIETLY: the plain wake let the
+	// firmware resume the master's last station and the fresh zone carried
+	// it into every room, so "create a group" meant "start playing" (Jens,
+	// 2026-09-06, after #805 had fixed the same for permanent groups on the
+	// app side). The quiet wake mutes, stops the resumed station and gives
+	// the level back on the join; the group then forms silent and plays
+	// what the user starts next.
+	if np := fetchNowPlaying(ctx, s.boxHost); np.Source == "STANDBY" {
+		if err := s.quietWake(ctx); err != nil {
+			s.logger.Warn("zone: quiet wake of the sleeping master failed, trying the plain wake", "err", err)
+		} else {
+			s.logger.Info("zone: woke the sleeping master quietly so forming the group does not start its last station")
+		}
+	}
 	if err := s.ensureBoxReadyErr(ctx); err != nil {
 		perr := s.speakerStaysSilent(ctx, c)
 		if perr != nil {


### PR DESCRIPTION
Forming a native zone wakes the main speaker; the plain wake let the firmware resume its last station and the new zone distributed it, so creating a group started playback (reported live 2026-09-06, normal group; #805 covered the permanent-group path on the app side). The zone form now uses the quiet wake the group-join endpoint already had (mute on first sign of life, stop the resumed station, restore the level on the join), extracted into `quietWake` and shared by both.

Not yet verified on hardware; to test: main speaker in standby, create a group from the app, expect silence until you press play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrDLQwFNah3qLAHWK5ELGM