### PR TITLE
fix(app): copying presets to another speaker works when both already hold the same stations

### DIFF
--- a/desktop-app/app_presets.go
+++ b/desktop-app/app_presets.go
@@ -138,34 +138,46 @@ func (a *App) CopyPresetsAcrossBoxes(srcHost string, srcPort int, dstHost string
 	if err := a.waitCopyTargetReady(dstHost, dstPort); err != nil {
 		return 0, err
 	}
-	copied := 0
-	var slotErrs []string
+	// The set the transfer is about: the same filter the per-slot loop applies.
+	var set []Preset
 	for _, p := range presets {
 		if p.Slot < 1 || p.Slot > 6 || p.Name == "" {
 			continue
 		}
-		// PUT the source preset verbatim (via boxPut, so the target's port
-		// fallback applies too) so radio, Spotify and queue presets keep all
-		// their fields (type, uri, account, art, bitrate, shuffle, items)
-		// with no field mapping. A rejected slot is reported but must not
-		// abort the transfer: the remaining slots still copy.
-		err := a.boxPut(dstHost, dstPort, fmt.Sprintf("%s/%d", presetAPIPath, p.Slot), p)
-		// A speaker can also go away DURING the copy: the same bundle shows a
-		// target that took six slots and dropped two of them mid-run. One
-		// re-wait and one retry costs nothing on the happy path and turns that
-		// into a complete transfer.
+		set = append(set, p)
+	}
+	copied := 0
+	var slotErrs []string
+	if len(set) > 0 {
+		// Whole set in ONE request when the target's agent knows the bulk
+		// endpoint. That is not a speed optimisation: writing the slots one at
+		// a time made the target judge each write against a half-written store,
+		// so transferring the same six stations in a different order collided
+		// with itself and failed (#882). One request also means one NAND write
+		// on the speaker instead of six.
+		supported, err := a.putPresetsBulk(dstHost, dstPort, set)
+		// A speaker can go away DURING the transfer. One re-wait and one retry
+		// costs nothing on the happy path, same as the per-slot path below.
 		if err != nil && isTransportNotReady(err) {
 			if werr := a.waitCopyTargetReady(dstHost, dstPort); werr == nil {
-				err = a.boxPut(dstHost, dstPort, fmt.Sprintf("%s/%d", presetAPIPath, p.Slot), p)
+				supported, err = a.putPresetsBulk(dstHost, dstPort, set)
 			}
 		}
-		if err != nil {
-			a.logger.Warn("copy presets: slot rejected by the target",
-				"src", srcHost, "dst", dstHost, "slot", p.Slot, "type", p.Type, "err", err)
-			slotErrs = append(slotErrs, fmt.Sprintf("preset %d (%s): %v", p.Slot, p.Name, err))
-			continue
+		switch {
+		case supported && err == nil:
+			copied = len(set)
+		case supported:
+			// The bulk write is all-or-nothing, so a refusal left the target
+			// exactly as it was. Report it and stop: there is no partial
+			// result to sync or to count.
+			a.logger.Warn("copy presets: the target refused the whole set, nothing was written",
+				"src", srcHost, "dst", dstHost, "slots", len(set), "err", err)
+			return 0, err
+		default:
+			a.logger.Info("copy presets: target agent has no bulk preset endpoint, copying slot by slot",
+				"src", srcHost, "dst", dstHost)
+			copied, slotErrs = a.copyPresetsPerSlot(dstHost, dstPort, set)
 		}
-		copied++
 	}
 	// Re-push the target's hardware keys so 1-6 on the speaker match the copy.
 	if _, err := a.SyncBoxPresets(dstHost, dstPort); err != nil {
@@ -189,6 +201,82 @@ func (a *App) CopyPresetsAcrossBoxes(srcHost string, srcPort int, dstHost string
 		return copied, fmt.Errorf("%s", strings.Join(slotErrs, "; "))
 	}
 	return copied, nil
+}
+
+// presetConflictPrefix marks the one preset-transfer failure that has a
+// friendly explanation instead of a raw status line: the target already holds
+// the station on a key the transfer does not rewrite. The frontend parses this
+// shape (copyreport.js) into a translated sentence, so it must stay stable.
+const presetConflictPrefix = "already-on-slot: "
+
+// putPresetsBulk PUTs the whole preset set to the target's collection endpoint.
+// supported is false when the target answers 404 or 405, i.e. it runs an agent
+// older than the bulk endpoint and the caller must fall back to the per-slot
+// loop. A 409 is turned into the stable already-on-slot message the frontend
+// translates; every other failure keeps the usual status+body error.
+func (a *App) putPresetsBulk(host string, port int, ps []Preset) (bool, error) {
+	b, err := json.Marshal(ps)
+	if err != nil {
+		return true, err
+	}
+	resp, err := a.boxDo(host, port, http.MethodPut, presetAPIPath, "application/json", string(b))
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusMethodNotAllowed {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		return false, nil
+	}
+	if resp.StatusCode == http.StatusConflict {
+		var c struct {
+			Code string `json:"code"`
+			Name string `json:"name"`
+			Slot int    `json:"slot"`
+		}
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		if json.Unmarshal(body, &c) == nil && c.Code == "already-on-slot" {
+			return true, fmt.Errorf("%s%q is already on key %d", presetConflictPrefix, c.Name, c.Slot)
+		}
+		return true, fmt.Errorf("status %d: %s", resp.StatusCode, string(body))
+	}
+	if resp.StatusCode >= 400 {
+		return true, readHTTPError(resp)
+	}
+	return true, nil
+}
+
+// copyPresetsPerSlot is the original slot-by-slot transfer, kept for target
+// speakers running an agent without the bulk endpoint. Returns how many slots
+// landed and one message per rejected slot.
+func (a *App) copyPresetsPerSlot(dstHost string, dstPort int, set []Preset) (int, []string) {
+	copied := 0
+	var slotErrs []string
+	for _, p := range set {
+		// PUT the source preset verbatim (via boxPut, so the target's port
+		// fallback applies too) so radio, Spotify and queue presets keep all
+		// their fields (type, uri, account, art, bitrate, shuffle, items)
+		// with no field mapping. A rejected slot is reported but must not
+		// abort the transfer: the remaining slots still copy.
+		err := a.boxPut(dstHost, dstPort, fmt.Sprintf("%s/%d", presetAPIPath, p.Slot), p)
+		// A speaker can also go away DURING the copy: the same bundle shows a
+		// target that took six slots and dropped two of them mid-run. One
+		// re-wait and one retry costs nothing on the happy path and turns that
+		// into a complete transfer.
+		if err != nil && isTransportNotReady(err) {
+			if werr := a.waitCopyTargetReady(dstHost, dstPort); werr == nil {
+				err = a.boxPut(dstHost, dstPort, fmt.Sprintf("%s/%d", presetAPIPath, p.Slot), p)
+			}
+		}
+		if err != nil {
+			a.logger.Warn("copy presets: slot rejected by the target",
+				"dst", dstHost, "slot", p.Slot, "type", p.Type, "err", err)
+			slotErrs = append(slotErrs, fmt.Sprintf("preset %d (%s): %v", p.Slot, p.Name, err))
+			continue
+		}
+		copied++
+	}
+	return copied, slotErrs
 }
 
 // hasSpotifyPreset reports whether any preset in the set is a Spotify one.

--- a/desktop-app/copypresets_bulk_test.go
+++ b/desktop-app/copypresets_bulk_test.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// The box-to-box transfer writes the WHOLE preset set in one request. Writing
+// slot by slot made the target judge every write against a half-written store,
+// so a user whose two speakers held the same six stations in a DIFFERENT ORDER
+// got a raw 409 dialog and a failed transfer (#882).
+
+// sixStations is the reported situation: both speakers hold these six.
+func sixStations() []Preset {
+	names := []string{"101 SMOOTH JAZZ", "WDR 5", "1LIVE", "Sunshine Live", "Radio Bob", "Exclusively Rush"}
+	var out []Preset
+	for i, n := range names {
+		out = append(out, Preset{Slot: i + 1, Name: n, Type: "radio", StreamURL: "http://example.com/" + n})
+	}
+	return out
+}
+
+// TestCopySendsTheWholeSetInOneRequest is the reported case end to end: the
+// source holds the same six stations as the target but with keys 1 and 6
+// swapped. One bulk request must carry the set, and no per-slot write may
+// happen at all.
+func TestCopySendsTheWholeSetInOneRequest(t *testing.T) {
+	source := sixStations()
+	source[0], source[5] = source[5], source[0]
+	source[0].Slot, source[5].Slot = 1, 6
+
+	src := newFakeBox(t, "127.0.0.2", source)
+	dst := newFakeBox(t, "127.0.0.3", nil)
+	dst.bulk = true
+	installProbe(t, func() bool { return true })
+
+	a := copyApp(t)
+	n, err := a.CopyPresetsAcrossBoxes(src.host, src.port(t), dst.host, dst.port(t))
+	if err != nil {
+		t.Fatalf("the swapped set failed to transfer: %v", err)
+	}
+	if n != 6 || dst.count() != 6 {
+		t.Errorf("copied %d, target holds %d, want 6 and 6", n, dst.count())
+	}
+	bulk, slot := dst.requests()
+	if bulk != 1 || slot != 0 {
+		t.Errorf("target saw %d bulk and %d per-slot writes, want exactly one bulk write", bulk, slot)
+	}
+	if dst.written[1] != "Exclusively Rush" || dst.written[6] != "101 SMOOTH JAZZ" {
+		t.Errorf("the swap did not land: key 1 = %q, key 6 = %q", dst.written[1], dst.written[6])
+	}
+}
+
+// TestCopyFallsBackToPerSlotOnAnOlderAgent: a target whose agent does not know
+// the collection PUT answers 405 (404 on an even older route table). The
+// transfer must quietly copy slot by slot instead of failing.
+func TestCopyFallsBackToPerSlotOnAnOlderAgent(t *testing.T) {
+	src := newFakeBox(t, "127.0.0.2", sixStations())
+	dst := newFakeBox(t, "127.0.0.3", nil) // bulk off: an older agent
+	installProbe(t, func() bool { return true })
+
+	a := copyApp(t)
+	n, err := a.CopyPresetsAcrossBoxes(src.host, src.port(t), dst.host, dst.port(t))
+	if err != nil {
+		t.Fatalf("copy failed against an older agent: %v", err)
+	}
+	if n != 6 || dst.count() != 6 {
+		t.Errorf("copied %d, target holds %d, want 6 and 6", n, dst.count())
+	}
+	bulk, slot := dst.requests()
+	if bulk != 1 || slot != 6 {
+		t.Errorf("target saw %d bulk and %d per-slot writes, want one refused bulk try and six per-slot writes", bulk, slot)
+	}
+}
+
+// TestCopyReportsAConflictAsAFriendlyMessage: the target refused the whole set
+// because one station sits on a key the set does not rewrite. The user must
+// get a message that names the station and the key, not the raw 409 body, and
+// the count must be 0 because nothing was written.
+func TestCopyReportsAConflictAsAFriendlyMessage(t *testing.T) {
+	src := newFakeBox(t, "127.0.0.2", sixStations())
+	dst := newFakeBox(t, "127.0.0.3", nil)
+	dst.bulk = true
+	dst.conflict = &presetConflict{Code: "already-on-slot", Name: "Exclusively Rush", Slot: 6}
+	installProbe(t, func() bool { return true })
+
+	a := copyApp(t)
+	n, err := a.CopyPresetsAcrossBoxes(src.host, src.port(t), dst.host, dst.port(t))
+	if err == nil {
+		t.Fatal("a refused set was reported as a success")
+	}
+	if n != 0 {
+		t.Errorf("reported %d copied, want 0: the bulk write is all-or-nothing", n)
+	}
+	if dst.count() != 0 {
+		t.Errorf("target holds %d presets after a refused set", dst.count())
+	}
+	msg := err.Error()
+	if !strings.HasPrefix(msg, presetConflictPrefix) {
+		t.Fatalf("error does not carry the parseable conflict shape: %q", msg)
+	}
+	if !strings.Contains(msg, `"Exclusively Rush"`) || !strings.Contains(msg, "key 6") {
+		t.Errorf("error does not name the station and its key: %q", msg)
+	}
+	if strings.Contains(msg, "{") {
+		t.Errorf("error still carries the raw JSON body: %q", msg)
+	}
+	if _, slot := dst.requests(); slot != 0 {
+		t.Errorf("the transfer fell back to per-slot writes after a real refusal (%d writes)", slot)
+	}
+}
+
+// TestCopyStillReportsAGenuineBulkFailure: a target that refuses the set for
+// any other reason must not be silently downgraded to the per-slot path, which
+// would walk straight back into the half-written-store problem.
+func TestCopyStillReportsAGenuineBulkFailure(t *testing.T) {
+	src := newFakeBox(t, "127.0.0.2", sixStations())
+	dst := newFakeBox(t, "127.0.0.3", nil)
+	dst.bulk = true
+	dst.bulkFails = true
+	installProbe(t, func() bool { return true })
+
+	a := copyApp(t)
+	n, err := a.CopyPresetsAcrossBoxes(src.host, src.port(t), dst.host, dst.port(t))
+	if err == nil {
+		t.Fatal("a rejected set was reported as a success")
+	}
+	if n != 0 {
+		t.Errorf("reported %d copied, want 0", n)
+	}
+	if _, slot := dst.requests(); slot != 0 {
+		t.Errorf("fell back to %d per-slot writes after a real rejection", slot)
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error does not carry the target's status: %v", err)
+	}
+}
+
+// TestCopySkipsSlotsWithoutAName keeps the existing filter: an empty source
+// slot is not part of the set and is not written to the target.
+func TestCopySkipsSlotsWithoutAName(t *testing.T) {
+	src := newFakeBox(t, "127.0.0.2", []Preset{
+		{Slot: 1, Name: "1LIVE", Type: "radio", StreamURL: "http://example.com/1"},
+		{Slot: 2, Name: "", Type: "radio"},
+		{Slot: 9, Name: "out of range", Type: "radio", StreamURL: "http://example.com/9"},
+	})
+	dst := newFakeBox(t, "127.0.0.3", nil)
+	dst.bulk = true
+	installProbe(t, func() bool { return true })
+
+	a := copyApp(t)
+	n, err := a.CopyPresetsAcrossBoxes(src.host, src.port(t), dst.host, dst.port(t))
+	if err != nil {
+		t.Fatalf("copy failed: %v", err)
+	}
+	if n != 1 || dst.count() != 1 {
+		t.Errorf("copied %d, target holds %d, want 1 and 1 (%v)", n, dst.count(), dst.written)
+	}
+}
+
+// TestCopyBulkCarriesEveryFieldVerbatim: a Spotify or folder key must reach the
+// target with its own fields, the same guarantee the per-slot copy gave.
+func TestCopyBulkCarriesEveryFieldVerbatim(t *testing.T) {
+	src := newFakeBox(t, "127.0.0.2", []Preset{
+		{Slot: 1, Name: "Chill", Type: "spotify", URI: "spotify:playlist:abc", Account: "user@example.com"},
+		{Slot: 2, Name: "Folder", Type: "queue", Shuffle: true,
+			Items: []byte(`[{"url":"http://nas/1.mp3","title":"One"}]`)},
+	})
+	dst := newFakeBox(t, "127.0.0.3", nil)
+	dst.bulk = true
+	installProbe(t, func() bool { return true })
+
+	a := copyApp(t)
+	if _, err := a.CopyPresetsAcrossBoxes(src.host, src.port(t), dst.host, dst.port(t)); err != nil {
+		t.Fatalf("copy failed: %v", err)
+	}
+	if dst.written[1] != "Chill" || dst.written[2] != "Folder" {
+		t.Errorf("target holds %v, want both keys", dst.written)
+	}
+}
+
+// TestPutPresetsBulkReportsAnOlderAgentAsUnsupported pins the seam the fallback
+// hangs on: 404 and 405 mean "no such endpoint", everything else is a real
+// answer the caller must surface.
+func TestPutPresetsBulkReportsAnOlderAgentAsUnsupported(t *testing.T) {
+	dst := newFakeBox(t, "127.0.0.3", nil)
+	a := copyApp(t)
+	set := []Preset{{Slot: 1, Name: "1LIVE", Type: "radio", StreamURL: "http://example.com/1"}}
+
+	supported, err := a.putPresetsBulk(dst.host, dst.port(t), set)
+	if supported || err != nil {
+		t.Fatalf("a 405 target reported supported=%v err=%v, want false and no error", supported, err)
+	}
+	dst.bulk = true
+	supported, err = a.putPresetsBulk(dst.host, dst.port(t), set)
+	if !supported || err != nil {
+		t.Fatalf("a current target reported supported=%v err=%v, want true and no error", supported, err)
+	}
+	dst.conflict = &presetConflict{Code: "already-on-slot", Name: `Rush "Live"`, Slot: 4}
+	supported, err = a.putPresetsBulk(dst.host, dst.port(t), set)
+	if !supported || err == nil {
+		t.Fatalf("a 409 reported supported=%v err=%v, want true and the conflict", supported, err)
+	}
+	// %q keeps a quote inside the station name escaped, which is what the
+	// frontend parser undoes; the important part is that the shape is stable.
+	if want := fmt.Sprintf("%s%q is already on key 4", presetConflictPrefix, `Rush "Live"`); err.Error() != want {
+		t.Errorf("conflict message = %q, want %q", err.Error(), want)
+	}
+}

--- a/desktop-app/copypresets_settle_test.go
+++ b/desktop-app/copypresets_settle_test.go
@@ -23,14 +23,32 @@ func installProbe(t *testing.T, ready func() bool) {
 	t.Cleanup(func() { copyTargetProbe = nil })
 }
 
+// presetConflict is the agent's 409 answer to a bulk write whose set would put
+// a station on two keys, or on a key the set does not rewrite (#836/#882).
+type presetConflict struct {
+	Code string `json:"code"`
+	Name string `json:"name"`
+	Slot int    `json:"slot"`
+}
+
 // fakeBox serves the preset API for both ends of a copy and records the writes
 // it accepted.
+//
+// bulk is off by default on purpose: an unconfigured fakeBox models a target
+// running an agent older than PUT /api/presets, which is exactly the fallback
+// path the existing tests below exercise. Tests that mean the current agent
+// switch it on.
 type fakeBox struct {
-	mu      sync.Mutex
-	srv     *httptest.Server
-	host    string
-	written map[int]string
-	fail    func(slot int) bool
+	mu        sync.Mutex
+	srv       *httptest.Server
+	host      string
+	written   map[int]string
+	fail      func(slot int) bool
+	bulk      bool
+	bulkPuts  int
+	slotPuts  int
+	conflict  *presetConflict
+	bulkFails bool
 }
 
 // newFakeBox binds on a caller-chosen loopback address, because a copy refuses
@@ -43,11 +61,38 @@ func newFakeBox(t *testing.T, host string, source []Preset) *fakeBox {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == presetAPIPath:
 			_ = json.NewEncoder(w).Encode(source)
+		case r.Method == http.MethodPut && r.URL.Path == presetAPIPath:
+			b.mu.Lock()
+			defer b.mu.Unlock()
+			b.bulkPuts++
+			if !b.bulk {
+				// An older agent's collection handler answers GET only.
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			var set []Preset
+			_ = json.NewDecoder(r.Body).Decode(&set)
+			if b.conflict != nil {
+				// All-or-nothing: a refused set writes nothing.
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusConflict)
+				_ = json.NewEncoder(w).Encode(b.conflict)
+				return
+			}
+			if b.bulkFails {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			for _, p := range set {
+				b.written[p.Slot] = p.Name
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "written": len(set)})
 		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, presetAPIPath+"/"):
 			var p Preset
 			_ = json.NewDecoder(r.Body).Decode(&p)
 			b.mu.Lock()
 			defer b.mu.Unlock()
+			b.slotPuts++
 			if b.fail != nil && b.fail(p.Slot) {
 				w.WriteHeader(http.StatusInternalServerError)
 				return
@@ -76,6 +121,13 @@ func (b *fakeBox) count() int {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return len(b.written)
+}
+
+// requests reports how many bulk and per-slot preset writes the box saw.
+func (b *fakeBox) requests() (bulk, slot int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.bulkPuts, b.slotPuts
 }
 
 // copyApp is an App wired for a copy: an HTTP client, a logger, and a live

--- a/desktop-app/frontend/src/copyreport.js
+++ b/desktop-app/frontend/src/copyreport.js
@@ -33,6 +33,22 @@ export function summarizePresetCopyError(message, totalValidSlots) {
   return { failedSlots, copied, detail: msg };
 }
 
+// presetCopyConflict recognises the ONE transfer failure that has a friendly
+// explanation: the target speaker already holds one of the stations on a key
+// the transfer does not rewrite, so the whole set was refused and nothing was
+// written (the agent's already-on-slot guard, #836, applied to the finished
+// set, #882). The Go side formats it as
+//   already-on-slot: "Station Name" is already on key 6
+// Returns {name, slot} or null when the message is something else.
+export function presetCopyConflict(message) {
+  const s = String(message == null ? '' : message);
+  const m = s.match(/already-on-slot:\s*"([\s\S]*)" is already on key (\d+)/);
+  if (!m) return null;
+  // The name is Go-quoted (%q), so a quote or backslash inside it arrives
+  // escaped; hand the caller back the name the user actually sees.
+  return { name: m[1].replace(/\\(["\\])/g, '$1'), slot: parseInt(m[2], 10) };
+}
+
 // countValidPresetSlots mirrors the Go-side copy filter (slot 1..6 with a
 // non-empty name) so "total - failed" equals what the backend attempted.
 export function countValidPresetSlots(presets) {

--- a/desktop-app/frontend/src/copyreport.test.js
+++ b/desktop-app/frontend/src/copyreport.test.js
@@ -1,6 +1,6 @@
 // Tests for the pure preset-copy rejection summary in copyreport.js.
 import { describe, it, expect } from 'vitest';
-import { summarizePresetCopyError, countValidPresetSlots } from './copyreport.js';
+import { summarizePresetCopyError, countValidPresetSlots, presetCopyConflict } from './copyreport.js';
 
 describe('summarizePresetCopyError', () => {
   it('reconstructs the copied count from the combined per-slot message', () => {
@@ -57,5 +57,28 @@ describe('countValidPresetSlots', () => {
     expect(countValidPresetSlots([])).toBe(0);
     expect(countValidPresetSlots(null)).toBe(0);
     expect(countValidPresetSlots(undefined)).toBe(0);
+  });
+});
+
+describe('presetCopyConflict', () => {
+  it('names the station and the key it already sits on', () => {
+    const r = presetCopyConflict('already-on-slot: "Exclusively Rush" is already on key 6');
+    expect(r).toEqual({ name: 'Exclusively Rush', slot: 6 });
+  });
+  it('unescapes a quoted station name, so the user sees what the key shows', () => {
+    // Go's %q escapes a quote inside the name; the parser must undo that.
+    const r = presetCopyConflict('already-on-slot: "Rush \\"Live\\"" is already on key 4');
+    expect(r.name).toBe('Rush "Live"');
+    expect(r.slot).toBe(4);
+  });
+  it('accepts an Error-like input via string coercion', () => {
+    const r = presetCopyConflict(new Error('already-on-slot: "101 SMOOTH JAZZ" is already on key 1'));
+    expect(r).toEqual({ name: '101 SMOOTH JAZZ', slot: 1 });
+  });
+  it('returns null for every other failure, so they keep their own handling', () => {
+    expect(presetCopyConflict('preset 2 (X): status 500')).toBeNull();
+    expect(presetCopyConflict('the target speaker is not answering yet')).toBeNull();
+    expect(presetCopyConflict('')).toBeNull();
+    expect(presetCopyConflict(null)).toBeNull();
   });
 });

--- a/desktop-app/frontend/src/i18n/bundles/ar.json
+++ b/desktop-app/frontend/src/i18n/bundles/ar.json
@@ -1255,6 +1255,7 @@
   "settingsView.copyPresetsPartial": "نُسخ {{n}} إعداد مسبق إلى {{target}}. لم يُنسخ: {{detail}}",
   "settingsView.copyPresetsSomeFailed": "تعذّر نسخ بعض الإعدادات المسبقة إلى {{target}}: {{detail}}",
   "settingsView.copyPresetsAllSlotIssues": "نُسخت الإعدادات المسبقة، لكن بعضها رُفض: {{detail}}",
+  "settingsView.copyPresetsConflict": "{{name}} موجود بالفعل على الزر {{n}} في السماعة الهدف. احذف هذا الزر هناك ثم أعد النقل.",
   "settingsView.copyPresetsAllTargets": "كل السمّاعات الأخرى",
   "settingsView.displayTrackConfirmBody": "تنبيه: لتحديث النص يجب على السمّاعة إعادة تخزين البثّ مؤقّتًا، فتنقطع الموسيقى نحو ثانية في كل مرة يتغيّر فيها العنوان أو النص. يُعرض المقطع دائمًا هنا في التطبيق دون أي انقطاع. هل تفعّل على أي حال؟",
   "settingsView.displayTrackConfirmTitle": "هل تعرض المقطع على شاشة السمّاعة؟",

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -929,6 +929,7 @@
   "settingsView.copyPresetsPartial": "{{n}} Presets nach {{target}} kopiert. Nicht kopiert: {{detail}}",
   "settingsView.copyPresetsSomeFailed": "Einige Presets konnten nicht nach {{target}} kopiert werden: {{detail}}",
   "settingsView.copyPresetsAllSlotIssues": "Presets kopiert, aber einige wurden abgelehnt: {{detail}}",
+  "settingsView.copyPresetsConflict": "{{name}} liegt auf dem Ziellautsprecher schon auf Taste {{n}}. Lösche die Taste dort und übertrage noch einmal.",
   "settingsView.firmwareLabel": "Lautsprecher-Firmware",
   "settingsView.syncing": "Wird übertragen ...",
   "settingsView.syncDoneToast": "Speichertasten neu übertragen ({{n}} Stück).",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -929,6 +929,7 @@
   "settingsView.copyPresetsPartial": "Copied {{n}} presets to {{target}}. Not copied: {{detail}}",
   "settingsView.copyPresetsSomeFailed": "Some presets could not be copied to {{target}}: {{detail}}",
   "settingsView.copyPresetsAllSlotIssues": "Presets copied, but some were rejected: {{detail}}",
+  "settingsView.copyPresetsConflict": "{{name}} is already on key {{n}} of the target speaker. Delete that key there, then transfer again.",
   "settingsView.firmwareLabel": "Speaker firmware",
   "settingsView.rebootHelp": "Restart the speaker. Use this if it stops responding, or after a change that only takes effect on a restart.",
   "settingsView.removeConflictBtn": "Remove {{mod}} leftovers",

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -1255,6 +1255,7 @@
   "settingsView.copyPresetsPartial": "Se copiaron {{n}} presintonías a {{target}}. No copiadas: {{detail}}",
   "settingsView.copyPresetsSomeFailed": "Algunas presintonías no se pudieron copiar a {{target}}: {{detail}}",
   "settingsView.copyPresetsAllSlotIssues": "Presintonías copiadas, pero algunas fueron rechazadas: {{detail}}",
+  "settingsView.copyPresetsConflict": "{{name}} ya está en la tecla {{n}} del altavoz de destino. Borra esa tecla allí y vuelve a transferir.",
   "settingsView.copyPresetsAllTargets": "Todos los demás altavoces",
   "settingsView.displayTrackConfirmBody": "Aviso: para actualizar el texto, el altavoz tiene que volver a cargar el búfer del stream, así que la música se cortará alrededor de un segundo cada vez que cambie la canción o el texto. La pista siempre se muestra aquí en la app sin ninguna interrupción. ¿Activar de todos modos?",
   "settingsView.displayTrackConfirmTitle": "¿Mostrar la pista en la pantalla del altavoz?",

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -1255,6 +1255,7 @@
   "settingsView.copyPresetsPartial": "{{n}} préréglages copiés vers {{target}}. Non copiés : {{detail}}",
   "settingsView.copyPresetsSomeFailed": "Certains préréglages n'ont pas pu être copiés vers {{target}} : {{detail}}",
   "settingsView.copyPresetsAllSlotIssues": "Préréglages copiés, mais certains ont été refusés : {{detail}}",
+  "settingsView.copyPresetsConflict": "{{name}} est déjà sur la touche {{n}} du haut-parleur cible. Supprime cette touche là-bas, puis relance le transfert.",
   "settingsView.copyPresetsAllTargets": "Toutes les autres enceintes",
   "settingsView.displayTrackConfirmBody": "Attention : pour mettre le texte à jour, l'enceinte doit retamponner le flux, donc la musique se coupera environ une seconde à chaque changement de titre ou de texte. Le morceau est toujours affiché ici dans l'app sans aucune interruption. Activer quand même ?",
   "settingsView.displayTrackConfirmTitle": "Afficher le morceau sur l'écran de l'enceinte ?",

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -1255,6 +1255,7 @@
   "settingsView.copyPresetsPartial": "{{n}} 件のプリセットを {{target}} にコピーしました。コピーできなかったもの: {{detail}}",
   "settingsView.copyPresetsSomeFailed": "一部のプリセットを {{target}} にコピーできませんでした: {{detail}}",
   "settingsView.copyPresetsAllSlotIssues": "プリセットをコピーしましたが、一部は拒否されました: {{detail}}",
+  "settingsView.copyPresetsConflict": "{{name}} は転送先スピーカーのキー {{n}} にすでに登録されています。転送先でそのキーを削除してから、もう一度転送してください。",
   "settingsView.copyPresetsAllTargets": "他のすべてのスピーカー",
   "settingsView.displayTrackConfirmBody": "ご注意: テキストを更新するにはスピーカーがストリームを再バッファリングする必要があるため、曲やテキストが変わるたびに音楽が約1秒途切れます。このアプリ内では曲名が常に途切れなく表示されます。それでもオンにしますか？",
   "settingsView.displayTrackConfirmTitle": "スピーカーのディスプレイに曲を表示しますか？",

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -1255,6 +1255,7 @@
   "settingsView.copyPresetsPartial": "Nukopijuota {{n}} išankstinių nustatymų į {{target}}. Nenukopijuota: {{detail}}",
   "settingsView.copyPresetsSomeFailed": "Kai kurių išankstinių nustatymų nepavyko nukopijuoti į {{target}}: {{detail}}",
   "settingsView.copyPresetsAllSlotIssues": "Išankstiniai nustatymai nukopijuoti, bet kai kurie buvo atmesti: {{detail}}",
+  "settingsView.copyPresetsConflict": "{{name}} jau yra paskirties kolonėlės {{n}} mygtuke. Ištrink tą mygtuką ten ir perkelk dar kartą.",
   "settingsView.copyPresetsAllTargets": "Visi kiti garsiakalbiai",
   "settingsView.displayTrackConfirmBody": "Atkreipk dėmesį: kad atnaujintų tekstą, garsiakalbis turi iš naujo buferizuoti srautą, todėl muzika nutrūks maždaug sekundei kaskart, kai pasikeičia daina ar tekstas. Programoje takelis visada rodomas be jokių pertrūkių. Vis tiek įjungti?",
   "settingsView.displayTrackConfirmTitle": "Rodyti takelį garsiakalbio ekrane?",

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -1255,6 +1255,7 @@
   "settingsView.copyPresetsPartial": "Uz {{target}} nokopēti {{n}} priekšiestatījumi. Nav nokopēti: {{detail}}",
   "settingsView.copyPresetsSomeFailed": "Dažus priekšiestatījumus neizdevās nokopēt uz {{target}}: {{detail}}",
   "settingsView.copyPresetsAllSlotIssues": "Priekšiestatījumi nokopēti, bet daži tika noraidīti: {{detail}}",
+  "settingsView.copyPresetsConflict": "{{name}} jau ir mērķa skaļruņa {{n}}. taustiņā. Izdzēs to taustiņu tur un pārsūti vēlreiz.",
   "settingsView.copyPresetsAllTargets": "Visi pārējie skaļruņi",
   "settingsView.displayTrackConfirmBody": "Ievēro: lai atjauninātu tekstu, skaļrunim jāpārbuferē straume, tāpēc mūzika uz aptuveni sekundi pārtrūks ikreiz, kad mainās dziesma vai teksts. Šeit, lietotnē, dziesma vienmēr tiek rādīta bez pārtraukumiem. Tomēr ieslēgt?",
   "settingsView.displayTrackConfirmTitle": "Rādīt dziesmu skaļruņa displejā?",

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -1255,6 +1255,7 @@
   "settingsView.copyPresetsPartial": "{{n}} presets gekopieerd naar {{target}}. Niet gekopieerd: {{detail}}",
   "settingsView.copyPresetsSomeFailed": "Sommige presets konden niet naar {{target}} worden gekopieerd: {{detail}}",
   "settingsView.copyPresetsAllSlotIssues": "Presets gekopieerd, maar sommige zijn geweigerd: {{detail}}",
+  "settingsView.copyPresetsConflict": "{{name}} staat al op toets {{n}} van de doelspeaker. Verwijder die toets daar en breng de presets opnieuw over.",
   "settingsView.copyPresetsAllTargets": "Alle andere luidsprekers",
   "settingsView.displayTrackConfirmBody": "Let op: om de tekst bij te werken moet de luidspreker de stream opnieuw bufferen, dus de muziek valt elke keer ongeveer een seconde weg als het nummer of de tekst verandert. Het nummer wordt hier in de app altijd zonder onderbreking getoond. Toch inschakelen?",
   "settingsView.displayTrackConfirmTitle": "Het nummer op het luidsprekerdisplay tonen?",

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -1255,6 +1255,7 @@
   "settingsView.copyPresetsPartial": "Skopiowano {{n}} zaprogramowanych stacji do {{target}}. Nie skopiowano: {{detail}}",
   "settingsView.copyPresetsSomeFailed": "Niektórych zaprogramowanych stacji nie udało się skopiować do {{target}}: {{detail}}",
   "settingsView.copyPresetsAllSlotIssues": "Stacje skopiowano, ale niektóre zostały odrzucone: {{detail}}",
+  "settingsView.copyPresetsConflict": "{{name}} jest już pod przyciskiem {{n}} w głośniku docelowym. Usuń tam ten przycisk i przenieś jeszcze raz.",
   "settingsView.copyPresetsAllTargets": "Wszystkie inne głośniki",
   "settingsView.displayTrackConfirmBody": "Uwaga: aby zaktualizować tekst, głośnik musi ponownie buforować strumień, więc muzyka będzie się urywać na około sekundę za każdą zmianą utworu lub tekstu. Utwór jest zawsze pokazywany tutaj w aplikacji bez żadnych przerw. Włączyć mimo to?",
   "settingsView.displayTrackConfirmTitle": "Pokazywać utwór na wyświetlaczu głośnika?",

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -1255,6 +1255,7 @@
   "settingsView.copyPresetsPartial": "{{n}} ön ayar {{target}} hoparlörüne kopyalandı. Kopyalanamayanlar: {{detail}}",
   "settingsView.copyPresetsSomeFailed": "Bazı ön ayarlar {{target}} hoparlörüne kopyalanamadı: {{detail}}",
   "settingsView.copyPresetsAllSlotIssues": "Ön ayarlar kopyalandı, ancak bazıları reddedildi: {{detail}}",
+  "settingsView.copyPresetsConflict": "{{name}} hedef hoparlörde zaten {{n}} numaralı tuşta. Oradaki tuşu sil ve aktarmayı yeniden başlat.",
   "settingsView.copyPresetsAllTargets": "Diğer tüm hoparlörler",
   "settingsView.displayTrackConfirmBody": "Dikkat: Metni güncellemek için hoparlörün akışı yeniden ara belleğe alması gerekir, bu yüzden şarkı veya metin her değiştiğinde müzik yaklaşık bir saniye kesilir. Parça burada uygulamada her zaman kesintisiz gösterilir. Yine de açılsın mı?",
   "settingsView.displayTrackConfirmTitle": "Parça hoparlör ekranında gösterilsin mi?",

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -1255,6 +1255,7 @@
   "settingsView.copyPresetsPartial": "Скопійовано пресети ({{n}}) на {{target}}. Не скопійовано: {{detail}}",
   "settingsView.copyPresetsSomeFailed": "Деякі пресети не вдалося скопіювати на {{target}}: {{detail}}",
   "settingsView.copyPresetsAllSlotIssues": "Пресети скопійовано, але деякі було відхилено: {{detail}}",
+  "settingsView.copyPresetsConflict": "{{name}} вже стоїть на кнопці {{n}} цільової колонки. Видали цю кнопку там і перенеси ще раз.",
   "settingsView.copyPresetsAllTargets": "Усі інші колонки",
   "settingsView.displayTrackConfirmBody": "Увага: щоб оновити текст, колонка має перебуферувати потік, тож музика перериватиметься приблизно на секунду щоразу, коли змінюється пісня чи текст. Тут, у застосунку, трек завжди показується без жодних перерв. Все одно ввімкнути?",
   "settingsView.displayTrackConfirmTitle": "Показувати трек на дисплеї колонки?",

--- a/desktop-app/frontend/src/i18n/bundles/zh-Hant.json
+++ b/desktop-app/frontend/src/i18n/bundles/zh-Hant.json
@@ -929,6 +929,7 @@
   "settingsView.copyPresetsPartial": "已把 {{n}} 個預設複製到 {{target}}。沒複製到的：{{detail}}",
   "settingsView.copyPresetsSomeFailed": "有些預設沒辦法複製到 {{target}}：{{detail}}",
   "settingsView.copyPresetsAllSlotIssues": "預設已複製，但有幾個被拒絕了：{{detail}}",
+  "settingsView.copyPresetsConflict": "{{name}} 已經在目標喇叭的按鍵 {{n}} 上。請先刪除該按鍵，再重新傳送。",
   "settingsView.firmwareLabel": "喇叭韌體",
   "settingsView.rebootHelp": "重新啟動喇叭。如果它沒反應了，或某項變更要重開才會生效，就用這個。",
   "settingsView.removeConflictBtn": "移除 {{mod}} 殘留",

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -347,6 +347,9 @@ import { renderMultiroom, initMultiroomView, stopMultiroomLive, resetMultiroomNo
 import { renderSpotifyAlpha, initSpotifyView } from './views/spotify.js';
 import { renderPodcasts, initPodcastsView } from './views/podcasts.js';
 import { appendSavedBundlePath, failReportSaveHosts } from './failreport.js';
+// Turning a refused preset transfer into a readable sentence is a pure
+// decision (copyreport.js, vitest-covered).
+import { presetCopyConflict } from './copyreport.js';
 // App-wide accessibility prefs (text size + theme). Applied to <html> before
 // the skeleton renders so the first paint already reflects the chosen size and
 // theme. The matching CSS lives in style.css (html.a11y-*).
@@ -5400,7 +5403,12 @@ function wirePresetTransferRow() {
         showToast(t('settingsView.copyPresetsDone', { n, target: target ? getBoxLabel(target) : thost }));
       }
     } catch (e) {
-      showError(e);
+      // The target already holds one of the stations on a key this transfer
+      // does not rewrite, so it refused the whole set and wrote nothing. That
+      // used to surface as the agent's raw 409 JSON in an error dialog (#882).
+      const conflict = presetCopyConflict(e);
+      if (conflict) showError(t('settingsView.copyPresetsConflict', { name: conflict.name, n: conflict.slot }));
+      else showError(e);
     } finally {
       btn.textContent = origLabel;
       updatePresetTransferRow();

--- a/desktop-app/frontend/src/views/settings.js
+++ b/desktop-app/frontend/src/views/settings.js
@@ -34,7 +34,7 @@ import { COUNTRIES, optFlag } from '../localization.js';
 // The box-to-box preset copy continues past rejected slots and reports them
 // as one combined error; reconstructing "how many still copied" from that
 // message is a pure decision in copyreport.js (vitest-covered).
-import { summarizePresetCopyError, countValidPresetSlots } from '../copyreport.js';
+import { summarizePresetCopyError, countValidPresetSlots, presetCopyConflict } from '../copyreport.js';
 import { balanceSourceBox, stereoPairsOf, inStereoPair } from '../groups.js';
 // Group keys (#863): the thumbs keys that carry a saved group are marked on
 // the remote key map; the document itself is edited on the Multi-Room tab.
@@ -2685,6 +2685,15 @@ function renderBoxSettings(s, box) {
         showToast(t('settingsView.copyPresetsDone', { n, target: targetName }));
         if (state.currentBox && state.currentBox.host === thost) await deps.loadPresets();
       } catch (e) {
+        // The target already holds one of the stations on a key this transfer
+        // does not rewrite, so it refused the whole set and wrote nothing. The
+        // user used to get the agent's raw 409 JSON in an error dialog (#882).
+        const conflict = presetCopyConflict(e);
+        if (conflict) {
+          showError(t('settingsView.copyPresetsConflict', { name: conflict.name, n: conflict.slot }));
+          copyBtn.disabled = false;
+          return;
+        }
         // A per-slot rejection is usually a PARTIAL success (the other slots
         // copied); saying only "error" hid that and read as all-or-nothing.
         const part = summarizePresetCopyError(e, await sourceSlotCount());

--- a/internal/presets/presets.go
+++ b/internal/presets/presets.go
@@ -301,6 +301,37 @@ func (s *Store) SetSlot(p Preset) error {
 	return s.Save()
 }
 
+// SetSlots adds or replaces SEVERAL slots and persists them in a SINGLE write.
+// Slots not named in ps are left exactly as they are.
+//
+// It exists because a whole-set write (the box-to-box preset transfer) used to
+// be a loop of SetSlot calls, i.e. one presets.json + presets.json.bak rewrite
+// per slot: six rewrites of the same file on the speaker's NAND for one user
+// action. It is also the only way the transfer can be all-or-nothing, because a
+// per-slot loop leaves a half-written store behind when a later slot is
+// refused.
+func (s *Store) SetSlots(ps []Preset) error {
+	for i := range ps {
+		capQueueItems(&ps[i])
+	}
+	s.mu.Lock()
+	for _, p := range ps {
+		replaced := false
+		for i, existing := range s.data {
+			if existing.Slot == p.Slot {
+				s.data[i] = p
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			s.data = append(s.data, p)
+		}
+	}
+	s.mu.Unlock()
+	return s.Save()
+}
+
 // RemoveSlot removes the preset for the given slot.
 func (s *Store) RemoveSlot(slot int) error {
 	s.mu.Lock()

--- a/internal/presets/presets_test.go
+++ b/internal/presets/presets_test.go
@@ -223,3 +223,68 @@ func TestSaveLoadQueueRoundtrip(t *testing.T) {
 		t.Errorf("round trip lost items:\n got  %+v\n want %+v", got.Items, want.Items)
 	}
 }
+
+// SetSlots replaces several slots in ONE persisted write. The box-to-box
+// preset transfer used to loop SetSlot, rewriting presets.json plus its backup
+// once per slot: six NAND rewrites of the same file for one user action, and a
+// half-written store whenever a later slot was refused (#882).
+func TestSetSlotsWritesTheWholeSetAndKeepsUnnamedSlots(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "presets.json")
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load(new): %v", err)
+	}
+	if err := s.SetSlot(Preset{Slot: 1, Name: "Old One", StreamURL: "http://example.com/old1", Type: "radio"}); err != nil {
+		t.Fatalf("SetSlot: %v", err)
+	}
+	if err := s.SetSlot(Preset{Slot: 4, Name: "Untouched", StreamURL: "http://example.com/keep", Type: "radio"}); err != nil {
+		t.Fatalf("SetSlot: %v", err)
+	}
+	// Slot 1 is replaced, slots 2 and 3 are new, slot 4 is not named at all.
+	if err := s.SetSlots([]Preset{
+		{Slot: 1, Name: "New One", StreamURL: "http://example.com/new1", Type: "radio"},
+		{Slot: 2, Name: "New Two", StreamURL: "http://example.com/new2", Type: "radio"},
+		{Slot: 3, Name: "New Three", StreamURL: "http://example.com/new3", Type: "radio"},
+	}); err != nil {
+		t.Fatalf("SetSlots: %v", err)
+	}
+	reloaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load(reload): %v", err)
+	}
+	want := map[int]string{1: "New One", 2: "New Two", 3: "New Three", 4: "Untouched"}
+	if len(reloaded.All()) != len(want) {
+		t.Fatalf("store holds %d slots after the set write, want %d", len(reloaded.All()), len(want))
+	}
+	for slot, name := range want {
+		got, ok := reloaded.Get(slot)
+		if !ok || got.Name != name {
+			t.Errorf("slot %d = %q (present %v), want %q", slot, got.Name, ok, name)
+		}
+	}
+}
+
+// A queue preset written through SetSlots is capped like every other write
+// path, so one folder preset cannot fill the speaker's flash and strand the
+// next OTA.
+func TestSetSlotsCapsQueueItems(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "presets.json")
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load(new): %v", err)
+	}
+	items := make([]PresetItem, MaxQueueItems+250)
+	for i := range items {
+		items[i] = PresetItem{URL: "http://nas/track.mp3"}
+	}
+	if err := s.SetSlots([]Preset{{Slot: 2, Name: "Everything", Type: "queue", Items: items}}); err != nil {
+		t.Fatalf("SetSlots: %v", err)
+	}
+	got, ok := s.Get(2)
+	if !ok {
+		t.Fatal("slot 2 missing")
+	}
+	if len(got.Items) != MaxQueueItems {
+		t.Errorf("stored %d items, want the cap of %d", len(got.Items), MaxQueueItems)
+	}
+}

--- a/internal/webui/presets_bulk_test.go
+++ b/internal/webui/presets_bulk_test.go
@@ -1,0 +1,280 @@
+package webui
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/JRpersonal/streborn/internal/presets"
+)
+
+// PUT /api/presets writes a WHOLE preset set in one request. The box-to-box
+// transfer used to PUT the slots one at a time, so the target judged every
+// write against a half-written store: two speakers holding the same six
+// stations in a DIFFERENT ORDER collided with themselves and the transfer died
+// with a raw 409 in the user's face (#882).
+
+// newBulkServer returns a Server with a real (temp-dir) preset store, plus the
+// store path so a test can read back exactly what landed on "NAND".
+func newBulkServer(t *testing.T) (*Server, *presets.Store) {
+	t.Helper()
+	store, err := presets.Load(filepath.Join(t.TempDir(), "presets.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &Server{
+		presets: store,
+		logger:  slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+	}, store
+}
+
+// bulkPut sends a set to PUT /api/presets through the collection handler, so
+// the method dispatch is covered too.
+func bulkPut(t *testing.T, s *Server, set []presets.Preset) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(set)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/presets", bytes.NewReader(body))
+	req.RemoteAddr = "192.0.2.10:51234"
+	s.handlePresets(rec, req)
+	return rec
+}
+
+// radioPreset is the shape a transfer carries for an internet-radio key.
+func radioPreset(slot int, name, url string) presets.Preset {
+	return presets.Preset{Slot: slot, Name: name, StreamURL: url, Type: "radio"}
+}
+
+// slotNames maps the store to slot -> name for readable assertions.
+func slotNames(store *presets.Store) map[int]string {
+	out := map[int]string{}
+	for _, p := range store.All() {
+		out[p.Slot] = p.Name
+	}
+	return out
+}
+
+// TestBulkPresetPutAcceptsTheSameStationsInADifferentOrder is the reported
+// case: both speakers already hold the same six stations, the source has them
+// in another order, and the transfer is a pure re-ordering. Every slot must
+// land and the request must answer 200.
+func TestBulkPresetPutAcceptsTheSameStationsInADifferentOrder(t *testing.T) {
+	s, store := newBulkServer(t)
+	names := []string{"101 SMOOTH JAZZ", "B", "C", "D", "E", "Exclusively Rush"}
+	for i, n := range names {
+		if err := store.SetSlot(radioPreset(i+1, n, "http://example.com/"+n)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// The source's order: slots 1 and 6 are swapped against the target's.
+	var set []presets.Preset
+	for i, n := range names {
+		slot := i + 1
+		switch slot {
+		case 1:
+			n = "Exclusively Rush"
+		case 6:
+			n = "101 SMOOTH JAZZ"
+		}
+		set = append(set, radioPreset(slot, n, "http://example.com/"+n))
+	}
+
+	rec := bulkPut(t, s, set)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("a pure re-ordering answered %d: %s", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		Written int   `json:"written"`
+		Slots   []int `json:"slots"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("answer is not the documented JSON: %v (%s)", err, rec.Body.String())
+	}
+	if out.Written != 6 {
+		t.Errorf("reported %d written, want 6", out.Written)
+	}
+	if len(out.Slots) != 6 {
+		t.Errorf("reported slots %v, want all six", out.Slots)
+	}
+	got := slotNames(store)
+	if got[1] != "Exclusively Rush" || got[6] != "101 SMOOTH JAZZ" {
+		t.Errorf("the swap did not land: slot 1 = %q, slot 6 = %q", got[1], got[6])
+	}
+	if len(got) != 6 {
+		t.Errorf("store holds %d slots, want 6", len(got))
+	}
+}
+
+// TestBulkPresetPutRefusesTheSameStationTwiceAndChangesNothing: a set that puts
+// one station on two keys is a genuine collision. It is refused, and because
+// the write is all-or-nothing the store must be byte-for-byte what it was.
+func TestBulkPresetPutRefusesTheSameStationTwiceAndChangesNothing(t *testing.T) {
+	s, store := newBulkServer(t)
+	if err := store.SetSlot(radioPreset(1, "Old One", "http://example.com/old1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetSlot(radioPreset(2, "Old Two", "http://example.com/old2")); err != nil {
+		t.Fatal(err)
+	}
+	before := slotNames(store)
+
+	rec := bulkPut(t, s, []presets.Preset{
+		radioPreset(1, "Jazz", "http://example.com/jazz"),
+		radioPreset(2, "Jazz again", "http://example.com/jazz"),
+	})
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("one station on two keys answered %d, want 409: %s", rec.Code, rec.Body.String())
+	}
+	var c struct {
+		Code string `json:"code"`
+		Name string `json:"name"`
+		Slot int    `json:"slot"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &c); err != nil {
+		t.Fatalf("409 body is not the documented JSON: %v (%s)", err, rec.Body.String())
+	}
+	if c.Code != "already-on-slot" || c.Slot != 2 || c.Name != "Jazz again" {
+		t.Errorf("409 body = %+v, want code already-on-slot naming the other key (slot 2)", c)
+	}
+	if got := slotNames(store); len(got) != len(before) || got[1] != before[1] || got[2] != before[2] {
+		t.Errorf("a refused set changed the store: before %v, after %v", before, got)
+	}
+}
+
+// TestBulkPresetPutRefusesAStationThatSitsOnASlotOutsideThePayload: the
+// duplicate rule is applied to the RESULT, so a key the set does not rewrite
+// still counts. Nothing may be deleted to make room (the loss-free promise of
+// #836) and nothing may be written.
+func TestBulkPresetPutRefusesAStationThatSitsOnASlotOutsideThePayload(t *testing.T) {
+	s, store := newBulkServer(t)
+	if err := store.SetSlot(radioPreset(5, "Keeper", "http://example.com/keeper")); err != nil {
+		t.Fatal(err)
+	}
+	before := slotNames(store)
+
+	rec := bulkPut(t, s, []presets.Preset{
+		radioPreset(1, "New One", "http://example.com/new1"),
+		radioPreset(2, "Keeper (copy)", "http://example.com/keeper"),
+	})
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("answered %d, want 409: %s", rec.Code, rec.Body.String())
+	}
+	var c struct {
+		Code string `json:"code"`
+		Name string `json:"name"`
+		Slot int    `json:"slot"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &c); err != nil {
+		t.Fatalf("409 body is not the documented JSON: %v (%s)", err, rec.Body.String())
+	}
+	if c.Code != "already-on-slot" || c.Slot != 5 || c.Name != "Keeper" {
+		t.Errorf("409 body = %+v, want it to name the untouched key 5 and its station", c)
+	}
+	got := slotNames(store)
+	if len(got) != len(before) || got[5] != "Keeper" {
+		t.Errorf("a refused set changed the store: before %v, after %v", before, got)
+	}
+	if _, ok := got[1]; ok {
+		t.Error("slot 1 was written even though the set was refused")
+	}
+}
+
+// TestBulkPresetPutLeavesSlotsTheSetDoesNotName: a partial set rewrites only
+// what it carries.
+func TestBulkPresetPutLeavesSlotsTheSetDoesNotName(t *testing.T) {
+	s, store := newBulkServer(t)
+	if err := store.SetSlot(radioPreset(4, "Untouched", "http://example.com/untouched")); err != nil {
+		t.Fatal(err)
+	}
+	rec := bulkPut(t, s, []presets.Preset{radioPreset(1, "New", "http://example.com/new")})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("answered %d: %s", rec.Code, rec.Body.String())
+	}
+	got := slotNames(store)
+	if got[4] != "Untouched" || got[1] != "New" {
+		t.Errorf("store = %v, want slot 4 kept and slot 1 written", got)
+	}
+}
+
+// TestBulkPresetPutRejectsAMalformedSet covers the structural gates: too many
+// entries, an impossible slot, the same slot twice, and a preset with nothing
+// playable in it (which would store a key that can never play, #252).
+func TestBulkPresetPutRejectsAMalformedSet(t *testing.T) {
+	cases := []struct {
+		name string
+		set  []presets.Preset
+		want int
+	}{
+		{"empty set", nil, http.StatusBadRequest},
+		{"seven presets", []presets.Preset{
+			radioPreset(1, "a", "http://example.com/1"), radioPreset(2, "b", "http://example.com/2"),
+			radioPreset(3, "c", "http://example.com/3"), radioPreset(4, "d", "http://example.com/4"),
+			radioPreset(5, "e", "http://example.com/5"), radioPreset(6, "f", "http://example.com/6"),
+			radioPreset(6, "g", "http://example.com/7"),
+		}, http.StatusBadRequest},
+		{"slot out of range", []presets.Preset{radioPreset(7, "a", "http://example.com/1")}, http.StatusBadRequest},
+		{"same slot twice", []presets.Preset{
+			radioPreset(1, "a", "http://example.com/1"), radioPreset(1, "b", "http://example.com/2"),
+		}, http.StatusBadRequest},
+		{"nothing playable", []presets.Preset{radioPreset(1, "a", "")}, http.StatusUnprocessableEntity},
+		{"self-proxy stream", []presets.Preset{radioPreset(1, "a", "http://127.0.0.1:8888/stream/3")}, http.StatusUnprocessableEntity},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, store := newBulkServer(t)
+			rec := bulkPut(t, s, tc.set)
+			if rec.Code != tc.want {
+				t.Fatalf("answered %d, want %d: %s", rec.Code, tc.want, rec.Body.String())
+			}
+			if len(store.All()) != 0 {
+				t.Errorf("a refused set wrote %d slots", len(store.All()))
+			}
+		})
+	}
+}
+
+// TestBulkPresetPutAcceptsSpotifyAndQueuePresets: a transfer carries whatever
+// the source holds. Spotify keys collide on their context URI; folder keys
+// carry no station at all and must never collide with each other.
+func TestBulkPresetPutAcceptsSpotifyAndQueuePresets(t *testing.T) {
+	s, store := newBulkServer(t)
+	rec := bulkPut(t, s, []presets.Preset{
+		{Slot: 1, Name: "Chill", Type: "spotify", URI: "spotify:playlist:abc"},
+		{Slot: 2, Name: "Folder A", Type: "queue", Items: []presets.PresetItem{{URL: "http://example.com/a.mp3"}}},
+		{Slot: 3, Name: "Folder B", Type: "queue", Items: []presets.PresetItem{{URL: "http://example.com/b.mp3"}}},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("answered %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(store.All()) != 3 {
+		t.Fatalf("store holds %d slots, want 3", len(store.All()))
+	}
+	// The same playlist on two keys is still a collision.
+	s2, _ := newBulkServer(t)
+	rec = bulkPut(t, s2, []presets.Preset{
+		{Slot: 1, Name: "Chill", Type: "spotify", URI: "spotify:playlist:abc"},
+		{Slot: 2, Name: "Chill copy", Type: "spotify", URI: "spotify:playlist:abc"},
+	})
+	if rec.Code != http.StatusConflict {
+		t.Errorf("the same playlist on two keys answered %d, want 409: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestPresetCollectionStillRefusesOtherMethods keeps the older-agent contract
+// the desktop fallback relies on: anything that is not GET or PUT is a 405.
+func TestPresetCollectionStillRefusesOtherMethods(t *testing.T) {
+	s, _ := newBulkServer(t)
+	rec := httptest.NewRecorder()
+	s.handlePresets(rec, httptest.NewRequest(http.MethodPost, "/api/presets", strings.NewReader("[]")))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("POST answered %d, want 405", rec.Code)
+	}
+}

--- a/internal/webui/presets_http.go
+++ b/internal/webui/presets_http.go
@@ -29,9 +29,190 @@ func (s *Server) handlePresets(w http.ResponseWriter, r *http.Request) {
 		// an empty store flooded the NAND log tail out of a bundle (#882).
 		s.notePresetsRead(r.RemoteAddr, len(all))
 		writeJSON(w, http.StatusOK, all)
+	case http.MethodPut:
+		s.handlePresetsBulkPut(w, r)
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
+}
+
+// maxBulkPresetBody bounds PUT /api/presets. Six times the per-slot cap, for
+// the same reason it is generous there: a queue preset carries the whole track
+// list of a DLNA folder, and a whole-set write may carry six of them.
+const maxBulkPresetBody = 6 << 20
+
+// handlePresetsBulkPut writes a WHOLE preset set in one go: PUT /api/presets
+// with a JSON array of at most six presets, each on a slot 1-6. Slots the
+// payload does not name are left untouched.
+//
+// It exists because the per-slot duplicate guard is the wrong rule for a
+// transfer. A box-to-box copy PUT the source slots one at a time, and the guard
+// (#836: refuse rather than silently delete the key a station already sits on)
+// looked at the HALF-WRITTEN store. Two speakers holding the same six stations
+// in a different order therefore failed mid-transfer with a 409 per swapped
+// pair (#882), even though the finished set would have been perfectly legal.
+// Here the duplicate rule is applied to the RESULT, so a re-ordering is fine
+// while a genuine collision is still refused, and refusing costs the user
+// nothing because nothing is written until the whole set is accepted.
+func (s *Server) handlePresetsBulkPut(w http.ResponseWriter, r *http.Request) {
+	var in []presets.Preset
+	if !decodeJSONRequest(w, r, maxBulkPresetBody, &in) {
+		return
+	}
+	if len(in) == 0 {
+		http.Error(w, "empty preset set", http.StatusBadRequest)
+		return
+	}
+	if len(in) > 6 {
+		http.Error(w, "too many presets, at most 6", http.StatusBadRequest)
+		return
+	}
+	inPayload := make(map[int]bool, len(in))
+	for i := range in {
+		p := &in[i]
+		if p.Slot < 1 || p.Slot > 6 {
+			http.Error(w, "invalid slot, must be 1-6", http.StatusBadRequest)
+			return
+		}
+		if inPayload[p.Slot] {
+			http.Error(w, "slot "+strconv.Itoa(p.Slot)+" appears twice", http.StatusBadRequest)
+			return
+		}
+		inPayload[p.Slot] = true
+		if p.Type == "" {
+			p.Type = "radio"
+		}
+		if p.Type == "spotify" {
+			p.URI = normalizeSpotifyURI(p.URI)
+		}
+		// Same art rule as the per-slot save: the store keeps the station's
+		// ORIGIN image URL, never this agent's own art-proxy wrapper (#696).
+		p.Art = healSelfArtProxy(p.Art)
+		if msg, code := bulkPresetRejection(*p); code != "" {
+			s.logger.Warn("bulk preset write refused: a preset in the set is not playable",
+				"slot", p.Slot, "name", p.Name, "code", code,
+				"from", r.RemoteAddr, "ua", r.Header.Get("User-Agent"))
+			writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+				"error": msg, "code": code, "slot": p.Slot,
+			})
+			return
+		}
+	}
+	// A station lives on at most ONE key, checked against the FINISHED set:
+	// two payload entries carrying the same station collide with each other,
+	// and a payload station also collides with a slot the payload does not
+	// rewrite. Nothing is ever deleted to make room, so the loss-free promise
+	// of #836 holds here too.
+	for i := range in {
+		for j := i + 1; j < len(in); j++ {
+			if !samePresetStation(in[i], in[j]) && !samePresetStation(in[j], in[i]) {
+				continue
+			}
+			s.logger.Info("bulk preset write refused: the set puts one station on two keys",
+				"slot", in[i].Slot, "otherSlot", in[j].Slot, "name", in[j].Name,
+				"from", r.RemoteAddr, "ua", r.Header.Get("User-Agent"))
+			writeJSON(w, http.StatusConflict, map[string]any{
+				"code": "already-on-slot", "slot": in[j].Slot, "name": in[j].Name,
+			})
+			return
+		}
+	}
+	for _, other := range s.presets.All() {
+		if inPayload[other.Slot] {
+			continue // this slot is being rewritten, so it cannot collide
+		}
+		for _, p := range in {
+			if !samePresetStation(p, other) {
+				continue
+			}
+			s.logger.Info("bulk preset write refused: a station in the set is already on a key the set does not rewrite",
+				"slot", p.Slot, "existingSlot", other.Slot, "name", other.Name,
+				"from", r.RemoteAddr, "ua", r.Header.Get("User-Agent"))
+			writeJSON(w, http.StatusConflict, map[string]any{
+				"code": "already-on-slot", "slot": other.Slot, "name": other.Name,
+			})
+			return
+		}
+	}
+	// One store write for the whole set: six SetSlot calls would rewrite
+	// presets.json plus its backup six times on the speaker's NAND for a
+	// single user action.
+	if err := s.presets.SetSlots(in); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	slots := make([]int, 0, len(in))
+	for _, p := range in {
+		slots = append(slots, p.Slot)
+	}
+	// Same forensic rule as the per-slot save: every accepted write names its
+	// writer, because a silent success path is a hole in a later bundle.
+	s.logger.Info("bulk preset write accepted",
+		"slots", slots, "count", len(in),
+		"from", r.RemoteAddr, "ua", r.Header.Get("User-Agent"))
+	// Sync the hardware keys, same mapping as the per-slot save. Best-effort:
+	// the store already holds the set, and a failed box push is retried by the
+	// caller's own /api/box/sync-presets.
+	if s.boxHost != "" {
+		for _, p := range in {
+			boxCtx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+			if err := s.writeBoxPreset(boxCtx, p.Slot, p.Name, boxPresetURL(p.Slot, p.Type == "spotify"), p.Art, p.Type == "spotify"); err != nil {
+				s.logger.Warn("box preset sync failed", "slot", p.Slot, "err", err)
+			}
+			cancel()
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status": "ok", "written": len(in), "slots": slots,
+	})
+}
+
+// bulkPresetRejection reports why a preset in a bulk set cannot be stored, as
+// the same {error, code} pair the per-slot save answers with, or "" when it is
+// fine. It keeps the structural gates that stop a dead preset from being stored
+// (#45/#105/#252) and deliberately drops the per-slot save's NETWORK probes and
+// Spotify enrichment: a whole-set write must not fan out into a dozen outbound
+// requests, and every preset in it was already vetted when it was first saved
+// on the source speaker.
+func bulkPresetRejection(p presets.Preset) (msg, code string) {
+	switch p.Type {
+	case "spotify":
+		if !playableSpotifyURI(p.URI) {
+			return "This Spotify preset has no replayable playlist, album or track.", "spotify-uri-unplayable"
+		}
+	case "queue":
+		for _, it := range p.Items {
+			if it.URL != "" {
+				return "", ""
+			}
+		}
+		return "This folder preset has no playable tracks.", "queue-empty"
+	default:
+		if p.StreamURL == "" {
+			return "This preset has no playable stream.", "stream-url-missing"
+		}
+		if !isHTTPURL(p.StreamURL) {
+			return "This preset has no playable stream.", "stream-url-invalid"
+		}
+		// A stream URL pointing back at an agent's own /stream/<n> proxy is a
+		// poisoned value (#252) and must never be stored: on this speaker it
+		// would dial itself.
+		if _, self := selfProxySlot(p.StreamURL); self {
+			return "This preset stores a speaker's own proxy address instead of the station.", "stream-url-self-proxy"
+		}
+	}
+	return "", ""
+}
+
+// samePresetStation reports whether p and other play the same thing. It mirrors
+// the per-slot duplicate rule exactly: the SAVED preset's type decides which
+// field is compared, and an empty field never collides (a queue preset carries
+// neither, so folders never collide with anything).
+func samePresetStation(p, other presets.Preset) bool {
+	if p.Type == "spotify" {
+		return p.URI != "" && other.URI == p.URI
+	}
+	return p.StreamURL != "" && other.StreamURL == p.StreamURL
 }
 
 func (s *Server) handlePresetSlot(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Reported on #882 with a bundle and screenshots. Pressing Transfer in Speaker settings to copy the keys from one speaker to another failed, and the dialog showed this:

```
Error: preset 1 (Exclusively Rush): status 409: {"code":"already-on-slot","name":"Exclusively Rush","slot":6}
; preset 6 (101 SMOOTH JAZZ): status 409: {"code":"already-on-slot","name":"101 SMOOTH JAZZ","slot":1}
```

Both speakers already held the same six stations, in a different order.

**Why.** Transfer wrote the keys one at a time, and the speaker refuses a key whose station already sits on another key. That guard is right and stays: it was added for #836, where the old behaviour silently deleted the other key and wiped a user's presets one after another. It is simply the wrong question for a transfer, which writes a whole set: the collision only exists half way through writing it, and disappears once the set is complete.

**The change.** A new `PUT /api/presets` takes the whole set at once. The duplicate rule is applied to the result rather than to the half-written state, so a reordering is accepted, while the same station twice in one set, or a station that also sits on a key the set does not name, is still refused by name and still deletes nothing. The set is written in a single store write, so a refused transfer leaves the speaker exactly as it was, and it is one NAND write instead of six. The per-key endpoint and its guard are untouched.

The desktop tries the bulk request first and falls back to the old key-by-key loop when the target answers 404 or 405, because the target speaker can be running an older agent. Waiting for the target, the mid-copy retry, the hardware re-sync and the Spotify credential transfer are unchanged.

A conflict now reads as a sentence: "{station} is already on key {n} of the target speaker. Delete that key there, then transfer again." In all 13 bundles.

**Tests**: the reported swap accepted end to end with one request and both keys swapped; the same station twice refused with nothing written; a station on a key outside the set refused; unnamed keys left alone; a malformed set refused six ways; an older agent's 405 falling back to six per-key writes; a conflict reported as the sentence and not as JSON. `go test ./internal/webui/ ./internal/presets/ ./cmd/agent/ -count=1` green, desktop module green, `golangci-lint` 0 issues in both, ARM cross-compile ok, `vitest` 26 files / 318 tests.

Not verified on hardware: the reporter's exact two speakers. The swap case is covered by a test against a fake speaker end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RvW1mQT7V9g3F8f3x7icD
