### PR TITLE
fix(agent): "Undo stereo pair" no longer takes a Multi-Room group apart

### DIFF
--- a/desktop-app/app_zone.go
+++ b/desktop-app/app_zone.go
@@ -439,8 +439,23 @@ func (a *App) DissolveStereoPair(host string, port int) error {
 	// intact in the Bose app: both calls had gone to an uninvolved speaker
 	// (field, 2026-08-04). Say what actually happened.
 	if nothing, _ := out["nothing"].(bool); nothing {
+		// noPair means the agent asked the pair authority and got a no, so the
+		// speaker may well be in a multiroom GROUP instead. Name that, because
+		// "Undo stereo pair" taking a group apart and reporting a pair undone is
+		// #907, and the log has to say which of the two answers arrived.
+		if noPair, _ := out["noPair"].(bool); noPair {
+			inZone, _ := out["inZone"].(bool)
+			a.logger.Info("stereo: no pair on this speaker, nothing was changed", "host", host, "inZone", inZone)
+			return fmt.Errorf("stereo-not-paired")
+		}
 		a.logger.Info("stereo: nothing to dissolve, this speaker is not in a pair", "host", host)
 		return fmt.Errorf("stereo-not-paired")
+	}
+	// Only `nothing` used to be inspected, so an incomplete teardown (ok:false)
+	// was reported to the user as a pair undone as well.
+	if ok, present := out["ok"].(bool); present && !ok {
+		a.logger.Info("stereo: dissolve not confirmed by the speaker", "host", host)
+		return fmt.Errorf("stereo-undo-unconfirmed")
 	}
 	a.relayStereoPairClear(out)
 	a.logger.Info("stereo: pair dissolved", "host", host)

--- a/desktop-app/frontend/src/i18n/bundles/ar.json
+++ b/desktop-app/frontend/src/i18n/bundles/ar.json
@@ -104,6 +104,7 @@
   "multiroom.noZone": "لا توجد مجموعة الآن.",
   "multiroom.stereoDissolved": "تم إلغاء الاقتران الاستريو. يعمل كلا مكبري الصوت بشكل منفصل مرة أخرى.",
   "multiroom.stereoNothingToUndo": "لا يوجد اقتران استريو لإلغائه حاليًا.",
+  "multiroom.stereoUndoNotAGroup": "لا يوجد إقران ستيريو على {{names}}. هذه المكبرات داخل مجموعة، و\"إلغاء الإقران الستيريو\" لا يفكك المجموعة. استخدم تفكيك المجموعة لذلك.",
   "multiroom.stereoCurrent": "زوج ستيريو حالي: {{names}}",
   "multiroom.stereoNoPair": "لا يوجد زوج ستيريو على هذه السماعات حاليا.",
   "multiroom.zoneDissolved": "تم حل المجموعة. تعمل مكبرات الصوت بشكل منفصل مرة أخرى.",

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -108,6 +108,7 @@
   "multiroom.noZone": "Gerade keine Gruppe.",
   "multiroom.stereoDissolved": "Stereopaar aufgelöst. Beide Lautsprecher spielen wieder einzeln.",
   "multiroom.stereoNothingToUndo": "Es gibt gerade kein Stereopaar zum Auflösen.",
+  "multiroom.stereoUndoNotAGroup": "Auf {{names}} gibt es kein Stereopaar, diese Lautsprecher sind in einer Gruppe. \"Stereopaar auflösen\" löst keine Gruppe auf, dafür ist \"Gruppe auflösen\" da.",
   "multiroom.stereoCurrent": "Aktuelles Stereopaar: {{names}}",
   "multiroom.stereoNoPair": "Auf diesen Lautsprechern gibt es gerade kein Stereopaar.",
   "multiroom.zoneDissolved": "Gruppe aufgelöst. Die Lautsprecher spielen wieder einzeln.",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -108,6 +108,7 @@
   "multiroom.noZone": "No group right now.",
   "multiroom.stereoDissolved": "Stereo pair undone. Both speakers play on their own again.",
   "multiroom.stereoNothingToUndo": "There is no stereo pair to undo right now.",
+  "multiroom.stereoUndoNotAGroup": "No stereo pair on {{names}}. Those speakers are in a group, and \"Undo stereo pair\" does not take a group apart. Use Ungroup for that.",
   "multiroom.stereoCurrent": "Stereo pair right now: {{names}}",
   "multiroom.stereoNoPair": "No stereo pair on these speakers right now.",
   "multiroom.zoneDissolved": "Group dissolved. The speakers play on their own again.",

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -104,6 +104,7 @@
   "multiroom.noZone": "Ahora mismo no hay ningún grupo.",
   "multiroom.stereoDissolved": "Pareja estéreo deshecha. Ambos altavoces vuelven a sonar por separado.",
   "multiroom.stereoNothingToUndo": "Ahora mismo no hay ninguna pareja estéreo que deshacer.",
+  "multiroom.stereoUndoNotAGroup": "No hay pareja estéreo en {{names}}. Esos altavoces están en un grupo, y \"Deshacer pareja estéreo\" no deshace un grupo. Usa Deshacer grupo para eso.",
   "multiroom.stereoCurrent": "Pareja estéreo actual: {{names}}",
   "multiroom.stereoNoPair": "Ahora mismo no hay ninguna pareja estéreo en estos altavoces.",
   "multiroom.zoneDissolved": "Grupo disuelto. Los altavoces vuelven a sonar por separado.",

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -104,6 +104,7 @@
   "multiroom.noZone": "Aucun groupe pour le moment.",
   "multiroom.stereoDissolved": "Paire stéréo dissoute. Les deux enceintes rejouent séparément.",
   "multiroom.stereoNothingToUndo": "Il n'y a aucune paire stéréo à dissoudre pour le moment.",
+  "multiroom.stereoUndoNotAGroup": "Pas de paire stéréo sur {{names}}. Ces enceintes sont dans un groupe, et \"Annuler la paire stéréo\" ne défait pas un groupe. Utilisez Dissoudre le groupe pour cela.",
   "multiroom.stereoCurrent": "Paire stéréo actuelle : {{names}}",
   "multiroom.stereoNoPair": "Aucune paire stéréo sur ces enceintes pour le moment.",
   "multiroom.zoneDissolved": "Groupe dissous. Les enceintes rejouent séparément.",

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -104,6 +104,7 @@
   "multiroom.noZone": "現在グループはありません。",
   "multiroom.stereoDissolved": "ステレオペアを解除しました。両方のスピーカーが再び個別に再生します。",
   "multiroom.stereoNothingToUndo": "解除できるステレオペアは現在ありません。",
+  "multiroom.stereoUndoNotAGroup": "{{names}} にステレオペアはありません。これらのスピーカーはグループに入っており、「ステレオペアを解除」ではグループは解除されません。グループの解除をお使いください。",
   "multiroom.stereoCurrent": "現在のステレオペア: {{names}}",
   "multiroom.stereoNoPair": "現在、これらのスピーカーにステレオペアはありません。",
   "multiroom.zoneDissolved": "グループを解除しました。スピーカーは再び個別に再生します。",

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -104,6 +104,7 @@
   "multiroom.noZone": "Šiuo metu grupės nėra.",
   "multiroom.stereoDissolved": "Stereo pora išardyta. Abi kolonėlės vėl groja atskirai.",
   "multiroom.stereoNothingToUndo": "Šiuo metu nėra stereo poros, kurią būtų galima išardyti.",
+  "multiroom.stereoUndoNotAGroup": "Ties {{names}} nėra stereo poros. Tos kolonėlės yra grupėje, o \"Atšaukti stereo porą\" grupės neišskaido. Tam naudokite Išskaidyti grupę.",
   "multiroom.stereoCurrent": "Dabartinė stereo pora: {{names}}",
   "multiroom.stereoNoPair": "Šiuo metu šiuose garsiakalbiuose stereo poros nėra.",
   "multiroom.zoneDissolved": "Grupė išardyta. Kolonėlės vėl groja atskirai.",

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -104,6 +104,7 @@
   "multiroom.noZone": "Pašlaik nav grupas.",
   "multiroom.stereoDissolved": "Stereo pāris atsaistīts. Abi skaļruņi atkal atskaņo atsevišķi.",
   "multiroom.stereoNothingToUndo": "Pašlaik nav stereo pāra, ko atsaistīt.",
+  "multiroom.stereoUndoNotAGroup": "Uz {{names}} nav stereo pāra. Šie skaļruņi ir grupā, un \"Atsaukt stereo pāri\" grupu neizjauc. Tam izmanto Izjaukt grupu.",
   "multiroom.stereoCurrent": "Pašreizējā stereo pāris: {{names}}",
   "multiroom.stereoNoPair": "Šobrīd uz šiem skaļruņiem nav stereo pāra.",
   "multiroom.zoneDissolved": "Grupa atsaistīta. Skaļruņi atkal atskaņo atsevišķi.",

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -104,6 +104,7 @@
   "multiroom.noZone": "Nu geen groep.",
   "multiroom.stereoDissolved": "Stereopaar opgeheven. Beide speakers spelen weer afzonderlijk.",
   "multiroom.stereoNothingToUndo": "Er is nu geen stereopaar om op te heffen.",
+  "multiroom.stereoUndoNotAGroup": "Geen stereopaar op {{names}}. Die speakers zitten in een groep, en \"Stereopaar ongedaan maken\" haalt een groep niet uit elkaar. Gebruik daarvoor Groep opheffen.",
   "multiroom.stereoCurrent": "Huidig stereopaar: {{names}}",
   "multiroom.stereoNoPair": "Er is op dit moment geen stereopaar op deze speakers.",
   "multiroom.zoneDissolved": "Groep opgeheven. De speakers spelen weer afzonderlijk.",

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -104,6 +104,7 @@
   "multiroom.noZone": "Teraz brak grupy.",
   "multiroom.stereoDissolved": "Para stereo rozłączona. Oba głośniki grają znów osobno.",
   "multiroom.stereoNothingToUndo": "Obecnie nie ma pary stereo do rozłączenia.",
+  "multiroom.stereoUndoNotAGroup": "Brak pary stereo na {{names}}. Te głośniki są w grupie, a \"Rozdziel parę stereo\" nie rozwiązuje grupy. Użyj do tego Rozwiąż grupę.",
   "multiroom.stereoCurrent": "Obecna para stereo: {{names}}",
   "multiroom.stereoNoPair": "W tej chwili na tych głośnikach nie ma pary stereo.",
   "multiroom.zoneDissolved": "Grupa rozwiązana. Głośniki grają znów osobno.",

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -104,6 +104,7 @@
   "multiroom.noZone": "Şu anda grup yok.",
   "multiroom.stereoDissolved": "Stereo çift ayrıldı. Her iki hoparlör yeniden tek başına çalıyor.",
   "multiroom.stereoNothingToUndo": "Şu anda ayrılacak bir stereo çift yok.",
+  "multiroom.stereoUndoNotAGroup": "{{names}} üzerinde stereo çift yok. Bu hoparlörler bir grupta ve \"Stereo çifti geri al\" bir grubu dağıtmaz. Bunun için Grubu dağıt seçeneğini kullanın.",
   "multiroom.stereoCurrent": "Şu anki stereo çift: {{names}}",
   "multiroom.stereoNoPair": "Şu anda bu hoparlörlerde stereo çift yok.",
   "multiroom.zoneDissolved": "Grup dağıtıldı. Hoparlörler yeniden tek başına çalıyor.",

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -104,6 +104,7 @@
   "multiroom.noZone": "Зараз групи немає.",
   "multiroom.stereoDissolved": "Стереопару роз'єднано. Обидві колонки знову грають окремо.",
   "multiroom.stereoNothingToUndo": "Зараз немає стереопари, яку можна роз'єднати.",
+  "multiroom.stereoUndoNotAGroup": "На {{names}} немає стереопари. Ці колонки в групі, а \"Скасувати стереопару\" не розпускає групу. Для цього скористайтеся Розпустити групу.",
   "multiroom.stereoCurrent": "Поточна стереопара: {{names}}",
   "multiroom.stereoNoPair": "Зараз на цих колонках немає стереопари.",
   "multiroom.zoneDissolved": "Групу роз'єднано. Колонки знову грають окремо.",

--- a/desktop-app/frontend/src/i18n/bundles/zh-Hant.json
+++ b/desktop-app/frontend/src/i18n/bundles/zh-Hant.json
@@ -108,6 +108,7 @@
   "multiroom.noZone": "目前沒有群組。",
   "multiroom.stereoDissolved": "立體聲配對已解除。兩台喇叭都恢復單獨播放。",
   "multiroom.stereoNothingToUndo": "目前沒有可以解除的立體聲配對。",
+  "multiroom.stereoUndoNotAGroup": "{{names}} 上沒有立體聲配對。這些喇叭在群組中，「解除立體聲配對」不會解散群組。請改用解散群組。",
   "multiroom.stereoCurrent": "目前的立體聲配對：{{names}}",
   "multiroom.stereoNoPair": "這些喇叭目前沒有立體聲配對。",
   "multiroom.zoneDissolved": "群組已解散。喇叭都恢復單獨播放。",

--- a/desktop-app/frontend/src/views/multiroom.js
+++ b/desktop-app/frontend/src/views/multiroom.js
@@ -1200,7 +1200,26 @@ async function doDissolveStereo(pairCands) {
     || livePairs[0] || null;
   const targets = stereoUndoTargets(pair, state.boxes || []);
   if (!targets.length) {
+    // No pair was identified anywhere, so this is the one-sided-leftover
+    // fallback: ask the speaker the user picked on the left, because a pair
+    // half can hold the record on its own.
+    //
+    // It must NOT fire on a speaker that is simply in a group. #907: three
+    // speakers in a plain multiroom group and no pair at all, and every
+    // left/right combination "succeeded" here and took the group apart, because
+    // the guess went out and the agent's ?stereo=1 path fell through to the
+    // multiroom teardown. The agent refuses that now; refusing before the
+    // request is sent is what lets the panel say which operation the user
+    // actually wants.
     const guess = pairCands.find(b => b.deviceID === ($('stereoLeft') || {}).value);
+    if (guess && zoneMasterOf(guess.deviceID, state.zoneLive)) {
+      const right = pairCands.find(b => b.deviceID === ($('stereoRight') || {}).value);
+      state.stereoMsg = `<div class="setup-warn">${escapeHtml(t('multiroom.stereoUndoNotAGroup', {
+        names: [guess, right].filter(Boolean).map(zoneLabel).join(', '),
+      }))}</div>`;
+      renderMultiroom(false);
+      return;
+    }
     if (guess) targets.push(guess);
   }
   if (!targets.length) {

--- a/internal/webui/zones_stereo.go
+++ b/internal/webui/zones_stereo.go
@@ -2134,14 +2134,65 @@ func (s *Server) handleZoneDissolve(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	// The stereo escalation is gated on explicit caller intent (?stereo=1, set
-	// by the app's undo-stereo-pair button): a plain multiroom dissolve that
-	// happens to hit a box in a firmware pair must keep its pre-existing
-	// no-op semantics instead of silently destroying the pair.
-	if !stereo && master.DeviceID == "" && wantStereo {
-		if g, err := c.GetGroup(ctx); err == nil && (g.ID != "" || len(g.Members) > 0) {
-			// A firmware-native stereo pair with no persisted zone: dissolve it
-			// as a pair. The members are partitioned relative to THIS box, not
+	// "Undo stereo pair" asks the PAIR AUTHORITY, always.
+	//
+	// This escalation used to carry `master.DeviceID == ""` as a precondition,
+	// which quietly made it unreachable on any speaker holding group state: the
+	// two blocks above fill master from the persisted document or from the live
+	// zone, so by the time intent was consulted there was already a master and
+	// the read never happened. `?stereo=1` therefore ADDED a path without ever
+	// RESTRICTING the handler to it, and the request fell through to the
+	// multiroom teardown below.
+	//
+	// #907, reported with a bundle that proves it twice over: three ST10s in a
+	// plain group, no pair anywhere (marge_group present=false on all three,
+	// the firmware answering /getGroup empty), and four presses of "Undo stereo
+	// pair" each logging `zone: dissolving (beta) slaves=2` and purging both
+	// peers' stores. The stereo arm's own log line appears in the same bundle
+	// exactly once, the day before, when she really did have a pair.
+	//
+	// Dropping the precondition also fixes the mirror case: a speaker carrying
+	// a stale multiroom document while it IS in a real firmware pair (paired in
+	// the Bose app, or the agent reinstalled over an old document) could never
+	// be unpaired from that speaker, because intent was never consulted there
+	// either.
+	//
+	// The read gets its OWN short budget rather than the dissolve's, for the
+	// reason spelled out at the top of this file: /getGroup HANGS on scm/BCO
+	// chassis, silently, and on the dissolve's context that hang would eat the
+	// whole request.
+	if !stereo && wantStereo {
+		gctx, gcancel := context.WithTimeout(ctx, 1500*time.Millisecond)
+		g, gerr := c.GetGroup(gctx)
+		gcancel()
+		pairConfirmed := gerr == nil && (g.ID != "" || len(g.Members) > 0)
+		// Group state we would otherwise tear down. This is the ONLY thing the
+		// refusal has to protect, and scoping it this way keeps the
+		// nothing-to-dissolve branch below reachable, which is where a phantom
+		// marge pair record gets cleared. Refusing on a speaker that holds
+		// nothing at all would have closed that escape hatch.
+		inZone := master.DeviceID != "" || len(slaves) > 0
+		if !pairConfirmed && inZone {
+			// Only a POSITIVE confirmation may act, so an unreadable answer
+			// refuses too. /getGroup hangs rather than refuses on scm/BCO
+			// chassis, and treating a hang as "carry on" is exactly what put
+			// the multiroom teardown behind this button. A STR-formed pair is
+			// covered by its own persisted document above and never reaches
+			// here, so the cost of refusing an unconfirmed pair is a retry,
+			// while the cost of continuing is somebody's group.
+			s.logger.Info("stereo: undo-pair refused, no pair confirmed on this speaker",
+				"readable", gerr == nil, "master", master.DeviceID, "slaves", len(slaves))
+			writeJSON(w, http.StatusOK, map[string]any{
+				"ok": false, "nothing": true, "noPair": true, "inZone": true,
+				"pairReadable": gerr == nil,
+			})
+			return
+		}
+		if pairConfirmed {
+			// The firmware confirms a pair, so dissolve it as a pair, whatever
+			// the local document happened to say. That covers both the
+			// no-persisted-zone case this was written for and a speaker holding
+			// a stale multiroom document over a real pair. The members are partitioned relative to THIS box, not
 			// the group master — the dissolve may run on the RIGHT/slave box
 			// (the store only exists on the master), where "everyone but the
 			// master" would be ourselves and the remote teardown would clear

--- a/internal/webui/zoneundopair_test.go
+++ b/internal/webui/zoneundopair_test.go
@@ -1,0 +1,163 @@
+// #907, reported with a bundle that proves it twice over: three SoundTouch 10s
+// in a plain multiroom group, no stereo pair anywhere, and four presses of
+// "Undo stereo pair" each took the group apart while the app painted "Stereo
+// pair undone". The stereo arm's own log line appears in the same bundle exactly
+// once, the day before, when she really did have a pair.
+//
+// The cause was that ?stereo=1 only ADDED a path. The escalation that consults
+// the pair authority carried `master.DeviceID == ""`, so on any speaker holding
+// group state it was unreachable and the request fell through to the multiroom
+// teardown.
+//
+// These tests pin the contract in both directions: under stereo intent, act
+// only on a POSITIVELY confirmed pair, and never on a group. The box host is
+// unroutable, as everywhere else in this package, so the firmware reads fail and
+// the assertions are about what the handler decides on its own.
+
+package webui
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/JRpersonal/streborn/internal/zones"
+)
+
+// undoPair drives DELETE /api/box/zone?stereo=1 and returns the decoded answer.
+func undoPair(t *testing.T, s *Server) map[string]any {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodDelete, "/api/box/zone?stereo=1", nil)
+	w := httptest.NewRecorder()
+	s.handleZoneDissolve(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (%s)", w.Code, w.Body.String())
+	}
+	var out map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("bad JSON: %v (%s)", err, w.Body.String())
+	}
+	return out
+}
+
+func multiroomDoc(permanent bool) zones.Zone {
+	return zones.Zone{
+		Master: "DEV-MASTER", MasterIP: "192.0.2.10", Permanent: permanent,
+		Slaves: []zones.Member{
+			{DeviceID: "DEV-A", IP: "192.0.2.20"},
+			{DeviceID: "DEV-B", IP: "192.0.2.21"},
+		},
+	}
+}
+
+// #907 itself. A plain multiroom group and no confirmed pair: refuse, report it
+// as a no-op rather than a success, and leave the document alone.
+func TestUndoStereoPairRefusesAMultiroomGroup(t *testing.T) {
+	s, st := staleDocServer(t, "192.0.2.10", multiroomDoc(false), true)
+
+	out := undoPair(t, s)
+	if out["noPair"] != true || out["nothing"] != true {
+		t.Fatalf("undo-pair on a group must report no pair, got %v", out)
+	}
+	if out["ok"] == true {
+		t.Fatalf("a refused undo must not report ok:true, which is what the app read as success: %v", out)
+	}
+	if out["inZone"] != true {
+		t.Fatalf("the refusal must say the speaker is in a zone, got %v", out)
+	}
+	if !storedGroup(t, st) {
+		t.Fatal("undo-pair deleted the stored group document")
+	}
+}
+
+// The hard project rule, pinned against the STEREO path specifically. The guard
+// in the multiroom fall-through protects a permanent document there; this asserts
+// the stereo path never gets that far.
+func TestUndoStereoPairKeepsAPermanentGroupDocument(t *testing.T) {
+	s, st := staleDocServer(t, "192.0.2.10", multiroomDoc(true), true)
+
+	out := undoPair(t, s)
+	if out["noPair"] != true {
+		t.Fatalf("undo-pair on a permanent group must refuse, got %v", out)
+	}
+	if !storedGroup(t, st) {
+		t.Fatal("undo-pair deleted a saved permanent group; it can only be rebuilt by hand from there")
+	}
+}
+
+// An unreadable pair authority must refuse as well. /getGroup hangs rather than
+// refuses on scm/BCO chassis, and treating a hang as "carry on" is what put the
+// multiroom teardown behind this button. The unroutable host in this package
+// makes every read fail, so this is the shape every test here exercises, and it
+// must never come out as a teardown.
+func TestUndoStereoPairRefusesWhenThePairCannotBeConfirmed(t *testing.T) {
+	s, st := staleDocServer(t, "192.0.2.10", multiroomDoc(false), true)
+
+	out := undoPair(t, s)
+	if out["pairReadable"] != false {
+		t.Fatalf("the answer must say the pair read failed, got %v", out)
+	}
+	if out["noPair"] != true || out["ok"] == true {
+		t.Fatalf("an unconfirmed pair must be refused, got %v", out)
+	}
+	if !storedGroup(t, st) {
+		t.Fatal("an unconfirmed pair read cost the stored group document")
+	}
+}
+
+// Regression, the direction that must keep working: a pair STR formed itself is
+// persisted with Stereo=true and needs no read at all, so it still dissolves.
+func TestUndoStereoPairStillDissolvesAPersistedPair(t *testing.T) {
+	pair := zones.Zone{
+		Master: "DEV-MASTER", MasterIP: "192.0.2.10", Stereo: true,
+		Slaves: []zones.Member{{DeviceID: "DEV-SLAVE", IP: "192.0.2.20", Role: "RIGHT"}},
+	}
+	s, _ := staleDocServer(t, "192.0.2.10", pair, true)
+
+	out := undoPair(t, s)
+	if out["noPair"] == true {
+		t.Fatalf("a persisted pair was refused: %v", out)
+	}
+	if out["stereo"] != true {
+		t.Fatalf("a persisted pair must still be dissolved as a pair, got %v", out)
+	}
+}
+
+// A speaker holding nothing at all must still reach the nothing-to-dissolve
+// branch, because that is where a phantom marge pair record gets cleared. The
+// refusal is scoped to group state for exactly this reason; refusing here too
+// would have closed that escape hatch.
+func TestUndoStereoPairOnAnEmptySpeakerStillReportsNothingToDissolve(t *testing.T) {
+	s, _ := staleDocServer(t, "192.0.2.10", zones.Zone{}, false)
+
+	out := undoPair(t, s)
+	if out["nothing"] != true {
+		t.Fatalf("an empty speaker must report nothing to dissolve, got %v", out)
+	}
+	if out["noPair"] == true {
+		t.Fatalf("the empty speaker took the refusal path and skipped the marge cleanup: %v", out)
+	}
+}
+
+// A plain Ungroup is unchanged by all of this: no ?stereo=1 means the multiroom
+// path, and #843's guard still keeps a persisted pair intact.
+func TestPlainUngroupIsUnaffectedByTheStereoGuard(t *testing.T) {
+	pair := zones.Zone{
+		Master: "DEV-MASTER", MasterIP: "192.0.2.10", Stereo: true,
+		Slaves: []zones.Member{{DeviceID: "DEV-SLAVE", IP: "192.0.2.20", Role: "RIGHT"}},
+	}
+	s, st := staleDocServer(t, "192.0.2.10", pair, true)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/box/zone", nil) // no ?stereo=1
+	w := httptest.NewRecorder()
+	s.handleZoneDissolve(w, req)
+	var out map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &out)
+	if out["stereoPairKept"] != true {
+		t.Fatalf("a plain Ungroup on a pair must keep it, got %v", out)
+	}
+	if !storedGroup(t, st) {
+		t.Fatal("a plain Ungroup deleted the stereo pair")
+	}
+}


### PR DESCRIPTION
Closes #907

shorty310 reported this last night with a bundle that proves it twice over: three SoundTouch 10s in a plain multiroom group, **no stereo pair anywhere**, and four presses of "Undo stereo pair" each tore the group apart while the app reported a pair undone.

Her bundle contains its own A/B. On 2026-09-09 every press logs the MULTIROOM arm:
```
15:19:40 zone: dissolving (beta)  master=DEV#871b2608 slaves=2
15:21:45 zone: dissolving (beta)  master=DEV#871b2608 slaves=2
15:23:57 zone: dissolving (beta)  master=DEV#871b2608 slaves=2
15:26:37 zone: dissolving (beta)  master=DEV#871b2608 slaves=2
```
The stereo arm's line appears exactly once in the whole bundle, on 2026-09-08, when she really did have a pair. `marge_group present=false` on all three speakers, and the firmware itself answered `/getGroup` empty.

## Cause

`?stereo=1` only ever **added** a path. The escalation that consults the pair authority carried `master.DeviceID == ""`, and the two blocks above it fill the master from the stored document or the live zone, so on any speaker holding group state the authority was never asked and the request fell through to the multiroom teardown. Which speaker got hit was decided by the **left dropdown alone**, because with no pair to find the app invents a target from that field.

Both shapes she described follow from that one predicate: with three speakers all grouped, every left pick holds group state, so every combination acts; with two grouped and one solo, only a left pick that is in the group does anything.

## Fix

Under stereo intent the authority is now always consulted, and **only a positive confirmation may act**. An unreadable answer refuses too: that read hangs rather than refuses on scm/BCO chassis, and treating a hang as "carry on" is what put the teardown behind this button. A pair STR formed itself is persisted and needs no read.

The refusal is scoped to speakers that hold group state, so a speaker holding nothing still reaches the nothing-to-dissolve branch, which is where a phantom pair record gets cleared.

Dropping the precondition also opens the mirror case: a speaker carrying a stale group document over a real firmware pair could not be unpaired from that speaker at all.

Two more halves of the same report:
* the app inspected one field of the answer, so a no-op **and** an incomplete teardown both read as "pair undone"
* the panel now refuses before sending when the picked speaker is in a group, naming the operation the user actually wants (new key in all 14 bundles)

## Testing

Seven tests, including two regression guards (a persisted pair still dissolves; a plain Ungroup is untouched) and one pinning the hard rule that a **saved permanent group survives this button**. `internal/webui`, `desktop-app` and the 29 frontend files all pass, plus the ARM cross-compile.

Not verified on hardware: the maintainer has no second ST10 free for a pair right now, so the positive-pair path is covered by tests and by her own 2026-09-08 log rather than a live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J85eNQD42xwUmATiY6k9Zk