### PR TITLE
fix(app): a station that spells itself with a hyphen is findable again

### DIFF
--- a/radiobrowser/punctsearch_test.go
+++ b/radiobrowser/punctsearch_test.go
@@ -1,0 +1,69 @@
+package radiobrowser
+
+import "testing"
+
+// A station whose own name carries punctuation was unfindable by typing it the
+// way a person says it: radio-browser's byname is a plain substring match, so
+// "Mi Soul" returned nothing while "Mi-Soul" returned the station. Reported by
+// a user with that exact example, and confirmed against the live API.
+func TestNormalizeNameIgnoresPunctuation(t *testing.T) {
+	same := [][2]string{
+		{"Mi Soul", "Mi-Soul"},
+		{"Mi Soul", "Mi-Soul Radio"}, // substring after normalising
+		{"Mi Soul", "mi.soul"},
+		{"1 Live", "1LIVE"},
+		{"Radio Paradise", "Radio  Paradise "},
+	}
+	for _, c := range same {
+		q, n := normalizeName(c[0]), normalizeName(c[1])
+		if q == "" || !contains(n, q) {
+			t.Errorf("%q should find %q, normalised %q vs %q", c[0], c[1], q, n)
+		}
+	}
+}
+
+// The whole-query comparison is what keeps it tight. "Missoula" contains both
+// "mi" and "soul" as separate pieces, so a per-token filter would drag public
+// radio from Montana into a search for a London soul station.
+func TestNormalizeNameStaysTight(t *testing.T) {
+	q := normalizeName("Mi Soul")
+	for _, other := range []string{
+		`KUFM 89.1 "Montana Public Radio" Missoula, MT`,
+		"MixStream Radio - Soul",
+		"Soul Mi Radio", // right words, wrong order: not a substring
+	} {
+		if contains(normalizeName(other), q) {
+			t.Errorf("%q must not match a search for \"Mi Soul\" (normalised %q)", other, normalizeName(other))
+		}
+	}
+}
+
+func TestNormalizeNameEdges(t *testing.T) {
+	if normalizeName("") != "" {
+		t.Error("empty stays empty")
+	}
+	if normalizeName("---") != "" {
+		t.Error("punctuation only collapses to empty")
+	}
+	// Digits carry meaning in station names and must survive.
+	if got := normalizeName("SWR 3"); got != "swr3" {
+		t.Errorf("normalizeName(\"SWR 3\") = %q, want \"swr3\"", got)
+	}
+	// Non-ASCII letters are letters.
+	if got := normalizeName("Österreich 1"); got != "österreich1" {
+		t.Errorf("normalizeName dropped a non-ASCII letter: %q", got)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(needle) > 0 && len(haystack) >= len(needle) && indexOf(haystack, needle) >= 0
+}
+
+func indexOf(h, n string) int {
+	for i := 0; i+len(n) <= len(h); i++ {
+		if h[i:i+len(n)] == n {
+			return i
+		}
+	}
+	return -1
+}

--- a/radiobrowser/radiobrowser.go
+++ b/radiobrowser/radiobrowser.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 )
 
 // Mirrors are the servers we try in order. First success wins; on
@@ -412,10 +413,82 @@ func (c *Client) SearchSmart(ctx context.Context, opts SearchOpts) ([]Station, e
 	add(nameRes.stations)
 	add(tagStations)
 
+	// Still nothing, and the user typed more than one word? Then the station
+	// they mean may simply spell itself with punctuation. See punctFallback.
+	if len(merged) == 0 && len(tokens) >= 2 {
+		if st, err := c.punctFallback(ctx, opts, tokens); err == nil {
+			add(st)
+		}
+	}
+
 	if len(merged) > opts.Limit {
 		merged = merged[:opts.Limit]
 	}
 	return merged, nil
+}
+
+// punctFallback finds a station whose own name carries punctuation the user did
+// not type.
+//
+// radio-browser's byname is a plain substring match, so "Mi Soul" finds nothing
+// while "Mi-Soul" finds the station: the searcher has to guess the spelling
+// they are searching in order to discover. Reported by a user with that exact
+// example, and confirmed against the live API (0 hits vs 2).
+//
+// So the longest word is asked for on its own, which is the part most likely to
+// be spelled plainly, and the answers are compared with the punctuation removed
+// from BOTH sides. Deliberately a whole-query comparison rather than a per-token
+// one: "Mi Soul" normalises to "misoul", which "Mi-Soul" contains and
+// "Missoula" does not, though the latter does contain both "mi" and "soul".
+// Measured on the live API: 181 stations came back for "Soul" and exactly the
+// two intended ones survived.
+//
+// Runs only when the ordinary search found nothing at all, so a working query
+// costs no extra request.
+func (c *Client) punctFallback(ctx context.Context, opts SearchOpts, tokens []string) ([]Station, error) {
+	longest := ""
+	for _, t := range tokens {
+		if len(t) > len(longest) {
+			longest = t
+		}
+	}
+	// One character is every station's substring; it would fetch a page of
+	// noise to filter nothing useful out of.
+	if len([]rune(longest)) < 3 {
+		return nil, nil
+	}
+	wide := opts
+	wide.Name = longest
+	wide.TagList = nil
+	wide.Limit = 400
+	if wide.Order == "" {
+		wide.Order = "votes"
+	}
+	st, err := c.Search(ctx, wide)
+	if err != nil {
+		return nil, err
+	}
+	want := normalizeName(opts.Name)
+	out := make([]Station, 0, 8)
+	for _, s := range st {
+		if strings.Contains(normalizeName(s.Name), want) {
+			out = append(out, s)
+		}
+	}
+	return out, nil
+}
+
+// normalizeName lower-cases and drops everything that is not a letter or a
+// digit, so "Mi-Soul", "Mi Soul" and "mi.soul" are one and the same name.
+func normalizeName(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range strings.ToLower(s) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // EnrichSiblingLogos fills an entry's empty Favicon/Homepage from a SIBLING


### PR DESCRIPTION
Reported in the Bose Only Facebook group seven weeks ago, in a thread full of praise for STR, and never answered:

> The search on the software is not fuzzy... if you don't type in the station name *exactly* then it won't find it (eg searching for Mi Soul brings up nothing, searching for Mi-Soul brings the station up).

Confirmed against the live API today:

```
byname/Mi%20Soul  ->  0 hits
byname/Mi-Soul    ->  2 hits  (Mi-Soul, Mi-Soul Radio)
byname/MiSoul     ->  0 hits
```

radio-browser's `byname` is a plain substring match on the station name, so punctuation **inside** the name defeats a query typed the way a person says it. The searcher has to guess the spelling they are searching in order to discover.

## The change

When a multi-word search comes back empty, STR asks again for the longest word alone and keeps the stations whose name matches once punctuation is stripped from both sides.

The comparison is on the **whole query**, not per token, and that is what keeps it tight: `Mi Soul` normalises to `misoul`, which `Mi-Soul` contains and `Missoula` does not, even though Missoula contains both `mi` and `soul`. Measured live: 181 stations came back for `Soul`, and exactly the two intended ones survived.

It runs only when the ordinary search found nothing, so a working query costs no extra request.

## Tests

Pairs that must match (`Mi Soul`/`Mi-Soul`, `1 Live`/`1LIVE`), the tight cases that must not (Missoula, and right-words-wrong-order), and the edges: digits survive because station names use them, and non-ASCII letters stay letters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J85eNQD42xwUmATiY6k9Zk