### PR TITLE
fix(presets): a preset key in a group plays again instead of turning the speakers amber

### DIFF
--- a/cmd/agent/nativedrop_ownmiss_test.go
+++ b/cmd/agent/nativedrop_ownmiss_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// The native-drop watchdog latches every slot on a speaker onto the slower UPnP
+// form after four strikes, and a strike is meant to mean "this speaker cannot
+// hold a native station it accepted".
+//
+// Three grouped SoundTouch 10s on 2026-09-13 collected four of them in six
+// minutes for something else entirely: the group master was asked for a slot it
+// did not have, its own proxy 404ed, and the box left the station each time. The
+// speaker was fine. Its keys were downgraded anyway.
+func TestOurOwn404IsNotAStrikeAgainstTheSpeaker(t *testing.T) {
+	withNoDropsRecorded(t)
+	withSlotMiss(t, 6, 200*time.Millisecond, true)
+
+	for i := 0; i < nativeDropBudget+2; i++ {
+		noteNativeStreamDropped()
+	}
+
+	if n := recordedDrops(); n != 0 {
+		t.Errorf("drops = %d, want 0: a station we refused ourselves is not evidence about the speaker", n)
+	}
+}
+
+// The watchdog still has to work. A speaker that abandons stations with no
+// refusal of ours in front of it collects its strikes as before.
+func TestADropWithNoRefusalOfOursStillCounts(t *testing.T) {
+	withNoDropsRecorded(t)
+	withSlotMiss(t, 0, 0, false)
+
+	noteNativeStreamDropped()
+	noteNativeStreamDropped()
+
+	if n := recordedDrops(); n != 2 {
+		t.Errorf("drops = %d, want 2", n)
+	}
+}
+
+// An old refusal is not an excuse. The chain in the field was sub-second; a
+// speaker that drops a station a minute later did it on its own.
+func TestAStaleRefusalDoesNotExcuseADrop(t *testing.T) {
+	withNoDropsRecorded(t)
+	withSlotMiss(t, 6, nativeDropOwnMissWindow+time.Second, true)
+
+	noteNativeStreamDropped()
+
+	if n := recordedDrops(); n != 1 {
+		t.Errorf("drops = %d, want 1", n)
+	}
+}
+
+func withSlotMiss(t *testing.T, slot int, ago time.Duration, ok bool) {
+	t.Helper()
+	prev := lastSlotMiss
+	lastSlotMiss = func() (int, time.Duration, bool) { return slot, ago, ok }
+	t.Cleanup(func() { lastSlotMiss = prev })
+}
+
+func withNoDropsRecorded(t *testing.T) {
+	t.Helper()
+	nativeDrops.Lock()
+	prev := nativeDrops.n
+	nativeDrops.n = 0
+	nativeDrops.Unlock()
+	t.Cleanup(func() {
+		nativeDrops.Lock()
+		nativeDrops.n = prev
+		nativeDrops.Unlock()
+	})
+}
+
+func recordedDrops() int {
+	nativeDrops.Lock()
+	defer nativeDrops.Unlock()
+	return nativeDrops.n
+}

--- a/cmd/agent/nativepresets.go
+++ b/cmd/agent/nativepresets.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/JRpersonal/streborn/internal/boxcli"
 	"github.com/JRpersonal/streborn/internal/presets"
+	"github.com/JRpersonal/streborn/internal/streamproxy"
 	"github.com/JRpersonal/streborn/internal/webui"
 )
 
