### PR TITLE
fix(agent): a failed skip on someone else's stream no longer puts STR's last station on the speaker

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -899,6 +899,18 @@ func run() error {
 	// WebSocket on 8080 (gabbo protocol) when the user physically presses a
 	// button. We hook the event and trigger our UPnP player.
 	renderer := upnp.NewBoseRenderer(*boxHost)
+	// The speaker's own playback clock, for the Spotify buffer-lag measurement
+	// (internal/spotify/boxlag.go): the app shows the position go-librespot has
+	// delivered, the room hears what the box has rendered, and this is the only
+	// side that can say how far apart they are. Measured on stream attach and on
+	// each track boundary, never polled.
+	//
+	// RelPosition, not PositionInfo: the measurement needs to know whether the
+	// box gave a readable clock, and PositionInfo reports call success while
+	// mapping an unreadable RelTime to zero. A zero there would be recorded as
+	// the box having played none of the audio it was given, i.e. the largest lag
+	// the measurement can express, and nothing in the bundle would say so.
+	spotifyMgr.SetBoxPositionFn(renderer.RelPosition)
 	// publishBoxPresets is the ONE place a box preset list read from the
 	// speaker (a gabbo presetsUpdated frame, the boot seed read, the
 	// reconcile's own /presets read) reaches the webui cache and the

--- a/docs/streaming/spotify.md
+++ b/docs/streaming/spotify.md
@@ -236,6 +236,58 @@ belongs in the fork), the detach line carries `seams`, and the
 `spotify_chain` section of `/api/debug/state` keeps the last seam's
 readings for a bundle after the NAND ring has rolled.
 
+### Lyrics run ahead of the audio: the buffer lag is measured, not corrected
+
+Field report (2026-09): with STR's Spotify entry the lyrics in the Spotify
+app run ahead of the sound, with the speaker's own Spotify entry they line
+up. The mechanism follows from the architecture above. go-librespot reports
+its position from the bytes it has written to the pipe, while that audio is
+still travelling through STR's batch and the box's own buffer, and STR
+deliberately keeps roughly ten seconds there (`leadCapSec` in
+`internal/spotify/engine.go`, the flush batch in `drain.go`). The app shows
+the delivered position; the lyrics follow the app.
+
+What was never known is the size of the offset on real hardware, and any
+correction applied before that number exists would be a guess. So
+`internal/spotify/boxlag.go` measures it and does nothing else: the drain
+publishes the delivered timeline of the last page it handed to the box, the
+speaker's own clock comes from UPnP `RelPosition` (`GetPositionInfo`'s
+`RelTime`), and the difference is logged as `spotify: buffer lag measured
+(audio delivered vs audio played)` with both sides and `diffSec`. The last
+reading is also in the `spotify_chain` section of `/api/debug/state`, so a
+field bundle carries it after the NAND ring has rolled.
+
+Event-driven only, once per attachment and once per track boundary: no
+ticker, no standing poll, nothing on the wire while nothing happens. A
+boundary caused by a skip is labelled `track-boundary after a skip`, because
+the box drops its buffer there and both clocks are mid-jump.
+
+The two clocks only mean something against a shared base, which is most of
+what the code does:
+
+- The baseline is taken in the drain, on the first audio page the new
+  attachment actually receives, not where the box attached. The engine keeps
+  producing while no box is attached (`engineHot`, see `recall.go`), so the
+  delivered counter at the attach instant is the value at the PREVIOUS
+  detach, and basing on it folded that whole detached window into every later
+  reading of the attachment.
+- Delivered counts only audio handed to the box. The pages a skip cut throws
+  away, and a batch dropped when the box goes, are never played, so the
+  box's `RelTime` cannot contain them; counting them inflated every later
+  reading by up to a full lead cap, i.e. by the same order of magnitude as
+  the quantity being measured.
+- The delivered timeline carries across go-librespot runs. The sink outlives
+  one engine run by design (crash restart, volume-config restart, the OTA
+  sidecar swap), and a per-run counter starting at zero under an attached box
+  made every later reading negative.
+- `RelPosition` reports whether the field was READABLE, not whether the call
+  succeeded. Bose answers `NOT_IMPLEMENTED` for fields it has no value for,
+  which parses as zero, and a zero box clock reads as the largest lag the
+  measurement can express. No usable clock means no line and no stored
+  reading; the same goes for a baseline that has not been taken yet and for a
+  timeline that was rebuilt underneath the box. A missing number is worth
+  more than a plausible wrong one.
+
 ## Why native Spotify works without the Bose cloud
 
 Spotify Connect has two login paths. Bose's app used the **account-linked**

