### PR TITLE
fix(agent): standby poll storm in the preset self-heal, and followers the firmware dropped keep playing

### DIFF
--- a/cmd/agent/reconcile.go
+++ b/cmd/agent/reconcile.go
@@ -150,6 +150,34 @@ func deferPresetResyncForStandby(logger *slog.Logger, src string) {
 		"asker", asker)
 }
 
+// retryHoldVerdict is what the steady-state retry gate decides for a box
+// that reads STANDBY (or nothing at all).
+type retryHoldVerdict int
+
+const (
+	// retryHoldDefer holds the pass: nothing is written, a pending ask is
+	// consumed through the standby deferral, the loop sleeps a full tick.
+	retryHoldDefer retryHoldVerdict = iota
+	// retryHoldRunAsk lets the pass run despite the reading, because a
+	// pending ask carries user-present evidence (repeated dead-key presses).
+	retryHoldRunAsk
+)
+
+// retryHoldDecision is the retry gate's verdict for a STANDBY/unreadable
+// reading, kept pure so the spin fixed on 2026-09-07 stays testable: a
+// pending ask on a sleeping box is DEFERRED (consumed), never left armed for
+// the wait loop to trip over, and only a standby-OK ask runs.
+func retryHoldDecision(src string, askPending, standbyOK bool) retryHoldVerdict {
+	if src != "STANDBY" && src != "" {
+		// Not a hold at all; callers only ask for the two readings above.
+		return retryHoldRunAsk
+	}
+	if askPending && standbyOK {
+		return retryHoldRunAsk
+	}
+	return retryHoldDefer
+}
+
 // proxyStreamURL returns the stable loopback URL for a preset. The Bose
 // UPnP player opens it — the stream proxy in the stick agent resolves the
 // real station redirect behind it and reconnects on token expiry without
