### PR TITLE
fix(spotify): a song no longer loses its last seconds when the next one starts

### DIFF
--- a/internal/spotify/appskip_test.go
+++ b/internal/spotify/appskip_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -109,4 +110,65 @@ func TestNoteTrackBoundaryCutStandsDown(t *testing.T) {
 		case <-time.After(50 * time.Millisecond):
 		}
 	})
+}
+
+// The field regression (living-room ST30, 2026-09-08): the box attaches
+// mid-stream, so the engine logs a "loaded track" line that never reaches a
+// boundary of its own. With the durations paired to boundaries by position,
+// that one extra load shifted every later pairing by one for good, and each
+// track that had played in FULL was measured against the duration of the
+// track before it. Two of the three boundaries in the captured log were
+// declared app skips and the box lost its buffered tail, which is heard as
+// the song ending a few seconds early.
+func TestAnExtraLoadWithoutABoundaryDoesNotDesyncTheDetector(t *testing.T) {
+	m := newAppSkipTestManager()
+	fired := make(chan struct{}, 4)
+	m.SetOnActivate(func(context.Context) { fired <- struct{}{} })
+	m.sink = io.Discard // a box is attached
+
+	load := func(ms int64) {
+		m.noteLibrespotLine(`level=info msg="loaded track \"x\" (position: 0ms, duration: ` +
+			strconv.FormatInt(ms, 10) + `ms, prefetched: true)"`)
+	}
+	quiet := func(what string) {
+		t.Helper()
+		select {
+		case <-fired:
+			t.Fatalf("%s played to its full length and must not be read as an app skip", what)
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	// The attach: a load with no boundary behind it, exactly what a box
+	// joining an already running stream produces.
+	load(233000)
+
+	// Every engine load names the track that is ABOUT to start, so the
+	// played time handed to a boundary belongs to the track loaded one step
+	// earlier. These are the four loads and the three full-length endings
+	// from the captured log.
+	load(213760) // Rollin'
+	m.noteTrackBoundaryCut(0, 0)
+	quiet("the track before the capture")
+
+	load(268826) // Gone Away
+	m.noteTrackBoundaryCut(213*vorbisRate, 4096)
+	quiet("Rollin'")
+
+	load(198081) // Freeze Me
+	m.noteTrackBoundaryCut(268*vorbisRate, 4096)
+	quiet("Gone Away")
+
+	load(228360) // Centuries
+	m.noteTrackBoundaryCut(198*vorbisRate, 4096)
+	quiet("Freeze Me")
+
+	// The detector still has to work: Centuries is cut 60 s short.
+	load(200000)
+	m.noteTrackBoundaryCut((228360-60000)*vorbisRate/1000, 4096)
+	select {
+	case <-fired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a genuine mid-track cut must still re-point the box")
+	}
 }

--- a/internal/spotify/engine.go
+++ b/internal/spotify/engine.go
@@ -499,17 +499,16 @@ func parseLoadedTrackDurMs(lc string) int64 {
 func (m *Manager) noteLibrespotLine(line string) {
 	lc := strings.ToLower(line)
 	// "loaded track" carries the duration the app-skip detector needs (see
-	// durQueueMs). The prefetch line names a duration too, but describes a
-	// track that may never play, so it must not enter the queue.
+	// loadedTrackDurMs). The prefetch line names a duration too, but
+	// describes a track that may never play, so it is ignored here.
+	//
+	// The newest load simply overwrites the slot. A load that never reaches a
+	// boundary is then forgotten at the next one instead of shifting every
+	// later pairing by one.
 	if strings.Contains(lc, `msg="loaded track`) {
 		if ms := parseLoadedTrackDurMs(lc); ms > 0 {
 			m.mu.Lock()
-			m.durQueueMs = append(m.durQueueMs, ms)
-			// Bounded: a load that never produces a boundary (aborted play)
-			// must not let the queue drift away from the stream for good.
-			if len(m.durQueueMs) > 4 {
-				m.durQueueMs = m.durQueueMs[len(m.durQueueMs)-4:]
-			}
+			m.loadedTrackDurMs = ms
 			m.mu.Unlock()
 		}
 	}

--- a/internal/spotify/manager.go
+++ b/internal/spotify/manager.go
@@ -299,16 +299,27 @@ type Manager struct {
 	// playlist) the box is re-pointed at the stream so it drops its buffer and
 	// plays the new playlist promptly instead of finishing the old buffer.
 	lastContext string
-	// durQueueMs / streamTrackDurMs feed the app-skip detector: every engine
-	// "loaded track" line queues that track's duration, and each BOS shifts
-	// the queue so streamTrackDurMs names the duration of the track whose
-	// pages are currently being forwarded. A BOS arriving while the forwarded
-	// granule is clearly short of that duration is a mid-track cut the agent
-	// did not issue (the Spotify app's own Next/Prev), and the box must drop
-	// its buffered tail like the STR skip paths do; without that, an app skip
-	// only became audible once the box had drained its whole pacing buffer,
-	// which a listener clocked at over 20 seconds (field, 2026-08-29).
-	durQueueMs       []int64
+	// loadedTrackDurMs / streamTrackDurMs feed the app-skip detector. The
+	// engine logs "loaded track" for the track it is about to start, always
+	// before that track's BOS, so the newest load names the track the NEXT
+	// boundary hands over to, and streamTrackDurMs names the duration of the
+	// track whose pages are being forwarded right now. A BOS arriving while
+	// the forwarded granule is clearly short of that duration is a mid-track
+	// cut the agent did not issue (the Spotify app's own Next/Prev), and the
+	// box must drop its buffered tail like the STR skip paths do; without
+	// that, an app skip only became audible once the box had drained its
+	// whole pacing buffer, which a listener clocked at over 20 seconds
+	// (field, 2026-08-29).
+	//
+	// One slot, overwritten, never a queue. A queue pairs durations with
+	// boundaries BY POSITION, and every load that produces no boundary (an
+	// attach mid-stream, a paused load, an aborted play) shifts that pairing
+	// by one for good. In the field that made STR compare each ended track
+	// against the duration of the one before it, so a track that had played
+	// in full looked cut short and the box lost the last seconds of every
+	// other song to a needless re-point (living-room ST30, 2026-09-08:
+	// 213 s played against 233 s expected, 198 s against 268 s).
+	loadedTrackDurMs int64
 	streamTrackDurMs int64
 	// pendingRepointFrom/To hold a context change announced by will_play that
 	// has not been acted on yet.

--- a/internal/spotify/ogg.go
+++ b/internal/spotify/ogg.go
@@ -293,22 +293,19 @@ func cutShortOfDuration(prevGran, prevBody, durMs int64) bool {
 	return prevGran*1000/vorbisRate < durMs-5000
 }
 
-// noteTrackBoundaryCut runs the app-skip detector at a track boundary: it
-// shifts the duration queue (see durQueueMs in Manager) and, when the ended
-// track was cut mid-play while NO STR-issued cut was armed, stamps the skip
-// boundary and re-points the box so its buffered tail of the old track is
-// dropped. STR's own skip and recall paths arm the cut first, so they never
-// trip this; a boundary with no known duration (agent restarted mid-play) is
+// noteTrackBoundaryCut runs the app-skip detector at a track boundary: the
+// track named by the newest load takes over as the one being forwarded (see
+// loadedTrackDurMs in Manager) and, when the ended track was cut mid-play
+// while NO STR-issued cut was armed, it stamps the skip boundary and
+// re-points the box so its buffered tail of the old track is dropped. STR's
+// own skip and recall paths arm the cut first, so they never trip this; a
+// boundary with no known duration (agent restarted mid-play) is
 // conservatively treated as natural.
 func (m *Manager) noteTrackBoundaryCut(prevGran, prevBody int64) {
 	m.mu.Lock()
 	endedMs := m.streamTrackDurMs
-	if len(m.durQueueMs) > 0 {
-		m.streamTrackDurMs = m.durQueueMs[0]
-		m.durQueueMs = m.durQueueMs[1:]
-	} else {
-		m.streamTrackDurMs = 0
-	}
+	m.streamTrackDurMs = m.loadedTrackDurMs
+	m.loadedTrackDurMs = 0
 	armed := time.Now().Before(m.skipCutUntil)
 	m.mu.Unlock()
 	if armed || !cutShortOfDuration(prevGran, prevBody, endedMs) {


### PR DESCRIPTION
Reported from the living room: Spotify tracks seem to move to the next song slightly too early. The speaker's own log says exactly what happens.

```
18:12:45  track boundary   played 213 s   (Rollin', full length 213.760 s)
18:12:45  mid-track boundary without an STR skip ... playedSec=213 durationSec=233
18:16:52  track boundary   played 268 s   (Gone Away, full length 268.826 s)
18:20:10  track boundary   played 198 s   (Freeze Me, full length 198.081 s)
18:20:10  mid-track boundary without an STR skip ... playedSec=198 durationSec=268
```

Every track played to its full length, and two of the three endings were declared a skip in the Spotify app. The consequence is not cosmetic: that verdict re-points the speaker so it drops the tail it has already buffered, which is the several seconds the listener never hears.

**Why.** The detector needs the length of the track that just ended. Those lengths come from the engine's `loaded track` lines and were paired with boundaries by position, through a queue. A load that never reaches a boundary of its own shifts that pairing by one permanently, and a speaker attaching to an already running stream produces one on the spot: the log shows the attach, and from there each ended track was measured against the length of the track before it. The queue's cap of four bounded the drift but never corrected it.

**The fix.** The engine names the track it is about to start, always before that track's boundary, so exactly one duration is in flight at any time. It is now handed over in a single slot that the newest load overwrites: a load without a boundary is forgotten at the next boundary instead of shifting everything after it. Nothing else about the detector changes, and a genuine mid-track cut still re-points the speaker.

**Test**: the captured sequence is replayed, attach load included, and every full-length ending must stay silent while a 60 s cut must still fire. It fails against the old code and passes with the fix.

`go test ./internal/spotify/ ./cmd/agent/ -count=1` green, `golangci-lint` 0 issues, ARM cross-compile ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RvW1mQT7V9g3F8f3x7icD
