### PR TITLE
fix(app): the remote key map opens where the keys are, not just the settings page

### DIFF
--- a/desktop-app/frontend/src/revealsection.test.js
+++ b/desktop-app/frontend/src/revealsection.test.js
@@ -1,0 +1,61 @@
+// The Multi-Room tab's "show on the remote key map" button dropped the user on
+// the settings page with everything still folded up (reported 2026-09-10:
+// "schickt den user nur auf die einstellungsseite aber nicht direkt in das
+// untermenue wo man die tasten belegen kann").
+//
+// The cause is not the section, it is what renderSettingsGroups does to it
+// afterwards: every section is moved into a collapsible GROUP, and the two that
+// hold these targets, Advanced and Info, start closed. Opening the section's own
+// <details> therefore reveals nothing.
+//
+// The view is read as source, the same way the bass-control tests read it: it
+// cannot be imported without a DOM and the Wails runtime.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const src = readFileSync(new URL('./views/settings.js', import.meta.url), 'utf8');
+
+describe('settings deep links', () => {
+  it('has one helper that opens the ancestors, not just the target', () => {
+    const fn = src.slice(src.indexOf('function revealInSettings'), src.indexOf('\n}', src.indexOf('function revealInSettings')));
+    expect(fn, 'revealInSettings must exist').toContain('revealInSettings');
+    // It has to walk UP. A single element.open cannot reveal a target whose
+    // group is closed.
+    expect(fn).toContain('parentElement');
+    expect(fn).toContain("'DETAILS'");
+    expect(fn).toContain('scrollIntoView');
+  });
+
+  // Both deep links must go through it. A bare scrollIntoView is the bug.
+  it('every deep link into a settings section goes through the helper', () => {
+    const scrolls = [...src.matchAll(/scrollIntoView/g)];
+    expect(scrolls.length, 'expected the helper plus the how-to nudge').toBeGreaterThan(0);
+    // The key-map link and the firmware banner are the two that live inside a
+    // collapsible group; neither may scroll on its own.
+    // Anchor on the CONSUMPTION site, not on the `let pendingKeyMapOpen = false`
+    // declaration further up the file.
+    const at = src.indexOf('if (pendingKeyMapOpen)');
+    expect(at, 'the pending-intent block must still be findable').toBeGreaterThan(-1);
+    const keyMap = src.slice(at, at + 400);
+    expect(keyMap).toContain('revealInSettings');
+    expect(keyMap).not.toContain('scrollIntoView');
+
+    const fwBtn = src.slice(src.indexOf("$('fwUpdateBtn')"), src.indexOf("$('fwUpdateBtn')") + 300);
+    expect(fwBtn).toContain('revealInSettings');
+    expect(fwBtn).not.toContain('scrollIntoView');
+  });
+
+  // The user came to look at the remote, so the scroll lands on the key map
+  // rather than on the section heading a screen above it.
+  it('the key-map link targets the remote itself', () => {
+    expect(src).toContain('id="webhookKeyMap"');
+    expect(src).toContain("revealInSettings($('webhookKeyMap')");
+  });
+
+  // The reason the helper is needed at all: expert sections are grouped into
+  // Advanced, and that group is created closed.
+  it('the advanced group really does start closed', () => {
+    const groups = src.slice(src.indexOf('const GROUPS'), src.indexOf('];', src.indexOf('const GROUPS')));
+    expect(groups).toMatch(/key:\s*'advanced'[^}]*open:\s*false/);
+  });
+});

--- a/desktop-app/frontend/src/views/settings.js
+++ b/desktop-app/frontend/src/views/settings.js
@@ -954,6 +954,29 @@ function remoteSvg() {
     + `<rect class="rc-body" x="4" y="4" width="192" height="420" rx="30"/>${keys}${marks}</svg>`;
 }
 
