### PR TITLE
fix(agent): three reports traced to the re-push watchdog and the play queue

### DIFF
--- a/desktop-app/frontend/src/i18n/bundles/ar.json
+++ b/desktop-app/frontend/src/i18n/bundles/ar.json
@@ -322,6 +322,7 @@
   "preset.copiedToKey": "نُسخ إلى الزر {{n}}: {{name}}",
   "preset.savedToKey": "حُفظ في الزر {{n}}: {{name}}",
   "preset.alreadyOnKey": "هذه المحطة موجودة بالفعل على الزر {{n}}.",
+  "preset.alreadyOnKeyNamed": "«{{name}}» موجود بالفعل على الزر {{n}}. شغّل أولًا ما تريد حفظه على السماعة، ثم احفظه.",
   "preset.sourceBadge": "من {{source}}",
   "preset.saveFailed": "فشل الحفظ: {{err}}",
   "play.errNoInternet": "لا يوجد إنترنت؟",

--- a/desktop-app/frontend/src/i18n/bundles/de.json
+++ b/desktop-app/frontend/src/i18n/bundles/de.json
@@ -349,6 +349,7 @@
   "preset.copiedToKey": "Auf Taste {{n}} kopiert: {{name}}",
   "preset.savedToKey": "Auf Taste {{n}} gespeichert: {{name}}",
   "preset.alreadyOnKey": "Dieser Sender liegt schon auf Taste {{n}}.",
+  "preset.alreadyOnKeyNamed": "\"{{name}}\" liegt schon auf Taste {{n}}. Starte erst das, was du speichern willst, auf dem Lautsprecher, dann sichere es.",
   "preset.sourceBadge": "von {{source}}",
   "preset.onSpeaker": "Auf dem Lautsprecher",
   "preset.boxNativeHint": "antippen zum Abspielen auf dem Lautsprecher",

--- a/desktop-app/frontend/src/i18n/bundles/en.json
+++ b/desktop-app/frontend/src/i18n/bundles/en.json
@@ -349,6 +349,7 @@
   "preset.copiedToKey": "Copied to key {{n}}: {{name}}",
   "preset.savedToKey": "Saved to key {{n}}: {{name}}",
   "preset.alreadyOnKey": "This station is already on key {{n}}.",
+  "preset.alreadyOnKeyNamed": "\"{{name}}\" is already on key {{n}}. Start the one you want on the speaker first, then save it.",
   "preset.sourceBadge": "from {{source}}",
   "preset.onSpeaker": "On the speaker",
   "preset.boxNativeHint": "tap to play on the speaker",

--- a/desktop-app/frontend/src/i18n/bundles/es.json
+++ b/desktop-app/frontend/src/i18n/bundles/es.json
@@ -322,6 +322,7 @@
   "preset.copiedToKey": "Copiado a la tecla {{n}}: {{name}}",
   "preset.savedToKey": "Guardado en la tecla {{n}}: {{name}}",
   "preset.alreadyOnKey": "Esta emisora ya está en la tecla {{n}}.",
+  "preset.alreadyOnKeyNamed": "\"{{name}}\" ya está en la tecla {{n}}. Pon primero en el altavoz lo que quieras guardar y guárdalo entonces.",
   "preset.sourceBadge": "de {{source}}",
   "preset.saveFailed": "Error al guardar: {{err}}",
   "play.errNoInternet": "¿sin internet?",

--- a/desktop-app/frontend/src/i18n/bundles/fr.json
+++ b/desktop-app/frontend/src/i18n/bundles/fr.json
@@ -322,6 +322,7 @@
   "preset.copiedToKey": "Copié sur la touche {{n}} : {{name}}",
   "preset.savedToKey": "Enregistré sur la touche {{n}} : {{name}}",
   "preset.alreadyOnKey": "Cette station est déjà sur la touche {{n}}.",
+  "preset.alreadyOnKeyNamed": "« {{name}} » est déjà sur la touche {{n}}. Lancez d’abord sur l’enceinte ce que vous voulez enregistrer, puis enregistrez-le.",
   "preset.sourceBadge": "de {{source}}",
   "preset.saveFailed": "Échec de l'enregistrement : {{err}}",
   "play.errNoInternet": "pas d'internet ?",

--- a/desktop-app/frontend/src/i18n/bundles/ja.json
+++ b/desktop-app/frontend/src/i18n/bundles/ja.json
@@ -322,6 +322,7 @@
   "preset.copiedToKey": "キー {{n}} にコピーしました: {{name}}",
   "preset.savedToKey": "キー {{n}} に保存しました: {{name}}",
   "preset.alreadyOnKey": "この局はすでにキー {{n}} に登録されています。",
+  "preset.alreadyOnKeyNamed": "「{{name}}」はすでにキー {{n}} にあります。保存したいものを先にスピーカーで再生してから保存してください。",
   "preset.sourceBadge": "提供元: {{source}}",
   "preset.saveFailed": "保存に失敗しました: {{err}}",
   "play.errNoInternet": "インターネットなし?",

--- a/desktop-app/frontend/src/i18n/bundles/lt.json
+++ b/desktop-app/frontend/src/i18n/bundles/lt.json
@@ -322,6 +322,7 @@
   "preset.copiedToKey": "Nukopijuota į mygtuką {{n}}: {{name}}",
   "preset.savedToKey": "Išsaugota mygtuke {{n}}: {{name}}",
   "preset.alreadyOnKey": "Ši stotis jau priskirta klavišui {{n}}.",
