### PR TITLE
Grouping speakers starts music when nothing was playing (#900)

### DIFF
--- a/internal/webui/resume_groupwake_test.go
+++ b/internal/webui/resume_groupwake_test.go
@@ -1,0 +1,68 @@
+package webui
+
+import (
+	"testing"
+	"time"
+)
+
+// Forming a group against a speaker that is asleep means STR wakes it first.
+// The wake looks exactly like a user pressing power, and the power-on resume
+// then started the last station: a group formed while nothing was playing and
+// music came on (#900, 2026-09-08).
+//
+// The existing guard asks whether the box is in a zone, because a standalone
+// box can only have been woken by a person. That reasoning has a hole of about
+// four seconds, which is precisely the window STR uses to wake a master BEFORE
+// the zone exists:
+//
+//	17:23:50 power-on detected, attempting last-station resume
+//	17:23:51 wake: quiet wake for a group operation
+//	17:23:53 wake resume: resumed last stream after power-on
+//	17:23:54 zone: forming (beta)
+//
+// A quiet wake is STR's own, so while one is armed a power-on frame is not a
+// user press.
+func TestQuietWakeMarksTheWakeAsSTRsOwn(t *testing.T) {
+	s := &Server{}
+	if s.quietWakeActive() {
+		t.Fatal("no quiet wake armed, must not report one")
+	}
+
+	s.quietWakeMu.Lock()
+	s.quietWakeVol = 32
+	s.quietWakeUntil = time.Now().Add(quietWakeRestoreAfter)
+	s.quietWakeMu.Unlock()
+
+	if !s.quietWakeActive() {
+		t.Error("a wake STR did for a group operation must be recognisable as its own")
+	}
+
+	// The zone join clears it, and from then on a power press is a power press
+	// again. Cleared here the way restoreQuietWakeVolume does, without the box
+	// call it would make.
+	s.quietWakeMu.Lock()
+	s.quietWakeUntil = time.Time{}
+	s.quietWakeMu.Unlock()
+
+	if s.quietWakeActive() {
+		t.Error("once the quiet wake is over, a wake must count as a user press again")
+	}
+}
+
+// The window is bounded: a speaker cannot be locked out of its power-on resume
+// for good because one group operation touched it.
+func TestQuietWakeWindowIsBounded(t *testing.T) {
+	s := &Server{}
+	s.quietWakeMu.Lock()
+	s.quietWakeVol = 20
+	s.quietWakeUntil = time.Now().Add(quietWakeRestoreAfter)
+	until := s.quietWakeUntil
+	s.quietWakeMu.Unlock()
+
+	if d := time.Until(until); d > time.Minute {
+		t.Errorf("quiet wake window is %v, too long to suppress a user's power press", d)
+	}
+	if !s.quietWakeActive() {
+		t.Fatal("armed wake not reported")
+	}
+}

--- a/internal/webui/resume_standby.go
+++ b/internal/webui/resume_standby.go
@@ -147,6 +147,15 @@ func (s *Server) ResumeLastPlay() {
 			s.logger.Info("wake resume: box is in a zone / stereo pair, not auto-resuming (self-wake guard)")
 			return
 		}
+		// The same self-wake guard, one step earlier in time: STR wakes a
+		// standby master to form a group, and at that moment there is no zone
+		// yet for boxInZone to find (#900). A quiet wake is STR's own doing by
+		// definition, so a power-on frame arriving inside its window is not a
+		// user pressing power.
+		if s.quietWakeActive() {
+			s.logger.Info("wake resume: STR woke this speaker for a group operation, not auto-resuming (self-wake guard)")
+			return
+		}
 
 		// Power-off bounce guard for boxes where the UPnP-source standby did not
 		// arm standbyStoppedRecently above. A rhino ST10 reports a power-off as a
@@ -325,6 +334,10 @@ func (s *Server) RecoverAfterReconnect() {
 		time.Sleep(2 * time.Second)
 		if s.boxInZone() {
 			s.logger.Info("reconnect recovery: box in a zone / stereo pair, standing down (self-wake guard)")
+			return
+		}
+		if s.quietWakeActive() {
+			s.logger.Info("reconnect recovery: STR woke this speaker for a group operation, standing down (self-wake guard)")
 			return
 		}
 		stuck, selLoc := s.boxStuckSelection()

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -858,6 +858,30 @@ func (s *Server) quietWake(ctx context.Context) error {
 	return nil
 }
 
+// quietWakeActive reports whether a quiet wake is still holding this speaker
+// down, i.e. STR itself pulled the box out of standby for a group operation
+// moments ago.
+//
+// The power-on resume needs this. Its own self-wake guard asks whether the box
+// is in a zone, on the reasoning that a standalone box can only have been woken
+// by a user pressing power. That is true right up until STR wakes the box in
+// order to form a zone: at that instant the zone does not exist yet, the guard
+// sees a standalone box and the last station starts playing. Reported on #900,
+// a group formed while nothing was playing and music started (2026-09-08):
+//
+//	17:23:50 power-on detected, attempting last-station resume
+//	17:23:51 wake: quiet wake for a group operation  mutedFrom=32
+//	17:23:53 wake resume: resumed last stream after power-on
+//	17:23:54 zone: forming (beta)
+//
+// The mute did not save it either: the zone join lifts the mute a second later
+// and the resumed stream becomes audible at full level.
+func (s *Server) quietWakeActive() bool {
+	s.quietWakeMu.Lock()
+	defer s.quietWakeMu.Unlock()
+	return !s.quietWakeUntil.IsZero()
+}
+
 // quietWakeRestoreAfter bounds how long a member stays muted after a quiet
 // wake when no zone join arrives.
 const quietWakeRestoreAfter = 20 * time.Second


### PR DESCRIPTION
Closes #900

## What the reporter saw

Nothing playing, create a group of two speakers, music starts. Reported as intermittent, which fits: it only happens when the speaker STR picks as master is actually asleep at that moment.

## What the log shows

The master's own agent log, four seconds end to end:

```
17:23:47  wake phase: start
17:23:50  wake phase: STANDBY, sending sys power
17:23:50  box ws: power-on wake (DO_NOT_RESUME restore), box will not resume natively
17:23:50  power-on detected, attempting last-station resume
17:23:51  wake: quiet wake for a group operation      mutedFrom=32
17:23:53  wake resume: resumed last stream after power-on   title="Exclusively Rush"
17:23:54  zone: forming (beta)
17:23:56  wake: level restored after a quiet wake     vol=32  why="zone joined"
```

STR woke the box to form the group, the box emitted the same `DO_NOT_RESUME` wake it emits for a user power press, and the power-on resume did what it is supposed to do for a power press.

## Why the existing guard missed it

`ResumeLastPlay` already has a self-wake guard, and its reasoning is sound: a box pulled out of standby by its stereo pair or zone emits an identical wake, so a box **in a zone** stands down while a standalone box resumes, because a standalone box can only have been woken by a person.

The hole is one of ordering. STR wakes the master *in order to* form the zone, so at resume time the zone does not exist yet and `boxInZone()` correctly reports "standalone".

The mute did not save it either. A quiet wake mutes the speaker, but the zone join lifts the mute a second later, and by then the resumed stream is running at the level it was muted from.

## The fix

A quiet wake is STR's own doing by definition, and it is already tracked with a bounded window (`quietWakeUntil`, 20 s). A power-on frame arriving while one is armed is therefore not a user press, so both resume paths that already carry the zone guard now stand down on it as well:

```
wake resume: STR woke this speaker for a group operation, not auto-resuming (self-wake guard)
```

Bounded on purpose: after 20 seconds a power press is a power press again, so a speaker cannot be locked out of its power-on resume because a group operation touched it once. Where the two collide, silence is the safer error than surprise music.

## Verification

Two new tests (`resume_groupwake_test.go`) cover the marker and the bound. The full `internal/webui` package passes (137 s, includes the existing quiet-wake and standby-bounce suites, which is where a regression here would land). `go build`, `go vet`, `gofmt` clean.

Bundle: `str-diagnostic-ST10-v0.9.77-20260908-222503.zip` on #900.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RvW1mQT7V9g3F8f3x7icD