+// revealInSettings brings a settings element into view for real.
+//
+// Opening the element's own <details> is not enough: renderSettingsGroups moves
+// every section into a collapsible GROUP, and the two groups that matter here,
+// Advanced and Info, start closed. A deep link that only opened the section
+// itself therefore left the user on the settings page with everything still
+// folded up and nothing to see, which is exactly how the Multi-Room tab's
+// "show on the remote key map" button was reported (2026-09-10: "schickt den
+// user nur auf die einstellungsseite aber nicht direkt in das untermenue").
+//
+// So open every <details> ANCESTOR as well, from the element outwards, and only
+// then scroll. Walking the ancestors rather than naming the group keeps this
+// correct if the grouping is ever changed again.
+function revealInSettings(el) {
+  if (!el) return;
+  let node = el;
+  while (node && node !== document.body) {
+    if (node.tagName === 'DETAILS') node.open = true;
+    node = node.parentElement;
+  }
+  try { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); } catch { /* older webview */ }
+}
+
 // openWebhookKeyMap takes the user to the remote key map in the webhook
 // section of THIS speaker's settings: the Multi-Room tab links here so a
 // thumbs key that was just bound to a group is seen marked on the remote.
@@ -1217,7 +1240,7 @@ function renderBoxSettings(s, box) {
       <summary class="settings-expert-summary">${escapeHtml(t('settingsView.webhookHeading'))} <span class="expert-badge">${escapeHtml(t('settingsView.expertBadge'))}</span><span class="str-badge" title="${escapeAttr(t('common.strOnlyHint'))}">${escapeHtml(t('common.strOnly'))}</span></summary>
       ${helpBlock(t('settingsView.webhookHelp'))}
       <small class="muted small" style="display:block;margin:0 0 8px">${escapeHtml(t('settingsView.webhookKeyTraceNote'))}</small>
-      <div class="rc-wrap">
+      <div class="rc-wrap" id="webhookKeyMap">
         ${remoteSvg()}
         <div class="rc-side">
           <small class="muted small">${escapeHtml(t('settingsView.webhookRemoteHint'))}</small>
@@ -1523,8 +1546,7 @@ function renderBoxSettings(s, box) {
   const fwBtn = $('fwUpdateBtn');
   if (fwBtn) {
     fwBtn.onclick = () => {
-      const banner = $('fwUpdateBanner');
-      if (banner) banner.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      revealInSettings($('fwUpdateBanner'));
     };
   }
   // Outdated-firmware banner links: open the Bose support guide / USB download
@@ -2555,11 +2577,9 @@ function renderBoxSettings(s, box) {
       // section and bring the remote into view, once, now that it is painted.
       if (pendingKeyMapOpen) {
         pendingKeyMapOpen = false;
-        const sec = $('webhookSection');
-        if (sec) {
-          sec.open = true;
-          try { sec.scrollIntoView({ behavior: 'smooth', block: 'start' }); } catch { /* older webview */ }
-        }
+        // The remote itself, not the section: the key map is the thing the user
+        // came to look at, and the section header can be a screen above it.
+        revealInSettings($('webhookKeyMap') || $('webhookSection'));
       }
     })();
     whTarget.onchange = () => { captureInto(prevTarget); prevTarget = whTarget.value; loadInto(whTarget.value); };


### PR DESCRIPTION
Reported 2026-09-10: the Multi-Room tab's "show on the remote key map" button lands the user on the speaker settings page with everything folded up, not in the submenu where the keys are assigned.

The section was never the problem. `renderSettingsGroups` moves every section into a collapsible group afterwards, and the group holding the webhook block, **Advanced**, is created `open: false`. So setting `webhookSection.open = true` revealed nothing and the scroll landed on an element with no height.

`revealInSettings` now opens every `<details>` ancestor from the target outwards and only then scrolls. It walks the ancestors instead of naming the group, so a future regrouping cannot break it again.

Two callers:
* the key map, now targeting the remote itself (`#webhookKeyMap`) rather than the section heading a screen above it
* the **Update** button beside the firmware version, which had the same latent bug: its banner sits in the Info group, also closed

New test reads the view as source, like the bass-control tests, and pins that the helper walks ancestors, that neither deep link scrolls on its own, and that the Advanced group really does start closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J85eNQD42xwUmATiY6k9Zk