+  "preset.alreadyOnKeyNamed": "\"{{name}}\" jau yra ties mygtuku {{n}}. Pirma paleisk kolonėlėje tai, ką nori išsaugoti, tada saugok.",
   "preset.sourceBadge": "iš {{source}}",
   "preset.saveFailed": "Nepavyko išsaugoti: {{err}}",
   "play.errNoInternet": "nėra interneto?",

--- a/desktop-app/frontend/src/i18n/bundles/lv.json
+++ b/desktop-app/frontend/src/i18n/bundles/lv.json
@@ -322,6 +322,7 @@
   "preset.copiedToKey": "Nokopēts pogā {{n}}: {{name}}",
   "preset.savedToKey": "Saglabāts pogā {{n}}: {{name}}",
   "preset.alreadyOnKey": "Šī stacija jau ir piešķirta taustiņam {{n}}.",
+  "preset.alreadyOnKeyNamed": "\"{{name}}\" jau ir uz taustiņa {{n}}. Vispirms atskaņo skaļrunī to, ko gribi saglabāt, un tad saglabā.",
   "preset.sourceBadge": "no {{source}}",
   "preset.saveFailed": "Saglabāt neizdevās: {{err}}",
   "play.errNoInternet": "nav interneta?",

--- a/desktop-app/frontend/src/i18n/bundles/nl.json
+++ b/desktop-app/frontend/src/i18n/bundles/nl.json
@@ -322,6 +322,7 @@
   "preset.copiedToKey": "Gekopieerd naar toets {{n}}: {{name}}",
   "preset.savedToKey": "Opgeslagen op toets {{n}}: {{name}}",
   "preset.alreadyOnKey": "Deze zender staat al op toets {{n}}.",
+  "preset.alreadyOnKeyNamed": "\"{{name}}\" staat al op toets {{n}}. Start eerst op de luidspreker wat je wilt opslaan, en sla het dan op.",
   "preset.sourceBadge": "van {{source}}",
   "preset.saveFailed": "Opslaan mislukt: {{err}}",
   "play.errNoInternet": "geen internet?",

--- a/desktop-app/frontend/src/i18n/bundles/pl.json
+++ b/desktop-app/frontend/src/i18n/bundles/pl.json
@@ -322,6 +322,7 @@
   "preset.copiedToKey": "Skopiowano do przycisku {{n}}: {{name}}",
   "preset.savedToKey": "Zapisano na przycisku {{n}}: {{name}}",
   "preset.alreadyOnKey": "Ta stacja jest już przypisana do przycisku {{n}}.",
+  "preset.alreadyOnKeyNamed": "\"{{name}}\" jest już na przycisku {{n}}. Najpierw włącz na głośniku to, co chcesz zapisać, a potem zapisz.",
   "preset.sourceBadge": "z {{source}}",
   "preset.saveFailed": "Zapis nie powiódł się: {{err}}",
   "play.errNoInternet": "brak internetu?",

--- a/desktop-app/frontend/src/i18n/bundles/tr.json
+++ b/desktop-app/frontend/src/i18n/bundles/tr.json
@@ -322,6 +322,7 @@
   "preset.copiedToKey": "{{n}} tuşuna kopyalandı: {{name}}",
   "preset.savedToKey": "{{n}} tuşuna kaydedildi: {{name}}",
   "preset.alreadyOnKey": "Bu istasyon zaten {{n}} tuşunda kayıtlı.",
+  "preset.alreadyOnKeyNamed": "\"{{name}}\" zaten {{n}} numaralı tuşta. Önce kaydetmek istediğini hoparlörde başlat, sonra kaydet.",
   "preset.sourceBadge": "kaynak: {{source}}",
   "preset.saveFailed": "Kaydedilemedi: {{err}}",
   "play.errNoInternet": "internet yok mu?",

--- a/desktop-app/frontend/src/i18n/bundles/uk.json
+++ b/desktop-app/frontend/src/i18n/bundles/uk.json
@@ -322,6 +322,7 @@
   "preset.copiedToKey": "Скопійовано на кнопку {{n}}: {{name}}",
   "preset.savedToKey": "Збережено на кнопку {{n}}: {{name}}",
   "preset.alreadyOnKey": "Ця станція вже призначена на клавішу {{n}}.",
+  "preset.alreadyOnKeyNamed": "\"{{name}}\" вже на кнопці {{n}}. Спершу увімкніть на колонці те, що хочете зберегти, а тоді збережіть.",
   "preset.sourceBadge": "з {{source}}",
   "preset.saveFailed": "Не вдалося зберегти: {{err}}",
   "play.errNoInternet": "немає інтернету?",

--- a/desktop-app/frontend/src/i18n/bundles/zh-Hant.json
+++ b/desktop-app/frontend/src/i18n/bundles/zh-Hant.json
@@ -349,6 +349,7 @@
   "preset.copiedToKey": "已複製到預設鍵 {{n}}：{{name}}",
   "preset.savedToKey": "已存到預設鍵 {{n}}：{{name}}",
   "preset.alreadyOnKey": "此電台已設定在按鍵 {{n}}。",
