### PR TITLE
The update cache no longer keeps every installer forever

### DIFF
--- a/desktop-app/app.go
+++ b/desktop-app/app.go
@@ -183,8 +183,10 @@ func (a *App) appCtx() context.Context {
 
 func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
-	// Clear any leftover "<exe>.old" from a previous self-update (#71).
+	// Clear any leftover "<exe>.old" from a previous self-update (#71),
+	// and the installers the update cache no longer needs.
 	a.cleanupOldBinary()
+	a.pruneStagedUpdates(appVersion)
 	// Route the dlna package's logs through our file logger so the
 	// per-interface SSDP M-SEARCH summary lines land in str.log next
 	// to the STR discovery cycles. Without this, a media server scan

--- a/desktop-app/update_app.go
+++ b/desktop-app/update_app.go
@@ -336,6 +336,7 @@ func (a *App) DownloadUpdate(version string) (string, error) {
 				return "", rerr
 			}
 			a.logger.Info("update downloaded and verified", "version", version, "path", finalPath, "attempts", attempt)
+			a.pruneStagedUpdates(appVersion)
 			return finalPath, nil
 		}
 		lastErr = err
@@ -580,6 +581,65 @@ func (a *App) RevealUpdateFile(path string) error {
 		return exec.Command("explorer", "/select,", filepath.FromSlash(path)).Start()
 	default:
 		return exec.Command("xdg-open", filepath.Dir(path)).Start()
+	}
+}
+
+// stagedVersionRe pulls the version out of a staged installer's file name,
+// e.g. "STR-Windows-v0.9.77.exe" or "STR-Linux-x64-v0.9.77.tar.gz".
+var stagedVersionRe = regexp.MustCompile(`v[0-9]+(?:\.[0-9]+)+`)
+
+// pruneStagedUpdates deletes installers the update cache no longer needs.
+// Every downloaded update used to stay there for good: one machine held eight
+// of them, 390 MB, in the user's AppData with nothing in the app hinting at it
+// (found 2026-09-08). An installer is removed when its version is not newer
+// than keepFrom, so the one the user is running and everything older go, while
+// an update already fetched but not applied yet survives a restart. A ".part"
+// is only touched when it has not grown for an hour, so a download in flight
+// is never pulled out from under itself. Best-effort throughout: a file still
+// locked is skipped and caught on the next run.
+func (a *App) pruneStagedUpdates(keepFrom string) {
+	dir, err := updateDir()
+	if err != nil {
+		return
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	var removed int
+	var freed int64
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		info, ierr := e.Info()
+		if ierr != nil {
+			continue
+		}
+		switch {
+		case strings.HasSuffix(name, ".part"):
+			if time.Since(info.ModTime()) < time.Hour {
+				continue
+			}
+		default:
+			v := stagedVersionRe.FindString(name)
+			if v == "" {
+				continue // not one of our installers, leave it alone
+			}
+			if v != keepFrom && !versionLess(v, keepFrom) {
+				continue // newer than what we run: a pending update, keep it
+			}
+		}
+		if rerr := os.Remove(filepath.Join(dir, name)); rerr != nil {
+			continue
+		}
+		removed++
+		freed += info.Size()
+	}
+	if removed > 0 {
+		a.logger.Info("update cleanup: removed staged installers",
+			"files", removed, "freedMB", freed/(1024*1024), "keptFrom", keepFrom, "dir", dir)
 	}
 }
 