@@ -268,9 +296,14 @@ func periodicPresetReconcile(store *presets.Store, boxHost string, logger *slog.
 	// ceiling to the first hold, not to the latest retry.
 	forceHeld := false
 	var forceHeldSince time.Time
+	// retryHoldLogged keeps the "retry pass held" line to ONE per hold
+	// episode: the hold is re-evaluated every maintenance tick for as long as
+	// the box sleeps, and a line per tick is noise in the NAND log.
+	retryHoldLogged := false
 	for {
 		force := !fullDone || forceHeld
 		retryDeferred := false
+		retryHeldSrc := ""
 		if force && everFullDone {
 			// A steady-state retry force (failed AddPresets, a transient
 			// /presets read error) is NOT the boot window: gate it like any
@@ -282,9 +315,25 @@ func periodicPresetReconcile(store *presets.Store, boxHost string, logger *slog.
 			// STANDBY before the first press, and gating it would regress the
 			// first-press-after-reboot registration (#4).
 			if src := boxNowPlayingSource(boxHost); src == "STANDBY" || src == "" {
-				retryDeferred = true
-				logger.Info("preset reconcile: retry pass held, box in standby or unreadable; resuming on wake or the next maintenance tick")
+				switch retryHoldDecision(src, presetResyncAsk.Load(), presetResyncStandbyOK.Load()) {
+				case retryHoldRunAsk:
+					// User-present evidence (repeated dead-key presses): the
+					// pending ask runs despite the STANDBY reading, exactly as
+					// the routine path below grants it.
+					presetResyncStandbyOK.Store(false)
+					presetResyncAsk.Store(false)
+				default:
+					retryDeferred = true
+					retryHeldSrc = src
+					if !retryHoldLogged {
+						logger.Info("preset reconcile: retry pass held, box in standby or unreadable; resuming on wake or the next maintenance tick")
+						retryHoldLogged = true
+					}
+				}
 			}
+		}
+		if !retryDeferred {
+			retryHoldLogged = false
 		}
 		if !retryDeferred && !force && presetResyncAsk.CompareAndSwap(true, false) {
 			// Dead-key self-heal (#342): a hardware press produced no
@@ -366,9 +415,26 @@ func periodicPresetReconcile(store *presets.Store, boxHost string, logger *slog.
 		}
 		if retryDeferred {
 			// Held pass: no reconcile at all this round (the missing-only
-			// heal would write the same failed slots right back). Maintenance
-			// cadence, but wake early on a fresh ask (= the box woke up).
-			for waited := time.Duration(0); waited < 5*time.Minute && !presetResyncAsk.Load(); waited += 10 * time.Second {
+			// heal would write the same failed slots right back).
+			//
+			// A pending ask cannot run into the sleeping box either, so it is
+			// consumed through the standby deferral (which resets the budgets
+			// so the wake re-asks) BEFORE the wait starts. Until 2026-09-07 the
+			// wait below exited at once on a pending ask this branch never
+			// consumed, and the loop spun: one /now_playing read per pass, some
+			// 25 a second, for as long as the box slept. A field bundle showed
+			// two ST10s in that state for hours, the firmware's syslog ring
+			// and the NAND agent log flooded (4 MB agent.log of one line). The
+			// wait therefore also has a floor of one tick no matter what: an
+			// asker that re-arms straight after the deferral (its budget was
+			// just reset) must not shorten it to zero.
+			if presetResyncAsk.CompareAndSwap(true, false) {
+				deferPresetResyncForStandby(logger, retryHeldSrc)
+			}
+			time.Sleep(10 * time.Second)
+			// Maintenance cadence, but wake early on a fresh ask (= the box
+			// woke up).
+			for waited := 10 * time.Second; waited < 5*time.Minute && !presetResyncAsk.Load(); waited += 10 * time.Second {
 				time.Sleep(10 * time.Second)
 			}
 			continue

--- a/cmd/agent/reconcile_retryhold_test.go
+++ b/cmd/agent/reconcile_retryhold_test.go
@@ -1,0 +1,30 @@
+package main
+
+import "testing"
+
+// The retry gate on a sleeping box: a pending ask is deferred, not left armed.
+// Leaving it armed is what made the maintenance wait exit immediately and the
+// loop spin at one /now_playing read per pass (field bundle 2026-09-07, two
+// ST10s at ~25 reads a second for hours).
+func TestRetryHoldDefersAPendingAskOnASleepingBox(t *testing.T) {
+	for _, src := range []string{"STANDBY", ""} {
+		if got := retryHoldDecision(src, true, false); got != retryHoldDefer {
+			t.Errorf("src=%q ask pending, no standby-OK: got %v, want defer", src, got)
+		}
+		if got := retryHoldDecision(src, false, false); got != retryHoldDefer {
+			t.Errorf("src=%q no ask: got %v, want defer", src, got)
+		}
+		// standby-OK without an ask has nothing to run.
+		if got := retryHoldDecision(src, false, true); got != retryHoldDefer {
+			t.Errorf("src=%q standby-OK but no ask: got %v, want defer", src, got)
+		}
+	}
+}
+
+// Repeated dead-key presses (the standby-OK grant) are user-present evidence,
+// so that one ask still runs against a STANDBY reading.
+func TestRetryHoldRunsAStandbyOKAsk(t *testing.T) {
+	if got := retryHoldDecision("STANDBY", true, true); got != retryHoldRunAsk {
+		t.Errorf("got %v, want run", got)
+	}
+}

--- a/internal/webui/dissolvestragglers.go
+++ b/internal/webui/dissolvestragglers.go
@@ -24,6 +24,7 @@ package webui
 
 import (
 	"context"
+	"net"
 	"time"
 
 	"github.com/JRpersonal/streborn/internal/boxapi"
@@ -39,21 +40,34 @@ const stragglerStopBudget = 8 * time.Second
 // producing sound, and "" otherwise. A speaker that is idle, in standby or
 // unreadable is not a straggler and must not be touched.
 func playingLocation(ctx context.Context, host string) string {
-	return playingLocationFn(ctx, host)
+	return playingStateFn(ctx, host).Location
 }
+
+// playingState is what the straggler sweep knows about a former member: the
+// source and location it reports while it is actually producing sound. Both
+// empty means idle, in standby or unreadable.
+type playingState struct {
+	Source   string
+	Location string
+}
+
+// groupSlaveSource is the source a speaker reports while it follows a zone
+// master. A former member that STILL says so after the zone is gone is, by its
+// own account, carrying the group's audio and nothing of its own.
+const groupSlaveSource = "GROUP_SLAVE"
 
 // Seams for the tests. Both calls below reach the firmware on a fixed port, so
 // a test server on a random port can never be reached through them: without
 // these, every case would silently take the "unreadable, leave it alone" path
 // and assert nothing at all. Production always uses the real implementations.
 var (
-	playingLocationFn = func(ctx context.Context, host string) string {
+	playingStateFn = func(ctx context.Context, host string) playingState {
 		np := fetchNowPlaying(ctx, host)
 		switch np.PlayStatus {
 		case "PLAY_STATE", "BUFFERING_STATE":
-			return np.Location
+			return playingState{Source: np.Source, Location: np.Location}
 		}
-		return ""
+		return playingState{}
 	}
 	stopKeyFn = func(ctx context.Context, host string) error {
 		return boxapi.New(host).Key(ctx, "STOP")
@@ -77,25 +91,47 @@ var (
 //     playing). Comparing host:port is exactly the test slaveMirrorAction already
 //     uses to recognise a slave on the master's stream.
 //
-// Both references empty disables the sweep: without something to compare against,
-// stopping speakers on a guess is not worth the risk. Anything matching neither
-// shape moved on to something of its own and is deliberately left alone.
+// Two more shapes, both from a field bundle of 2026-09-07 (three speakers
+// playing a music library, the firmware dropped the two followers out of the
+// zone by itself, and both played on in their rooms while every app showed
+// them in standby):
+//
+//   - same server: the master plays a music-library TRACK, and its location
+//     moves on to the next track every few minutes. A follower that dropped out
+//     keeps the track it had, so the exact compare fails although it is
+//     audibly still on the group's programme. A follower whose location sits on
+//     the same host:port as the master's (the media server) is therefore a
+//     straggler too. Loopback hosts are excluded from this rule on purpose: a
+//     member on 127.0.0.1:8888 plays its OWN proxy, and equality already covers
+//     a zone slave mirroring the master's loopback item.
+//   - still a slave: a member that reports the GROUP_SLAVE source has, by its
+//     own account, nothing of its own playing. Whatever its location says, it
+//     is carrying the group's audio.
+//
+// The master location empty AND no mirror proxy disables the sweep: without
+// something to compare against, stopping speakers on a guess is not worth the
+// risk. Anything matching none of the shapes moved on to something of its own
+// and is deliberately left alone.
 func (s *Server) stopStragglers(ctx context.Context, masterLocation, mirrorHostPort string, members []boxapi.ZoneMember) {
 	if (masterLocation == "" && mirrorHostPort == "") || len(members) == 0 {
 		return
 	}
+	serverHostPort := groupServerHostPort(masterLocation)
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), stragglerStopBudget)
 	defer cancel()
 	for _, m := range members {
 		if m.IP == "" || m.IP == s.boxHost {
 			continue // no address, or ourselves: the master keeps playing
 		}
-		loc := playingLocation(ctx, m.IP)
-		if loc == "" {
+		st := playingStateFn(ctx, m.IP)
+		loc := st.Location
+		if loc == "" && st.Source != groupSlaveSource {
 			continue // idle or unreadable: nothing to stop
 		}
 		onGroupStream := (masterLocation != "" && loc == masterLocation) ||
-			(mirrorHostPort != "" && hostPortOf(loc) == mirrorHostPort)
+			(mirrorHostPort != "" && hostPortOf(loc) == mirrorHostPort) ||
+			(serverHostPort != "" && hostPortOf(loc) == serverHostPort) ||
+			st.Source == groupSlaveSource
 		if !onGroupStream {
 			// It moved on to something of its own while the group ran. Leaving
 			// it alone is the whole point of comparing at all.
@@ -111,4 +147,26 @@ func (s *Server) stopStragglers(ctx context.Context, masterLocation, mirrorHostP
 		s.logger.Info("dissolve: stopped a member still carrying the group's stream",
 			"member", m.IP)
 	}
+}
+
+// groupServerHostPort is the host:port a group's programme comes from when the
+// master plays from a network server (a music library, a stream the members
+// pull themselves), or "" when the master's location is empty or on a loopback
+// host, where host:port equality would say nothing about the group.
+func groupServerHostPort(masterLocation string) string {
+	hp := hostPortOf(masterLocation)
+	if hp == "" {
+		return ""
+	}
+	host := hp
+	if h, _, err := net.SplitHostPort(hp); err == nil {
+		host = h
+	}
+	if host == "localhost" {
+		return ""
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		return ""
+	}
+	return hp
 }

--- a/internal/webui/dissolvestragglers_test.go
+++ b/internal/webui/dissolvestragglers_test.go
@@ -59,19 +59,19 @@ func (f *fakeSpeaker) stops() int {
 // through the "unreadable, leave it alone" branch and assert nothing.
 func withFakeFleet(t *testing.T, byHost map[string]*fakeSpeaker) {
 	t.Helper()
-	prevLoc := playingLocationFn
+	prevLoc := playingStateFn
 	prevStop := stopKeyFn
-	playingLocationFn = func(_ context.Context, host string) string {
+	playingStateFn = func(_ context.Context, host string) playingState {
 		f := byHost[host]
 		if f == nil {
-			return ""
+			return playingState{}
 		}
 		f.mu.Lock()
 		defer f.mu.Unlock()
 		if f.status != "PLAY_STATE" && f.status != "BUFFERING_STATE" {
-			return ""
+			return playingState{}
 		}
-		return f.location
+		return playingState{Source: f.source, Location: f.location}
 	}
 	stopKeyFn = func(_ context.Context, host string) error {
 		f := byHost[host]
@@ -83,7 +83,7 @@ func withFakeFleet(t *testing.T, byHost map[string]*fakeSpeaker) {
 		f.mu.Unlock()
 		return nil
 	}
-	t.Cleanup(func() { playingLocationFn, stopKeyFn = prevLoc, prevStop })
+	t.Cleanup(func() { playingStateFn, stopKeyFn = prevLoc, prevStop })
 }
 
 func newDissolveServer() *Server {
@@ -205,5 +205,74 @@ func TestMirrorSweepLeavesAForeignProxyAlone(t *testing.T) {
 
 	if got := other.stops(); got != 0 {
 		t.Errorf("a speaker on a foreign proxy was stopped %d time(s)", got)
+	}
+}
+
+// The 2026-09-07 bundle: the master plays a music library and has moved on to
+// the next track since the follower dropped out. The follower still plays the
+// earlier track from the SAME server, so it is on the group's programme and
+// must be stopped although the locations differ.
+func TestAFollowerOnTheSameMediaServerIsStopped(t *testing.T) {
+	const server = "http://192.0.2.17:10243/WMPNSSv4/3763749585/"
+	follower := newFakeSpeaker("STORED_MUSIC", "PLAY_STATE", server+"1_track-before.mp3")
+	defer follower.srv.Close()
+	withFakeFleet(t, map[string]*fakeSpeaker{"192.0.2.54": follower})
+
+	s := newDissolveServer()
+	s.stopStragglers(context.Background(), server+"1_track-now.mp3", "",
+		[]boxapi.ZoneMember{{DeviceID: "DEV-A", IP: "192.0.2.54"}})
+
+	if got := follower.stops(); got != 1 {
+		t.Errorf("stop keys sent = %d, want 1", got)
+	}
+}
+
+// A member on its OWN local proxy is not on the master's programme just
+// because the master's location is a loopback proxy URL as well: the
+// same-server rule never applies to loopback hosts.
+func TestAMemberOnItsOwnLoopbackProxyIsLeftAlone(t *testing.T) {
+	own := newFakeSpeaker("UPNP", "PLAY_STATE", "http://127.0.0.1:8888/stream/5")
+	defer own.srv.Close()
+	withFakeFleet(t, map[string]*fakeSpeaker{"192.0.2.54": own})
+
+	s := newDissolveServer()
+	s.stopStragglers(context.Background(), "http://127.0.0.1:8888/stream/2", "",
+		[]boxapi.ZoneMember{{DeviceID: "DEV-A", IP: "192.0.2.54"}})
+
+	if got := own.stops(); got != 0 {
+		t.Errorf("a member on its own proxy was stopped %d time(s)", got)
+	}
+}
+
+// A former member that still reports the GROUP_SLAVE source carries the
+// group's audio by its own account, whatever its location says.
+func TestAMemberStillReportingGroupSlaveIsStopped(t *testing.T) {
+	slave := newFakeSpeaker("GROUP_SLAVE", "PLAY_STATE", "")
+	defer slave.srv.Close()
+	withFakeFleet(t, map[string]*fakeSpeaker{"192.0.2.54": slave})
+
+	s := newDissolveServer()
+	s.stopStragglers(context.Background(), "http://192.0.2.17:10243/track.mp3", "",
+		[]boxapi.ZoneMember{{DeviceID: "DEV-A", IP: "192.0.2.54"}})
+
+	if got := slave.stops(); got != 1 {
+		t.Errorf("stop keys sent = %d, want 1", got)
+	}
+}
+
+func TestGroupServerHostPort(t *testing.T) {
+	cases := map[string]string{
+		"":                                 "",
+		"http://127.0.0.1:8888/stream/2":   "",
+		"http://localhost:8888/stream/2":   "",
+		"http://192.0.2.17:10243/a/b.mp3":  "192.0.2.17:10243",
+		"http://[::1]:8888/stream/2":       "",
+		"http://192.0.2.10:17008/stream/1": "192.0.2.10:17008",
+		"bt://phone":                       "phone",
+	}
+	for in, want := range cases {
+		if got := groupServerHostPort(in); got != want {
+			t.Errorf("groupServerHostPort(%q) = %q, want %q", in, got, want)
+		}
 	}
 }

--- a/internal/webui/dissolvesweep.go
+++ b/internal/webui/dissolvesweep.go
@@ -1,0 +1,123 @@
+package webui
+
+// A group can end without anybody pressing "dissolve": the master's firmware
+// drops followers that stop answering (a follower on a bad Wi-Fi minute) and
+// reports the zone gone. Nothing then tells those followers to stop, and a
+// follower that reconnects a moment later carries on with the programme it
+// had, alone in its room, while its own state says STANDBY to every app.
+//
+// A field bundle of 2026-09-07 shows exactly that on two ST10s: the master
+// (a music library) dropped them three times in fifteen minutes, both played
+// on, and the owner's report was "the speakers play although they are not
+// grouped; the app shows them in standby". The only sweep that existed ran on
+// the user's own dissolve, and by then the followers were on the track before
+// the master's and read as "playing something else".
+//
+// So a firmware dissolve schedules the same straggler sweep, delayed and
+// re-checked: the firmware also announces a dissolve on its way THROUGH a
+// group change (/setZone tears the old zone down first), and a sweep fired at
+// that moment would silence members the re-form is about to serve. Each pass
+// therefore waits, then runs only while the stored document is unchanged, the
+// firmware still reports no zone, and no form/dissolve drive holds the serial.
+
+import (
+	"context"
+	"time"
+
+	"github.com/JRpersonal/streborn/internal/boxapi"
+	"github.com/JRpersonal/streborn/internal/zones"
+)
+
+// firmwareDissolveSweepDelays are the waits before each sweep pass, measured
+// from the previous pass. The first pass sits well past the ~300 ms self-
+// dissolve of a fresh zone (#70) and a /setZone rebuild; the later passes
+// catch a follower that was unreachable (the very Wi-Fi drop that cost it the
+// zone) when the first pass looked.
+var firmwareDissolveSweepDelays = []time.Duration{20 * time.Second, 40 * time.Second, 2 * time.Minute}
+
+// Seams for the tests: the firmware zone read and the sleep.
+var (
+	firmwareZoneFn = func(ctx context.Context, host string) (boxapi.Zone, error) {
+		return boxapi.New(host).GetZone(ctx)
+	}
+	dissolveSweepSleep = time.Sleep
+)
+
+// scheduleStragglerSweepAfterFirmwareDissolve starts the delayed sweep for the
+// stored group z (already known to be a native multiroom document). The
+// master's location is captured NOW, while it still names the programme the
+// followers were given; by the time a pass runs the master may have moved on.
+func (s *Server) scheduleStragglerSweepAfterFirmwareDissolve(z zones.Zone) {
+	if len(z.Slaves) == 0 {
+		return
+	}
+	if !s.dissolveSweepBusy.CompareAndSwap(false, true) {
+		return // a sweep for this collapse is already pending
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	masterLocation := playingLocation(ctx, s.boxHost)
+	cancel()
+	go func() {
+		defer s.dissolveSweepBusy.Store(false)
+		s.runStragglerSweepAfterFirmwareDissolve(zoneDocFingerprint(z), masterLocation, z.Slaves)
+	}()
+}
+
+// runStragglerSweepAfterFirmwareDissolve is the pass loop. It returns after the
+// first pass that actually swept, or once the group is back or gone for good.
+func (s *Server) runStragglerSweepAfterFirmwareDissolve(fingerprint, masterLocation string, slaves []zones.Member) {
+	if masterLocation == "" {
+		s.logger.Info("zone: firmware dissolve, the master plays nothing to compare against, followers are left alone")
+		return
+	}
+	members := make([]boxapi.ZoneMember, 0, len(slaves))
+	for _, m := range slaves {
+		members = append(members, boxapi.ZoneMember{DeviceID: m.DeviceID, IP: m.IP, Role: m.Role})
+	}
+	for i, delay := range firmwareDissolveSweepDelays {
+		dissolveSweepSleep(delay)
+		if s.zones == nil {
+			return
+		}
+		z, ok := s.zones.Get()
+		if !ok {
+			// STR itself dissolved the group meanwhile; that path ran its
+			// own sweep.
+			return
+		}
+		if zoneDocFingerprint(z) != fingerprint {
+			// A different group was formed since; it takes care of itself.
+			return
+		}
+		if !s.zoneFormSerial.TryLock() {
+			// A form or dissolve drive is running right now: not the moment
+			// to touch members. The next pass looks again.
+			continue
+		}
+		swept := s.sweepIfFirmwareZoneStillGone(masterLocation, members, i)
+		s.zoneFormSerial.Unlock()
+		if swept {
+			return
+		}
+	}
+}
+
+// sweepIfFirmwareZoneStillGone reads the master's live zone and sweeps only when
+// the firmware still reports none. It reports whether a sweep ran.
+func (s *Server) sweepIfFirmwareZoneStillGone(masterLocation string, members []boxapi.ZoneMember, pass int) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), stragglerStopBudget)
+	defer cancel()
+	fz, err := firmwareZoneFn(ctx, s.boxHost)
+	if err != nil {
+		s.logger.Info("zone: firmware dissolve sweep skipped, the master's zone is unreadable", "pass", pass, "err", err)
+		return false
+	}
+	if fz.Master != "" && len(fz.Members) > 0 {
+		s.logger.Info("zone: the group is live again after the firmware's dissolve, no sweep", "pass", pass, "members", len(fz.Members))
+		return true
+	}
+	s.logger.Info("zone: the firmware dropped the group by itself, sweeping followers still carrying its programme",
+		"pass", pass, "followers", len(members))
+	s.stopStragglers(ctx, masterLocation, "", members)
+	return true
+}

--- a/internal/webui/dissolvesweep_test.go
+++ b/internal/webui/dissolvesweep_test.go
@@ -1,0 +1,168 @@
+package webui
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/JRpersonal/streborn/internal/boxapi"
+	"github.com/JRpersonal/streborn/internal/zones"
+)
+
+// withDissolveSweepSeams makes the sweep passes instant and lets a test decide
+// what the master's firmware zone reads on each pass.
+func withDissolveSweepSeams(t *testing.T, zoneReads []boxapi.Zone, zoneErr error) *[]time.Duration {
+	t.Helper()
+	prevZone, prevSleep := firmwareZoneFn, dissolveSweepSleep
+	var mu sync.Mutex
+	slept := &[]time.Duration{}
+	call := 0
+	firmwareZoneFn = func(_ context.Context, _ string) (boxapi.Zone, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if zoneErr != nil {
+			return boxapi.Zone{}, zoneErr
+		}
+		if call < len(zoneReads) {
+			z := zoneReads[call]
+			call++
+			return z, nil
+		}
+		return boxapi.Zone{}, nil
+	}
+	dissolveSweepSleep = func(d time.Duration) {
+		mu.Lock()
+		*slept = append(*slept, d)
+		mu.Unlock()
+	}
+	t.Cleanup(func() { firmwareZoneFn, dissolveSweepSleep = prevZone, prevSleep })
+	return slept
+}
+
+func newSweepServer(t *testing.T, z zones.Zone) *Server {
+	t.Helper()
+	st, err := zones.Load(filepath.Join(t.TempDir(), "zones.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Set(z); err != nil {
+		t.Fatal(err)
+	}
+	return &Server{logger: slog.New(slog.NewTextHandler(io.Discard, nil)), boxHost: "192.0.2.10", zones: st}
+}
+
+var sweepDoc = zones.Zone{Master: "DEV-M", MasterIP: "192.0.2.10", Slaves: []zones.Member{{DeviceID: "DEV-A", IP: "192.0.2.54"}}}
+
+// The reported case: the firmware dropped the follower, the master moved on to
+// the next track, the follower still plays the earlier track from the same
+// server. After the delay, with the zone still gone, it is stopped.
+func TestFirmwareDissolveSweepStopsAFollowerStillOnTheProgramme(t *testing.T) {
+	const server = "http://192.0.2.17:10243/lib/"
+	follower := newFakeSpeaker("STORED_MUSIC", "PLAY_STATE", server+"track-1.mp3")
+	defer follower.srv.Close()
+	withFakeFleet(t, map[string]*fakeSpeaker{"192.0.2.54": follower})
+	withDissolveSweepSeams(t, nil, nil) // every read: no zone
+
+	s := newSweepServer(t, sweepDoc)
+	s.runStragglerSweepAfterFirmwareDissolve(zoneDocFingerprint(sweepDoc), server+"track-2.mp3", sweepDoc.Slaves)
+
+	if got := follower.stops(); got != 1 {
+		t.Errorf("stop keys sent = %d, want 1", got)
+	}
+}
+
+// The firmware also announces a dissolve on its way through a /setZone rebuild.
+// When the pass finds the zone live again, nothing is touched.
+func TestFirmwareDissolveSweepStandsDownWhenTheZoneIsBack(t *testing.T) {
+	const server = "http://192.0.2.17:10243/lib/"
+	follower := newFakeSpeaker("STORED_MUSIC", "PLAY_STATE", server+"track-1.mp3")
+	defer follower.srv.Close()
+	withFakeFleet(t, map[string]*fakeSpeaker{"192.0.2.54": follower})
+	withDissolveSweepSeams(t, []boxapi.Zone{{Master: "DEV-M", Members: []boxapi.ZoneMember{{DeviceID: "DEV-A", IP: "192.0.2.54"}}}}, nil)
+
+	s := newSweepServer(t, sweepDoc)
+	s.runStragglerSweepAfterFirmwareDissolve(zoneDocFingerprint(sweepDoc), server+"track-2.mp3", sweepDoc.Slaves)
+
+	if got := follower.stops(); got != 0 {
+		t.Errorf("a member of a live zone was stopped %d time(s)", got)
+	}
+}
+
+// A follower unreachable on the first pass (the Wi-Fi drop that cost it the
+// zone) is caught by a later pass once it answers again.
+func TestFirmwareDissolveSweepRetriesAnUnreachableFollower(t *testing.T) {
+	const server = "http://192.0.2.17:10243/lib/"
+	follower := newFakeSpeaker("STORED_MUSIC", "PLAY_STATE", server+"track-1.mp3")
+	defer follower.srv.Close()
+	fleet := map[string]*fakeSpeaker{}
+	withFakeFleet(t, fleet) // empty fleet: nobody answers yet
+	slept := withDissolveSweepSeams(t, nil, nil)
+	// The follower "comes back" after the first sleep.
+	prev := dissolveSweepSleep
+	dissolveSweepSleep = func(d time.Duration) {
+		prev(d)
+		fleet["192.0.2.54"] = follower
+	}
+
+	s := newSweepServer(t, sweepDoc)
+	s.runStragglerSweepAfterFirmwareDissolve(zoneDocFingerprint(sweepDoc), server+"track-2.mp3", sweepDoc.Slaves)
+
+	if got := follower.stops(); got != 1 {
+		t.Errorf("stop keys sent = %d, want 1", got)
+	}
+	if len(*slept) < 1 {
+		t.Errorf("expected at least one delayed pass, slept %v", *slept)
+	}
+}
+
+// A different group formed meanwhile takes care of itself; the old sweep stands down.
+func TestFirmwareDissolveSweepStandsDownForANewGroup(t *testing.T) {
+	const server = "http://192.0.2.17:10243/lib/"
+	follower := newFakeSpeaker("STORED_MUSIC", "PLAY_STATE", server+"track-1.mp3")
+	defer follower.srv.Close()
+	withFakeFleet(t, map[string]*fakeSpeaker{"192.0.2.54": follower})
+	withDissolveSweepSeams(t, nil, nil)
+
+	s := newSweepServer(t, sweepDoc)
+	other := sweepDoc
+	other.Slaves = []zones.Member{{DeviceID: "DEV-B", IP: "192.0.2.55"}}
+	if err := s.zones.Set(other); err != nil {
+		t.Fatal(err)
+	}
+	s.runStragglerSweepAfterFirmwareDissolve(zoneDocFingerprint(sweepDoc), server+"track-2.mp3", sweepDoc.Slaves)
+
+	if got := follower.stops(); got != 0 {
+		t.Errorf("a member outside the current group was stopped %d time(s)", got)
+	}
+}
+
+// An unreadable master zone is not "gone": no pass sweeps on it.
+func TestFirmwareDissolveSweepSkipsWhenTheZoneIsUnreadable(t *testing.T) {
+	const server = "http://192.0.2.17:10243/lib/"
+	follower := newFakeSpeaker("STORED_MUSIC", "PLAY_STATE", server+"track-1.mp3")
+	defer follower.srv.Close()
+	withFakeFleet(t, map[string]*fakeSpeaker{"192.0.2.54": follower})
+	withDissolveSweepSeams(t, nil, errors.New("timeout"))
+
+	s := newSweepServer(t, sweepDoc)
+	s.runStragglerSweepAfterFirmwareDissolve(zoneDocFingerprint(sweepDoc), server+"track-2.mp3", sweepDoc.Slaves)
+
+	if got := follower.stops(); got != 0 {
+		t.Errorf("a follower was stopped %d time(s) on an unreadable zone", got)
+	}
+}
+
+// Repeated dissolve frames for one collapse schedule one sweep.
+func TestFirmwareDissolveScheduleIsIdempotentWhileBusy(t *testing.T) {
+	s := newSweepServer(t, sweepDoc)
+	s.dissolveSweepBusy.Store(true)
+	s.scheduleStragglerSweepAfterFirmwareDissolve(sweepDoc) // must return at once, no goroutine
+	if !s.dissolveSweepBusy.Load() {
+		t.Error("busy flag was cleared by a rejected schedule")
+	}
+}

--- a/internal/webui/resume_standby.go
+++ b/internal/webui/resume_standby.go
@@ -852,6 +852,7 @@ func (s *Server) NoteBoxZoneState(master string) {
 	s.noteZoneDocDoubt()
 	s.logger.Info("zone: the speaker reported its zone dissolved while a group document is still stored",
 		"master", z.Master, "slaves", len(z.Slaves))
+	s.scheduleStragglerSweepAfterFirmwareDissolve(z)
 }
 
 // resumeOnPowerOnEnabled reports whether "resume the last station on power-on"

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -73,6 +73,10 @@ type Server struct {
 	// wrong verdict across a restart. Only the resulting clear reaches NAND.
 	zoneDocDoubt   string
 	zoneDocDoubtMu sync.Mutex
+	// dissolveSweepBusy marks a straggler sweep scheduled by a firmware
+	// zone-dissolve frame (dissolvesweep.go) so repeated frames for the same
+	// collapse schedule one sweep, not one per frame.
+	dissolveSweepBusy atomic.Bool
 	// memberIDs remembers, per member IP, the SoundTouch deviceID that
 	// speaker's own firmware reported. Zone forming corrects the caller's
 	// deviceID from a live /info read, because a two-chip chassis announces


### PR DESCRIPTION
Two agent fixes from a field bundle of 2026-09-07 (three speakers grouped on a music library; after the update the two followers "play although they are not grouped, the app shows them in standby").

**1. Preset self-heal spun on a sleeping box.** The steady-state retry gate held its pass while the box read STANDBY but never consumed the pending re-sync ask, and the maintenance wait exits early on a pending ask. Result: one `/now_playing` read per pass, about 25 a second, for as long as the box slept. Both ST10s in the bundle were in that state: the firmware HSM log flooded with source reads, the NAND `agent.log` at 4 MB of one repeated line, the syslog rings useless. The held pass now consumes the ask through the standby deferral, sleeps a full tick regardless, and logs the hold once per episode. Pure decision helper + tests.

**2. Followers the firmware dropped out of a zone played on alone.** The straggler sweep only ran on the user's own dissolve, and compared exact locations; with a music library the master had moved on to the next track, so the followers on the earlier track were "playing something else" and left alone. Now: same host:port as the master's programme (loopback excluded) and a member still reporting `GROUP_SLAVE` both count as carrying the group's audio; and a firmware-announced dissolve schedules the same sweep, delayed and re-checked (20 s / 60 s / 3 min) so the dissolve the firmware emits on its way through a `/setZone` rebuild never silences members the rebuild is about to serve. Tests cover the stop, the stand-down when the zone is back, the retry for an unreachable follower, a replaced group, an unreadable zone, and idempotent scheduling.

Hardware verification on the fleet is pending; the spin fix is verified by the log cadence in the bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrDLQwFNah3qLAHWK5ELGM