+  "preset.alreadyOnKeyNamed": "「{{name}}」已經在按鍵 {{n}} 上了。請先在喇叭上播放你想儲存的內容，再儲存。",
   "preset.sourceBadge": "來自 {{source}}",
   "preset.onSpeaker": "喇叭上的預設",
   "preset.boxNativeHint": "點一下就在喇叭上播放",

--- a/desktop-app/frontend/src/main.js
+++ b/desktop-app/frontend/src/main.js
@@ -6419,7 +6419,19 @@ const APP_PLAY_FRESH_MS = 2 * 60 * 1000;
 function showPresetSaveError(err) {
   const s = String(err);
   const m = /already-on-slot/.test(s) && s.match(/"slot":\s*(\d+)/);
-  if (m) { showToast(t('preset.alreadyOnKey', { n: m[1] })); return; }
+  if (m) {
+    // Name WHAT it collided with. Without it the note reads as a refusal to
+    // have more than one of something, which is how a user with three Spotify
+    // playlists concluded he could only keep one (#925). The agent's 409
+    // carries the other preset's name, and saying it turns the refusal into the
+    // answer: he reads back the playlist the speaker was still on.
+    const nm = (s.match(/"name":\s*"((?:[^"\\]|\\.)*)"/) || [])[1];
+    const name = nm ? nm.replace(/\\(.)/g, '$1') : '';
+    showToast(name
+      ? t('preset.alreadyOnKeyNamed', { name, n: m[1] })
+      : t('preset.alreadyOnKey', { n: m[1] }));
+    return;
+  }
   showError(t('preset.saveFailed', { err: s }));
 }
 

--- a/desktop-app/frontend/src/presetconflict.test.js
+++ b/desktop-app/frontend/src/presetconflict.test.js
@@ -1,0 +1,60 @@
+// #925: "I can only add one Spotify playlist. After that I get 'This channel is
+// already on Button 1'."
+//
+// The duplicate guard is right: for a Spotify preset it compares the playlist
+// URI, and two playlists have different URIs. What the save captures is whatever
+// the SPEAKER is playing, read live from it at save time, so saving while the
+// previous playlist is still the one playing stores that URI again and the guard
+// correctly calls it a duplicate.
+//
+// The message is what left him stuck. "This station is already on key 1" names
+// nothing and calls a playlist a station, so it reads as a refusal to have more
+// than one of them. The agent's 409 carries the other preset's name all along.
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const main = readFileSync(new URL('./main.js', import.meta.url), 'utf8');
+const dir = fileURLToPath(new URL('./i18n/bundles/', import.meta.url));
+const langs = readdirSync(dir).filter((f) => f.endsWith('.json')).map((f) => f.replace('.json', ''));
+const bundle = (l) => JSON.parse(readFileSync(new URL(`./i18n/bundles/${l}.json`, import.meta.url), 'utf8'));
+
+// The name extraction, mirrored here so it can be exercised on real 409 bodies.
+const nameFrom = (s) => {
+  const nm = (s.match(/"name":\s*"((?:[^"\\]|\\.)*)"/) || [])[1];
+  return nm ? nm.replace(/\\(.)/g, '$1') : '';
+};
+
+describe('the already-on-key refusal', () => {
+  it('pulls the colliding name out of the agent 409', () => {
+    expect(nameFrom('{"code":"already-on-slot","slot":1,"name":"Rock Classics"}')).toBe('Rock Classics');
+    // A name carrying a quote, which is what breaks a naive regex.
+    const withQuote = '{"code":"already-on-slot","slot":2,"name":"Rock \\"Live\\""}';
+    expect(nameFrom(withQuote)).toBe('Rock "Live"');
+    // No name in the body: fall back rather than print an empty pair of quotes.
+    expect(nameFrom('{"code":"already-on-slot","slot":3}')).toBe('');
+  });
+
+  it('uses the named message when there is a name, and the old one otherwise', () => {
+    const at = main.indexOf('function showPresetSaveError');
+    const fn = main.slice(at, at + 1200);
+    expect(fn).toContain('preset.alreadyOnKeyNamed');
+    expect(fn).toContain('preset.alreadyOnKey');
+    // The choice is made on whether a name came back, so a 409 without one
+    // still gets a sentence rather than an empty pair of quotes.
+    expect(fn).toContain('showToast(name');
+  });
+
+  it('has the named message in every language, with both placeholders', () => {
+    for (const l of langs) {
+      const v = bundle(l)['preset.alreadyOnKeyNamed'];
+      expect(v, l).toBeTruthy();
+      expect(v, l + ' lost the name').toContain('{{name}}');
+      expect(v, l + ' lost the key number').toContain('{{n}}');
+    }
+    // It has to say what to do, or it is only a politer refusal.
+    expect(bundle('en')['preset.alreadyOnKeyNamed']).toMatch(/start/i);
+    expect(bundle('de')['preset.alreadyOnKeyNamed']).toMatch(/Starte/);
+    expect(bundle('de')['preset.alreadyOnKeyNamed']).not.toMatch(/\s[-–—]\s/);
+  });
+});

