### PR TITLE
feat(app): the Multi-Room tab shows how many groups exist right now

### DIFF
--- a/desktop-app/frontend/src/groups.js
+++ b/desktop-app/frontend/src/groups.js
@@ -278,6 +278,7 @@ export async function fetchZoneLive(boxes, { maxAgeMs = 0, minBoxes = 1 } = {}, 
     try {
       const results = await Promise.allSettled(strBoxes.map(b => fetchZone(b.host, b.port)));
       state.zoneLive = mergeZoneLive(state.zoneLive, strBoxes, results);
+      notifyZoneLive();
     } catch { /* keep previous entries */ }
   })();
   try {
@@ -286,6 +287,32 @@ export async function fetchZoneLive(boxes, { maxAgeMs = 0, minBoxes = 1 } = {}, 
     _inFlight = null;
   }
   return true;
+}
+
+// ---- Zone change listeners ----
+//
+// UI that hangs off state.zoneLive OUTSIDE the two views (the group-count
+// badge on the Multi-Room tab) must follow EVERY refresh path: the music-tab
+// poll, the Multi-Room poll and the optimistic group edits. Rather than each
+// caller remembering to repaint it (the same drift that once left the
+// Multi-Room tab stale), the shared poll notifies registered listeners after
+// every completed round, and an optimistic edit calls notifyZoneLive itself.
+// No poll of its own, no timer.
+const _zoneListeners = new Set();
+
+// onZoneLive registers fn to run after each zoneLive change. Returns the
+// unsubscribe function.
+export function onZoneLive(fn) {
+  _zoneListeners.add(fn);
+  return () => _zoneListeners.delete(fn);
+}
+
+// notifyZoneLive runs every listener; one that throws must not break the poll
+// or starve the others.
+export function notifyZoneLive() {
+  for (const fn of _zoneListeners) {
+    try { fn(); } catch { /* a listener bug must not stop the poll */ }
+  }
 }
 
 // resetZoneLivePoll clears the poll's debounce/busy bookkeeping. Test-only.
@@ -546,4 +573,44 @@ export function storedPermanentGroupsOf(zoneLive, boxes) {
     out.push({ masterKey: up(b.deviceID), masterBox: b, members });
   });
   return out;
+}
+
+// groupCount returns how many groups currently shape playback across the
+// discovered speakers, for the count badge on the Multi-Room tab:
+//
+//   - every distinct LIVE multiroom zone: a master with at least one member,
+//     proven either by a discovered box that reports following it or by a
+//     row other than the master itself in the master's own member list, so a
+//     zone whose followers dropped out of discovery still counts once and a
+//     master whose members[] came back empty does not count at all;
+//   - plus every STORED permanent group that is not live right now. A live
+//     permanent group is one group, never two, so a stored entry whose master
+//     is already counted live is skipped.
+//
+// Stereo pairs are firmware groups, not zones: masterOf reads the zone field
+// only, so a pair never shows up here. Pure, so groups.test.js covers it.
+export function groupCount(zoneLive, boxes) {
+  const up = (s) => String(s || '').toUpperCase();
+  const strBoxes = (boxes || []).filter((b) => b && b.kind !== 'stock' && b.deviceID);
+  const live = new Set();
+  for (const b of strBoxes) {
+    const m = masterOf(b.deviceID, zoneLive);
+    if (!m || live.has(m)) continue;
+    if (m !== up(b.deviceID)) {
+      // A follower's self-report is proof the zone exists.
+      live.add(m);
+      continue;
+    }
+    const own = (zoneLive || {})[b.deviceID] || {};
+    const host = b.host || '';
+    const others = (own.members || []).filter((x) => {
+      const id = up(x && x.deviceID);
+      const ip = (x && x.ip) || '';
+      if (!id && !ip) return false;
+      return !((id && id === m) || (ip && ip === host));
+    });
+    if (others.length || followersOf(b.deviceID, zoneLive, strBoxes).length) live.add(m);
+  }
+  const stored = storedPermanentGroupsOf(zoneLive, strBoxes).filter((g) => !live.has(g.masterKey));
+  return live.size + stored.length;
 }

