### PR TITLE
fix(agent): a radio stream no longer jumps back and repeats after a reconnect

### DIFF
--- a/internal/streamproxy/edgepin_test.go
+++ b/internal/streamproxy/edgepin_test.go
@@ -1,0 +1,86 @@
+package streamproxy
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+)
+
+func pinServer() *Server {
+	return &Server{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+}
+
+// The behaviour #823 is about: a station URL that redirects somewhere else is
+// dialled once through the redirect and afterwards straight at the node.
+func TestEdgePinReusesTheResolvedNode(t *testing.T) {
+	s := pinServer()
+	const station = "https://playerservices.streamtheworld.com/api/livestream-redirect/RADIO538AAC.aac"
+	const edge = "https://184.104.206.29/RADIO538AAC.aac"
+
+	if got := s.edgeFor(station); got != station {
+		t.Fatalf("with nothing pinned the station itself must be dialled, got %q", got)
+	}
+
+	s.pinEdge(station, edge)
+	if got := s.edgeFor(station); got != edge {
+		t.Errorf("a reconnect dialled %q, want the pinned edge %q", got, edge)
+	}
+
+	// A reconnect resolves to itself. That must not be recorded as a new pin
+	// of the edge onto itself, which would make the map grow per reconnect.
+	s.pinEdge(edge, edge)
+	s.edgeMu.Lock()
+	n := len(s.edgePins)
+	s.edgeMu.Unlock()
+	if n != 1 {
+		t.Errorf("the pin map holds %d entries after a reconnect, want 1", n)
+	}
+}
+
+// A node that stops answering must not strand the listener on it.
+func TestEdgePinDroppedWhenTheNodeRefuses(t *testing.T) {
+	s := pinServer()
+	const station = "https://example.invalid/api/livestream-redirect/X.aac"
+	const edge = "https://198.51.100.7/X.aac"
+
+	s.pinEdge(station, edge)
+	s.dropEdgePinByEdge(edge)
+
+	if got := s.edgeFor(station); got != station {
+		t.Errorf("after the node refused, the next attempt dialled %q, want the station %q", got, station)
+	}
+}
+
+// Dropping something that was never pinned, or an empty URL, must be harmless:
+// both happen on every ordinary failure of an unredirected station.
+func TestEdgePinDropIsSafeWhenNothingIsPinned(t *testing.T) {
+	s := pinServer()
+	s.dropEdgePinByEdge("")
+	s.dropEdgePinByEdge("https://nothing.example/stream")
+	s.pinEdge("", "https://x.example/a")
+	s.pinEdge("https://x.example/a", "")
+	s.edgeMu.Lock()
+	n := len(s.edgePins)
+	s.edgeMu.Unlock()
+	if n != 0 {
+		t.Errorf("the pin map holds %d entries, want 0", n)
+	}
+}
+
+// Two stations playing at once keep their own nodes.
+func TestEdgePinPerStation(t *testing.T) {
+	s := pinServer()
+	s.pinEdge("https://a.example/station", "https://1.1.1.1/a")
+	s.pinEdge("https://b.example/station", "https://2.2.2.2/b")
+	if got := s.edgeFor("https://a.example/station"); got != "https://1.1.1.1/a" {
+		t.Errorf("station a dialled %q", got)
+	}
+	if got := s.edgeFor("https://b.example/station"); got != "https://2.2.2.2/b" {
+		t.Errorf("station b dialled %q", got)
+	}
+	// Dropping one leaves the other alone.
+	s.dropEdgePinByEdge("https://1.1.1.1/a")
+	if got := s.edgeFor("https://b.example/station"); got != "https://2.2.2.2/b" {
+		t.Errorf("dropping station a's node disturbed station b: %q", got)
+	}
+}

--- a/internal/streamproxy/streamproxy.go
+++ b/internal/streamproxy/streamproxy.go
@@ -41,6 +41,12 @@ type Server struct {
 	logger *slog.Logger
 	client *http.Client
 
+	// edgePins maps a station URL to the edge server a redirect resolved it to,
+	// so a reconnect rebuilds the same connection rather than rolling the CDN's
+	// dice again (#823). See pinEdge.
+	edgeMu   sync.Mutex
+	edgePins map[string]string
+
 	failMu   sync.Mutex
 	lastFail map[string]time.Time
 
@@ -385,7 +391,7 @@ func (s *Server) handleRaw(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		var boseAlive bool
-		boseAlive, lastErr = s.streamOne(r.Context(), w, r, url, !headersSent)
+		boseAlive, lastErr = s.streamOne(r.Context(), w, r, s.edgeFor(url), !headersSent)
 		if errors.Is(lastErr, errPlaylistIsHLS) && !headersSent {
 			// The URL had no .m3u8 suffix but its body is an HLS playlist; demux
 			// it (#252). serveHLS only errors before writing audio, so http.Error
@@ -614,7 +620,7 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		curURL := s.resolvePresetURL(slot, curStream)
-		boseAlive, err := s.streamOne(r.Context(), w, r, curURL, !headersSent)
+		boseAlive, err := s.streamOne(r.Context(), w, r, s.edgeFor(curURL), !headersSent)
 		lastErr = err
 		if errors.Is(err, errPlaylistIsHLS) && !headersSent {
 			// A preset whose URL had no .m3u8 suffix but serves an HLS playlist
@@ -680,6 +686,80 @@ func (s *Server) streamOne(ctx context.Context, w http.ResponseWriter, r *http.R
 	return s.streamOneDepth(ctx, w, r, url, sendHeaders, 0)
 }
 
+// Reconnecting to the SAME edge server, not just to the same station.
+//
+// A station URL is often a redirect endpoint rather than a stream: ask
+// streamtheworld's /api/livestream-redirect/ for a station and it answers with
+// one of its edge nodes, a different one nearly every time. Those nodes are not
+// aligned with each other, so two of them can be half a minute apart in the
+// same broadcast. Rebuilding a dropped connection through the redirect
+// therefore resumed the station at a random point, and a listener heard the
+// programme jump backwards and repeat a stretch it had already played (#823:
+// 41 reconnects across 15 distinct edge addresses in eight minutes on one ST30,
+// on every station the reporter tried).
+//
+// So the edge a redirect resolved to is remembered for this listening session
+// and reused when the connection has to be rebuilt. It is a hint, never a
+// requirement: the moment the pinned edge itself refuses, the pin is dropped
+// and the next attempt goes through the redirect again, which is what this path
+// always did.
+func (s *Server) pinEdge(station, edge string) {
+	if station == "" || edge == "" || edge == station {
+		return
+	}
+	s.edgeMu.Lock()
+	prev := s.edgePins[station]
+	if s.edgePins == nil {
+		s.edgePins = map[string]string{}
+	}
+	s.edgePins[station] = edge
+	s.edgeMu.Unlock()
+	if prev == "" {
+		s.logger.Info("stream proxy: pinned the station's edge server for reconnects", "station", station, "edge", edge)
+	}
+}
+
+// edgeFor returns the edge to dial for a station: the pinned one when there is
+// one, otherwise the station URL itself.
+func (s *Server) edgeFor(station string) string {
+	s.edgeMu.Lock()
+	defer s.edgeMu.Unlock()
+	if e := s.edgePins[station]; e != "" {
+		return e
+	}
+	return station
+}
+
+// dropEdgePinByEdge forgets a pin whose edge is the URL that just failed, so
+// the next attempt goes through the station's redirect again.
+//
+// Called ONLY when the edge refused a connection or answered a non-200. A
+// mid-stream stall must not drop the pin: constant rebuilding is the situation
+// this whole mechanism exists for, and rebuilding to the same node is the
+// point. The map holds one entry per station being listened to, so the scan is
+// over a handful of strings.
+func (s *Server) dropEdgePinByEdge(edge string) {
+	if edge == "" {
+		return
+	}
+	s.edgeMu.Lock()
+	station := ""
+	for st, e := range s.edgePins {
+		if e == edge {
+			station = st
+			break
+		}
+	}
+	if station != "" {
+		delete(s.edgePins, station)
+	}
+	s.edgeMu.Unlock()
+	if station != "" {
+		s.logger.Info("stream proxy: the pinned edge server stopped answering, resolving the station again",
+			"station", station, "edge", edge)
+	}
+}
+
 // streamOneDepth is streamOne with a playlist-resolution recursion guard: an
 // audio/x-mpegurl response that turns out to be a plain M3U/PLS pointer file is
 // re-fetched at its first real stream URL (depth+1), capped so a playlist that
@@ -735,6 +815,7 @@ func (s *Server) streamOneDepth(ctx context.Context, w http.ResponseWriter, r *h
 			s.logger.Debug("stream proxy upstream fail (dedup)", "url", url, "err", err)
 		}
 		s.recordFailure(url, err)
+		s.dropEdgePinByEdge(url)
 		if sendHeaders {
 			http.Error(w, "upstream unreachable", http.StatusBadGateway)
 			return false, err
@@ -752,11 +833,21 @@ func (s *Server) streamOneDepth(ctx context.Context, w http.ResponseWriter, r *h
 			s.logger.Debug("stream proxy upstream status (dedup)", "status", resp.StatusCode, "url", url)
 		}
 		s.recordFailure(url, statusErr)
+		s.dropEdgePinByEdge(url)
 		if sendHeaders {
 			http.Error(w, "upstream status: "+resp.Status, http.StatusBadGateway)
 			return false, statusErr
 		}
 		return true, statusErr
+	}
+
+	// The answer is usable, so remember which edge served it. resp.Request is
+	// the LAST request the client made, i.e. the one after every redirect, so
+	// this is the concrete node rather than the station's redirect endpoint.
+	// A no-op when nothing redirected, and a no-op on a reconnect, which dialed
+	// the pinned edge and therefore resolved to itself.
+	if resp.Request != nil && resp.Request.URL != nil {
+		s.pinEdge(url, resp.Request.URL.String())
 	}
 
 	// HLS/DASH/playlist detected by MIME type (a URL without the telltale


### PR DESCRIPTION
> **Not for the current release.** This is the audio path and it wants time on real hardware first. Opened so the diagnosis does not sit in a chat log.

## The report

#823, RuudK79, 2026-09-02: a station jumps back about 20 to 30 seconds and then loops on that stretch. Any station. Present across every STR version he has run. He delivered three diagnostics on 09-09.

## What his log says

One ST30, eight minutes of Radio 538:

| | |
|---|---|
| `reconnectCount` | 41 |
| distinct upstream IP addresses | **15** |
| stall-triggered closes | 15 |
| DNS resolutions that failed outright | 12 |
| `upstreamURL` | `https://playerservices.streamtheworld.com/api/livestream-redirect/RADIO538AAC.aac` |

That URL is a **redirect endpoint, not a stream**. Every request to it is answered with a different edge node, and the nodes are not aligned with each other: two of them can be half a minute apart in the same broadcast. The proxy re-requested the preset's own URL on every reconnect, so every reconnect rolled the dice again and spliced audio in at whatever point that node happened to be at.

Backwards twenty or thirty seconds, then the same passage again, on no station in particular, because it is a property of the CDN rather than of the station. That is his report, exactly.

The reconnects themselves have their own causes on his line (his upstream goes quiet for fifteen seconds at a time, and his router is his only nameserver and intermittently fails to resolve). They are supposed to be inaudible. Splicing them from a random node is what makes them audible.

## The change

The edge a redirect resolves to is remembered for the listening session and reused when the connection has to be rebuilt, so the position stays continuous across a reconnect. `resp.Request.URL` after the client's redirect chain is the concrete node.

It is a hint, never a requirement:

- a refusal to connect, or a non-200 from the pinned node, drops the pin and the next attempt goes through the station's redirect again, which is exactly what this path did before;
- a **mid-stream stall deliberately does not** drop it. Constant rebuilding is the situation the pin exists for, and rebuilding to the same node is the entire point;
- a station that does not redirect pins nothing, and `edgeFor` hands back the station URL unchanged.

## Tests

Four cases: the reconnect dials the resolved node, a reconnect resolving to itself does not grow the map, a refusing node is dropped so the station is resolved again, and two stations playing at once keep their own nodes. Dropping something never pinned and pinning empty strings are covered because both happen on every ordinary failure of an unredirected station. Full `internal/streamproxy` suite green.

## Before merging

Run a station on real hardware for a while and confirm the pin line appears once rather than per reconnect, and that a node going away still recovers. Ruud is the one who can confirm the symptom is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J85eNQD42xwUmATiY6k9Zk