--- a/desktop-app/update_prune_test.go
+++ b/desktop-app/update_prune_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// stageUpdateCache points os.UserCacheDir at a temp dir and returns the
+// updates/ folder inside it, so the prune can be exercised without touching
+// the real per-user cache.
+func stageUpdateCache(t *testing.T) string {
+	t.Helper()
+	base := t.TempDir()
+	t.Setenv("LocalAppData", base)   // Windows
+	t.Setenv("XDG_CACHE_HOME", base) // Linux
+	t.Setenv("HOME", base)           // macOS and the Linux fallback
+	dir, err := updateDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func writeStaged(t *testing.T, dir, name string, age time.Duration) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte("installer"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if age > 0 {
+		old := time.Now().Add(-age)
+		if err := os.Chtimes(p, old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return p
+}
+
+func newPruneApp() *App {
+	return &App{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+}
+
+// Every downloaded installer used to stay in the cache for good: eight of them,
+// 390 MB, on one machine. What is running and what is older than it is dead
+// weight and must go; an update already downloaded but not applied yet is the
+// one thing that must survive, or the user pays for the download twice.
+func TestPruneStagedUpdatesKeepsOnlyThePendingOne(t *testing.T) {
+	dir := stageUpdateCache(t)
+	older := writeStaged(t, dir, "STR-Windows-v0.9.53.exe", 0)
+	running := writeStaged(t, dir, "STR-Windows-v0.9.76.exe", 0)
+	pending := writeStaged(t, dir, "STR-Windows-v0.9.77.exe", 0)
+	foreign := writeStaged(t, dir, "notes.txt", 0)
+
+	newPruneApp().pruneStagedUpdates("v0.9.76")
+
+	for _, gone := range []string{older, running} {
+		if _, err := os.Stat(gone); !os.IsNotExist(err) {
+			t.Errorf("%s should have been removed, err=%v", filepath.Base(gone), err)
+		}
+	}
+	for _, kept := range []string{pending, foreign} {
+		if _, err := os.Stat(kept); err != nil {
+			t.Errorf("%s should have been kept: %v", filepath.Base(kept), err)
+		}
+	}
+}
+
+// A ".part" is a download in flight. Deleting a fresh one would pull the file
+// out from under the transfer that is still writing it; an hour-old one is a
+// leftover from a run that died and is pure waste.
+func TestPruneStagedUpdatesSparesADownloadInFlight(t *testing.T) {
+	dir := stageUpdateCache(t)
+	live := writeStaged(t, dir, "STR-Windows-v0.9.78.exe.part", 0)
+	stale := writeStaged(t, dir, "STR-Windows-v0.9.60.exe.part", 3*time.Hour)
+
+	newPruneApp().pruneStagedUpdates("v0.9.77")
+
+	if _, err := os.Stat(live); err != nil {
+		t.Errorf("a fresh .part must survive: %v", err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("an hour-old .part should have been removed, err=%v", err)
+	}
+}
+
+// The installers are named per platform, so the version has to be found in all
+// three shapes, and a name without one must never be deleted.
+func TestStagedVersionRe(t *testing.T) {
+	cases := map[string]string{
+		"STR-Windows-v0.9.77.exe":      "v0.9.77",
+		"STR-macOS-v0.9.77.zip":        "v0.9.77",
+		"STR-Linux-x64-v0.9.77.tar.gz": "v0.9.77",
+		"STR-Windows-v0.10.0.exe":      "v0.10.0",
+		"STR-Windows-v0.9.77.exe.part": "v0.9.77",
+		"notes.txt":                    "",
+		"streborn-armv7l":              "",
+		"STR-Windows-vNext.exe":        "",
+	}
+	for name, want := range cases {
+		if got := stagedVersionRe.FindString(name); got != want {
+			t.Errorf("%s: got %q, want %q", name, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## What I found

While looking into why an in-app update download was slow on the maintainer's machine, the staging folder turned out to hold **390 MB**: every installer STR had ever downloaded, back to v0.9.53 from 21 August.

```
STR-Windows-v0.9.53.exe   50 MB
STR-Windows-v0.9.68.exe   51 MB
STR-Windows-v0.9.72.exe   51 MB
STR-Windows-v0.9.73.exe   51 MB
STR-Windows-v0.9.74.exe   51 MB
STR-Windows-v0.9.75.exe   51 MB
STR-Windows-v0.9.76.exe   51 MB
STR-Windows-v0.9.77.exe   52 MB
```

`DownloadUpdate` renames the verified `.part` to its final name and never looks at the folder again. Nothing prunes it, and nothing in the UI mentions the folder, so it grows by ~51 MB per update until the user finds it by accident. On a small SSD or a roaming profile that matters.

## The rule

An installer goes when its version is **not newer than the running app**. That deletes the one currently installed and everything before it, and keeps the one case that must be kept: an update already downloaded but not applied yet, so a restart does not cost the user the download a second time.

A `.part` is only removed when it has not grown for an hour, so a transfer in flight is never deleted underneath itself. Files whose names carry no version are left alone.

Runs at startup next to the existing `.old` binary cleanup, and again after each successful download. Best-effort throughout: a locked file is skipped and picked up on the next run.

## Verification

Three tests, all new:

- `TestPruneStagedUpdatesKeepsOnlyThePendingOne` - older and running go, pending and unrelated files stay
- `TestPruneStagedUpdatesSparesADownloadInFlight` - a fresh `.part` survives, a three-hour-old one does not
- `TestStagedVersionRe` - the version is found in the Windows, macOS and Linux asset names, and a name without one yields nothing

`go build`, `go vet` and `gofmt` clean.

## Not in this PR

The slow download that led here is not STR's doing. Measured on the same line at the same minute: `release-assets.githubusercontent.com` delivered 0.14 to 3.3 MB/s and swung between those within minutes, while `codeload.github.com` gave 13.2 MB/s and Cloudflare 16.9 MB/s. Parallel range requests were tested and did not reliably help, so there is no code change to justify here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RvW1mQT7V9g3F8f3x7icD