--- a/desktop-app/frontend/src/groups.test.js
+++ b/desktop-app/frontend/src/groups.test.js
@@ -5,6 +5,9 @@ import { state } from './state.js';
 import {
   zoneBoxes,
   storedPermanentGroupsOf,
+  groupCount,
+  onZoneLive,
+  notifyZoneLive,
   masterOf,
   isFollower,
   followersOf,
@@ -636,5 +639,91 @@ describe('storedPermanentGroupsOf', () => {
     const boxes = [{ deviceID: 'AAA', host: '10.0.0.1', kind: 'str' }];
     const zoneLive = { AAA: { master: 'AAA', members: [{ deviceID: 'BBB', ip: '10.0.0.2' }], permanent: true, remembered: [{ ip: '10.0.0.2' }] } };
     expect(storedPermanentGroupsOf(zoneLive, boxes)).toEqual([]);
+  });
+});
+
+describe('groupCount', () => {
+  const boxes = [master, boxA, boxB, stock];
+
+  it('is 0 with no zone data', () => {
+    expect(groupCount({}, boxes)).toBe(0);
+    expect(groupCount(undefined, boxes)).toBe(0);
+  });
+
+  it('counts one live zone once, however many members report it', () => {
+    expect(groupCount(liveMap(), boxes)).toBe(1);
+  });
+
+  it('counts a zone whose followers dropped out of discovery, from the master row alone', () => {
+    const zl = { [master.deviceID]: liveMap()[master.deviceID] };
+    expect(groupCount(zl, [master])).toBe(1);
+  });
+
+  it('counts a zone a follower alone reports (master not discovered)', () => {
+    const zl = { [boxA.deviceID]: liveMap()[boxA.deviceID] };
+    expect(groupCount(zl, [boxA, boxB])).toBe(1);
+  });
+
+  it('ignores a master whose member list holds only itself', () => {
+    const zl = { [master.deviceID]: { master: master.deviceID, members: [{ deviceID: master.deviceID, ip: master.host }] } };
+    expect(groupCount(zl, boxes)).toBe(0);
+  });
+
+  it('counts two separate zones as two', () => {
+    const zl = {
+      [master.deviceID]: { master: master.deviceID, members: [{ deviceID: master.deviceID, ip: master.host }, { deviceID: boxA.deviceID, ip: boxA.host }] },
+      [boxA.deviceID]: { master: master.deviceID, members: [] },
+      [boxB.deviceID]: { master: boxB.deviceID, members: [{ deviceID: boxB.deviceID, ip: boxB.host }, { ip: '192.0.2.7' }] },
+    };
+    expect(groupCount(zl, boxes)).toBe(2);
+  });
+
+  it('adds a stored permanent group that is not live', () => {
+    const zl = {
+      ...liveMap(),
+      [boxB.deviceID]: { master: '', members: [], permanent: true, remembered: [{ ip: '192.0.2.7', name: 'Kueche' }] },
+    };
+    expect(groupCount(zl, boxes)).toBe(2);
+  });
+
+  it('counts a live permanent group once, not as live plus stored', () => {
+    const zl = liveMap();
+    zl[master.deviceID] = { ...zl[master.deviceID], permanent: true, remembered: [{ ip: boxA.host }, { ip: boxB.host }] };
+    expect(groupCount(zl, boxes)).toBe(1);
+  });
+
+  it('does not count a stereo pair as a group', () => {
+    const zl = {
+      [boxA.deviceID]: { master: '', members: [], stereo: { id: 'pair-1', masterDeviceID: boxA.deviceID, members: [{ deviceID: boxA.deviceID, role: 'LEFT' }, { deviceID: boxB.deviceID, role: 'RIGHT' }] } },
+      [boxB.deviceID]: { master: '', members: [], stereo: { id: 'pair-1', masterDeviceID: boxA.deviceID, members: [{ deviceID: boxA.deviceID, role: 'LEFT' }, { deviceID: boxB.deviceID, role: 'RIGHT' }] } },
+    };
+    expect(groupCount(zl, boxes)).toBe(0);
+  });
+});
+
+describe('onZoneLive', () => {
+  beforeEach(() => resetZoneLivePoll());
+
+  it('runs listeners after a completed poll round and on notifyZoneLive', async () => {
+    let calls = 0;
+    const off = onZoneLive(() => { calls++; });
+    state.zoneLive = {};
+    const fetchZone = async () => ({ master: master.deviceID, members: [] });
+    await fetchZoneLive([master, boxA], { maxAgeMs: 0, minBoxes: 1 }, fetchZone);
+    expect(calls).toBe(1);
+    notifyZoneLive();
+    expect(calls).toBe(2);
+    off();
+    notifyZoneLive();
+    expect(calls).toBe(2);
+  });
+
+  it('keeps polling when a listener throws', async () => {
+    const off = onZoneLive(() => { throw new Error('boom'); });
+    state.zoneLive = {};
+    const fetchZone = async () => ({ master: master.deviceID, members: [] });
+    await expect(fetchZoneLive([master], { maxAgeMs: 0, minBoxes: 1 }, fetchZone)).resolves.toBe(true);
+    expect(state.zoneLive[master.deviceID]).toBeTruthy();
+    off();
   });
 });