--- a/internal/boxws/client.go
+++ b/internal/boxws/client.go
@@ -111,6 +111,14 @@ type Client struct {
 	lastInvalidSourceAt time.Time
 	lastPresetPressAt   time.Time
 
+	// lastSkipFailAt is when the box last reported that its OWN skip on a UPnP
+	// source failed (QPLAY_SKIP_*_FAILED). That failure is followed by the
+	// firmware tearing the source down, and the teardown restore is
+	// indistinguishable on the wire from a standby wake, so the dispatcher
+	// consults this stamp before it reports a wake (see skipWakeWindow).
+	// Guarded by mu, like the teardown stamps above.
+	lastSkipFailAt time.Time
+
 	// lastOwnCmdAt is when STR itself last issued a transport-mutating SOAP
 	// command (SetURI/Play/Pause/Stop), stamped via NoteOwnTransportCommand from
 	// the upnp renderer's OnTransportCommand hook. The box answers a SOAP Stop
@@ -488,6 +496,39 @@ func (c *Client) BoxErrors() []BoxErrorNote {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return append([]BoxErrorNote(nil), c.boxErrors...)
+}
+
+// skipWakeWindow is how close a failed native skip must be for the
+// DO_NOT_RESUME restore that follows it to be read as that skip's source
+// teardown rather than as a power-on wake.
+//
+// The two events are one firmware sequence: the QPLAY_SKIP_*_FAILED error, the
+// source drop, and the restore of the selection arrive within a second of each
+// other. Five seconds is generous enough to cover a box that is slow to give up
+// (an INVALID_SOURCE dwell of a few seconds is normal, see upnpEpisode) while
+// staying far below the time it takes a person to press skip and then power.
+const skipWakeWindow = 5 * time.Second
+
+// noteSkipFailure records that the box just failed its own skip. Same shape as
+// noteExplainedActivity: a bare stamp written where the frame is recognised,
+// read at the decision it has to inform. See lastSkipFailAt.
+func (c *Client) noteSkipFailure() {
+	c.mu.Lock()
+	c.lastSkipFailAt = time.Now()
+	c.mu.Unlock()
+}
+
+// sinceSkipFailure reports how long ago the box failed its own skip and whether
+// that was inside skipWakeWindow. A box that has never failed a skip reports
+// recent=false, never a zero-age match.
+func (c *Client) sinceSkipFailure() (age time.Duration, recent bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.lastSkipFailAt.IsZero() {
+		return 0, false
+	}
+	age = time.Since(c.lastSkipFailAt)
+	return age, age < skipWakeWindow
 }
 
 // NoteSelection records the preset location the box just selected, so an error

--- a/internal/boxws/dispatch.go
+++ b/internal/boxws/dispatch.go
@@ -29,12 +29,14 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 		// well: reported on 2026-08-06, "my ST20s do skip through songs using
 		// the remote, but doing so also triggers the webhook" (#536).
 		c.noteExplainedActivity()
+		c.noteSkipFailure()
 		if c.handler != nil {
 			c.handler.OnRemoteSkip(ctx, true)
 		}
 		return
 	case strings.Contains(s, "QPLAY_SKIP_PREV_FAILED"):
 		c.noteExplainedActivity()
+		c.noteSkipFailure()
 		if c.handler != nil {
 			c.handler.OnRemoteSkip(ctx, false)
 		}
@@ -599,6 +601,24 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 			// what it says. STR now stands down; playback only follows an explicit
 			// user action: a real preset press (slot 1-6 below) or an app recall.
 			if strings.Contains(pe.Inner, "DO_NOT_RESUME") {
+				// A failed remote skip produces the SAME restore. The box cannot
+				// skip a UPnP source, answers QPLAY_SKIP_*_FAILED and tears the
+				// source down, and the teardown restores the selection as
+				// INVALID_SOURCE + DO_NOT_RESUME - byte for byte the standby-wake
+				// shape. Reading it as a power-on made STR push its own last
+				// station onto a speaker somebody was streaming to from elsewhere:
+				// press Next on the remote during a Music Assistant stream and the
+				// speaker "wants to switch presets" (Christian1985l, discussion
+				// #827). A skip moments ago explains this frame, so it is a
+				// teardown, not a wake. Only this branch is gated: a powerState
+				// event (handled above) is the box saying it powered on, which no
+				// teardown fakes, so a genuine power press inside the window still
+				// resumes.
+				if since, recent := c.sinceSkipFailure(); recent {
+					c.logger.Info("box ws: DO_NOT_RESUME restore right after a failed remote skip - source teardown, not a power-on; not resuming",
+						"sinceSkipMs", since.Milliseconds())
+					return
+				}
 				// The box left standby and, unable to play its UPNP selection
 				// itself, restored it as INVALID_SOURCE + DO_NOT_RESUME. On this
 				// firmware that is the ONLY power-on signal: no powerStateUpdated is

--- a/internal/boxws/skipwake_test.go
+++ b/internal/boxws/skipwake_test.go
@@ -1,0 +1,159 @@
+package boxws
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The DO_NOT_RESUME restore that follows a failed remote skip is the box
+// tearing its own UPnP source down, not a power-on. Reading it as a wake made
+// STR resume its last station over whatever was playing, which is what a user
+// streaming from Music Assistant heard as the speaker "wanting to switch
+// presets" when he pressed Next (discussion #827).
+func TestSkipFailureSuppressesTheWakeThatItsTeardownFakes(t *testing.T) {
+	var buf bytes.Buffer
+	h := &recHandler{}
+	c := New(slog.New(slog.NewTextHandler(&buf, nil)), "ws://127.0.0.1:8080/", h)
+
+	c.handleMessage(context.Background(), []byte(
+		`<updates><errorUpdate>QPLAY_SKIP_NEXT_FAILED</errorUpdate></updates>`))
+	c.handleMessage(context.Background(), []byte(
+		`<updates><nowSelectionUpdated><preset id="0">`+
+			`<ContentItem source="INVALID_SOURCE" type="DO_NOT_RESUME"/>`+
+			`</preset></nowSelectionUpdated></updates>`))
+
+	if h.powerWakes != 0 {
+		t.Fatalf("the teardown after a failed skip must not fire OnPowerWake, got %d", h.powerWakes)
+	}
+	// The skip itself must still reach the handler: the suppression may not
+	// swallow the key press it is reacting to.
+	if len(h.skips) != 1 || !h.skips[0] {
+		t.Fatalf("the skip key must still be dispatched, got %v", h.skips)
+	}
+	// A bundle has to show WHY nothing resumed, otherwise the next report of
+	// this shape is undiagnosable.
+	if got := buf.String(); !strings.Contains(got, "failed remote skip") {
+		t.Fatalf("the stand-down must be logged, got:\n%s", got)
+	}
+}
+
+// Outside the window the same frame is what it says it is: the only power-on
+// signal this firmware sends. The suppression must not disable the power-on
+// resume for the rest of the session.
+func TestWakeStillFiresWhenTheSkipFailureIsOld(t *testing.T) {
+	h := &recHandler{}
+	c := newTestClient(h)
+	c.handleMessage(context.Background(), []byte(
+		`<updates><errorUpdate>QPLAY_SKIP_PREV_FAILED</errorUpdate></updates>`))
+	// Age the stamp past the window instead of sleeping: the value is what the
+	// guard reads, and a real box takes seconds to get here.
+	c.mu.Lock()
+	c.lastSkipFailAt = time.Now().Add(-skipWakeWindow - time.Second)
+	c.mu.Unlock()
+
+	c.handleMessage(context.Background(), []byte(
+		`<updates><nowSelectionUpdated><preset id="0">`+
+			`<ContentItem source="INVALID_SOURCE" type="DO_NOT_RESUME"/>`+
+			`</preset></nowSelectionUpdated></updates>`))
+
+	if h.powerWakes != 1 {
+		t.Fatalf("a wake outside the skip window must still resume: wakes=%d", h.powerWakes)
+	}
+}
+
+// A box that has never failed a skip must not read the zero stamp as "a skip
+// just happened".
+func TestWakeFiresWhenNoSkipEverFailed(t *testing.T) {
+	h := &recHandler{}
+	c := newTestClient(h)
+	if age, recent := c.sinceSkipFailure(); recent {
+		t.Fatalf("an unset stamp must not count as recent (age=%v)", age)
+	}
+	c.handleMessage(context.Background(), []byte(
+		`<updates><nowSelectionUpdated><preset id="0">`+
+			`<ContentItem source="INVALID_SOURCE" type="DO_NOT_RESUME"/>`+
+			`</preset></nowSelectionUpdated></updates>`))
+	if h.powerWakes != 1 {
+		t.Fatalf("a plain wake must resume: wakes=%d", h.powerWakes)
+	}
+}
+
+// doNotResumeRestore is the frame both a standby wake and a source teardown
+// produce; telling the two apart is the whole subject of this file.
+const doNotResumeRestore = `<updates><nowSelectionUpdated><preset id="0">` +
+	`<ContentItem source="INVALID_SOURCE" type="DO_NOT_RESUME"/>` +
+	`</preset></nowSelectionUpdated></updates>`
+
+const skipNextFailed = `<updates><errorUpdate>QPLAY_SKIP_NEXT_FAILED</errorUpdate></updates>`
+
+// The guard only ever looks BACKWARDS, and that has to stay true: a wake
+// decided before the box reported its failed skip was decided on the evidence
+// available then. A stamp applied to a frame that is already past would make
+// the suppression depend on frame ORDER inside one flap, which the firmware
+// does not guarantee.
+func TestAWakeIsNotSuppressedByASkipFailureThatArrivesAfterIt(t *testing.T) {
+	h := &recHandler{}
+	c := newTestClient(h)
+	c.handleMessage(context.Background(), []byte(doNotResumeRestore))
+	c.handleMessage(context.Background(), []byte(skipNextFailed))
+	if h.powerWakes != 1 {
+		t.Fatalf("a wake that preceded the skip failure must still resume: wakes=%d", h.powerWakes)
+	}
+}
+
+// What "one-shot vs sticky" actually means here. The stamp is NOT consumed by
+// the first frame it suppresses, on purpose: the firmware repeats the restore
+// while the source flaps, so a one-shot guard would let the second copy through
+// and resume anyway. The only thing bounding it is the window, and once that has
+// passed the next restore resumes with no new event needed to re-arm anything.
+func TestTheSuppressionCoversEveryRestoreInTheWindowAndEndsWithIt(t *testing.T) {
+	// The window has to stay far below the time it takes a person to press skip
+	// and then power, or the guard starts swallowing real power-ons.
+	if skipWakeWindow > 5*time.Second {
+		t.Fatalf("skipWakeWindow grew to %v; at that length it covers a deliberate power press", skipWakeWindow)
+	}
+	h := &recHandler{}
+	c := newTestClient(h)
+	c.handleMessage(context.Background(), []byte(skipNextFailed))
+	c.handleMessage(context.Background(), []byte(doNotResumeRestore))
+	c.handleMessage(context.Background(), []byte(doNotResumeRestore))
+	if h.powerWakes != 0 {
+		t.Fatalf("every restore inside the window is the same teardown: wakes=%d", h.powerWakes)
+	}
+	// Age the stamp past the window. Nothing else changes: no new frame, no
+	// reset call, so this pins that the guard expires by itself.
+	c.mu.Lock()
+	c.lastSkipFailAt = time.Now().Add(-skipWakeWindow - time.Millisecond)
+	c.mu.Unlock()
+	c.handleMessage(context.Background(), []byte(doNotResumeRestore))
+	if h.powerWakes != 1 {
+		t.Fatalf("the suppression must expire with the window, not latch: wakes=%d", h.powerWakes)
+	}
+}
+
+// A genuine power press reports itself as a powerState event, which no source
+// teardown produces. That path stays unguarded so pressing power right after a
+// skip still brings the music back.
+//
+// Note what this does NOT cover: the firmware in the field (27.0.6, verified on
+// a Portable/taigan) sends no powerStateUpdated at all, so on those boxes the
+// DO_NOT_RESUME restore is the only power-on signal there is and a real power-on
+// inside the window IS swallowed. Reaching that needs a skip failure and a
+// power-ON within five seconds of each other, which in turn needs the box to
+// have gone to standby in between - and that path stands the resume down anyway
+// (standbyStoppedRecently, #197).
+func TestPowerStateWakeIsNotSuppressedByARecentSkipFailure(t *testing.T) {
+	h := &recHandler{}
+	c := newTestClient(h)
+	c.handleMessage(context.Background(), []byte(
+		`<updates><errorUpdate>QPLAY_SKIP_NEXT_FAILED</errorUpdate></updates>`))
+	c.handleMessage(context.Background(), []byte(
+		`<updates><powerStateUpdated>POWER_ON</powerStateUpdated></updates>`))
+	if h.powerWakes != 1 {
+		t.Fatalf("a powerState ON must resume even right after a skip: wakes=%d", h.powerWakes)
+	}
+}

--- a/internal/spotify/boxlag.go
+++ b/internal/spotify/boxlag.go
@@ -1,0 +1,213 @@
+// boxlag.go: how far the audio the speaker is playing lags behind the audio
+// STR has delivered.
+//
+// Why this exists. With STR's Spotify entry the lyrics in the Spotify app run
+// ahead of the sound; with the speaker's own Spotify entry they line up (field
+// report, 2026-09). The mechanism is understood: go-librespot reports its
+// position from the bytes it has written to the pipe, while that audio is still
+// on its way through STR's batch and the box's own buffer, and STR deliberately
+// keeps roughly ten seconds there (see leadCapSec in engine.go and the chunk
+// window in oggchain.go). The Spotify app therefore shows a position that is
+// ahead of what the room hears, and the lyrics follow that position.
+//
+// What is NOT known is the size of the offset on real hardware, and nothing has
+// ever recorded it. Any correction applied before that number exists would be a
+// guess. This file measures it and does nothing else: no offset is applied, no
+// behaviour changes.
+//
+// The two clocks:
+//
+//   - delivered: the drain publishes the continuous audio timeline of the last
+//     page it accepted for the box (deliveredGran). That is the position
+//     go-librespot has produced, i.e. the one the Spotify app shows.
+//   - the box: UPnP GetPositionInfo's RelTime, the speaker's own account of how
+//     much of this stream it has rendered.
+//
+// Both are measured from the moment the box received the first audio of this
+// attachment (lagBaseGran is the delivered timeline at that page), so the
+// difference is the audio in flight. The baseline is taken in the drain and not
+// where the box attaches, because the two must share one instant: the engine
+// keeps producing while no box is attached (engineHot, see recall.go), and
+// basing on the counter's value at the previous detach folded that whole
+// detached window into every later reading. Whether the box's RelTime really
+// restarts on a re-attach is exactly what the attach measurement below is for:
+// it is taken when both sides should read zero, so a bundle shows whether the
+// boundary numbers can be trusted.
+//
+// What the delivered side deliberately does NOT count: audio the drain produced
+// with no box attached, and audio a skip cut threw away. The box never received
+// either, so its RelTime cannot contain it, and counting it would inflate every
+// later difference by that amount (see drain.go).
+//
+// Event-driven only: once per attach and once per track boundary. No ticker, no
+// standing poll - this runs on every speaker in the field and a periodic probe
+// would cost NAND and CPU for a number that only changes when something happens.
+
+package spotify
+
+import (
+	"context"
+	"math"
+	"time"
+)
+
+// boxLagMeasurement is one comparison of the two clocks. Seconds, rounded to
+// two decimals: the interesting quantity is on the order of ten seconds and the
+// SOAP round trip alone costs more precision than that.
+type boxLagMeasurement struct {
+	At           time.Time `json:"at"`
+	Reason       string    `json:"reason"`
+	DeliveredSec float64   `json:"deliveredSec"`
+	BoxRelSec    float64   `json:"boxRelSec"`
+	DiffSec      float64   `json:"diffSec"`
+}
+
+// boxLagReadTimeout bounds the one SOAP query a measurement makes. Short: a box
+// that does not answer promptly is not worth waiting for, the measurement is
+// diagnostic and the next track boundary comes around anyway.
+const boxLagReadTimeout = 4 * time.Second
+
+// boxLagReasonAttach names the one reading whose box clock may legitimately be
+// zero: the box has just started this stream. Everywhere else a zero RelTime is
+// a box with no usable clock, not a box at the start of a track.
+const boxLagReasonAttach = "attach"
+
+// SetBoxPositionFn wires in the box's own playback clock (UPnP
+// RelPosition's RelTime). The reader must report ok=false when the box gave no
+// USABLE clock, not merely when the query failed: see upnp.RelPosition. Without
+// it no measurement is taken at all, which is what keeps the agent's own tests
+// and any non-UPnP consumer free of it.
+func (m *Manager) SetBoxPositionFn(fn func(context.Context) (time.Duration, bool)) {
+	m.mu.Lock()
+	m.boxPositionFn = fn
+	m.mu.Unlock()
+}
+
+// noteStreamAttached ARMS the per-attachment baseline of the delivered
+// timeline. Called from ServeOgg once the sink is registered; the drain takes
+// the actual baseline on the first audio page that reaches this box, which is
+// the moment its own clock starts. See the file header for why the counter's
+// value at this instant is the wrong base.
+func (m *Manager) noteStreamAttached() {
+	m.mu.Lock()
+	m.lagRebase = true
+	m.mu.Unlock()
+}
+
+// triggerBoxLag is what the live paths call: it samples the delivered side HERE,
+// at the event, and does the box's SOAP round trip in the background so the
+// drain never waits on it.
+//
+// The sample cannot move into the goroutine. The drain runs on: the next page
+// advances the delivered timeline and an attach re-baselines it outright, so a
+// goroutine that sampled whenever it happened to be scheduled compared two
+// different instants and logged the result as a measurement. A boundary reading
+// that raced the following attach came out negative that way; the drain test
+// pins the order.
+func (m *Manager) triggerBoxLag(reason string) {
+	fn, deliveredGran, ok := m.boxLagSample(reason)
+	if !ok {
+		return
+	}
+	go m.readBoxLag(fn, reason, deliveredGran)
+}
+
+// measureBoxLag is triggerBoxLag start to finish in the caller's goroutine, for
+// tests that want the reading before they assert on it.
+func (m *Manager) measureBoxLag(reason string) {
+	if fn, deliveredGran, ok := m.boxLagSample(reason); ok {
+		m.readBoxLag(fn, reason, deliveredGran)
+	}
+}
+
+// boxLagSample takes the delivered side of one measurement and reports whether
+// there is anything to compare it against. ok=false means no reading is taken at
+// all: no position reader wired, nothing attached, or no baseline for this
+// attachment yet.
+func (m *Manager) boxLagSample(reason string) (fn func(context.Context) (time.Duration, bool), deliveredGran int64, ok bool) {
+	m.mu.Lock()
+	fn = m.boxPositionFn
+	attached := m.sink != nil
+	rebasePending := m.lagRebase
+	deliveredGran = m.deliveredGran - m.lagBaseGran
+	// A delivered timeline that has fallen BELOW its own baseline was rebuilt
+	// under the attached box: go-librespot restarted (the sink survives an
+	// engine run, so nothing re-attaches), or a skip cut rolled unsent audio
+	// back. The baseline belongs to a timeline that no longer exists, so retake
+	// it here and report nothing rather than log a negative lag.
+	rebuilt := deliveredGran < 0
+	if rebuilt {
+		m.lagBaseGran = m.deliveredGran
+	}
+	m.mu.Unlock()
+	switch {
+	case fn == nil || !attached:
+		return nil, 0, false
+	case rebasePending:
+		m.logger.Debug("spotify: no audio delivered since the box attached, no buffer-lag measurement", "at", reason)
+		return nil, 0, false
+	case rebuilt:
+		m.logger.Debug("spotify: delivered timeline was rebuilt under the attached box, re-baselined instead of measuring", "at", reason)
+		return nil, 0, false
+	}
+	return fn, deliveredGran, true
+}
+
+// readBoxLag reads the speaker's own clock and logs it against the delivered
+// side sampled at the trigger. reason names the event ("attach" /
+// "track-boundary") so a bundle can tell the baseline reading from the
+// steady-state ones.
+//
+// Best effort: a box that gives no usable clock means no line and no stored
+// measurement. A made-up number here would be read as a measured one, which is
+// the one wrong answer this could give.
+func (m *Manager) readBoxLag(fn func(context.Context) (time.Duration, bool), reason string, deliveredGran int64) {
+	ctx, cancel := context.WithTimeout(context.Background(), boxLagReadTimeout)
+	defer cancel()
+	rel, ok := fn(ctx)
+	// Not just "did the call succeed". A box that answers with no usable RelTime
+	// reports zero, and a zero anywhere but at an attach says the box has played
+	// none of the audio it was handed, i.e. the whole delivered timeline sits in
+	// the buffer - the largest lag this can express, growing without bound over
+	// a track and indistinguishable in a bundle from a real reading.
+	if !ok || (rel <= 0 && reason != boxLagReasonAttach) {
+		m.logger.Debug("spotify: no usable box position, no buffer-lag measurement",
+			"at", reason, "readable", ok, "relSec", rel.Seconds())
+		return
+	}
+	delivered := round2(float64(deliveredGran) / float64(vorbisRate))
+	boxSec := round2(rel.Seconds())
+	lag := boxLagMeasurement{
+		At: time.Now(), Reason: reason,
+		DeliveredSec: delivered, BoxRelSec: boxSec, DiffSec: round2(delivered - boxSec),
+	}
+	m.mu.Lock()
+	m.lastLag = lag
+	m.mu.Unlock()
+	// The raw inputs, not just the difference: the number is only readable
+	// against them (a box whose RelTime did not restart on a re-attach produces
+	// a nonsense difference, and the two sides are what show that).
+	// The number is the point of the exercise, but a line per track boundary
+	// on every box in the field is a NAND append every three minutes for a
+	// measurement nothing acts on yet. The first one of a session is logged
+	// at INFO so a bundle always carries one, the rest at Debug; the debug
+	// section keeps the newest reading either way.
+	if m.loggedBoxLag {
+		m.logger.Debug("spotify: buffer lag measured (audio delivered vs audio played)",
+			"at", reason, "deliveredSec", lag.DeliveredSec, "boxRelSec", lag.BoxRelSec, "diffSec", lag.DiffSec)
+		return
+	}
+	m.loggedBoxLag = true
+	m.logger.Info("spotify: buffer lag measured (audio delivered vs audio played)",
+		"at", reason, "deliveredSec", lag.DeliveredSec, "boxRelSec", lag.BoxRelSec, "diffSec", lag.DiffSec)
+}
+
+// LastBoxLag returns the most recent measurement; the zero value when none has
+// been taken.
+func (m *Manager) LastBoxLag() boxLagMeasurement {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastLag
+}
+
+func round2(f float64) float64 { return math.Round(f*100) / 100 }

--- a/internal/spotify/boxlag_drain_test.go
+++ b/internal/spotify/boxlag_drain_test.go
@@ -1,0 +1,273 @@
+// Tests for the half of the buffer-lag measurement that lives in the drain:
+// what publishes the delivered timeline, and what triggers a reading. The
+// measurement's own arithmetic is in boxlag_test.go.
+
+package spotify
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// lagDrainHarness is a manager with a box attached, the real drain step, and a
+// counting position reader standing in for the speaker's UPnP clock.
+func lagDrainHarness(t *testing.T, reads *atomic.Int32) (*Manager, *oggDrain) {
+	t.Helper()
+	chain := newTestChain(t, 1<<40, nil)
+	holdSeams(chain)
+	m, d, _ := newDrainHarness(t, chain, 1<<20)
+	m.logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	m.boxPositionFn = func(context.Context) (time.Duration, bool) {
+		reads.Add(1)
+		return 10 * time.Second, true
+	}
+	return m, d
+}
+
+// waitForReads waits for the measurement goroutines the drain fires to land.
+func waitForReads(reads *atomic.Int32, want int32, d time.Duration) int32 {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if reads.Load() >= want {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return reads.Load()
+}
+
+// waitForLag waits until a measurement with the given trigger has been stored.
+// The read and the store happen in the background goroutine, so counting reads
+// is not enough to assert on the stored number.
+func waitForLag(m *Manager, reason string, d time.Duration) boxLagMeasurement {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if got := m.LastBoxLag(); got.Reason == reason {
+			return got
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return m.LastBoxLag()
+}
+
+// The drain is what actually triggers a reading, and nothing pinned that
+// wiring. The contract is one query per event and nothing in between: this runs
+// on every speaker in the field, so an event that fired twice, or a page that
+// queried at all, would be a standing poll by another name.
+//
+// Two tracks after an attach make exactly two queries: the first track's
+// boundary has no baseline yet and is skipped without touching the box, the
+// first audio page takes the baseline and reads once, the second track's
+// boundary reads once.
+func TestDrainMeasuresOncePerEventAndNeverPerPage(t *testing.T) {
+	var reads atomic.Int32
+	m, d := lagDrainHarness(t, &reads)
+	m.noteStreamAttached()
+
+	feed(d, synthVorbisTrack(1, 60, false))
+	feed(d, synthVorbisTrack(2, 60, false))
+
+	waitForReads(&reads, 2, 3*time.Second)
+	// Give a third (wrong) query time to arrive before declaring the count.
+	time.Sleep(150 * time.Millisecond)
+	if got := reads.Load(); got != 2 {
+		t.Fatalf("an attach and two track boundaries must produce exactly two box queries, got %d", got)
+	}
+	if lag := waitForLag(m, "track-boundary", time.Second); lag.Reason != "track-boundary" {
+		t.Fatalf("the boundary reading must name its trigger, got %+v", lag)
+	}
+}
+
+// The baseline belongs to the first audio the attachment RECEIVES, not to the
+// counter's value where the box attached: the engine keeps producing while no
+// box is attached (engineHot), so basing on that value folded the whole
+// detached window into every reading of the new attachment.
+func TestAttachBaselineIgnoresAudioFromBeforeTheAttach(t *testing.T) {
+	var reads atomic.Int32
+	m, d := lagDrainHarness(t, &reads)
+	m.noteStreamAttached()
+	feed(d, synthVorbisTrack(1, 1000, false)) // several seconds on this attachment
+	waitForLag(m, boxLagReasonAttach, 3*time.Second)
+	// Forget that first attach reading, so the one asserted on below is
+	// unambiguously the second attachment's.
+	m.mu.Lock()
+	m.lastLag = boxLagMeasurement{}
+	m.mu.Unlock()
+
+	// The box drops the stream and re-fetches it: a new attachment on the same
+	// running engine.
+	m.noteStreamAttached()
+	feed(d, synthVorbisTrack(2, 1000, false))
+
+	lag := waitForLag(m, boxLagReasonAttach, 3*time.Second)
+	if lag.Reason != boxLagReasonAttach {
+		t.Fatalf("the first audio page of a new attachment must take the attach reading, got %+v", lag)
+	}
+	if lag.DeliveredSec > 1 {
+		t.Fatalf("the attach baseline counted %.2f s of audio from before the attach: %+v", lag.DeliveredSec, lag)
+	}
+}
+
+// go-librespot restarts (crash-restart loop, the volume-config restart, the OTA
+// sidecar swap) build a new drain while the sink stays open. The delivered
+// timeline must continue where it was: a per-run counter starting at zero made
+// every later reading negative until the box happened to re-attach.
+func TestDeliveredTimelineSurvivesAnEngineRestart(t *testing.T) {
+	var reads atomic.Int32
+	m, d := lagDrainHarness(t, &reads)
+	m.noteStreamAttached()
+	feed(d, synthVorbisTrack(1, 300, false))
+	m.mu.Lock()
+	afterFirstRun := m.deliveredGran
+	m.mu.Unlock()
+	if afterFirstRun == 0 {
+		t.Fatal("the first run delivered no audio, the test proves nothing")
+	}
+
+	// The engine restarted: a new drain and a new chain, the same Manager, the
+	// box still attached.
+	chain := newTestChain(t, 1<<40, nil)
+	holdSeams(chain)
+	d2 := m.newOggDrain(1<<20, 0, chain)
+	d2.paused = true
+	feed(d2, synthVorbisTrack(2, 300, false))
+
+	m.mu.Lock()
+	afterRestart, base := m.deliveredGran, m.lagBaseGran
+	m.mu.Unlock()
+	if afterRestart < afterFirstRun {
+		t.Fatalf("the delivered timeline went backwards across an engine restart: %d -> %d granules",
+			afterFirstRun, afterRestart)
+	}
+	// And the boundary that opened the new run still measured: a timeline that
+	// had restarted at zero would have fallen below its baseline, and the
+	// measurement would have been skipped as rebuilt instead.
+	lag := waitForLag(m, "track-boundary", 3*time.Second)
+	if want := float64(afterFirstRun-base) / vorbisRate; lag.DeliveredSec < want-0.01 {
+		t.Fatalf("the reading after the restart saw %.2f s delivered, want the first run's %.2f s carried over: %+v",
+			lag.DeliveredSec, want, lag)
+	}
+}
+
+// skipCutHarness is the drain with a fake sink and a fake box clock, plus the
+// flush size the test needs: 1 writes every page straight through (so the
+// delivered timeline and the sink's bytes must match exactly at any moment), a
+// large one keeps everything in the batch.
+func skipCutHarness(t *testing.T, flushBytes int) (*Manager, *oggDrain, *fakeSink) {
+	t.Helper()
+	chain := newTestChain(t, 1<<40, nil)
+	holdSeams(chain)
+	m, d, sink := newDrainHarness(t, chain, flushBytes)
+	m.logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	m.boxPositionFn = func(context.Context) (time.Duration, bool) { return 10 * time.Second, true }
+	m.noteStreamAttached()
+	return m, d, sink
+}
+
+// Audio a skip cut throws away never reaches the box, so the box's own clock
+// cannot contain it and the delivered side must not either. Counting it made
+// every reading for the rest of the attachment too large by the dropped amount,
+// which is bounded by the lead cap, i.e. by the very quantity being measured.
+func TestSkipCutDoesNotCountTheStaleAudioItDrops(t *testing.T) {
+	m, d, sink := skipCutHarness(t, 1) // every page goes straight to the box
+
+	track := synthVorbisTrack(1, 400, false)
+	feed(d, track[:len(track)/2])
+	m.NoteSkip() // the user skips mid-track
+	feed(d, track[len(track)/2:])
+
+	m.mu.Lock()
+	delivered := m.deliveredGran
+	m.mu.Unlock()
+	got := sinkGranules(t, sink.buf.Bytes())
+	if delivered != got {
+		t.Fatalf("delivered timeline %d granules, the box was handed %d (%.2f s counted but dropped)",
+			delivered, got, float64(delivered-got)/vorbisRate)
+	}
+	// The cut has to have thrown something away, or the equality above is met by
+	// a run in which nothing was dropped.
+	if full := sinkGranules(t, bytes.Join(track, nil)); delivered >= full {
+		t.Fatalf("the skip cut dropped nothing (%d of %d granules delivered), the test proves nothing", delivered, full)
+	}
+}
+
+// The other half of the same cut: the batch that was waiting for the box when
+// the boundary arrived is dropped too, and it was counted when it was batched.
+func TestSkipCutDoesNotCountTheBatchItThrowsAway(t *testing.T) {
+	m, d, sink := skipCutHarness(t, 1<<20) // one big batch, nothing reaches the box yet
+
+	feed(d, synthVorbisTrack(1, 400, false))
+	m.mu.Lock()
+	batched := m.deliveredGran
+	m.mu.Unlock()
+	if batched == 0 {
+		t.Fatal("nothing was batched, the test proves nothing")
+	}
+	m.NoteSkip()
+	feed(d, synthVorbisTrack(2, 10, false)[:1]) // the boundary the cut waits for
+
+	m.mu.Lock()
+	delivered := m.deliveredGran
+	m.mu.Unlock()
+	if got := sinkGranules(t, sink.buf.Bytes()); delivered != got {
+		t.Fatalf("the dropped batch stayed on the delivered timeline: %d granules delivered, %d handed to the box",
+			delivered, got)
+	}
+}
+
+// sinkGranules is the audio actually written to the box: the sum of the granule
+// advances over the pages in the byte stream, which is the same quantity the
+// drain publishes as the delivered timeline.
+func sinkGranules(t *testing.T, b []byte) int64 {
+	t.Helper()
+	var total, trackMax int64
+	for off := 0; off+27 <= len(b); {
+		if string(b[off:off+4]) != "OggS" {
+			t.Fatalf("the sink holds something that is not a page stream, at offset %d", off)
+		}
+		nsegs := int(b[off+26])
+		if off+27+nsegs > len(b) {
+			t.Fatalf("truncated page header at offset %d", off)
+		}
+		body := 0
+		for _, l := range b[off+27 : off+27+nsegs] {
+			body += int(l)
+		}
+		if b[off+5]&0x02 != 0 { // BOS: the next track's granules start again
+			trackMax = 0
+		}
+		if gran := oggGranule(b[off:]); gran > trackMax {
+			total, trackMax = total+gran-trackMax, gran
+		}
+		off += 27 + nsegs + body
+	}
+	return total
+}
+
+// The delivered timeline is measured from the attach, so it may only advance
+// while a box is attached. A counter that moved for pages nobody received would
+// report audio the speaker never got and inflate every later difference.
+func TestDeliveredTimelineStaysPutWithNoBoxAttached(t *testing.T) {
+	var reads atomic.Int32
+	m, d := lagDrainHarness(t, &reads)
+	m.mu.Lock()
+	m.sink = nil
+	m.mu.Unlock()
+
+	feed(d, synthVorbisTrack(1, 60, false))
+
+	m.mu.Lock()
+	delivered := m.deliveredGran
+	m.mu.Unlock()
+	if delivered != 0 {
+		t.Fatalf("the delivered timeline advanced to %d granules with nothing attached", delivered)
+	}
+	if got := reads.Load(); got != 0 {
+		t.Fatalf("the box was queried %d times with nothing attached", got)
+	}
+}

--- a/internal/spotify/boxlag_test.go
+++ b/internal/spotify/boxlag_test.go
@@ -1,0 +1,219 @@
+package spotify
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// lagTestManager is a manager with a box attached and a known delivered
+// timeline: 30 s of audio handed out since the box attached.
+func lagTestManager(buf *bytes.Buffer, pos func(context.Context) (time.Duration, bool)) *Manager {
+	m := &Manager{logger: slog.New(slog.NewTextHandler(buf, nil))}
+	m.sink = io.Discard
+	m.lagBaseGran = 100 * vorbisRate
+	m.deliveredGran = 130 * vorbisRate
+	m.boxPositionFn = pos
+	return m
+}
+
+// The number the field report needs: STR has delivered 30 s since the box
+// attached, the box says it has played 20 s of them, so 10 s are still in the
+// buffer and the Spotify app's position (and its lyrics) runs that far ahead.
+func TestMeasureBoxLagComputesTheDifference(t *testing.T) {
+	var buf bytes.Buffer
+	m := lagTestManager(&buf, func(context.Context) (time.Duration, bool) {
+		return 20 * time.Second, true
+	})
+	m.measureBoxLag("track-boundary")
+
+	got := m.LastBoxLag()
+	if got.DeliveredSec != 30 || got.BoxRelSec != 20 || got.DiffSec != 10 {
+		t.Fatalf("measurement = %+v, want delivered 30, box 20, diff 10", got)
+	}
+	if got.Reason != "track-boundary" || got.At.IsZero() {
+		t.Fatalf("the measurement must carry its trigger and time: %+v", got)
+	}
+	line := buf.String()
+	if !strings.Contains(line, "diffSec=10") || !strings.Contains(line, "deliveredSec=30") ||
+		!strings.Contains(line, "boxRelSec=20") {
+		t.Fatalf("the INFO line must carry both sides and the difference:\n%s", line)
+	}
+}
+
+// A box that will not answer GetPositionInfo must leave no measurement behind.
+// A stored zero would read as "no lag at all", which is the one conclusion this
+// must never invite.
+func TestMeasureBoxLagSkipsAnUnreadablePosition(t *testing.T) {
+	var buf bytes.Buffer
+	m := lagTestManager(&buf, func(context.Context) (time.Duration, bool) {
+		return 0, false
+	})
+	m.measureBoxLag("attach")
+
+	if got := m.LastBoxLag(); got != (boxLagMeasurement{}) {
+		t.Fatalf("an unreadable position stored a measurement: %+v", got)
+	}
+	if strings.Contains(buf.String(), "buffer lag measured") {
+		t.Fatalf("an unreadable position must not be logged as a measurement:\n%s", buf.String())
+	}
+}
+
+// The other half of the same trap, and the one a box actually walks into: it
+// ANSWERS, but with no usable RelTime, which parses as zero. Mid-track that zero
+// is not a position, it is the claim that the box has played none of the 30 s it
+// was handed - the largest lag this can express, growing for as long as the
+// track lasts, and indistinguishable in a bundle from a real reading.
+func TestMeasureBoxLagSkipsAZeroPositionMidTrack(t *testing.T) {
+	var buf bytes.Buffer
+	m := lagTestManager(&buf, func(context.Context) (time.Duration, bool) {
+		return 0, true
+	})
+	m.measureBoxLag("track-boundary")
+
+	if got := m.LastBoxLag(); got != (boxLagMeasurement{}) {
+		t.Fatalf("a zero box clock stored a full-track lag: %+v", got)
+	}
+	if strings.Contains(buf.String(), "buffer lag measured") {
+		t.Fatalf("a zero box clock must not be logged as a measurement:\n%s", buf.String())
+	}
+}
+
+// A delivered timeline below its own baseline means the timeline was rebuilt
+// under the attached box (a go-librespot restart with the sink still open). The
+// difference would be negative, which is not a lag: re-baseline and report
+// nothing.
+func TestMeasureBoxLagRebaselinesARebuiltTimeline(t *testing.T) {
+	var buf bytes.Buffer
+	m := lagTestManager(&buf, func(context.Context) (time.Duration, bool) {
+		return 60 * time.Second, true
+	})
+	m.deliveredGran = 10 * vorbisRate // a fresh run's timeline, below the base
+	m.measureBoxLag("track-boundary")
+
+	if got := m.LastBoxLag(); got != (boxLagMeasurement{}) {
+		t.Fatalf("a rebuilt timeline stored a negative measurement: %+v", got)
+	}
+	if m.lagBaseGran != 10*vorbisRate {
+		t.Fatalf("the baseline must follow the rebuilt timeline, got %d", m.lagBaseGran)
+	}
+}
+
+// Nothing attached means there is no playback to measure: no SOAP query goes
+// out (the box is not disturbed) and nothing is recorded.
+func TestMeasureBoxLagDoesNothingWithNoBoxAttached(t *testing.T) {
+	var buf bytes.Buffer
+	asked := 0
+	m := lagTestManager(&buf, func(context.Context) (time.Duration, bool) {
+		asked++
+		return 5 * time.Second, true
+	})
+	m.sink = nil
+
+	m.measureBoxLag("track-boundary")
+
+	if asked != 0 {
+		t.Fatalf("the box was queried %d times with nothing attached", asked)
+	}
+	if got := m.LastBoxLag(); got != (boxLagMeasurement{}) {
+		t.Fatalf("a measurement was recorded with nothing attached: %+v", got)
+	}
+}
+
+// With no position reader wired (the agent that never got one, and every test
+// that does not want the traffic) the measurement is a no-op.
+func TestMeasureBoxLagDoesNothingWithoutAPositionReader(t *testing.T) {
+	var buf bytes.Buffer
+	m := lagTestManager(&buf, nil)
+	m.measureBoxLag("attach")
+	if got := m.LastBoxLag(); got != (boxLagMeasurement{}) {
+		t.Fatalf("a measurement appeared without a position reader: %+v", got)
+	}
+}
+
+// An attach only ARMS the baseline; the drain takes it on the first audio page
+// the box actually receives (see boxlag_drain_test.go). Until then there is no
+// shared base, so a reading arriving in between would be measured against the
+// previous attachment's timeline: it must be skipped, not reported.
+func TestMeasureBoxLagWaitsForTheBaselineAfterAnAttach(t *testing.T) {
+	var buf bytes.Buffer
+	asked := 0
+	m := lagTestManager(&buf, func(context.Context) (time.Duration, bool) {
+		asked++
+		return 20 * time.Second, true
+	})
+	m.noteStreamAttached()
+	m.measureBoxLag("attach")
+
+	if got := m.LastBoxLag(); got != (boxLagMeasurement{}) {
+		t.Fatalf("a measurement was taken before the attachment had a baseline: %+v", got)
+	}
+	if asked != 0 {
+		t.Fatalf("the box was queried %d times with no baseline to compare against", asked)
+	}
+}
+
+// Units. Granules are samples at the stream's own rate and RelTime is a clock
+// in seconds, so the divisor is the one place the two sides can silently drift
+// apart: at 48000 (the other rate an Ogg stream can carry) the delivered side
+// would read 9 % short and nothing else in the code would notice. A fractional
+// second is used deliberately - a whole-second fixture passes under a divisor
+// that is merely off by a factor the fixture happens to absorb.
+func TestMeasureBoxLagConvertsGranulesAtTheStreamSampleRate(t *testing.T) {
+	var buf bytes.Buffer
+	m := lagTestManager(&buf, func(context.Context) (time.Duration, bool) {
+		return 1500 * time.Millisecond, true
+	})
+	m.lagBaseGran = 0
+	m.deliveredGran = 11*vorbisRate + vorbisRate/2 // 11.5 s of audio handed out
+
+	m.measureBoxLag("track-boundary")
+
+	got := m.LastBoxLag()
+	if got.DeliveredSec != 11.5 || got.BoxRelSec != 1.5 || got.DiffSec != 10 {
+		t.Fatalf("measurement = %+v, want delivered 11.5, box 1.5, diff 10", got)
+	}
+}
+
+// The box query is bounded. The drain fires this per track boundary and never
+// waits on it, so a speaker that accepts the SOAP connection and then says
+// nothing must not hold the goroutine: on a box whose :8091 has wedged that is
+// one stuck goroutine per track, for the rest of the session.
+func TestMeasureBoxLagBoundsTheBoxQuery(t *testing.T) {
+	var buf bytes.Buffer
+	var deadline time.Time
+	var haveDeadline bool
+	m := lagTestManager(&buf, func(ctx context.Context) (time.Duration, bool) {
+		deadline, haveDeadline = ctx.Deadline()
+		return 20 * time.Second, true
+	})
+	m.measureBoxLag("track-boundary")
+
+	if !haveDeadline {
+		t.Fatal("the box query ran with no deadline; a silent speaker would hold it forever")
+	}
+	if left := time.Until(deadline); left > boxLagReadTimeout {
+		t.Fatalf("the query deadline is %v away, longer than boxLagReadTimeout %v", left, boxLagReadTimeout)
+	}
+}
+
+// The measurement rides in the Spotify debug section, so a diagnostic bundle
+// carries the number even after the NAND log ring has rolled.
+func TestChainSnapshotCarriesTheLastLagMeasurement(t *testing.T) {
+	var buf bytes.Buffer
+	m := lagTestManager(&buf, func(context.Context) (time.Duration, bool) {
+		return 20 * time.Second, true
+	})
+	m.measureBoxLag("track-boundary")
+
+	snap := m.ChainSnapshot()
+	if snap["lastLagDiffSec"] != 10.0 || snap["lastLagDeliveredSec"] != 30.0 ||
+		snap["lastLagBoxRelSec"] != 20.0 || snap["lastLagReason"] != "track-boundary" {
+		t.Fatalf("the debug section must carry the measurement, got %v %v %v %v",
+			snap["lastLagDeliveredSec"], snap["lastLagBoxRelSec"], snap["lastLagDiffSec"], snap["lastLagReason"])
+	}
+}

--- a/internal/spotify/drain.go
+++ b/internal/spotify/drain.go
@@ -51,6 +51,17 @@ type oggDrain struct {
 	granOffset, leadBaseGran int64
 	leadBaseAt               time.Time
 	leadAnchored             bool
+	// Delivered timeline for the buffer-lag measurement (boxlag.go). Separate
+	// from the pacing timeline above on purpose: pacing counts what the engine
+	// produced, this counts only what was actually handed to the box.
+	//   - deliveredBase: the manager's timeline when this run started. The sink
+	//     outlives one go-librespot run (that is the seam design), so a drain
+	//     starting its own count at zero would send the timeline backwards under
+	//     an attached box on every engine restart.
+	//   - delivered: granules handed to the box during this run.
+	//   - flushed: delivered at the last write that reached the box, i.e. the
+	//     point a dropped batch is rolled back to.
+	deliveredBase, delivered, flushed int64
 }
 
 // newOggDrain returns the drain state for one go-librespot run. flushBytes is
@@ -58,7 +69,46 @@ type oggDrain struct {
 // ahead of realtime the box is fed (0 disables pacing), chain is the seam
 // cutter for long tracks (oggchain.go).
 func (m *Manager) newOggDrain(flushBytes int, leadCapSec float64, chain *oggChain) *oggDrain {
-	return &oggDrain{m: m, flushBytes: flushBytes, leadCapSec: leadCapSec, chain: chain, pendingSince: time.Now()}
+	// Continue the delivered timeline where the previous run left it: an engine
+	// restart (crash-restart loop, a deliberate volume-config restart, the OTA
+	// sidecar swap) builds a new drain while the box stays attached, and a
+	// timeline that restarted at zero there made every later buffer-lag reading
+	// negative until the box happened to re-attach.
+	m.mu.Lock()
+	base := m.deliveredGran
+	m.mu.Unlock()
+	return &oggDrain{m: m, flushBytes: flushBytes, leadCapSec: leadCapSec, chain: chain,
+		pendingSince: time.Now(), deliveredBase: base}
+}
+
+// noteDelivered extends the delivered timeline by audio that is actually being
+// handed to the box, publishes it for the buffer-lag measurement (boxlag.go)
+// and takes the per-attachment baseline when one is armed (see
+// noteStreamAttached). It reports whether it took that baseline, i.e. whether
+// this is the first audio the current attachment receives.
+func (d *oggDrain) noteDelivered(advance int64) (tookBaseline bool) {
+	m := d.m
+	d.delivered += advance
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.deliveredGran = d.deliveredBase + d.delivered
+	if !m.lagRebase {
+		return false
+	}
+	m.lagBaseGran, m.lagRebase = m.deliveredGran, false
+	return true
+}
+
+// dropUnsent rolls the delivered timeline back to the last write that reached
+// the box. The batched pages being thrown away here were counted when they were
+// batched, but the box never received them, so its own clock cannot contain
+// them. No baseline is taken: nothing was delivered.
+func (d *oggDrain) dropUnsent() {
+	m := d.m
+	d.delivered = d.flushed
+	m.mu.Lock()
+	m.deliveredGran = d.deliveredBase + d.delivered
+	m.mu.Unlock()
 }
 
 // page processes one checksum-valid Ogg page from the engine.
@@ -130,8 +180,14 @@ func (d *oggDrain) page(ctx context.Context, page []byte) {
 		d.hdr = append(d.hdr, page...)
 	}
 	d.trackBody += bodyLen
+	// How much new audio this page adds to the current track. Granules are the
+	// track's own sample clock and restart per track, so the ADVANCE is what
+	// extends the continuous timelines; it is computed for every page, including
+	// the ones that are about to be dropped, because d.maxGran has to track the
+	// engine's production either way.
+	advance := int64(0)
 	if gran > d.maxGran {
-		d.maxGran = gran
+		advance, d.maxGran = gran-d.maxGran, gran
 	}
 	if d.maxGran > vorbisRate { // at least one second streamed
 		kbps := int(d.trackBody * 8 * vorbisRate / (d.maxGran * 1000))
@@ -161,16 +217,27 @@ func (d *oggDrain) page(ctx context.Context, page []byte) {
 		// so song endings are never clipped. The cut disarms here and the
 		// pacing re-anchors, so the new track gets its instant prefill.
 		if htype&0x02 != 0 {
+			boundary := "track-boundary"
 			if m.skipCutArmed() {
 				m.logger.Info("spotify: skip cut, boundary reached; dropped the old track's unsent tail", "droppedKB", len(d.pending)/1024)
 				d.pending = d.pending[:0]
+				d.dropUnsent() // the box never got this batch: keep the lag honest
 				m.clearSkipCut()
 				m.noteSkipBoundary()
 				d.leadAnchored = false
+				// Named apart for the lag measurement below: a skip makes the
+				// box drop its buffer, so the two clocks are mid-jump here and
+				// the number must not be read like a steady-state one.
+				boundary = "track-boundary after a skip"
 			} else if len(d.pending) > 0 {
 				m.forward(sink, d.pending)
-				d.pending = d.pending[:0]
+				d.pending, d.flushed = d.pending[:0], d.delivered
 			}
+			// One buffer-lag measurement per track boundary (boxlag.go). The
+			// delivered side is sampled here, the box's SOAP round trip runs in
+			// the background: the drain is pacing live audio and must never wait
+			// on the box.
+			m.triggerBoxLag(boundary)
 		} else if m.skipCutArmed() && gran > 0 {
 			// Stale audio between the user's skip and the new track's
 			// boundary. The first version PACED these pages to realtime, so
@@ -179,6 +246,19 @@ func (d *oggDrain) page(ctx context.Context, page []byte) {
 			// nothing the user wants to hear: drop them outright and race
 			// to the boundary.
 			return
+		}
+		// Publish the delivered timeline for the buffer-lag measurement
+		// (boxlag.go). After the skip cut above, because those pages are dropped
+		// and the box's own clock can never contain them; still before the pacing
+		// wait below, because the number this is compared against is the position
+		// go-librespot reports to the Spotify app, i.e. the page that has just
+		// left the engine's pipe rather than the one the pacing is holding back.
+		if advance > 0 && d.noteDelivered(advance) {
+			// First audio of a new attachment: both clocks are at their start, so
+			// this is the zero check the attach reading exists for. Taken here
+			// rather than where the box attached, so the two sides share one
+			// instant.
+			m.triggerBoxLag(boxLagReasonAttach)
 		}
 		// Realtime pacing: anchor once per attachment at the first audio
 		// page, then hold each page until its position on the continuous
@@ -249,7 +329,7 @@ func (d *oggDrain) page(ctx context.Context, page []byte) {
 		// same rule as the tail flush before a real BOS above.
 		if seam || len(d.pending) >= d.flushBytes || time.Since(d.pendingSince) > maxFlushAge {
 			m.forward(sink, d.pending)
-			d.pending = d.pending[:0]
+			d.pending, d.flushed = d.pending[:0], d.delivered
 		}
 		d.chain.probe(now, "")
 		return
@@ -260,6 +340,7 @@ func (d *oggDrain) page(ctx context.Context, page []byte) {
 	// go-librespot so it stops producing (no racing) until a box attaches
 	// and ServeOgg resumes it.
 	d.pending = d.pending[:0]
+	d.dropUnsent() // same rule as the skip cut: undelivered audio is not delivered
 	// A seam still waiting for its proof line gets it now: the box is gone,
 	// so its memory reading will not move for this link any more. The link
 	// byte count is deliberately NOT reset, an HTTP re-attach frees nothing

--- a/internal/spotify/manager.go
+++ b/internal/spotify/manager.go
@@ -345,6 +345,22 @@ type Manager struct {
 	// captured from /status and metadata events to feed the resume store.
 	resume      *resumeStore
 	curTrackURI string
+	// Buffer-lag measurement (boxlag.go): deliveredGran is the continuous audio
+	// timeline of the last page the drain HANDED TO the box, lagBaseGran its
+	// value when the current attachment received its first audio, boxPositionFn
+	// reads the speaker's own clock and lastLag holds the most recent comparison
+	// for the debug section. lagRebase is set when a box attaches and consumed
+	// by the drain when it takes that baseline, so a reading that arrives in
+	// between is skipped instead of being measured against the previous
+	// attachment. Measured only, never applied. Guarded by mu.
+	deliveredGran int64
+	lagBaseGran   int64
+	lagRebase     bool
+	boxPositionFn func(context.Context) (time.Duration, bool)
+	lastLag       boxLagMeasurement
+	// loggedBoxLag keeps the buffer-lag line to one INFO per agent run; see
+	// measureBoxLag.
+	loggedBoxLag bool
 	// lowDisk is set when the configDir filesystem is below spotifyMinFreeBytes, so
 	// go-librespot is not started (it cannot persist its credential on a full NAND).
 	// Surfaced in ServeInfo so the desktop app shows "box NAND full" instead of
@@ -469,6 +485,7 @@ func (m *Manager) SeamsTotal() int {
 func (m *Manager) ChainSnapshot() map[string]any {
 	m.mu.Lock()
 	s := m.chainSnap
+	lag := m.lastLag
 	m.mu.Unlock()
 	out := map[string]any{
 		"enabled":         s.Enabled,
@@ -485,6 +502,14 @@ func (m *Manager) ChainSnapshot() map[string]any {
 		"liveSerial":      s.LiveSerial,
 		"enginePID":       m.EnginePID(),
 		"memAvailKB":      int64(-1),
+		// The last buffer-lag measurement (boxlag.go). It rides in this section
+		// because it is the same subject: how much audio sits between the engine
+		// and the room. Zero values mean none has been taken yet.
+		"lastLagAt":           lag.At,
+		"lastLagReason":       lag.Reason,
+		"lastLagDeliveredSec": lag.DeliveredSec,
+		"lastLagBoxRelSec":    lag.BoxRelSec,
+		"lastLagDiffSec":      lag.DiffSec,
 	}
 	if m.MemAvailKB != nil {
 		out["memAvailKB"] = m.MemAvailKB()

--- a/internal/spotify/serve.go
+++ b/internal/spotify/serve.go
@@ -309,6 +309,15 @@ func (m *Manager) ServeOgg(w http.ResponseWriter, r *http.Request) {
 	m.sinkSeams = 0
 	m.mu.Unlock()
 	m.logger.Info("spotify: box attached to Ogg stream", "remote", r.RemoteAddr, "headerBytes", len(hdr), "reattach", reattach)
+	// Buffer-lag baseline (boxlag.go): arm it here, take it in the drain on the
+	// first audio page this box receives. Delivered audio is then counted from
+	// the same instant the box's own RelTime counts from, and the reading taken
+	// there is the zero check - both sides should read about the same, and a
+	// bundle that shows they do not is what tells us how to read the per-track
+	// numbers. Reading it HERE instead would compare a box that has not started
+	// the new transport yet (its RelTime can still be the previous URI's clock)
+	// against a delivered counter that stopped at the previous detach.
+	m.noteStreamAttached()
 
 	// A fresh (non-reattach) attach is a clean recall start, not a storm: clear
 	// any accumulated re-point backoff so the next genuine playlist switch is

--- a/internal/upnp/position_test.go
+++ b/internal/upnp/position_test.go
@@ -1,6 +1,9 @@
 package upnp
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 )
@@ -21,6 +24,57 @@ func TestParseClock(t *testing.T) {
 	for in, want := range cases {
 		if got := parseClock(in); got != want {
 			t.Errorf("parseClock(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// The distinction PositionInfo cannot express: "the box is at zero" and "the
+// box has no value for this field" both parse to a zero duration, and only the
+// first one is a position.
+func TestParseClockOKSeparatesAZeroFromAnUnreadableField(t *testing.T) {
+	cases := map[string]bool{
+		"0:00:00":         true,
+		"0:03:27":         true,
+		"00:00":           true,
+		"NOT_IMPLEMENTED": false, // the firmware's answer for a field it has no value for
+		"":                false,
+		"garbage:in:here": false,
+		"1:2:3:4":         false,
+	}
+	for in, wantOK := range cases {
+		if _, ok := parseClockOK(in); ok != wantOK {
+			t.Errorf("parseClockOK(%q) ok = %v, want %v", in, ok, wantOK)
+		}
+	}
+}
+
+// RelPosition reports readability, not call success: a box that ANSWERS with a
+// field it has no value for must come back ok=false, so a caller comparing
+// positions skips instead of recording a zero as "played nothing at all".
+func TestRelPositionReportsReadability(t *testing.T) {
+	cases := []struct {
+		name, rel string
+		wantDur   time.Duration
+		wantOK    bool
+	}{
+		{"a real position", "0:01:07", time.Minute + 7*time.Second, true},
+		{"the start of a track", "0:00:00", 0, true},
+		{"a field the firmware has no value for", "NOT_IMPLEMENTED", 0, false},
+		{"no field at all", "", 0, false},
+	}
+	for _, c := range cases {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			body := `<s:Envelope><s:Body><u:GetPositionInfoResponse><TrackDuration>0:04:11</TrackDuration>`
+			if c.rel != "" {
+				body += `<RelTime>` + c.rel + `</RelTime>`
+			}
+			_, _ = w.Write([]byte(body + `</u:GetPositionInfoResponse></s:Body></s:Envelope>`))
+		}))
+		r := &Renderer{ControlURL: srv.URL, Client: srv.Client()}
+		got, ok := r.RelPosition(context.Background())
+		srv.Close()
+		if got != c.wantDur || ok != c.wantOK {
+			t.Errorf("%s: RelPosition = (%v, %v), want (%v, %v)", c.name, got, ok, c.wantDur, c.wantOK)
 		}
 	}
 }

--- a/internal/upnp/upnp.go
+++ b/internal/upnp/upnp.go
@@ -475,12 +475,40 @@ func xmlEscapeAttr(s string) string {
 // H:MM:SS, and Bose also answers "NOT_IMPLEMENTED" for fields it has no value
 // for, so anything unparseable is reported as zero rather than as an error.
 func (r *Renderer) PositionInfo(ctx context.Context) (rel, dur time.Duration, ok bool) {
-	body := `<?xml version="1.0"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:GetPositionInfo xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID></u:GetPositionInfo></s:Body></s:Envelope>`
-	out, err := r.soapCallBody(ctx, "GetPositionInfo", body)
+	out, err := r.getPositionInfo(ctx)
 	if err != nil {
 		return 0, 0, false
 	}
-	return parseClock(innerText(string(out), "RelTime")), parseClock(innerText(string(out), "TrackDuration")), true
+	return parseClock(innerText(out, "RelTime")), parseClock(innerText(out, "TrackDuration")), true
+}
+
+// RelPosition asks the renderer for RelTime alone and, unlike PositionInfo,
+// reports whether that field was READABLE rather than whether the call
+// succeeded.
+//
+// The distinction matters wherever the position is compared against another
+// clock. Bose answers "NOT_IMPLEMENTED" for fields it has no value for, and
+// PositionInfo maps that to zero, which a caller cannot tell from a stream that
+// really is at 0:00:00 - and a false zero there reads as "the box has played
+// nothing of what it was given", i.e. the maximum possible lag. ok=false means
+// "no usable clock", so such a caller can skip instead of recording a fiction.
+func (r *Renderer) RelPosition(ctx context.Context) (time.Duration, bool) {
+	out, err := r.getPositionInfo(ctx)
+	if err != nil {
+		return 0, false
+	}
+	return parseClockOK(innerText(out, "RelTime"))
+}
+
+// getPositionInfo runs the GetPositionInfo query and returns the response
+// envelope. Shared by the two readers above so both send the identical body.
+func (r *Renderer) getPositionInfo(ctx context.Context) (string, error) {
+	body := `<?xml version="1.0"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:GetPositionInfo xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID></u:GetPositionInfo></s:Body></s:Envelope>`
+	out, err := r.soapCallBody(ctx, "GetPositionInfo", body)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
 }
 
 // innerText pulls the text of the first <tag>...</tag> out of an XML blob. The
@@ -504,9 +532,18 @@ func innerText(doc, tag string) string {
 // including the "NOT_IMPLEMENTED" the firmware answers for unknown fields,
 // is zero.
 func parseClock(s string) time.Duration {
+	d, _ := parseClockOK(s)
+	return d
+}
+
+// parseClockOK is parseClock plus the verdict a comparing caller needs: ok is
+// false for anything that is not a well-formed clock, which is what tells "the
+// box has no value for this field" apart from "the box is at zero". Both map to
+// a zero duration, and only one of them is a position.
+func parseClockOK(s string) (time.Duration, bool) {
 	parts := strings.Split(s, ":")
 	if len(parts) < 2 || len(parts) > 3 {
-		return 0
+		return 0, false
 	}
 	var total time.Duration
 	units := []time.Duration{time.Hour, time.Minute, time.Second}
@@ -519,9 +556,9 @@ func parseClock(s string) time.Duration {
 		}
 		n, err := strconv.Atoi(p)
 		if err != nil || n < 0 {
-			return 0
+			return 0, false
 		}
 		total += time.Duration(n) * units[i]
 	}
-	return total
+	return total, true
 }

--- a/internal/webui/queueplay.go
+++ b/internal/webui/queueplay.go
@@ -491,6 +491,28 @@ func nowPlayingStandby(body string) bool {
 	return false
 }
 
+// nowPlayingStatus reads the play status out of a now_playing body, empty when
+// the box reported none (a box that has just left standby, and the source
+// teardown while it is in progress). The typed element first so a track title
+// containing "STOP_STATE" cannot be mistaken for one; some firmwares put the
+// status on an attribute instead, which is what the scan covers.
+func nowPlayingStatus(body string) string {
+	if m := reNowPlayStatus.FindStringSubmatch(body); m != nil {
+		return m[1]
+	}
+	switch {
+	case strings.Contains(body, "PLAY_STATE"):
+		return "PLAY_STATE"
+	case strings.Contains(body, "BUFFERING_STATE"):
+		return "BUFFERING_STATE"
+	case strings.Contains(body, "PAUSE_STATE"):
+		return "PAUSE_STATE"
+	case strings.Contains(body, "STOP_STATE"):
+		return "STOP_STATE"
+	}
+	return ""
+}
+
 // pollNowPlaying reads the box's now_playing once and returns the play status,
 // the current/total position, and whether the box is in standby. Zero values on
 // any error.
@@ -507,20 +529,7 @@ func (s *Server) pollNowPlaying() (status string, pos, total time.Duration, stan
 	resp.Body.Close()
 	body := string(b)
 	standby = nowPlayingStandby(body)
-	if m := reNowPlayStatus.FindStringSubmatch(body); m != nil {
-		status = m[1]
-	} else {
-		switch { // some firmwares put it on an attribute; fall back to a scan
-		case strings.Contains(body, "PLAY_STATE"):
-			status = "PLAY_STATE"
-		case strings.Contains(body, "BUFFERING_STATE"):
-			status = "BUFFERING_STATE"
-		case strings.Contains(body, "PAUSE_STATE"):
-			status = "PAUSE_STATE"
-		case strings.Contains(body, "STOP_STATE"):
-			status = "STOP_STATE"
-		}
-	}
+	status = nowPlayingStatus(body)
 	if m := reNowPlayTime.FindStringSubmatch(body); m != nil {
 		if t, err := strconv.Atoi(m[1]); err == nil {
 			total = time.Duration(t) * time.Second

--- a/internal/webui/resume_foreign.go
+++ b/internal/webui/resume_foreign.go
@@ -1,0 +1,193 @@
+// Foreign-content guard for the automatic power-on resume.
+//
+// The DO_NOT_RESUME restore that drives ResumeLastPlay is not only sent on a
+// power-on. The firmware sends the identical frame when it tears STR's UPnP
+// source down, and one of the ways it does that is a failed skip: the box
+// cannot skip a UPnP source, answers QPLAY_SKIP_*_FAILED and drops the source
+// (see webui.HardwareSkip and internal/boxws). During that drop the box reports
+// no play state at all, so the busy check ResumeLastPlay relies on reads "awake
+// and idle" and the resume pushes STR's last station.
+//
+// That is harmless while the speaker is STR's. It is not harmless when somebody
+// is streaming to the speaker from something else: pressing Next on the remote
+// during a Music Assistant stream made the speaker jump to an STR station, which
+// the reporter described as the speaker wanting to switch presets (Christian1985l,
+// discussion #827).
+//
+// boxws now suppresses the wake for the skip it can see on the bus. This is the
+// second, independent half: whatever the frame claimed, a speaker that is
+// carrying content STR does not serve belongs to whoever put it there, and the
+// automatic resume stands down.
+//
+// Freshness is part of the test, not an extra. A ContentItem alone says what the
+// box is TUNED to, not what is happening now: the firmware restores the last
+// selection when it comes out of standby, so a user whose evening ended on Music
+// Assistant is still carrying that foreign item the next morning. Standing down
+// on it would silently turn the power-on resume off for that user for good, with
+// one log line to show for it. So the stand-down needs the item AND a live play
+// status in the same reading (PLAY / BUFFERING / PAUSE): that is a speaker
+// somebody is using right now. A restored selection on a box that reports no
+// play state is history, and the resume proceeds.
+
+package webui
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// strAgentPorts are the ports an STR agent answers audio on: 8888 direct (sm2
+// chassis) and 17008 through the PREROUTING REDIRECT (BCO chassis), the latter
+// also being the mirror proxy a group follower pulls from. A location on either
+// comes from an STR agent, this box's own or another speaker's.
+var strAgentPorts = map[string]bool{"8888": true, "17008": true}
+
+// locationServedBySTR reports whether a box-facing content location is one STR
+// itself put there. ownStream is the resume target (the stream STR last played),
+// used for the one shape that is ours without carrying an STR address: a media
+// library track, which STR pushes straight from the user's NAS.
+//
+// It answers TRUE for anything it cannot judge. The guard exists to keep STR off
+// a speaker that demonstrably belongs to someone else right now, and an empty,
+// relative or unparseable location demonstrates nothing - refusing to resume on
+// it would break the ordinary power-on case (a bare INVALID_SOURCE with no
+// ContentItem is the normal wake signature, see boxStuckSelection).
+func locationServedBySTR(loc, ownStream string) bool {
+	loc = strings.TrimSpace(loc)
+	if loc == "" {
+		return true
+	}
+	// A native radio ContentItem is a station descriptor, not a stream address:
+	// the box resolves it through STR's own LOCAL_INTERNET_RADIO adapter. The
+	// speaker reports it in the relative "/station?data=" form, which has no
+	// host to judge anyway.
+	if strings.Contains(loc, "/station?data=") {
+		return true
+	}
+	u, err := url.Parse(loc)
+	if err != nil || u.Host == "" {
+		return true // not an address we can attribute: see the contract above
+	}
+	switch u.Hostname() {
+	case "127.0.0.1", "localhost", "::1":
+		return true // this agent's own proxy
+	}
+	if strAgentPorts[u.Port()] {
+		return true
+	}
+	// The library case: STR pushed a track from a media server, so the box
+	// carries the server's address, not STR's. The resume target names that
+	// same server (the queue plays one server at a time), which is what tells
+	// this apart from a stream a foreign controller pushed.
+	if hp := hostPortOf(ownStream); hp != "" && hp == hostPortOf(loc) {
+		return true
+	}
+	return false
+}
+
+// foreignLocation returns the first location among locs that STR does not serve.
+// Callers pass what the box reported at the wake and what it reports now, so a
+// content item that was only visible in one of the two readings still counts.
+func foreignLocation(locs []string, ownStream string) (loc string, foreign bool) {
+	for _, l := range locs {
+		if !locationServedBySTR(l, ownStream) {
+			return l, true
+		}
+	}
+	return "", false
+}
+
+// boxReading is one now_playing read: every ContentItem location it carried,
+// and whether the box reported live playback at that moment. The two travel
+// together because the verdict needs both from the SAME instant - a location
+// from one reading and a play status from another would say nothing about
+// whether that location is what is playing.
+type boxReading struct {
+	locations []string
+	playing   bool
+}
+
+// readBox reads the box's now_playing once. Best effort: an unreachable or
+// unreadable box returns the zero reading, which the caller reads as "no
+// evidence of foreign content" and proceeds exactly as before.
+func (s *Server) readBox() boxReading {
+	if s.nowPlayingBodyFn != nil {
+		return parseBoxReading(s.nowPlayingBodyFn())
+	}
+	if s.boxHost == "" {
+		return boxReading{}
+	}
+	cl := &http.Client{Timeout: 4 * time.Second}
+	resp, err := cl.Get("http://" + s.boxHost + ":8090/now_playing")
+	if err != nil {
+		return boxReading{}
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+	return parseBoxReading(string(b))
+}
+
+// parseBoxReading turns one now_playing body into a reading. PAUSE counts as
+// live: a paused foreign stream is still somebody's speaker, and pushing a
+// station over it is the same interruption.
+func parseBoxReading(body string) boxReading {
+	switch nowPlayingStatus(body) {
+	case "PLAY_STATE", "BUFFERING_STATE", "PAUSE_STATE":
+		return boxReading{locations: contentLocations(body), playing: true}
+	}
+	return boxReading{locations: contentLocations(body)}
+}
+
+// contentLocations pulls the location attributes out of a now_playing body,
+// in document order.
+func contentLocations(body string) []string {
+	ms := reNowPlayLocation.FindAllStringSubmatch(body, -1)
+	out := make([]string, 0, len(ms))
+	for _, m := range ms {
+		out = append(out, m[1])
+	}
+	return out
+}
+
+// foreignContentStandDown reports whether the box is PLAYING content STR does
+// not serve, and logs the stand-down with the host so a diagnostic bundle names
+// what was playing instead. prior is what the box reported when the wake
+// arrived, ownStream the resume target.
+//
+// Two readings are consulted, each on its own: the one taken at the wake instant
+// (the teardown is over in a second or two, so it is the only one that can still
+// catch it) and one taken now. A foreign location without a live play status in
+// the same reading is a restored selection, not a speaker in use - see the file
+// header - and does not stand the resume down.
+func (s *Server) foreignContentStandDown(prior boxReading, ownStream string) bool {
+	// The live read is taken only when the prior one did not already decide:
+	// building both eagerly cost a :8090 round trip on every wake, including
+	// the ordinary ones this guard has nothing to say about.
+	readers := []func() boxReading{
+		func() boxReading { return prior },
+		s.readBox,
+	}
+	for _, read := range readers {
+		rd := read()
+		loc, foreign := foreignLocation(rd.locations, ownStream)
+		if !foreign {
+			continue
+		}
+		if !rd.playing {
+			// Logged: this is the case that used to cancel the resume, so a
+			// bundle from a user who wonders why it did NOT has to show it.
+			s.logger.Info("wake resume: the speaker's last selection is content STR does not serve, but nothing is playing, so it is not evidence of a live foreign stream; resuming",
+				"host", hostPortOf(loc))
+			continue
+		}
+		// The host, not the whole URL: it is what identifies the other
+		// controller, and a full media URL can carry a token.
+		s.logger.Info("wake resume: the speaker is playing content STR does not serve, not resuming",
+			"host", hostPortOf(loc))
+		return true
+	}
+	return false
+}

--- a/internal/webui/resume_foreign_shapes_test.go
+++ b/internal/webui/resume_foreign_shapes_test.go
@@ -1,0 +1,59 @@
+// The two content shapes STR itself produces that do NOT carry an STR address,
+// exercised through the whole ResumeLastPlay path rather than through the
+// predicate alone: a native station descriptor and a media-library file on the
+// user's own server. Both are what the box reports after an ordinary power-on
+// for a user whose last play was a hardware preset or an album, so a guard that
+// called either of them foreign would silently kill the power-on resume for
+// them.
+
+package webui
+
+import (
+	"testing"
+	"time"
+)
+
+// A station STR registered natively is reported back by the speaker as a bare
+// "/station?data=..." descriptor: no host, nothing to attribute. It is the
+// normal shape after a hardware preset press, so it must resume.
+func TestResumeLastPlayProceedsOnANativeStationDescriptor(t *testing.T) {
+	s, rec := resumeTestServer(t, `<nowPlaying source="INVALID_SOURCE">`+
+		`<ContentItem source="LOCAL_INTERNET_RADIO" type="DO_NOT_RESUME" `+
+		`location="/station?data=eyJuYW1lIjoiV0RSIn0="/></nowPlaying>`)
+	s.ResumeLastPlay()
+	if !waitForSOAP(rec, 6*time.Second) {
+		t.Fatalf("a native station selection must not stand the power-on resume down: %v", rec.list())
+	}
+}
+
+// A library track: STR pushes the user's own media server URL straight at the
+// box, so the box carries an address that is neither STR's nor a stranger's.
+// The resume target names the same server, which is what tells it apart from a
+// stream a foreign controller pushed.
+func TestResumeLastPlayProceedsOnALibraryTrackFromTheSameServer(t *testing.T) {
+	s, rec := resumeTestServer(t, `<nowPlaying source="INVALID_SOURCE">`+
+		`<ContentItem source="UPNP" location="http://192.0.2.28:9000/disk/track-42.flac"/></nowPlaying>`)
+	s.lastPlayMu.Lock()
+	s.lastPlay = &lastPlayInfo{
+		boxURL: "http://192.0.2.28:9000/disk/track-43.flac",
+		title:  "Next Track", mime: "audio/flac", ts: time.Now(),
+	}
+	s.lastPlayMu.Unlock()
+
+	s.ResumeLastPlay()
+	if !waitForSOAP(rec, 6*time.Second) {
+		t.Fatalf("a library track from the resume target's own server must still resume: %v", rec.list())
+	}
+}
+
+// The mirror stream a group follower pulls from the master runs on the agent's
+// externally reachable port, i.e. another speaker's LAN address. It is STR's
+// own audio and must not read as a stranger's.
+func TestResumeLastPlayProceedsOnAnotherSpeakersAgentPort(t *testing.T) {
+	s, rec := resumeTestServer(t, `<nowPlaying source="INVALID_SOURCE">`+
+		`<ContentItem source="UPNP" location="http://192.0.2.7:17008/stream/4"/></nowPlaying>`)
+	s.ResumeLastPlay()
+	if !waitForSOAP(rec, 6*time.Second) {
+		t.Fatalf("an STR agent port on another speaker must not stand the resume down: %v", rec.list())
+	}
+}

--- a/internal/webui/resume_foreign_test.go
+++ b/internal/webui/resume_foreign_test.go
@@ -1,0 +1,226 @@
+package webui
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The predicate the guard rests on. The false cases are the ones that must
+// stand the resume down; every true case is a shape STR itself produces and
+// would break if it were called foreign.
+func TestLocationServedBySTR(t *testing.T) {
+	const ownStream = "http://127.0.0.1:8888/stream/2"
+	cases := []struct {
+		name, loc, own string
+		want           bool
+	}{
+		{"this agent's own proxy", "http://127.0.0.1:8888/stream/2", ownStream, true},
+		{"the redirect port on the box's LAN address", "http://192.0.2.7:17008/stream/4", ownStream, true},
+		{"a group follower on the master's mirror proxy", "http://192.0.2.10:17008/stream/1", ownStream, true},
+		{"the Spotify Ogg stream", "http://127.0.0.1:8888/spotify/stream-3.ogg", ownStream, true},
+		{"a native station descriptor", "/station?data=eyJuYW1lIjoiV0RSIn0=", ownStream, true},
+		{"no content item at all", "", ownStream, true},
+		{"something that is not a URL", "AUX", ownStream, true},
+		{"a media library track STR pushed from the NAS",
+			"http://192.0.2.28:9000/disk/track-42.flac", "http://192.0.2.28:9000/disk/track-7.flac", true},
+		{"a stream another controller pushed", "http://192.0.2.50:8095/stream/flow.mp3", ownStream, false},
+		{"a foreign server while STR's target is its own proxy",
+			"http://192.0.2.99:1400/audio.mp3", ownStream, false},
+	}
+	for _, c := range cases {
+		if got := locationServedBySTR(c.loc, c.own); got != c.want {
+			t.Errorf("%s: locationServedBySTR(%q) = %v, want %v", c.name, c.loc, got, c.want)
+		}
+	}
+}
+
+// The reader must see every ContentItem in the body, not just the first: the
+// teardown restore and the item that was playing can both be present.
+func TestContentLocationsReadsEveryItem(t *testing.T) {
+	body := `<nowPlaying source="INVALID_SOURCE">` +
+		`<ContentItem source="UPNP" location="http://192.0.2.50:8095/stream/flow.mp3"/>` +
+		`<previous location="http://127.0.0.1:8888/stream/2"/></nowPlaying>`
+	got := contentLocations(body)
+	if len(got) != 2 || got[0] != "http://192.0.2.50:8095/stream/flow.mp3" {
+		t.Fatalf("contentLocations = %v, want both items in document order", got)
+	}
+}
+
+// The freshness rule, per reading. The teardown is over in a second or two, so
+// the reading taken at the wake INSTANT is the only one that can catch it: a
+// live foreign stream there stands the resume down even though the box is idle
+// by the time the settle is over.
+func TestForeignContentStandDownReadsEachReadingOnItsOwn(t *testing.T) {
+	const ownStream = "http://127.0.0.1:8888/stream/2"
+	const foreign = `<ContentItem source="UPNP" location="http://192.0.2.50:8095/stream/flow.mp3"/>`
+	cases := []struct {
+		name, prior, now string
+		want             bool
+	}{
+		{"live at the wake instant, gone by the settle",
+			`<nowPlaying source="UPNP">` + foreign + `<playStatus>PLAY_STATE</playStatus></nowPlaying>`,
+			`<nowPlaying source="INVALID_SOURCE"/>`, true},
+		{"nothing at the wake instant, live by the settle",
+			`<nowPlaying source="INVALID_SOURCE"/>`,
+			`<nowPlaying source="UPNP">` + foreign + `<playStatus>BUFFERING_STATE</playStatus></nowPlaying>`, true},
+		{"a restored selection in both, nothing playing",
+			`<nowPlaying source="INVALID_SOURCE">` + foreign + `</nowPlaying>`,
+			`<nowPlaying source="INVALID_SOURCE">` + foreign + `</nowPlaying>`, false},
+		{"playing, but it is STR's own stream",
+			`<nowPlaying source="UPNP"><ContentItem source="UPNP" location="` + ownStream + `"/>` +
+				`<playStatus>PLAY_STATE</playStatus></nowPlaying>`,
+			`<nowPlaying source="UPNP"/>`, false},
+	}
+	for _, c := range cases {
+		s, _ := newPlayTestServer(t)
+		s.nowPlayingBodyFn = func() string { return c.now }
+		if got := s.foreignContentStandDown(parseBoxReading(c.prior), ownStream); got != c.want {
+			t.Errorf("%s: stand down = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// resumeTestServer builds a Server that can run ResumeLastPlay end to end
+// without touching a box: no boxHost (so the wake and the zone probe are
+// no-ops), a seamed play state and a seamed now_playing body.
+func resumeTestServer(t *testing.T, nowPlaying string) (*Server, *soapRecorder) {
+	t.Helper()
+	s, rec := newPlayTestServer(t)
+	s.resumeOnPowerOnPath = t.TempDir() + "/resume-on-power-on" // absent = default on
+	s.playStateFn = func() (standby, busy bool) { return false, false }
+	s.nowPlayingBodyFn = func() string { return nowPlaying }
+	s.lastPlayMu.Lock()
+	s.lastPlay = &lastPlayInfo{boxURL: "http://127.0.0.1:8888/stream/2", title: "Last Station", ts: time.Now()}
+	s.lastPlayMu.Unlock()
+	return s, rec
+}
+
+// waitForSOAP waits for the resume goroutine (2 s settle) to either push or
+// give up.
+func waitForSOAP(rec *soapRecorder, d time.Duration) bool {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if rec.count() > 0 {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+// #827: the speaker is carrying a Music Assistant stream when the teardown's
+// DO_NOT_RESUME restore arrives. Pushing STR's last station over it is the
+// audible "the speaker wants to switch presets".
+func TestResumeLastPlayDeclinesOnForeignContent(t *testing.T) {
+	s, rec := resumeTestServer(t, `<nowPlaying source="INVALID_SOURCE">`+
+		`<ContentItem source="UPNP" location="http://192.0.2.50:8095/stream/flow.mp3"/>`+
+		`<playStatus>PLAY_STATE</playStatus></nowPlaying>`)
+	s.ResumeLastPlay()
+	if waitForSOAP(rec, 4*time.Second) {
+		t.Fatalf("STR pushed its own station onto a speaker streaming from elsewhere: %v", rec.list())
+	}
+}
+
+// A paused foreign stream is still somebody's speaker: pushing a station over it
+// is the same interruption, so PAUSE counts as live.
+func TestResumeLastPlayDeclinesOnPausedForeignContent(t *testing.T) {
+	s, rec := resumeTestServer(t, `<nowPlaying source="UPNP">`+
+		`<ContentItem source="UPNP" location="http://192.0.2.50:8095/stream/flow.mp3"/>`+
+		`<playStatus>PAUSE_STATE</playStatus></nowPlaying>`)
+	s.ResumeLastPlay()
+	if waitForSOAP(rec, 4*time.Second) {
+		t.Fatalf("STR pushed its own station over a paused foreign stream: %v", rec.list())
+	}
+}
+
+// The morning after. The firmware restores the last selection when it comes out
+// of standby, so a user whose evening ended on Music Assistant is still carrying
+// that foreign item when they switch the speaker on - with nothing playing.
+// Standing down on it would turn the power-on resume off for that user for good.
+func TestResumeLastPlayProceedsOnAStaleForeignSelection(t *testing.T) {
+	s, rec := resumeTestServer(t, `<nowPlaying source="INVALID_SOURCE">`+
+		`<ContentItem source="UPNP" location="http://192.0.2.50:8095/stream/flow.mp3"/>`+
+		`<playStatus>STOP_STATE</playStatus></nowPlaying>`)
+	s.ResumeLastPlay()
+	if !waitForSOAP(rec, 6*time.Second) {
+		t.Fatalf("a restored foreign selection with nothing playing killed the power-on resume: %v", rec.list())
+	}
+}
+
+// The same shape as the box reports it after a night in standby: the restored
+// selection, and no play status at all.
+func TestResumeLastPlayProceedsOnAForeignSelectionWithNoPlayState(t *testing.T) {
+	s, rec := resumeTestServer(t, `<nowPlaying source="INVALID_SOURCE">`+
+		`<ContentItem source="UPNP" location="http://192.0.2.50:8095/stream/flow.mp3"/></nowPlaying>`)
+	s.ResumeLastPlay()
+	if !waitForSOAP(rec, 6*time.Second) {
+		t.Fatalf("a foreign selection with no play state killed the power-on resume: %v", rec.list())
+	}
+}
+
+// The other half: a genuine power-on, where the box carries STR's own selection
+// (or none at all), still brings the last station back.
+func TestResumeLastPlayProceedsOnItsOwnContent(t *testing.T) {
+	s, rec := resumeTestServer(t, `<nowPlaying source="INVALID_SOURCE">`+
+		`<ContentItem source="UPNP" location="http://127.0.0.1:8888/stream/2"/></nowPlaying>`)
+	s.ResumeLastPlay()
+	if !waitForSOAP(rec, 6*time.Second) {
+		t.Fatalf("the power-on resume did not push the last station: %v", rec.list())
+	}
+	if !rec.has("SetAVTransportURI") {
+		t.Fatalf("want a SetAVTransportURI, got %v", rec.list())
+	}
+}
+
+// The stand-down names the other controller by HOST, never by URL. A stream a
+// foreign controller pushed routinely carries a session token in its path or
+// query, and this line goes into a diagnostic bundle users mail around (the
+// redaction rule in CLAUDE.md).
+func TestForeignStandDownLogsTheHostAndNotTheURL(t *testing.T) {
+	var buf bytes.Buffer
+	s, _ := newPlayTestServer(t)
+	s.logger = slog.New(slog.NewTextHandler(&buf, nil))
+	s.nowPlayingBodyFn = func() string {
+		return `<nowPlaying source="UPNP"><ContentItem source="UPNP" ` +
+			`location="http://192.0.2.50:8095/stream/flow.mp3?token=s3cr3tsession"/>` +
+			`<playStatus>PLAY_STATE</playStatus></nowPlaying>`
+	}
+	if !s.foreignContentStandDown(boxReading{}, "http://127.0.0.1:8888/stream/2") {
+		t.Fatal("a live foreign stream must stand the resume down")
+	}
+	got := buf.String()
+	if !strings.Contains(got, "192.0.2.50:8095") {
+		t.Fatalf("the log must name the other controller so a bundle is diagnosable:\n%s", got)
+	}
+	if strings.Contains(got, "s3cr3tsession") || strings.Contains(got, "flow.mp3") {
+		t.Fatalf("the log leaked the media URL, not just its host:\n%s", got)
+	}
+}
+
+// The guard judges CONTENT, not playback. A speaker playing one of its own
+// sources (AUX, Bluetooth, the Wave's tuner) reports a play status and no
+// content location at all, and that is not evidence of a foreign controller:
+// standing down here would make this a second, weaker copy of the busy check
+// that already owns that case further down ResumeLastPlay.
+func TestForeignGuardIgnoresALivePlayStatusWithNoContentAtAll(t *testing.T) {
+	s, _ := newPlayTestServer(t)
+	s.nowPlayingBodyFn = func() string {
+		return `<nowPlaying source="AUX"><playStatus>PLAY_STATE</playStatus></nowPlaying>`
+	}
+	if s.foreignContentStandDown(boxReading{}, "http://127.0.0.1:8888/stream/2") {
+		t.Fatal("a play status with no content location must not read as foreign content")
+	}
+}
+
+// An unreadable box must not disable the resume: the guard only ever acts on
+// evidence it actually has.
+func TestResumeLastPlayProceedsWhenTheBoxSaysNothing(t *testing.T) {
+	s, rec := resumeTestServer(t, "")
+	s.ResumeLastPlay()
+	if !waitForSOAP(rec, 6*time.Second) {
+		t.Fatalf("an empty now_playing must not stand the resume down: %v", rec.list())
+	}
+}

--- a/internal/webui/resume_standby.go
+++ b/internal/webui/resume_standby.go
@@ -81,11 +81,31 @@ func (s *Server) ResumeLastPlay() {
 	s.lastPlayMu.Unlock()
 
 	go func() {
+		// What the box reports at the MOMENT of the wake, before the settle
+		// sleep below can let it be replaced. A source teardown (the shape this
+		// resume cannot tell from a wake) is over in a second or two, so this is
+		// the only reading that can still catch a foreign stream in progress.
+		// See foreignContentStandDown.
+		//
+		// Taken CONCURRENTLY with the settle below, never in front of it: the
+		// read can block for its full 4 s timeout on a slow box, and the
+		// standby-bounce guard right after the settle measures its 6 s window
+		// from the power-off. Spending the read serially pushed that budget to
+		// 6.2 s and let the guard miss, which is the #197 regression this
+		// resume must not reintroduce. What does not arrive within the settle
+		// is simply not used.
+		priorCh := make(chan boxReading, 1)
+		go func() { priorCh <- s.readBox() }()
 		// Let the power transition settle so the box's reported state is
 		// unambiguous before we decide. The DO_NOT_RESUME wake that triggers this
 		// fires on a power-on, but the box can also reach standby again right
 		// after, so settle then read the real state.
 		time.Sleep(2 * time.Second)
+		var priorRead boxReading
+		select {
+		case priorRead = <-priorCh:
+		default:
+		}
 
 		// scm power-off bounce guard (#197). Some ST20 (scm) firmware oscillates
 		// UPNP->STANDBY->UPNP on a power-off, and the STANDBY->UPNP restore arrives
@@ -102,6 +122,17 @@ func (s *Server) ResumeLastPlay() {
 		// playing music").
 		if s.standbyStoppedRecently() {
 			s.logger.Info("wake resume: standby bounce detected (box just powered off STR's source), not resuming (#197)")
+			return
+		}
+
+		// Foreign-content guard: the wake frame is also what a UPnP source
+		// teardown looks like, and a teardown happens while somebody else is
+		// streaming to this speaker (a failed remote skip on a Music Assistant
+		// stream, discussion #827). A speaker that is PLAYING content STR does
+		// not serve belongs to whoever put it there, and that outranks anything
+		// the frame claimed. A merely restored foreign selection does not: see
+		// foreignContentStandDown.
+		if s.foreignContentStandDown(priorRead, boxURL) {
 			return
 		}
 

--- a/internal/webui/resume_wake_budget_test.go
+++ b/internal/webui/resume_wake_budget_test.go
@@ -1,0 +1,44 @@
+// The wake resume decides inside a TIME budget, and this file pins it.
+//
+// The #197 power-off bounce guard is a 6 s window measured from the moment STR
+// saw the box drop UPNP -> STANDBY (standbyBounceWakeWindow). ResumeLastPlay was
+// written to spend 2 s of that budget on its settle sleep, which is what the
+// window's own comment sizes it against. Anything else the goroutine does BEFORE
+// that guard spends the same budget, and a box read is the one kind of work that
+// can spend seconds of it without looking like it does.
+
+package webui
+
+import (
+	"testing"
+	"time"
+)
+
+// A box that is slow to answer :8090 at the wake instant must not cost the
+// power-off bounce guard its window. The read that the foreign-content guard
+// needs is taken before the settle sleep, and a box in the middle of a power
+// transition is exactly the box that answers late: at the production readBox
+// timeout the guard is already past 6 s when it is finally consulted, so STR
+// re-wakes a speaker the user had just switched off (#197 deqw, and the ST10
+// shape Svagerka reported as "off does not stick").
+func TestASlowBoxReadDoesNotSpendThePowerOffBounceWindow(t *testing.T) {
+	s, rec := resumeTestServer(t, `<nowPlaying source="UPNP"/>`)
+	// As slow as the production read can be: readBox's own HTTP timeout.
+	s.nowPlayingBodyFn = func() string {
+		time.Sleep(4 * time.Second)
+		return `<nowPlaying source="UPNP"/>`
+	}
+	// The power-off STR saw, and the bounce restore that follows it ~200 ms
+	// later. noteStandbyStop arms both stamps, so both are set here.
+	s.standbyStopMu.Lock()
+	s.lastStandbyStop = time.Now().Add(-200 * time.Millisecond)
+	s.standbyStopMu.Unlock()
+	s.lastUserStopMu.Lock()
+	s.lastUserStop = time.Now().Add(-200 * time.Millisecond)
+	s.lastUserStopMu.Unlock()
+
+	s.ResumeLastPlay()
+	if waitForSOAP(rec, 20*time.Second) {
+		t.Fatalf("the bounce guard timed out and STR re-woke a box the user had just switched off: %v", rec.list())
+	}
+}

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -496,6 +496,11 @@ type Server struct {
 	// playStateFn overrides boxPlayState for tests. nil = the real :8090 probe.
 	playStateFn func() (standby, busy bool)
 
+	// nowPlayingBodyFn seams the raw now_playing read behind the foreign-content
+	// guard (resume_foreign.go), so the decision is assertable without a live
+	// box. nil = the real :8090 fetch.
+	nowPlayingBodyFn func() string
+
 	// resumeOnPowerOnPath persists the per-box opt-out for "resume the last
 	// station when the speaker is switched on" (default on; file absent or "1").
 	// Empty falls back to defaultResumeOnPowerOnPath.


### PR DESCRIPTION
From discussion #827: pressing Back or Forward on the remote while a Music Assistant stream plays makes the speaker "want to switch presets".

**What actually happens.** The firmware's own skip cannot act on a plain HTTP stream and fails. The failed skip tears the speaker's source down, and on the bus a teardown is indistinguishable from a power-on: the same restore frame with the same do-not-resume marker. STR read it as a power-on and pushed the station it last played, which is the preset switch the reporter hears. The part before that, the firmware hunting for something else to play, happens before STR sees anything and is not ours.

**Two guards, deliberately independent.**

- The speaker announces the failure itself (`QPLAY_SKIP_NEXT_FAILED` / `QPLAY_SKIP_PREV_FAILED`), which the bus handler already short-circuits on, so it now stamps the moment and a source restore within five seconds is treated as the teardown it is. Only that branch is gated: a real power press arrives as a power-state event, which no teardown fakes, so switching the speaker on right after a skip still resumes.
- The resume itself reads what the speaker is playing, at the moment of the wake and again after the settle, and stands down when the content is not something STR serves. Loopback, the agent's own ports, native station descriptors and the resume target's own host count as ours; anything unjudgeable counts as ours too, so a bare restore with no content item resumes exactly as before.

The prior reading is taken concurrently with the settle that is already being spent, because doing it serially would have pushed the standby-bounce guard past its window and reintroduced #197.

**Also in here, no behaviour change.** A mail reports that the Spotify app's lyrics run ahead of the audio on the STR entry. That is the reported position counting the music when it is handed to the speaker while ten seconds of it are still buffered there. Before shifting anything, the agent now measures the real gap, once when the speaker attaches and once per track boundary, and puts it in the diagnostic file. One reading is logged at INFO per agent run, the rest at debug, and there is no new poll or timer.

**Verification**: `go test ./cmd/agent/ ./internal/webui/ ./internal/boxws/ ./internal/spotify/ ./internal/upnp/ -count=1` green, `golangci-lint` 0 issues, ARM cross-compile ok. Hardware confirmation needs a remote key press on a foreign stream, which is with the reporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrDLQwFNah3qLAHWK5ELGM
