### PR TITLE
Concurrent writes to the same NAND file could lose or tear one of them

### DIFF
--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -19,13 +19,56 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 )
+
+// Writes to the same path are serialized in this process.
+//
+// The temp sibling is named after the target ("<path>.tmp"), which is what
+// keeps the rename on one filesystem and leaves at most ONE stale file behind
+// after a kill. The cost is that two goroutines writing the same path share
+// that name: the second one truncates the first one's temp file mid-write, and
+// then the first one either renames a torn mix into place or fails outright.
+// The second half was seen in the field on 2026-09-08, a preset recall and the
+// resume guard both updating last-play.json in the same moment:
+//
+//	last-play persist failed err="rename: rename /mnt/nv/streborn/last-play.json.tmp
+//	  /mnt/nv/streborn/last-play.json: no such file or directory"
+//
+// A per-path lock is the right fix here rather than a unique temp name: the
+// agent is the only writer of these files, and unique names would litter a
+// 31 MB NAND with one orphan per unclean shutdown. The map holds one entry per
+// store file, about a dozen for the life of the process.
+var (
+	pathLocksMu sync.Mutex
+	pathLocks   = map[string]*sync.Mutex{}
+)
+
+// lockFor returns the mutex guarding path, creating it on first use.
+func lockFor(path string) *sync.Mutex {
+	key := filepath.Clean(path)
+	pathLocksMu.Lock()
+	defer pathLocksMu.Unlock()
+	m, ok := pathLocks[key]
+	if !ok {
+		m = &sync.Mutex{}
+		pathLocks[key] = m
+	}
+	return m
+}
 
 // WriteFile durably writes data to path. It writes a sibling temp file (same
 // directory, so the rename stays on one filesystem and is itself atomic),
 // fsyncs its data, renames it over path, then fsyncs the directory. On any
 // failure the temp file is removed and the original path is left untouched.
+//
+// Concurrent writes to the same path are serialized, so the file always holds
+// one complete version and the last writer wins. See the pathLocks comment.
 func WriteFile(path string, data []byte, perm os.FileMode) error {
+	mu := lockFor(path)
+	mu.Lock()
+	defer mu.Unlock()
+
 	dir := filepath.Dir(path)
 	tmp := path + ".tmp"
 	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)

--- a/internal/atomicfile/concurrent_test.go
+++ b/internal/atomicfile/concurrent_test.go
@@ -1,0 +1,128 @@
+package atomicfile
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// Two goroutines writing the same file used to share one temp name: the second
+// truncated the first one's temp file mid-write, so the first either renamed a
+// torn mix into place or failed outright. The field case was a preset recall
+// and the resume guard both updating last-play.json in the same moment
+// (2026-09-08):
+//
+//	last-play persist failed err="rename: ... last-play.json.tmp -> last-play.json:
+//	  no such file or directory"
+//
+// Not a cosmetic error: the file that failed to be written is the one the
+// speaker resumes from after a power cut.
+func TestConcurrentWritesToTheSamePathAllSucceed(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "last-play.json")
+
+	const writers = 24
+	payloads := make([][]byte, writers)
+	for i := range payloads {
+		// Long enough that a torn write is visible rather than lucky.
+		payloads[i] = bytes.Repeat([]byte(fmt.Sprintf("%02d", i)), 4096)
+	}
+
+	errs := make(chan error, writers)
+	var start sync.WaitGroup
+	start.Add(1)
+	var done sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		done.Add(1)
+		go func(i int) {
+			defer done.Done()
+			start.Wait()
+			errs <- WriteFile(p, payloads[i], 0o644)
+		}(i)
+	}
+	start.Done()
+	done.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Errorf("concurrent WriteFile: %v", err)
+		}
+	}
+
+	got, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	// Whoever won, the file must hold exactly one writer's payload, whole.
+	var matched bool
+	for _, want := range payloads {
+		if bytes.Equal(got, want) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		t.Fatalf("file holds a torn mix: %d bytes, starts %q, ends %q",
+			len(got), first(got, 16), last(got, 16))
+	}
+	if _, err := os.Stat(p + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("temp file left behind: %v", err)
+	}
+}
+
+// Different paths must not serialize against each other, and must not collide.
+func TestConcurrentWritesToDifferentPathsStayIndependent(t *testing.T) {
+	dir := t.TempDir()
+	const files = 12
+	var wg sync.WaitGroup
+	for i := 0; i < files; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			p := filepath.Join(dir, fmt.Sprintf("store-%02d.json", i))
+			if err := WriteFile(p, []byte(fmt.Sprintf(`{"n":%d}`, i)), 0o644); err != nil {
+				t.Errorf("WriteFile %s: %v", p, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	for i := 0; i < files; i++ {
+		p := filepath.Join(dir, fmt.Sprintf("store-%02d.json", i))
+		got, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("ReadFile %s: %v", p, err)
+		}
+		if want := fmt.Sprintf(`{"n":%d}`, i); string(got) != want {
+			t.Errorf("%s = %q, want %q", p, got, want)
+		}
+	}
+}
+
+// The lock is keyed by the cleaned path, so two spellings of the same file
+// share it rather than racing each other.
+func TestLockIsSharedAcrossPathSpellings(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "presets.json")
+	b := filepath.Join(dir, "sub", "..", "presets.json")
+	if lockFor(a) != lockFor(b) {
+		t.Fatal("the same file got two different locks")
+	}
+}
+
+func first(b []byte, n int) []byte {
+	if len(b) < n {
+		return b
+	}
+	return b[:n]
+}
+
+func last(b []byte, n int) []byte {
+	if len(b) < n {
+		return b
+	}
+	return b[len(b)-n:]
+}