--- a/desktop-app/frontend/src/i18n/bundles/ar.json
+++ b/desktop-app/frontend/src/i18n/bundles/ar.json
@@ -61,6 +61,7 @@
   "nav.speakerSettings": "إعدادات السمّاعة",
   "nav.setupStick": "إعداد السمّاعة",
   "nav.multiroom": "تعدّد الغرف",
+  "nav.multiroomBadgeTitle": "{{n}} مجموعة نشطة: تحدد أي السماعات تعمل معًا",
   "nav.spotify": "Spotify",
   "nav.podcasts": "البودكاست",
   "nav.newFeatureDot": "ميزة STR جديدة، ألقِ نظرة",

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -61,6 +61,7 @@
   "nav.speakerSettings": "Lautsprecher-Einstellungen",
   "nav.setupStick": "Lautsprecher einrichten",
   "nav.multiroom": "Multi-Room",
+  "nav.multiroomBadgeTitle": "{{n}} aktive Gruppe(n): sie bestimmen, welche Lautsprecher zusammen spielen",
   "nav.spotify": "Spotify",
   "nav.podcasts": "Podcasts",
   "nav.newFeatureDot": "Neue STR-Funktion, schau rein",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -61,6 +61,7 @@
   "nav.speakerSettings": "Speaker settings",
   "nav.setupStick": "Set up speaker",
   "nav.multiroom": "Multi-room",
+  "nav.multiroomBadgeTitle": "{{n}} active group(s): they decide which speakers play together",
   "nav.spotify": "Spotify",
   "nav.podcasts": "Podcasts",
   "nav.newFeatureDot": "New STR feature, take a look",

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -61,6 +61,7 @@
   "nav.speakerSettings": "Ajustes del altavoz",
   "nav.setupStick": "Configurar el altavoz",
   "nav.multiroom": "Multisala",
+  "nav.multiroomBadgeTitle": "{{n}} grupo(s) activo(s): deciden qué altavoces suenan juntos",
   "nav.spotify": "Spotify",
   "nav.podcasts": "Podcasts",
   "nav.newFeatureDot": "Nueva función de STR, échale un vistazo",

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -61,6 +61,7 @@
   "nav.speakerSettings": "Réglages de l'enceinte",
   "nav.setupStick": "Configurer l'enceinte",
   "nav.multiroom": "Multiroom",
+  "nav.multiroomBadgeTitle": "{{n}} groupe(s) actif(s) : ils déterminent quelles enceintes jouent ensemble",
   "nav.spotify": "Spotify",
   "nav.podcasts": "Podcasts",
   "nav.newFeatureDot": "Nouvelle fonction STR, jette un œil",

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -61,6 +61,7 @@
   "nav.speakerSettings": "スピーカー設定",
   "nav.setupStick": "スピーカーを設定",
   "nav.multiroom": "マルチルーム",
+  "nav.multiroomBadgeTitle": "有効なグループ: {{n}}。どのスピーカーが一緒に再生するかを決めます",
   "nav.spotify": "Spotify",
   "nav.podcasts": "ポッドキャスト",
   "nav.newFeatureDot": "STRの新機能。タップしてみてください",

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -61,6 +61,7 @@
   "nav.speakerSettings": "Garsiakalbio nustatymai",
   "nav.setupStick": "Nustatyti garsiakalbį",
   "nav.multiroom": "Multiroom",
+  "nav.multiroomBadgeTitle": "Aktyvios grupės: {{n}}. Jos nustato, kurios kolonėlės groja kartu",
   "nav.spotify": "Spotify",
   "nav.podcasts": "Tinklalaidės",
   "nav.newFeatureDot": "Nauja STR funkcija, pažiūrėk",

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -61,6 +61,7 @@
   "nav.speakerSettings": "Skaļruņa iestatījumi",
   "nav.setupStick": "Iestatīt skaļruni",
   "nav.multiroom": "Multiroom",
