### PR TITLE
fix(app): a station you picked from Find stations shows its artist and track again

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -51,5 +51,6 @@ usb-stick/rc.local text eol=lf
 # checkout. Treating them as binary keeps git from line-ending
 # transforming a real ELF the moment CI fills it in.
 desktop-app/agentbin/streborn-armv7l binary
+desktop-app/agentbin/go-librespot-armv7l binary
 sticksetup/embedded/winformat.exe    binary
 *.html text eol=lf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,7 +261,7 @@ jobs:
         with:
           persist-credentials: false
 
-      # Two go:embed targets are tracked as EMPTY stubs so a clean checkout
+      # Three go:embed targets are tracked as EMPTY stubs so a clean checkout
       # compiles, and CI overwrites them with the real binaries in a later job.
       # A local `make wails-build` fills them and deletes frontend/dist/.gitkeep,
       # and committing that state puts a 13 MB binary in the history and breaks
@@ -271,7 +271,7 @@ jobs:
         run: |
           set -e
           fail=0
-          for f in desktop-app/agentbin/streborn-armv7l sticksetup/embedded/winformat.exe; do
+          for f in desktop-app/agentbin/streborn-armv7l desktop-app/agentbin/go-librespot-armv7l sticksetup/embedded/winformat.exe; do
             if [ ! -f "$f" ]; then
               echo "::error file=$f::tracked stub is missing"; fail=1; continue
             fi

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -225,6 +225,7 @@ import {
   dismissNotice,
   noticeDismissed,
   activeSlotFromLocation,
+  proxiedRadioPlaying,
   orionStationPayload,
   nativeSlotStale,
   isLostStrKey,
@@ -6875,14 +6876,14 @@ function scheduleLiveTitle() {
     if (state.currentBox !== box) { liveTitleActive = false; return; }   // speaker changed
     const loc = state.nowLocation || '';
     if (loc === '') { liveTitleActive = false; return; }                 // playback stopped
-    // Slot-based, not a raw /stream/ match: a NATIVE radio preset carries the
-    // ORION "/station?data=<base64>" descriptor, which the raw regex never
-    // matched, so on native playback this loop spun without ever fetching a
-    // title and the Play tab showed no artist/track at all (#597).
-    // activeSlotFromLocation decodes the descriptor (the #555 fix) and also
-    // correctly yields null for a native station pointing straight at a CDN,
-    // where the proxy has no title to offer.
-    const isRadio = !/\/spotify\//.test(loc) && activeSlotFromLocation(loc) !== null;
+    // Anything the stream proxy is serving, which is where a live title comes
+    // from. This used to ask for a preset SLOT instead, which is a narrower
+    // question: a station started from Find stations has no slot, so the poll
+    // never ran and the Play tab showed no artist or track while the speaker's
+    // own page showed both (#922). The predicate still covers the ORION
+    // descriptor a native preset carries (#597/#555) and still says no to a
+    // native station pointing straight at a CDN, where there is no title to get.
+    const isRadio = proxiedRadioPlaying(loc);
     if (isRadio) {
       let title = '';
       try { title = (await StreamTitle(box.host, box.port)) || ''; } catch {}
@@ -7033,10 +7034,10 @@ function renderNowPlayingBar() {
       ? `${state.nowSpotifyArtist} - ${state.nowSpotifyTrack}`
       : state.nowSpotifyTrack;
     displayName = name ? `${t('status.playlistLabel')}: "${name}" · ${song}` : song;
-  } else if (!/\/spotify\//.test(loc) && activeSlotFromLocation(loc) !== null && state.nowTitle) {
-    // Slot-based like the title poller above: the raw /stream/ regex missed
-    // NATIVE radio locations (ORION descriptor), so the status line dropped
-    // the artist/track exactly when the box played natively (#597).
+  } else if (proxiedRadioPlaying(loc) && state.nowTitle) {
+    // The same predicate as the title poller above, and it has to be the same
+    // one: fixing only the poll would fetch a title that this line then refused
+    // to print (#922).
     displayName = name ? `${t('status.stationLabel')}: "${name}" · ${state.nowTitle}` : state.nowTitle;
   }
   // Match the source case-insensitively: the firmware is not consistent about

--- a/desktop-app/frontend/src/proxiedradio.test.js
+++ b/desktop-app/frontend/src/proxiedradio.test.js
@@ -1,0 +1,73 @@
+// #922, reported by shorty310 eight hours after v0.9.79 shipped: a station
+// started from Find stations plays, but the app shows no artist and no track,
+// while the page the speaker itself serves shows both.
+//
+// The app asked the speaker for the live title only when it could resolve a
+// preset SLOT number out of the now-playing location. A station started from
+// Find stations is pushed as /stream/raw?u=<base64> and belongs to no preset, so
+// there is no slot, so the poll never ran. The agent had "Rush - Freewill" the
+// whole time, which is exactly why the remote showed it.
+//
+// A slot number was always the wrong question. What both call sites actually
+// want to know is whether the stream proxy is in the path, because that is where
+// an ICY title comes from.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { proxiedRadioPlaying, activeSlotFromLocation } from './utils.js';
+
+const main = readFileSync(new URL('./main.js', import.meta.url), 'utf8');
+
+// A real ORION descriptor: /station?data=<base64url of the JSON>.
+const orion = (streamUrl) =>
+  '/station?data=' + Buffer.from(JSON.stringify({ streamUrl, name: 'Some Station' }))
+    .toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+describe('what counts as proxied radio', () => {
+  it('says yes to the ad-hoc station that started this bug', () => {
+    // The exact location from the reporter's bundle.
+    const raw = 'http://192.0.2.1:8888/stream/raw?u=aHR0cHM6Ly8yLm15c3RyZWFtaW5nLm5ldC9lci1hcHAvcnVzaC9pY2VjYXN0LmF1ZGlv';
+    expect(proxiedRadioPlaying(raw)).toBe(true);
+    // And the reason it was broken: there is no slot to find in it.
+    expect(activeSlotFromLocation(raw)).toBe(null);
+  });
+
+  it('still says yes to everything it said yes to before', () => {
+    expect(proxiedRadioPlaying('http://192.0.2.1:8888/stream/3')).toBe(true);
+    expect(proxiedRadioPlaying(orion('http://192.0.2.1:8888/stream/5'))).toBe(true);
+  });
+
+  it('covers an ORION descriptor wrapping the ad-hoc form too', () => {
+    expect(proxiedRadioPlaying(orion('http://192.0.2.1:8888/stream/raw?u=aHR0cDovL3g='))).toBe(true);
+  });
+
+  // The two cases that must stay false, for opposite reasons: Spotify carries its
+  // own now-playing fields, and a native station goes straight to the station's
+  // own server with the proxy nowhere in the path, so there is no title to ask
+  // anybody for.
+  it('says no to Spotify and to native playback', () => {
+    expect(proxiedRadioPlaying('http://192.0.2.1:8888/spotify/stream-2.ogg')).toBe(false);
+    expect(proxiedRadioPlaying('https://2.mystreaming.net/er-app/rush/icecast.audio')).toBe(false);
+    expect(proxiedRadioPlaying(orion('https://stream.example.org/live.mp3'))).toBe(false);
+    expect(proxiedRadioPlaying('')).toBe(false);
+    expect(proxiedRadioPlaying(null)).toBe(false);
+  });
+});
+
+describe('both places that ask', () => {
+  // Fixing only the poll would fetch a title the status line then refused to
+  // print, so the two have to agree.
+  it('use the one predicate, not a slot number', () => {
+    const poll = main.slice(main.indexOf('const isRadio ='), main.indexOf('const isRadio =') + 120);
+    expect(poll).toContain('proxiedRadioPlaying(loc)');
+    expect(poll).not.toContain('activeSlotFromLocation');
+
+    const at = main.indexOf("} else if (proxiedRadioPlaying(loc) && state.nowTitle) {");
+    expect(at, 'the status line must use it as well').toBeGreaterThan(-1);
+  });
+
+  // activeSlotFromLocation is still the right tool for lighting up a preset
+  // tile; this change was not about deleting it.
+  it('leaves the preset highlighting on the slot lookup', () => {
+    expect(main).toContain('const activeSlot = activeSlotFromLocation(state.nowLocation);');
+  });
+});

--- a/desktop-app/frontend/src/utils.js
+++ b/desktop-app/frontend/src/utils.js
@@ -432,6 +432,36 @@ export function clearNoticeDismissal(kind) {
   storeDel(dismissKey(kind));
 }
 
+// proxiedRadioPlaying reports whether what the speaker is playing right now is
+// radio coming THROUGH STR's stream proxy, which is the only case where the
+// agent has a live ICY title to hand out.
+//
+// It exists because the two places that ask used activeSlotFromLocation() for
+// it, and a slot number is a narrower question than the one they were asking.
+// A station started from Find stations is pushed as /stream/raw?u=<base64> and
+// belongs to no preset, so it has no slot, so the app never asked for its title
+// and the Play tab showed no artist or track (#922, reported on v0.9.79). The
+// speaker's own page kept showing it, because the agent had the title all along.
+//
+// Three shapes count, and the fourth deliberately does not:
+//   /stream/<n>          a preset recall through the proxy
+//   /stream/raw?u=<b64>  an ad-hoc station from Find stations or the library
+//   /station?data=<b64>  the ORION descriptor, when its streamUrl is one of those
+//   a bare CDN address   NATIVE playback, where the proxy is not in the path and
+//                        has no title to offer
+// Spotify is excluded here as well; it has its own now-playing fields.
+export function proxiedRadioPlaying(loc) {
+  if (!loc || /\/spotify\//.test(loc)) return false;
+  if (proxiedRadioURL(loc)) return true;
+  const payload = orionStationPayload(loc);
+  return !!(payload && payload.streamUrl && proxiedRadioURL(String(payload.streamUrl)));
+}
+
+// proxiedRadioURL matches the two proxy paths the agent serves radio on.
+function proxiedRadioURL(u) {
+  return /\/stream\/\d+(?:[/?#]|$)/.test(u) || /\/stream\/raw(?:[/?#]|$)/.test(u);
+}
+
 // activeSlotFromLocation extracts the slot number from a stream proxy
 // URL like http://127.0.0.1:8888/stream/3. Since build 2335 the
 // speaker's content items always run through the proxy, so the older

--- a/desktop-app/logexport.go
+++ b/desktop-app/logexport.go
@@ -21,6 +21,7 @@ import (
 	"archive/zip"
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -761,7 +762,61 @@ var userPathRegex = regexp.MustCompile(`(?i)([/\\]+(?:Users|home)[/\\]+)([^/\\\s
 // cannot accidentally skip a scrub the other paths already do — the exact hole
 // that leaked real device IDs and friendly names through anonymizeText while
 // sanitizeLog scrubbed them (see #187/#197 diagnostic bundles).
+// proxyPayloadRegex finds the base64 upstream STR's stream proxy carries in its
+// own URLs, /stream/raw?u=<payload>. Both encodings appear in the field, and a
+// payload can itself wrap another proxy URL, so the unwrapper below loops.
+var proxyPayloadRegex = regexp.MustCompile(`(/stream/raw\?u=)([A-Za-z0-9+/_-]+={0,2})`)
+
+// scrubProxyPayloads rewrites the addresses hidden INSIDE those payloads.
+//
+// It has to run before the text passes, because a base64 blob is opaque to every
+// regex in this file: on issue #844 the log line's proxy host was correctly
+// masked to 192.0.2.1 while the payload beside it still decoded to the
+// reporter's real media server, and that bundle is public. Same shape as the
+// device-ID and SSID holes this file already carries comments about, one level
+// further down.
+//
+// A payload that does not decode, or decodes to something that is not a URL, is
+// left exactly as it was: a bundle is diagnostic evidence and mangling a value
+// nobody can read is worse than leaving it.
+func scrubProxyPayloads(s string) string {
+	return proxyPayloadRegex.ReplaceAllStringFunc(s, func(m string) string {
+		sub := proxyPayloadRegex.FindStringSubmatch(m)
+		prefix, payload := sub[1], sub[2]
+		dec, enc, ok := decodeProxyPayload(payload)
+		if !ok {
+			return m
+		}
+		// Recurse first, so a doubly wrapped upstream is reached as well.
+		cleaned := scrubPII(scrubProxyPayloads(dec))
+		if cleaned == dec {
+			return m
+		}
+		return prefix + enc.EncodeToString([]byte(cleaned))
+	})
+}
+
+// decodeProxyPayload tries the encodings the proxy has used, and reports which
+// one worked so the value can be put back the way it was found.
+func decodeProxyPayload(payload string) (string, *base64.Encoding, bool) {
+	for _, enc := range []*base64.Encoding{
+		base64.RawURLEncoding, base64.URLEncoding,
+		base64.RawStdEncoding, base64.StdEncoding,
+	} {
+		if dec, err := enc.DecodeString(payload); err == nil {
+			s := string(dec)
+			if strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://") {
+				return s, enc, true
+			}
+		}
+	}
+	return "", nil, false
+}
+
 func scrubPII(s string) string {
+	// Encoded first: an address inside a base64 payload is invisible to every
+	// regex below it (#844, a public bundle).
+	s = scrubProxyPayloads(s)
 	s = ipv4Regex.ReplaceAllStringFunc(s, func(ip string) string { return maskIP(ip) })
 	return scrubIdentities(s)
 }

--- a/desktop-app/logexport_test.go
+++ b/desktop-app/logexport_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -390,5 +391,71 @@ func TestScrubPII_LeavesStationNamesAlone(t *testing.T) {
 	got := scrubPII(in)
 	if !strings.Contains(got, "Radio Swiss Jazz") || !strings.Contains(got, "BBC Radio 4") {
 		t.Fatalf("station names must survive the scrub:\n%s", got)
+	}
+}
+
+// A reporter's real media-server address sat in a PUBLIC bundle on issue #844,
+// inside a bundle the exporter had already anonymised. The log line's proxy host
+// was correctly masked to 192.0.2.1 while the payload beside it still decoded to
+// 192.168.1.120, because STR's own proxy carries the upstream as base64 and a
+// regex over text cannot see into it.
+//
+// Third instance of the hole this file already carries comments about: a value
+// that survives because it is encoded rather than written out.
+func TestAnAddressHiddenInAProxyPayloadIsScrubbed(t *testing.T) {
+	// Verbatim from the 844 bundle.
+	const line = `url="http://192.0.2.1:8888/stream/raw?u=aHR0cDovLzE5Mi4xNjguMS4xMjA6NTAwMDIvbS9ORExOQS8yNjYxOC5mbGFj"`
+
+	got := scrubPII(line)
+	if strings.Contains(got, "192.168.1.120") {
+		t.Fatalf("the address is still in plain sight: %s", got)
+	}
+	// The point is what it DECODES to, which is how it got out in the first place.
+	m := proxyPayloadRegex.FindStringSubmatch(got)
+	if m == nil {
+		t.Fatalf("the proxy URL was mangled away entirely: %s", got)
+	}
+	dec, _, ok := decodeProxyPayload(m[2])
+	if !ok {
+		t.Fatalf("the rewritten payload no longer decodes: %s", got)
+	}
+	if strings.Contains(dec, "192.168.1.120") {
+		t.Fatalf("the payload still decodes to the reporter's address: %s", dec)
+	}
+	// The path has to survive, or the bundle stops being evidence.
+	if !strings.Contains(dec, "/m/NDLNA/26618.flac") {
+		t.Fatalf("the upstream path was lost, so the log line says nothing any more: %s", dec)
+	}
+}
+
+// Both encodings appear in the field, and a payload can wrap another proxy URL.
+func TestProxyPayloadScrubHandlesEveryWrapperShape(t *testing.T) {
+	inner := base64.RawURLEncoding.EncodeToString([]byte("http://192.168.5.9:8200/x.mp3"))
+	for name, s := range map[string]string{
+		"raw url": "/stream/raw?u=" + inner,
+		"std":     "/stream/raw?u=" + base64.StdEncoding.EncodeToString([]byte("http://192.168.5.9:8200/x.mp3")),
+		"doubled": "/stream/raw?u=" + base64.RawURLEncoding.EncodeToString([]byte("http://192.0.2.1:8888/stream/raw?u="+inner)),
+	} {
+		if got := scrubPII(s); strings.Contains(got, "192.168.5.9") {
+			t.Fatalf("%s: address survived in the text: %s", name, got)
+		} else if m := proxyPayloadRegex.FindStringSubmatch(got); m != nil {
+			if dec, _, ok := decodeProxyPayload(m[2]); ok && strings.Contains(dec, "192.168.5.9") {
+				t.Fatalf("%s: address survived one level down: %s", name, dec)
+			}
+		}
+	}
+}
+
+// A payload that is not a URL is left alone. A bundle is evidence, and mangling
+// a value nobody can read is worse than leaving it.
+func TestANonURLPayloadIsLeftExactlyAsFound(t *testing.T) {
+	for _, s := range []string{
+		"/stream/raw?u=bm90LWEtdXJs", // "not-a-url"
+		"/stream/raw?u=!!!notbase64!!!",
+		"/stream/raw?u=",
+	} {
+		if got := scrubPII(s); got != scrubIdentities(s) {
+			t.Fatalf("an unreadable payload was rewritten: %q -> %q", s, got)
+		}
 	}
 }


### PR DESCRIPTION
Closes #922

Three findings from the sweep after v0.9.79, each traced in a bundle or in the repo.

## #922: no artist or track for a station from Find stations

shorty310 filed this eight hours after the release. The station plays, the app shows no metadata, and the page the speaker itself serves shows it correctly.

The app polls for the live title only when it can resolve a preset **slot number** out of the now-playing location:

```js
const isRadio = !/\/spotify\//.test(loc) && activeSlotFromLocation(loc) !== null;
```

A station started from Find stations is pushed as `/stream/raw?u=<base64>` and belongs to no preset, so there is no slot, so `StreamTitle()` was never called. His bundle shows the agent had it the whole time:

```
09:09:51.881  play request  direct=false codec=MP3 url=https://2.mystreaming.net/er-app/rush/icecast.audio
09:11:02.100  stream proxy ICY title  title="Rush - Freewill"
```

A slot number was always the wrong question. Both call sites want to know whether the **stream proxy is in the path**, because that is where an ICY title comes from. `proxiedRadioPlaying()` answers that: true for `/stream/<n>`, for `/stream/raw`, and for an ORION descriptor wrapping either; false for Spotify and for a native station pointing straight at a CDN, where there is no title to ask anybody for.

Both the poll and the status line move to it. Fixing only the poll would fetch a title the status line then refused to print.

Not new in v0.9.79: the gate narrowed to slots in v0.9.50.

## A real address is public inside an anonymised bundle

`scrubPII` masks IPv4 over plain text. STR's own proxy carries the upstream as base64 in `/stream/raw?u=`, which no regex can see into, so on issue #844 the log line reads:

```
url="http://192.0.2.1:8888/stream/raw?u=aHR0cDovLzE5Mi4xNjguMS4xMjA6NTAwMDIvbS9ORExOQS8yNjYxOC5mbGFj"
```

The host was masked correctly. The payload decodes to `http://192.168.1.120:50002/m/NDLNA/26618.flac`.

Third instance of the hole this file already carries comments about (#187/#197 device IDs, #592 SSIDs): a value that survives because it is encoded rather than written out. Payloads are now decoded, scrubbed and re-encoded **before** the text passes, across `RawURL`/`URL`/`RawStd`/`Std` encodings and through a double wrapper. A payload that does not decode to a URL is left byte for byte as found, because a bundle is evidence and mangling something unreadable is worse than leaving it.

**This does not undo the disclosure.** The attachment on #844 stays servable from its GitHub URL even if the comment is edited. That is Jens' call, and it needs GitHub support to actually remove.

## The CI guard misses the stub most likely to be filled

`.github/workflows/build.yml` checks that the tracked `go:embed` stubs are still empty. There are three; it loops over two. The one it misses is `desktop-app/agentbin/go-librespot-armv7l`, the ~16 MB Spotify engine, and it is the only stub a **documented** workflow tells developers to fill: CLAUDE.md says to run `make engine-embed` before a fleet-capable dev build, and the Makefile only prints a reminder to undo it by hand.

I filled that exact stub today for the fleet roll and restored it by hand. A `git add -A` at the wrong moment puts 16 MB in the history, and the job whose own comment says this was "caught by hand three times in one evening" would not have flagged it.

Guard now covers all three, and `.gitattributes` pins the third as `binary` alongside the others.

## Tests

`proxiedradio.test.js` pins the predicate against the reporter's exact location plus the ORION and native shapes, and asserts both call sites use it. The logexport tests use the verbatim #844 line and check what the payload **decodes to**, not just what the text says, plus both encodings, the double wrapper, and that an unreadable payload is untouched.

## Not in here

#900 is confirmed still broken on v0.9.79, and the cause is now pinned: the quiet-wake guard did ship, but a third path starts the audio. The re-push watchdog's group check stands down for a follower and falls through for the master, and it fires 0.3 s after the zone join lifts the quiet-wake mute. That needs a zone-join timestamp that does not exist yet and a hardware test, so it gets its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J85eNQD42xwUmATiY6k9Zk