### PR DESCRIPTION
## The evidence

From a field diagnostic on v0.9.77 (2026-09-08), an ST10:

```
15:09:55.304 WARN last-play persist failed
  err="rename: rename /mnt/nv/streborn/last-play.json.tmp
       /mnt/nv/streborn/last-play.json: no such file or directory"
```

Rename of a file the process had just created and fsynced, one line after a wake and a preset recall.

## The cause

`atomicfile.WriteFile` names its temp sibling after the target, `<path>.tmp`. That is deliberate: it keeps the rename on one filesystem, and it leaves at most one stale file behind after a kill. But the name is **fixed**, so two goroutines writing the same path share it:

1. A opens `last-play.json.tmp` (`O_TRUNC`), writes, fsyncs.
2. B opens the *same* name with `O_TRUNC`, writes its own payload, renames it into place. The temp name is gone.
3. A renames `last-play.json.tmp` → **ENOENT**.

The reported error is the visible half. The quieter half is worse: if B truncates and writes while A is still writing, A's rename publishes a **torn mix** of both payloads, and nothing logs anything.

Three call sites can reach `persistLastPlay` from different goroutines (`playback.go:583`, `resume_guard.go:79` and `:104`), which matches the bundle exactly: an app recall and the resume guard in the same second.

This is not a last-play problem. The same helper writes `presets.json`, `zones.json`, `group-keys.json`, `webhooks.json`, `recent.json`, `mediaservers.json` and the Spotify resume state. It exists precisely because these files came back at **0 bytes** after an overnight standby power cut (2026-07-15), so silently publishing a torn version is the failure mode it was built to prevent.

## The fix

Writes to the same path are serialized in the process with a per-path mutex. The file always holds one complete version, and the last writer wins.

A per-path lock rather than a unique temp name, deliberately: the agent is the only writer of these files, so an in-process lock is sufficient, and unique names would litter a 31 MB NAND shared with the Bose firmware with one orphan per unclean shutdown. The map holds one entry per store file, about a dozen for the life of the process.

## Verification

`TestConcurrentWritesToTheSamePathAllSucceed` fires 24 goroutines at one path with 8 KB payloads and requires every write to succeed and the result to equal exactly one payload, whole. On the code before this change it fails immediately, and on Windows it fails harder than the field case did:

```
concurrent WriteFile: rename: ... last-play.json.tmp -> last-play.json: Zugriff verweigert
ReadFile: ... last-play.json: Das System kann die angegebene Datei nicht finden.
```

With the fix, all six tests in the package pass under `-race`. Two more guard the edges: different paths must not serialize against each other, and two spellings of one path must share a lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RvW1mQT7V9g3F8f3x7icD