--- a/internal/streamproxy/offsetrange_test.go
+++ b/internal/streamproxy/offsetrange_test.go
@@ -1,0 +1,46 @@
+// #844: a library FLAC that never played once, restarted six times in two
+// minutes.
+//
+// The box asked the proxy for `bytes=253170-` while reading the file's header.
+// The proxy forwarded no Range at all, so the upstream answered from byte 0, the
+// box read a few kilobytes of the wrong part of the file, gave up with
+// AUDIO_ERROR_DECODER and retried five seconds later.
+//
+// Forwarding every Range would be wrong: "bytes=0-" is what a plain player sends
+// for any stream, radio included, and a live stream handed a Range can answer in
+// ways nobody here wants. A non-zero start is the thing no radio listener ever
+// asks for, so that is the only shape that travels.
+
+package streamproxy
+
+import "testing"
+
+func TestOnlyAnOffsetRangeTravelsUpstream(t *testing.T) {
+	forwarded := map[string]string{
+		// The exact header from the #844 bundle.
+		"bytes=253170-":   "bytes=253170-",
+		"bytes=1024-2047": "bytes=1024-2047",
+		"BYTES=500-":      "BYTES=500-", // case is the caller's business
+		"  bytes=900-  ":  "bytes=900-", // trimmed, value preserved
+	}
+	for in, want := range forwarded {
+		if got := offsetRange(in); got != want {
+			t.Fatalf("offsetRange(%q) = %q, want %q", in, got, want)
+		}
+	}
+
+	// Everything a radio player sends, and everything malformed, stays behind.
+	for _, in := range []string{
+		"",           // no header at all, the overwhelming majority
+		"bytes=0-",   // every plain player, for every stream
+		"bytes=0",    //
+		"bytes=-500", // a suffix range: not an offset into the file
+		"bytes=",     // malformed
+		"items=5-10", // not a byte range
+		"0-100",      // no unit
+	} {
+		if got := offsetRange(in); got != "" {
+			t.Fatalf("offsetRange(%q) = %q, want it held back", in, got)
+		}
+	}
+}