@@ -107,6 +108,19 @@ func disableNativePresets(reason string) {
 // speaker.
 const nativeDropBudget = 4
 
+// nativeDropOwnMissWindow is how recently our own stream proxy must have
+// refused a slot for the drop that follows to be read as our fault rather than
+// the speaker's. The chain is sub-second in the field (404 at 07:25:00.651,
+// source back to INVALID_SOURCE at 07:25:01.396); a speaker that genuinely
+// abandons a station it accepted does so after playing, with no refusal of ours
+// in front of it.
+const nativeDropOwnMissWindow = 10 * time.Second
+
+// lastSlotMiss is the proxy's own record of the last slot it could not serve,
+// as a variable so a test can say "we refused one 200 ms ago" without standing
+// up a proxy and a preset store to make it happen.
+var lastSlotMiss = streamproxy.LastSlotMiss
+
 var nativeDrops struct {
 	sync.Mutex
 	n int
@@ -124,6 +138,20 @@ var nativeDrops struct {
 // After a few drops the speaker is put back on the UPnP form, which works there.
 // A slower path is a far better outcome than a station that keeps falling over.
 func noteNativeStreamDropped() {
+	// A station the box abandoned because OUR OWN proxy refused the fetch is not
+	// evidence about the box. Three grouped SoundTouch 10s on 2026-09-13 spent
+	// four presses on a slot the group master did not have; the master's proxy
+	// 404ed each one, the box left the station each time, and the fourth strike
+	// latched every slot on that speaker onto the slower form for good. The
+	// speaker had done nothing wrong. Same reasoning as nativeDropIsOurOwnWrite
+	// on the write side.
+	if slot, ago, ok := lastSlotMiss(); ok && ago < nativeDropOwnMissWindow {
+		if l := nativeReadyLogger; l != nil {
+			l.Info("native presets: the station was dropped after our own proxy refused the fetch, not counting it against the speaker",
+				"slot", slot, "ago", ago.Round(time.Millisecond))
+		}
+		return
+	}
 	nativeDrops.Lock()
 	nativeDrops.n++
 	n := nativeDrops.n

--- a/internal/streamproxy/slotmiss.go
+++ b/internal/streamproxy/slotmiss.go
@@ -1,0 +1,46 @@
+package streamproxy
+
+import (
+	"sync"
+	"time"
+)
+
+// The last time the proxy was asked for a slot it cannot serve.
+//
+// It is recorded because the failure is invisible where it does damage. A box
+// that fetches /stream/<slot> and gets a 404 leaves the station it had just
+// been given, and the agent's native-preset watchdog reads that as "this
+// speaker cannot keep a native station" and eventually puts every slot on the
+// slower UPnP form. Three grouped SoundTouch 10s on 2026-09-13 spent four
+// presses that way on a slot only the follower had, each one refused by the
+// master's own proxy, and the speaker was blamed for all four.
+//
+// A slot miss is our answer, not the speaker's fault, so the watchdog needs to
+// be able to tell that one of ours came first. Package-level because there is
+// one proxy per agent and the watchdog lives in another package with no handle
+// on the server.
+var lastMiss struct {
+	sync.Mutex
+	slot int
+	at   time.Time
+}
+
+// noteSlotMiss records that the proxy refused a fetch for slot, having nothing
+// playable there.
+func noteSlotMiss(slot int) {
+	lastMiss.Lock()
+	lastMiss.slot = slot
+	lastMiss.at = time.Now()
+	lastMiss.Unlock()
+}
+
+// LastSlotMiss reports the most recent slot the proxy could not serve and how
+// long ago it was refused. ok is false when this agent has never refused one.
+func LastSlotMiss() (slot int, ago time.Duration, ok bool) {
+	lastMiss.Lock()
+	defer lastMiss.Unlock()
+	if lastMiss.at.IsZero() {
+		return 0, 0, false
+	}
+	return lastMiss.slot, time.Since(lastMiss.at), true
+}

--- a/internal/streamproxy/slotmiss_test.go
+++ b/internal/streamproxy/slotmiss_test.go
@@ -1,0 +1,34 @@
+package streamproxy
+
+import (
+	"testing"
+	"time"
+)
+
+// The watchdog in cmd/agent asks this package "did we refuse a fetch just now",
+// so a station the box dropped because of our own 404 is not counted against
+// the speaker. Nothing else records that, so the record has to be right.
+func TestASlotMissIsRememberedWithItsAge(t *testing.T) {
+	prevSlot, prevAt := lastMiss.slot, lastMiss.at
+	t.Cleanup(func() { lastMiss.slot, lastMiss.at = prevSlot, prevAt })
+
+	lastMiss.slot, lastMiss.at = 0, time.Time{}
+	if _, _, ok := LastSlotMiss(); ok {
+		t.Fatal("an agent that never refused a slot must report none")
+	}
+
+	noteSlotMiss(6)
+	slot, ago, ok := LastSlotMiss()
+	if !ok || slot != 6 {
+		t.Fatalf("LastSlotMiss() = (%d, %v, %v), want slot 6", slot, ago, ok)
+	}
+	if ago < 0 || ago > time.Minute {
+		t.Errorf("age = %v, want a fresh refusal", ago)
+	}
+
+	// The newest refusal is the one a drop has to be judged against.
+	noteSlotMiss(2)
+	if slot, _, _ := LastSlotMiss(); slot != 2 {
+		t.Errorf("slot = %d, want the most recent refusal (2)", slot)
+	}
+}

--- a/internal/streamproxy/streamproxy.go
+++ b/internal/streamproxy/streamproxy.go
@@ -519,6 +519,10 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		// the only branch in the recall chain with no trace at all (#252).
 		s.logger.Warn("stream proxy: box fetched a slot with no playable preset",
 			"slot", slot, "found", ok, "queue", ok && p.Type == "queue")
+		// The box will now leave the station it was just handed. Record the
+		// refusal so the native-preset watchdog does not read that as the
+		// speaker being unable to hold one. See slotmiss.go.
+		noteSlotMiss(slot)
 		http.Error(w, "no preset", http.StatusNotFound)
 		return
 	}

--- a/internal/webui/groupnativestation_test.go
+++ b/internal/webui/groupnativestation_test.go
@@ -1,0 +1,58 @@
+package webui
+
+import (
+	"strings"
+	"testing"
+)
+
+// Eileen Wilson's three grouped SoundTouch 10s, 2026-09-13. She pressed key 6
+// in the app and got a solid amber LED and silence on all three; the same key
+// played twenty seconds after the group was undone.
+//
+// The recall went to the speaker that holds "Exclusively Rush" on key 6. That
+// speaker was a follower, so the firmware handed the content item to the master
+// to play, and the location in it named the station by slot:
+// http://127.0.0.1:8888/stream/6. On the master, 127.0.0.1 is the master, and
+// its key 6 was empty. Its own proxy answered "box fetched a slot with no
+// playable preset slot=6 found=false" and 404ed, and the box reported
+// AUDIO_ERROR_BAD_URL.
+//
+// A slot number is not a name another speaker can resolve. The follower's own
+// LAN address would not do either, because two rhino ST10s cannot reach each
+// other's web port at all. So the station itself travels in the URL.
+func TestAGroupFollowersStationCarriesTheStreamNotTheSlot(t *testing.T) {
+	const (
+		slotURL = "http://127.0.0.1:8888/stream/6"
+		stream  = "https://exclusive.example/rush"
+	)
+
+	if got := nativeStationURLFor(slotURL, stream, false); got != slotURL {
+		t.Errorf("standalone speaker: got %q, want the slot form %q", got, slotURL)
+	}
+
+	got := nativeStationURLFor(slotURL, stream, true)
+	if got == slotURL {
+		t.Fatal("a follower still named the slot, which only the master can resolve")
+	}
+	if !strings.Contains(got, "/stream/raw?u=") {
+		t.Fatalf("follower URL = %q, want the raw form that carries the station", got)
+	}
+
+	// The marge keeper and the reconcile both read a native location back to
+	// decide what a slot holds. If the raw form did not unwind to the origin
+	// stream, a grouped recall would quietly rewrite the user's preset.
+	if back := unwrapRawStreamProxy(got); back != stream {
+		t.Errorf("unwrapRawStreamProxy(%q) = %q, want the origin %q", got, back, stream)
+	}
+}
+
+// A preset with no stream URL has nothing to put in the raw form. Better to
+// leave the recall exactly as it was than to invent a URL for it.
+func TestAStationWithNoStreamKeepsTheSlotForm(t *testing.T) {
+	const slotURL = "http://127.0.0.1:8888/stream/2"
+	for _, stream := range []string{"", "   "} {
+		if got := nativeStationURLFor(slotURL, stream, true); got != slotURL {
+			t.Errorf("stream %q: got %q, want %q", stream, got, slotURL)
+		}
+	}
+}

--- a/internal/webui/nativestation.go
+++ b/internal/webui/nativestation.go
@@ -17,6 +17,8 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+
+	"github.com/JRpersonal/streborn/internal/boxurl"
 )
 
 // NativeStation is what a native radio location describes.
@@ -106,6 +108,56 @@ func DecodeNativeStation(loc string) (NativeStation, bool) {
 }
 
 // rawStreamProxyPath is the ad-hoc stream proxy route (boxurl.RawStream).
+// nativeStationURL picks the proxy URL to put inside a native station for this
+// speaker: the slot form normally, the raw form while this speaker is a group
+// follower.
+//
+// A native station is activated by the speaker itself, so the URL only has to
+// mean something locally, and /stream/<slot> is the better form: the per-slot
+// machinery (the re-push watchdog, recall verification, a queue preset's live
+// track) is all keyed on that number.
+//
+// In a group it stops being local. The firmware hands a follower's content item
+// to the MASTER to play, and the master reads 127.0.0.1 as itself, so the slot
+// is looked up in the master's preset store. Three grouped SoundTouch 10s,
+// 2026-09-13: key 6 held a station on the follower the recall went to and
+// nothing on the master, the master fetched its own /stream/6, its proxy
+// answered "box fetched a slot with no playable preset slot=6 found=false", and
+// the user got a solid amber LED and silence on all three. The same keys played
+// as soon as the group was undone.
+//
+// Naming the follower's own LAN address instead is not the way out: two rhino
+// ST10s cannot reach each other's web port at all, so the master's fetch would
+// simply fail differently. The raw form carries the station in the URL, so
+// whichever speaker ends up fetching resolves it against its own proxy and no
+// preset store is consulted.
+//
+// An unreadable zone keeps the slot form. Guessing "follower" on a read error
+// would take the slot machinery away from the standalone majority for nothing.
+func (s *Server) nativeStationURL(slot int, slotURL, streamURL string) string {
+	standDown, why := s.zonePushWouldFightGroup()
+	url := nativeStationURLFor(slotURL, streamURL, standDown)
+	if url != slotURL {
+		s.logger.Info("native station: the master resolves this station, not this speaker, so it travels in the URL",
+			"slot", slot, "reason", why)
+	}
+	return url
+}
+
+// nativeStationURLFor is the choice itself, without the zone read.
+//
+// masterResolves says this speaker will not be the one fetching: it is a group
+// follower, or it is in a group and cannot tell which end it is, and either way
+// a slot number means whatever the master has in that slot. Without a stream
+// URL to put in the raw form there is nothing to fall back to, so the slot form
+// stays and the recall fails the way it did before rather than differently.
+func nativeStationURLFor(slotURL, streamURL string, masterResolves bool) string {
+	if !masterResolves || strings.TrimSpace(streamURL) == "" {
+		return slotURL
+	}
+	return boxurl.RawStream(streamURL)
+}
+
 var rawStreamProxyPath = regexp.MustCompile(`^/stream/raw$`)
 
 // unwrapRawStreamProxy unwinds "/stream/raw?u=<base64 URL>" wrappers (an

--- a/internal/webui/playback.go
+++ b/internal/webui/playback.go
@@ -509,7 +509,7 @@ func (s *Server) handlePlaySlot(w http.ResponseWriter, r *http.Request) {
 	// source back to the form the native work exists to avoid. Falls through to
 	// the UPnP push on any refusal, so a speaker that cannot do this keeps
 	// exactly today's behaviour. See nativeselect.go.
-	if loc := s.nativePresetLocation(p.Name, playURL, p.Art); loc != "" {
+	if loc := s.nativePresetLocation(p.Name, s.nativeStationURL(slot, playURL, p.StreamURL), p.Art); loc != "" {
 		if err := s.selectNativeStation(playCtx, loc, p.Name); err == nil {
 			s.logger.Info("preset slot recall (app): started natively, the speaker fetches the stream itself",
 				"slot", slot, "name", p.Name)


### PR DESCRIPTION
Three ST10s, grouped, three diagnostic bundles taken minutes apart on 2026-09-13. The owner pressed preset key 6 in the app, got silence and a solid amber LED on all three, and the same key played twenty seconds after the group was undone.

## The amber LED

The recall went to the speaker that holds "Exclusively Rush" on key 6. That speaker was a **follower**, so the firmware handed the content item to the master to play, as it should. The location in that item names the station by **slot**:

```
http://127.0.0.1:8888/stream/6
```

On the master, `127.0.0.1` is the master, and its key 6 was empty. Its own proxy answered the fetch 300 ms later:

```
stream proxy: box fetched a slot with no playable preset slot=6 found=false
```

then 404, then `AUDIO_ERROR_BAD_URL`, then amber. In the third bundle the group was gone, the speaker fetched for itself, and both keys played.

A slot number is not a name another speaker can resolve. Naming the follower's own LAN address is no way out either: **two rhino ST10s cannot reach each other's web port at all**, so the master's fetch would just fail differently.

So a follower's native station now carries the stream in the URL, `/stream/raw?u=<base64>`, which whichever speaker ends up fetching resolves against its own proxy with no preset store involved. Everything else keeps the slot form, which the per-slot machinery (the re-push watchdog, recall verification, a queue preset's live track) is keyed on, and an unreadable zone keeps it too. The raw form round-trips back to the origin stream through the existing `unwrapRawStreamProxy`, so the marge keeper and the reconcile still agree on what a slot holds — that is asserted in the test.

## The speaker was blamed for it

Each of those failures counted as a strike against the **speaker**, and at the fourth the watchdog decided it could not hold a native station and moved all six of its keys onto the slower UPnP form for good:

```
native presets: this speaker keeps dropping the station it just started,
switching its presets back to the slower form that works here drops=4
```

It had done nothing wrong. It dropped the station because our own proxy refused the fetch. The watchdog already ignores its own footprint for preset writes (`nativeDropIsOurOwnWrite`); it now does the same for a slot it refused itself, within ten seconds. A drop with no refusal of ours in front of it still counts, as before — the field chain is sub-second, and a speaker that genuinely abandons a station does so after playing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J85eNQD42xwUmATiY6k9Zk