+  "nav.multiroomBadgeTitle": "Aktīvās grupas: {{n}}. Tās nosaka, kuri skaļruņi atskaņo kopā",
   "nav.spotify": "Spotify",
   "nav.podcasts": "Podkāsti",
   "nav.newFeatureDot": "Jauna STR funkcija, apskaties",

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -61,6 +61,7 @@
   "nav.speakerSettings": "Speakerinstellingen",
   "nav.setupStick": "Speaker instellen",
   "nav.multiroom": "Multiroom",
+  "nav.multiroomBadgeTitle": "{{n}} actieve groep(en): zij bepalen welke speakers samen spelen",
   "nav.spotify": "Spotify",
   "nav.podcasts": "Podcasts",
   "nav.newFeatureDot": "Nieuwe STR-functie, kijk eens",

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -61,6 +61,7 @@
   "nav.speakerSettings": "Ustawienia głośnika",
   "nav.setupStick": "Skonfiguruj głośnik",
   "nav.multiroom": "Multiroom",
+  "nav.multiroomBadgeTitle": "Aktywne grupy: {{n}}. Decydują, które głośniki grają razem",
   "nav.spotify": "Spotify",
   "nav.podcasts": "Podcasty",
   "nav.newFeatureDot": "Nowa funkcja STR, zobacz",

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -61,6 +61,7 @@
   "nav.speakerSettings": "Hoparlör ayarları",
   "nav.setupStick": "Hoparlörü kur",
   "nav.multiroom": "Multiroom",
+  "nav.multiroomBadgeTitle": "{{n}} etkin grup: hangi hoparlörlerin birlikte çalacağını belirler",
   "nav.spotify": "Spotify",
   "nav.podcasts": "Podcast'ler",
   "nav.newFeatureDot": "Yeni STR özelliği, göz at",

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -61,6 +61,7 @@
   "nav.speakerSettings": "Налаштування колонки",
   "nav.setupStick": "Налаштувати колонку",
   "nav.multiroom": "Мультирум",
+  "nav.multiroomBadgeTitle": "Активні групи: {{n}}. Вони визначають, які динаміки грають разом",
   "nav.spotify": "Spotify",
   "nav.podcasts": "Подкасти",
   "nav.newFeatureDot": "Нова функція STR, погляньте",

--- a/desktop-app/frontend/src/i18n/bundles/zh-Hant.json
+++ b/desktop-app/frontend/src/i18n/bundles/zh-Hant.json
@@ -61,6 +61,7 @@
   "nav.speakerSettings": "喇叭設定",
   "nav.setupStick": "設定喇叭",
   "nav.multiroom": "多房間",
+  "nav.multiroomBadgeTitle": "使用中的群組：{{n}}，決定哪些喇叭一起播放",
   "nav.spotify": "Spotify",
   "nav.podcasts": "Podcast",
   "nav.newFeatureDot": "STR 新功能，看看吧",

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -254,6 +254,9 @@ import {
   inStereoPair,
   pairMemberBoxes,
   balanceSourceBox,
+  groupCount,
+  onZoneLive,
+  notifyZoneLive,
 } from './groups.js';
 import { pairDisplayName } from './stereoNames.js';
 