--- a/internal/streamproxy/streamproxy.go
+++ b/internal/streamproxy/streamproxy.go
@@ -463,6 +463,21 @@ func (s *Server) handleRaw(w http.ResponseWriter, r *http.Request) {
 // Deliberately cheap: no extra request, no timer, nothing written to the
 // speaker's flash, and no new log LINE. It rides on one that was being written
 // anyway, once per stream start.
+// offsetRange returns the caller's Range header when it asks for a NON-ZERO
+// start, and "" otherwise. See the forwarding site for why only an offset
+// qualifies: a zero-start range is what every player sends for every stream.
+func offsetRange(h string) string {
+	v := strings.TrimSpace(h)
+	if !strings.HasPrefix(strings.ToLower(v), "bytes=") {
+		return ""
+	}
+	spec := strings.TrimSpace(v[len("bytes="):])
+	if spec == "" || strings.HasPrefix(spec, "-") || strings.HasPrefix(spec, "0-") || spec == "0" {
+		return ""
+	}
+	return v
+}
+
 func requestFacts(r *http.Request) []any {
 	if r == nil {
 		return nil
@@ -688,6 +703,22 @@ func (s *Server) streamOneDepth(ctx context.Context, w http.ResponseWriter, r *h
 	// now-playing text. The box never sees the icy-metaint contract.
 	req.Header.Set("Icy-MetaData", "1")
 	req.Header.Set("User-Agent", "STR-Proxy/1.0")
+	// Carry a MID-FILE range request upstream. The box asks for one when it is
+	// reading a finite file's header or seeking, and this proxy answered every
+	// such request from byte 0, so the box got a few kilobytes of the wrong part,
+	// gave up with AUDIO_ERROR_DECODER and retried every five seconds. A library
+	// FLAC asked for bytes=253170- and never played once (#844).
+	//
+	// Only an OFFSET range is forwarded. "bytes=0-" is what a plain player sends
+	// for any stream and says nothing, while a non-zero start is something no
+	// radio listener ever asks for, so this cannot reach a live stream. An
+	// upstream that does not do ranges ignores the header and answers 200, which
+	// is exactly what this path did before.
+	if r != nil {
+		if rng := offsetRange(r.Header.Get("Range")); rng != "" {
+			req.Header.Set("Range", rng)
+		}
+	}
 
 	resp, err := s.client.Do(req)
 	if err != nil {

--- a/internal/webui/queuegap_test.go
+++ b/internal/webui/queuegap_test.go
@@ -1,0 +1,59 @@
+// #923: six to seven seconds of silence between folder tracks.
+//
+// Timed against the same Synology folder played twice on one ST20, once driven
+// by STR and once by the box itself: 157 s against 150 s, and 236 s against
+// 230 s. The box's own advance is 0.8 s, which is why the Bose app sounds
+// gapless and STR does not.
+//
+// The chassis finishes a file and freezes in PLAY_STATE at EOF instead of
+// emitting STOP, so the STOP branch never runs and every track ends on the
+// wall-clock net at end + queueTimerMargin.
+//
+// Those six seconds are a grace for a box that reports NO position: with nothing
+// to corroborate the length against, cutting a buffering track short is the
+// worse failure. A box that reports a position AND reports it sitting at the end
+// has already said the track is over.
+
+package webui
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTheGraceIsSkippedWhenTheBoxConfirmsTheEnd(t *testing.T) {
+	s := quietServer("192.0.2.10")
+	const end = 3 * time.Minute
+
+	// The #923 shape: the box reports a position, and it is at the end.
+	if m := s.advanceMargin(end, end); m != 0 {
+		t.Fatalf("margin %s with the position at the end; that is the gap users hear", m)
+	}
+	// Just inside the epsilon still counts as the end.
+	if m := s.advanceMargin(end-queueEndEpsilon+time.Second, end); m != 0 {
+		t.Fatalf("margin %s for a position inside the end epsilon", m)
+	}
+}
+
+func TestTheGraceStaysWhereThereIsNothingToCorroborateWith(t *testing.T) {
+	s := quietServer("192.0.2.10")
+	const end = 3 * time.Minute
+
+	// No position at all: the FRITZ!Box-class case the margin was written for.
+	if m := s.advanceMargin(0, end); m != queueTimerMargin {
+		t.Fatalf("margin %s with no position reported, want the full %s", m, queueTimerMargin)
+	}
+	// A position that is nowhere near the end: the track is still running, and
+	// cutting it off is the failure the grace exists to prevent.
+	if m := s.advanceMargin(30*time.Second, end); m != queueTimerMargin {
+		t.Fatalf("margin %s mid-track, want the full %s", m, queueTimerMargin)
+	}
+}
+
+// The floor is the poll interval, and it stays where it is: a faster poll would
+// run on every speaker all day for this one case.
+func TestThePollIntervalIsNotTightened(t *testing.T) {
+	if queuePollInterval < 4*time.Second {
+		t.Fatalf("queuePollInterval dropped to %s; that runs on every speaker all day", queuePollInterval)
+	}
+}

--- a/internal/webui/queueplay.go
+++ b/internal/webui/queueplay.go
@@ -443,7 +443,7 @@ func (s *Server) runQueueWatcher(ctx context.Context) {
 		// past it. This covers both a missed STOP frame and a box that freezes at
 		// PLAY_STATE on a finite file's EOF (#219), neither of which the STOP path
 		// above can catch.
-		if sawPlay && end > 0 && time.Since(start) >= end+queueTimerMargin {
+		if sawPlay && end > 0 && time.Since(start) >= end+s.advanceMargin(lastPos, end) {
 			s.advanceAndPlay(true, curGen)
 			continue
 		}
@@ -459,6 +459,30 @@ func (s *Server) runQueueWatcher(ctx context.Context) {
 			s.advanceAndPlay(true, curGen)
 		}
 	}
+}
+
+// advanceMargin is how long past the track length the wall-clock net waits.
+//
+// The six seconds exist for a box that reports NO position: with nothing to
+// corroborate the length against, the timer has to be generous, or a track that
+// buffers mid-way gets cut off. A box that DOES report a position and reports it
+// sitting at the end of the track has already said the track is over, and making
+// it wait another six seconds is the gap users hear.
+//
+// Measured on an ST20 playing one Synology folder twice, once through STR and
+// once by the box itself (#923): 157 s against 150 s, and 236 s against 230 s.
+// The box's own advance is 0.8 s. The chassis finishes the file and freezes in
+// PLAY_STATE at EOF rather than emitting STOP, so the STOP branch never runs and
+// every track ends on this timer.
+//
+// The remaining floor is the four second poll, which stays where it is: a faster
+// poll would run on every speaker all day for one case (see the project rule on
+// sparing the box hardware).
+func (s *Server) advanceMargin(lastPos, end time.Duration) time.Duration {
+	if lastPos > 0 && nearEnd(lastPos, end) {
+		return 0
+	}
+	return queueTimerMargin
 }
 
 func nearEnd(progress, end time.Duration) bool {

--- a/internal/webui/resume_standby.go
+++ b/internal/webui/resume_standby.go
@@ -674,6 +674,36 @@ func zoneRoleFromMaster(masterID, selfID string) (follower, known bool) {
 //     down. Being in a group is already the risky state, and here the choice
 //     is only between a station the user restarts and a push that fights a
 //     group that is currently playing.
+//
+// zoneSettleWindow is how long after a zone membership change the re-push
+// watchdog holds off. It has to outlast the whole form handshake: in the #900
+// bundle the quiet wake's STOP lands 2.7 s before "zone: formed", and the
+// firmware's zoneUpdated can trail the drive by a second more. Fifteen seconds
+// covers that with room, and the cost of being wrong in this direction is a
+// station the user starts again, while the cost the other way is music in a
+// room nobody asked.
+const zoneSettleWindow = 15 * time.Second
+
+// noteZoneChanged stamps a zone membership change.
+func (s *Server) noteZoneChanged() {
+	s.quietWakeMu.Lock()
+	s.zoneChangedAt = time.Now()
+	s.quietWakeMu.Unlock()
+}
+
+// zoneJustChanged reports whether the speaker joined, led or left a zone within
+// zoneSettleWindow, and how long ago.
+func (s *Server) zoneJustChanged() (bool, time.Duration) {
+	s.quietWakeMu.Lock()
+	at := s.zoneChangedAt
+	s.quietWakeMu.Unlock()
+	if at.IsZero() {
+		return false, 0
+	}
+	age := time.Since(at)
+	return age < zoneSettleWindow, age
+}
+
 func (s *Server) zonePushWouldFightGroup() (standDown bool, reason string) {
 	if s.boxHost == "" {
 		return false, ""
@@ -878,6 +908,11 @@ func (s *Server) forgetZoneDocDoubt() {
 // live group's document on a single observation. That is exactly the
 // mid-handshake race the two-observation rule exists to survive.
 func (s *Server) NoteBoxZoneState(master string) {
+	// Stamp every membership change, joining and leaving alike. The re-push
+	// watchdog reads it to tell a dropped stream from one that ended because the
+	// group changed (#900). Free: this hook already fires on exactly these
+	// events, so it costs no timer, no poll and no write to the speaker.
+	s.noteZoneChanged()
 	if strings.TrimSpace(master) != "" {
 		// Joined a zone: a level muted for a quiet group wake comes back now.
 		s.restoreQuietWakeVolume("zone joined")
@@ -1801,19 +1836,30 @@ func (s *Server) maybeRePush() {
 			return
 		}
 	}
-	standby, busy := s.boxPlayState()
+	standby, busy, buffering := s.boxPlayStateDetail()
 	if standby {
 		s.logger.Info("re-push: box went to standby, not resuming (treated as user power-off)")
 		return
 	}
 	if busy {
-		// Recovered (playing/paused again, or the user switched). Reset the
-		// attempt counter so a later genuine drop starts a fresh backoff window.
-		s.lastPlayMu.Lock()
-		if s.lastPlay != nil {
-			s.lastPlay.rePushes = 0
+		// Playing or paused again, or the user switched: this is a recovery, so
+		// the attempt counter resets and a later genuine drop starts a fresh
+		// backoff window.
+		//
+		// BUFFERING is NOT a recovery, and counting it as one is why the hard
+		// stop below never engaged. A library file the box cannot read has it
+		// retrying every five seconds, each retry reads as busy, and each reset
+		// put the counter back to zero: six re-pushes of the same track in two
+		// minutes, every one of them logged attempt=1 max=10, so the cap was
+		// decorative (#844). A box that is buffering has not recovered, it is
+		// still trying.
+		if !buffering {
+			s.lastPlayMu.Lock()
+			if s.lastPlay != nil {
+				s.lastPlay.rePushes = 0
+			}
+			s.lastPlayMu.Unlock()
 		}
-		s.lastPlayMu.Unlock()
 		return
 	}
 
@@ -1862,6 +1908,26 @@ func (s *Server) maybeRePush() {
 	// indeterminate answer also stands down: this runs on a speaker that is
 	// idle, so the cost of not pushing is a station the user restarts, while
 	// the cost of pushing into a group is the fight above.
+	// A zone that changed a moment ago is not a dropped stream. Forming a group
+	// wakes the master, and the quiet wake's own STOP tears down whatever the
+	// firmware had just restored, which arms this watchdog; 0.14 s after the
+	// group formed it then pushed back a station the user had switched off two
+	// minutes earlier, and the whole group played it (#900, traced on v0.9.79).
+	//
+	// This covers the MASTER, which the role check below deliberately does not:
+	// a master that really loses its stream still has to recover it, because the
+	// group is listening to that one. What separates the two cases is not the
+	// role, it is whether a zone edit just happened.
+	//
+	// The rule is the one the form path already follows: never start audio that
+	// was not playing before the user's action. A master that WAS playing keeps
+	// its recovery, because zones_stereo.go carries that stream forward itself
+	// rather than leaving it to this watchdog.
+	if changed, age := s.zoneJustChanged(); changed {
+		s.logger.Info("re-push: not resuming, the speaker's group changed a moment ago (that is not a dropped stream)",
+			"ago", age.Round(time.Millisecond).String())
+		return
+	}
 	if standDown, why := s.zonePushWouldFightGroup(); standDown {
 		s.logger.Info("re-push: not resuming, " + why)
 		return
@@ -2092,11 +2158,23 @@ func (s *Server) pushDisplayDefault() {
 // and idle" and trigger a resume. One quick retry first so a single hiccup does
 // not abort a legitimate stream recovery (where the box really is awake+idle).
 func (s *Server) boxPlayState() (standby, busy bool) {
+	standby, busy, _ = s.boxPlayStateDetail()
+	return standby, busy
+}
+
+// boxPlayStateDetail is boxPlayState plus whether the box is merely BUFFERING.
+//
+// The two are not the same question. For "may I push to this box" buffering
+// counts as busy and always has. For "has this box recovered" it does not: a box
+// retrying a file it cannot read buffers forever, and treating that as recovery
+// is what kept the re-push hard stop from ever engaging (#844).
+func (s *Server) boxPlayStateDetail() (standby, busy, buffering bool) {
 	if s.playStateFn != nil {
-		return s.playStateFn()
+		standby, busy = s.playStateFn()
+		return standby, busy, false
 	}
 	if s.boxHost == "" {
-		return true, false
+		return true, false, false
 	}
 	cl := &http.Client{Timeout: 5 * time.Second}
 	var lastErr error
@@ -2113,11 +2191,12 @@ func (s *Server) boxPlayState() (standby, busy bool) {
 		resp.Body.Close()
 		body := string(b)
 		standby = strings.Contains(body, "STANDBY")
-		busy = strings.Contains(body, "PLAY_STATE") || strings.Contains(body, "BUFFERING_STATE") || strings.Contains(body, "PAUSE_STATE")
-		return standby, busy
+		buffering = strings.Contains(body, "BUFFERING_STATE")
+		busy = strings.Contains(body, "PLAY_STATE") || buffering || strings.Contains(body, "PAUSE_STATE")
+		return standby, busy, buffering
 	}
 	// Could not read the box state: assume standby so we never resume/wake on an
 	// uncertain state (silence beats spontaneous playback).
 	s.logger.Warn("box play-state query failed, assuming standby (will not resume/re-push)", "err", lastErr)
-	return true, false
+	return true, false, false
 }

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -42,6 +42,15 @@ type Server struct {
 	// quietWake is a member wake done for a group join: the level the speaker
 	// had before it was muted for the wake, restored once the speaker joins a
 	// zone or the window runs out. Guarded by quietWakeMu.
+	// zoneChangedAt is when the speaker last joined, led or left a zone, as the
+	// firmware itself reported it. It exists so the re-push watchdog can tell a
+	// stream that DROPPED from one that ended because the group changed under it
+	// (#900). Deliberately not derived from quietWakeUntil: the zone join is what
+	// CLEARS that, so reading it here is a race that the push wins or loses by a
+	// quarter of a second. Guarded by quietWakeMu, which already covers the other
+	// piece of group-wake state and is taken on the same events.
+	zoneChangedAt time.Time
+
 	quietWakeMu    sync.Mutex
 	quietWakeVol   int
 	quietWakeUntil time.Time

--- a/internal/webui/zonesettle_test.go
+++ b/internal/webui/zonesettle_test.go
@@ -1,0 +1,103 @@
+// #900, and the three wrong answers it drew before this one.
+//
+// Forming a group of idle speakers made music come out of the one that ended up
+// leading it. Traced on shorty310's v0.9.79 bundle: forming the group wakes the
+// master, the quiet wake's own STOP tears down what the firmware had just
+// restored, that disconnect arms the re-push watchdog, and 0.14 s after
+// "zone: formed" it pushes back a station the user had switched off two minutes
+// earlier. It went out over UPnP, which only STR drives, so it was not the
+// speaker doing it.
+//
+// The guard that looks right and is not: quietWakeActive() is CLEARED BY the
+// zone join, 0.31 s before the push lands. These tests pin the timing so that
+// mistake cannot be made a fourth time.
+
+package webui
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAZoneChangeHoldsTheRePushWatchdog(t *testing.T) {
+	s := quietServer("192.0.2.10")
+
+	// Nothing recorded yet: a speaker that has never been in a group must not be
+	// held, or the recovery this watchdog exists for never runs at all.
+	if held, _ := s.zoneJustChanged(); held {
+		t.Fatal("a speaker with no zone history was held")
+	}
+
+	s.noteZoneChanged()
+	held, age := s.zoneJustChanged()
+	if !held {
+		t.Fatal("a zone change that just happened did not hold the watchdog")
+	}
+	if age > time.Second {
+		t.Fatalf("age reads %s for a change made just now", age)
+	}
+}
+
+// The window has to outlast the whole form handshake. In the bundle the quiet
+// wake's STOP lands 2.7 s BEFORE "zone: formed", and the firmware's zoneUpdated
+// can trail the drive by a second more, so anything tight enough to expire
+// inside a normal group formation would let the push through again.
+func TestTheWindowOutlastsAGroupFormation(t *testing.T) {
+	if zoneSettleWindow < 10*time.Second {
+		t.Fatalf("zoneSettleWindow is %s; the observed handshake alone spans ~3 s and the firmware trails it", zoneSettleWindow)
+	}
+	s := quietServer("192.0.2.10")
+	s.quietWakeMu.Lock()
+	s.zoneChangedAt = time.Now().Add(-(zoneSettleWindow - 2*time.Second))
+	s.quietWakeMu.Unlock()
+	if held, _ := s.zoneJustChanged(); !held {
+		t.Fatal("a change two seconds inside the window did not hold")
+	}
+}
+
+// And it has to end, or a speaker that joined a group once would lose its stream
+// recovery for good.
+func TestTheHoldExpires(t *testing.T) {
+	s := quietServer("192.0.2.10")
+	s.quietWakeMu.Lock()
+	s.zoneChangedAt = time.Now().Add(-(zoneSettleWindow + time.Second))
+	s.quietWakeMu.Unlock()
+	if held, age := s.zoneJustChanged(); held {
+		t.Fatalf("still held %s after the change; recovery would never run again", age)
+	}
+}
+
+// Leaving a group counts too. Ungrouping tears the stream down exactly the same
+// way, and the watchdog would push into the aftermath.
+func TestLeavingAZoneCountsAsAChange(t *testing.T) {
+	s := quietServer("192.0.2.10")
+	s.NoteBoxZoneState("") // the firmware reporting no master: dissolved
+	if held, _ := s.zoneJustChanged(); !held {
+		t.Fatal("a dissolve did not stamp a zone change")
+	}
+}
+
+func TestJoiningAZoneStampsTheChange(t *testing.T) {
+	s := quietServer("192.0.2.10")
+	s.NoteBoxZoneState("DEV-MASTER")
+	if held, _ := s.zoneJustChanged(); !held {
+		t.Fatal("a join did not stamp a zone change")
+	}
+}
+
+// The trap, stated as a test so the reasoning survives. quietWakeActive() is
+// cleared by the very event this guard has to react to, so the two must not be
+// confused for one another: at the moment the push lands, the quiet wake is
+// already over and the zone change is not.
+func TestTheZoneStampOutlivesTheQuietWake(t *testing.T) {
+	s := quietServer("192.0.2.10")
+	s.armQuietWakeRestore(30)        // group operation begins, level muted
+	s.NoteBoxZoneState("DEV-MASTER") // the join: restores the level AND stamps
+
+	if s.quietWakeActive() {
+		t.Fatal("the quiet wake should be over once the zone is joined; that is the race")
+	}
+	if held, _ := s.zoneJustChanged(); !held {
+		t.Fatal("the zone stamp must survive the join, or the watchdog is unguarded exactly when it fires")
+	}
+}


### PR DESCRIPTION
Refs #900, #844, #923

Three open reports, each traced in its own bundle before anything was written. One of them had two earlier analyses that were confidently wrong, so the reasoning is laid out in full.

## #900: grouping idle speakers starts music

All three of shorty310's speakers were in standby and silent. Forming the group wakes the master; the quiet wake's own STOP closes the stream proxy, that disconnect arms the re-push watchdog, the speaker becomes master, and **0.14 s after `zone: formed`** the watchdog pushes back a station he had played and switched off two minutes earlier.

```
07:25:47.227  stream proxy end: bose disconnected          <- the quiet wake's own STOP
07:25:49.932  zone: formed  liveMaster=DEV#c91ce962
07:25:50.073  re-push: box dropped the stream while idle   attempt=1 max=10
07:25:50.674  source changed  LOCAL_INTERNET_RADIO -> UPNP
```

The discriminator is the transport. The firmware's own power-on resume always shows as `LOCAL_INTERNET_RADIO` with an orion-station line beside it; this went out over **UPnP, which only STR drives**. The same watchdog on the same speaker stood down correctly twice in earlier rounds, while it was a *follower*.

**Two guards that look right and are not**, both checked rather than assumed:

- `quietWakeActive()` is **cleared by the zone join**, 0.31 s before the push lands. Using it here wins this instance by a quarter of a second and loses the next. It is the fourth obvious-looking cause this issue has attracted.
- Standing the master down outright breaks the case the code documents at `resume_standby.go:1856`: *"A master that loses its stream still has to recover it, and the whole group is listening to that one."*

What separates the cases is not the role, it is whether a zone edit just happened. The speaker records every membership change the firmware reports, on `NoteBoxZoneState`, a hook that **already fires on exactly those events** — no timer, no poll, no write to the speaker. The watchdog holds for 15 s after one, master included. That window has to outlast the form handshake: in the bundle the STOP lands 2.7 s *before* `zone: formed`.

## #923: a six to seven second gap between folder tracks

Measured against the same Synology folder played twice on one ST20, once through STR and once by the box itself: **157 s vs 150 s**, and **236 s vs 230 s**. The box's own advance is 0.8 s, which is why the Bose app sounds gapless.

The chassis finishes a file and freezes in `PLAY_STATE` at EOF instead of emitting STOP, so the stop branch never runs and every track ends on `end + queueTimerMargin`, six seconds, checked every four.

Those six seconds are a grace for a box reporting **no position**: with nothing to corroborate the length against, cutting a buffering track short is the worse failure. A box that reports a position and reports it at the end has already said the track is over. The grace now applies only where there is nothing to confirm it with.

The 4 s poll stays. Tightening it would run on every speaker all day for one case.

## #844: a library file restarted forever, never playing once

Two faults, both in the log.

The box asked for `bytes=253170-` while reading the FLAC's header. The proxy forwarded **no Range at all**, so the upstream answered from byte 0, the box read the wrong part, gave up with `AUDIO_ERROR_DECODER` and retried every 5 s. Only an **offset** range travels now: `bytes=0-` is what every plain player sends for every stream and says nothing, while a non-zero start is something no radio listener ever asks for, so this cannot reach a live stream.

The second fault is why it never stopped. All six pushes logged `attempt=1 max=10` — the hard stop was decorative. The counter resets whenever the box reads busy, and **`BUFFERING_STATE` counts as busy**, so the box's own 5 s retries zeroed it four times per cycle. A box that is buffering has not recovered.

## What is NOT fixed, and it matters

**#900 has a second path, and this PR does not close it.** I reproduced the report on two speakers here before writing anything, and my reproduction took a different route:

```
20:31:14.445  wake phase: STANDBY, sending sys power
20:31:14.475  source changed  STANDBY -> LOCAL_INTERNET_RADIO   <- 30 ms, the firmware itself
20:31:14.731  stream proxy raw start                            <- audio already flowing
20:31:15.897  wake: quiet wake for a group operation  mutedFrom=10
20:31:16.771  wake: level restored  why="zone joined"
```

No re-push line anywhere. The firmware resumes its own last station on the wake, and the mute lands 1.4 s after audio is already flowing, then the zone join lifts it 0.9 s later. `quietWake` already knows the mute cannot be written before power-on (the firmware overwrites it) and polls for the first sign of life, and the code's own comment predicts this outcome: *"The mute did not save it either."* Closing that needs a decision about what should happen when a group forms around a master the firmware has just restarted, so it is not in here.

## Verification

Unit tests cover all three, including the `quietWakeActive` trap as an explicit assertion so it cannot be made a fourth time. `go build`, both module test suites, `golangci-lint` and the ARM cross-compile are clean.

**Not verified on hardware**: #923 and #844 need a DLNA folder and a seekable library file, and it is past midnight here. #900's re-push path is unit-tested but its live reproduction went down the other route, so the guard itself is untested on a speaker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J85eNQD42xwUmATiY6k9Zk