@@ -560,7 +563,7 @@ document.querySelector('#app').innerHTML = `
     <button class="tab-btn" data-view="recent">${escapeHtml(t('nav.recent'))}</button>
     <button class="tab-btn" data-view="settings">${escapeHtml(t('nav.speakerSettings'))}</button>
     <button class="tab-btn" data-view="setup">${escapeHtml(t('nav.setupStick'))}</button>
-    <button class="tab-btn" data-view="multiroom">${escapeHtml(t('nav.multiroom'))}</button>
+    <button class="tab-btn" data-view="multiroom">${escapeHtml(t('nav.multiroom'))}<span class="tab-badge" id="multiroomTabBadge" hidden></span></button>
     <button class="tab-btn" data-view="spotify">${escapeHtml(t('nav.spotify'))}</button>
     <button class="tab-btn" data-view="podcasts">${escapeHtml(t('nav.podcasts'))}<span class="beta-pill planned-pill">${escapeHtml(t('common.planned'))}</span></button>
   </div>
@@ -1982,6 +1985,10 @@ function applyBoxList(list) {
   // Mark which speakers are currently playing (small speaker icon on their tile).
   refreshBoxPlaying();
   updateSettingsTabBadge();
+  // The group count depends on the box list too (a stored permanent group is
+  // read off its master's record), so recount on every list refresh; the zone
+  // poll above recounts again once its round lands.
+  updateMultiroomTabBadge();
   // localStorage is reliably restored by this first box refresh (see below), so
   // paint the new-feature discovery dots here; a module-load call runs too early.
   renderNavDots();
@@ -2448,6 +2455,7 @@ async function dissolveGroupFrame(masterKey) {
     await DissolveZone(masterBox.host, masterBox.port);
     await Promise.allSettled(followers.map(b => Stop(b.host, b.port)));
     state.zoneLive = applyOptimisticZone(state.zoneLive, masterBox, []);
+    notifyZoneLive();
     showToast(t('group.dissolvedToast'));
   } catch (e) {
     showToast(t('multiroom.formFailed', { err: String((e && e.message) || e || '') }));
@@ -3218,6 +3226,25 @@ function updateSettingsTabBadge() {
   const needsUpdate = state.boxes.some(boxNeedsUpdate);
   btn.classList.toggle('has-update', needsUpdate);
 }
+
+// updateMultiroomTabBadge shows how many groups exist right now (live zones
+// plus stored permanent groups, see groupCount) as a small count on the
+// Multi-Room tab, so a user sees at a glance that groups exist and shape which
+// speakers play together, without opening the tab (Jens, 2026-09-07). Fed by
+// the shared zone poll through onZoneLive, so it is right as soon as the first
+// round lands and after every refresh path (music-tab poll, Multi-Room poll,
+// optimistic group edits). Hidden at zero; no poll or timer of its own.
+function updateMultiroomTabBadge() {
+  const el = $('multiroomTabBadge');
+  if (!el) return;
+  const n = groupCount(state.zoneLive, state.boxes);
+  el.hidden = n === 0;
+  el.textContent = n ? String(n) : '';
+  const tip = n ? t('nav.multiroomBadgeTitle', { n }) : '';
+  el.title = tip;
+  el.setAttribute('aria-label', tip);
+}
+onZoneLive(updateMultiroomTabBadge);
 
 // foreignMod maps a leftover /mnt/nv directory name (as the agent reports it in
 // foreignDirs / conflictingMod) to a human-readable name of the OTHER SoundTouch
@@ -5674,6 +5701,7 @@ async function runGroupMemberToggle(edits) {
     // (including the master's OWN entry); the confirming poll below
     // corrects it shortly after.
     state.zoneLive = applyOptimisticZone(state.zoneLive, box, next);
+    notifyZoneLive();
     renderBoxSelect();
   } catch (e) {
     showError(String(e));

--- a/desktop-app/frontend/src/style.css
+++ b/desktop-app/frontend/src/style.css
@@ -542,6 +542,27 @@ body {
   background: #2f80ed;
   box-shadow: 0 0 0 2px var(--c-bg);
 }
+/* Count pill on the Multi-Room tab: how many groups (live zones + stored
+   permanent groups) exist right now. Brand-tinted like the group frames so it
+   reads as "state", not as an alert like the blue update dot; the tint rides
+   on --brand, which is retuned per theme, so it holds up in light and dark. */
+.tab-badge {
+  display: inline-block;
+  min-width: 16px;
+  margin-left: 6px;
+  padding: 0 5px;
+  border-radius: 9px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 16px;
+  text-align: center;
+  vertical-align: middle;
+  color: var(--brand);
+  background: color-mix(in srgb, var(--brand) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--brand) 55%, transparent);
+  white-space: nowrap;
+}
+.tab-badge[hidden] { display: none; }
 .view.hidden { display: none; }
 .hidden { display: none !important; }
 


### PR DESCRIPTION
Jens, 2026-09-07: the Multi-Room tab should carry a small badge with the number of current temporary and permanent groups, so users see at once that groups exist and shape which speakers play together.

- `groupCount(zoneLive, boxes)` in `groups.js`: distinct live zones (a master with at least one member, proven by a follower's self-report or a member row other than the master) plus stored permanent groups whose master is not live (a live permanent group counts once). Stereo pairs never count.
- Fed by the shared zone poll through a small listener registry (`onZoneLive` / `notifyZoneLive`), so the badge follows the music-tab poll, the Multi-Room poll and the optimistic group edits; no poll or timer of its own. Hidden at zero.
- Tooltip `nav.multiroomBadgeTitle` in all 13 bundles; `.tab-badge` pill in `style.css`, brand-tinted, fine in light and dark.
- 11 new cases in `groups.test.js`; i18n parity and coverage pass; `npm run build` ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrDLQwFNah3qLAHWK5ELGM
